### PR TITLE
Move feature descriptions out of std.Target.Cpu.Feature

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1383,8 +1383,8 @@ pub fn parseTargetQuery(options: std.Target.Query.ParseOptions) error{ParseFaile
                 diags.unknown_feature_name.?,
                 @tagName(diags.arch.?),
             });
-            for (diags.arch.?.allFeaturesList()) |feature| {
-                std.debug.print(" {s}: {s}\n", .{ feature.name, feature.description });
+            for (diags.arch.?.allFeaturesList(), diags.arch.?.allFeaturesDescList()) |feature, desc| {
+                std.debug.print(" {s}: {s}\n", .{ feature.name, desc });
             }
             return error.ParseFailed;
         },

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -847,9 +847,6 @@ pub const Cpu = struct {
         /// otherwise null.
         llvm_name: ?[:0]const u8,
 
-        /// Human-friendly UTF-8 text.
-        description: []const u8,
-
         /// Sparse `Set` of features this depends on.
         dependencies: Set,
 
@@ -1404,6 +1401,40 @@ pub const Cpu = struct {
                 .wasm32, .wasm64 => &wasm.all_features,
 
                 else => &[0]Cpu.Feature{},
+            };
+        }
+
+        /// Human-friendly UTF-8 description text for all CPU features Zig is aware of.
+        /// Indexes correspond 1:1 with the return of `allFeaturesList`.
+        ///
+        /// TODO: Move these descriptions strings back into `Cpu.Feature`.
+        ///       See https://github.com/ziglang/zig/issues/21010
+        pub fn allFeaturesDescList(arch: Arch) []const []const u8 {
+            return switch (arch) {
+                .arm, .armeb, .thumb, .thumbeb => &arm.feature_descs,
+                .aarch64, .aarch64_be => &aarch64.feature_descs,
+                .arc => &arc.feature_descs,
+                .avr => &avr.feature_descs,
+                .bpfel, .bpfeb => &bpf.feature_descs,
+                .csky => &csky.feature_descs,
+                .hexagon => &hexagon.feature_descs,
+                .loongarch32, .loongarch64 => &loongarch.feature_descs,
+                .m68k => &m68k.feature_descs,
+                .mips, .mipsel, .mips64, .mips64el => &mips.feature_descs,
+                .msp430 => &msp430.feature_descs,
+                .powerpc, .powerpcle, .powerpc64, .powerpc64le => &powerpc.feature_descs,
+                .amdgcn => &amdgpu.feature_descs,
+                .riscv32, .riscv64 => &riscv.feature_descs,
+                .sparc, .sparc64 => &sparc.feature_descs,
+                .spirv32, .spirv64 => &spirv.feature_descs,
+                .s390x => &s390x.feature_descs,
+                .x86, .x86_64 => &x86.feature_descs,
+                .xtensa => &xtensa.feature_descs,
+                .nvptx, .nvptx64 => &nvptx.feature_descs,
+                .ve => &ve.feature_descs,
+                .wasm32, .wasm64 => &wasm.feature_descs,
+
+                else => &.{},
             };
         }
 

--- a/lib/std/Target/aarch64.zig
+++ b/lib/std/Target/aarch64.zig
@@ -247,7 +247,6 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.a510)] = .{
         .llvm_name = "a510",
-        .description = "Cortex-A510 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .fuse_adrp_add,
             .fuse_aes,
@@ -256,7 +255,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a520)] = .{
         .llvm_name = "a520",
-        .description = "Cortex-A520 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .fuse_adrp_add,
             .fuse_aes,
@@ -265,7 +263,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a65)] = .{
         .llvm_name = "a65",
-        .description = "Cortex-A65 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .enable_select_opt,
             .fuse_address,
@@ -277,7 +274,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a710)] = .{
         .llvm_name = "a710",
-        .description = "Cortex-A710 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .addr_lsl_fast,
             .alu_lsl_fast,
@@ -291,7 +287,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a720)] = .{
         .llvm_name = "a720",
-        .description = "Cortex-A720 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .addr_lsl_fast,
             .alu_lsl_fast,
@@ -305,7 +300,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a76)] = .{
         .llvm_name = "a76",
-        .description = "Cortex-A76 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .addr_lsl_fast,
             .alu_lsl_fast,
@@ -317,7 +311,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a78)] = .{
         .llvm_name = "a78",
-        .description = "Cortex-A78 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .addr_lsl_fast,
             .alu_lsl_fast,
@@ -331,7 +324,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.a78c)] = .{
         .llvm_name = "a78c",
-        .description = "Cortex-A78C ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .addr_lsl_fast,
             .alu_lsl_fast,
@@ -345,197 +337,160 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.addr_lsl_fast)] = .{
         .llvm_name = "addr-lsl-fast",
-        .description = "Address operands with logical shift of up to 3 places are cheap",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aes)] = .{
         .llvm_name = "aes",
-        .description = "Enable AES support (FEAT_AES, FEAT_PMULL)",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.aggressive_fma)] = .{
         .llvm_name = "aggressive-fma",
-        .description = "Enable Aggressive FMA for floating-point.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.alternate_sextload_cvt_f32_pattern)] = .{
         .llvm_name = "alternate-sextload-cvt-f32-pattern",
-        .description = "Use alternative pattern for sextload convert to f32",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.altnzcv)] = .{
         .llvm_name = "altnzcv",
-        .description = "Enable alternative NZCV format for floating point comparisons (FEAT_FlagM2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.alu_lsl_fast)] = .{
         .llvm_name = "alu-lsl-fast",
-        .description = "Add/Sub operations with lsl shift <= 4 are cheap",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.am)] = .{
         .llvm_name = "am",
-        .description = "Enable v8.4-A Activity Monitors extension (FEAT_AMUv1)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.amvs)] = .{
         .llvm_name = "amvs",
-        .description = "Enable v8.6-A Activity Monitors Virtualization support (FEAT_AMUv1p1)",
         .dependencies = featureSet(&[_]Feature{
             .am,
         }),
     };
     result[@intFromEnum(Feature.arith_bcc_fusion)] = .{
         .llvm_name = "arith-bcc-fusion",
-        .description = "CPU fuses arithmetic+bcc operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.arith_cbz_fusion)] = .{
         .llvm_name = "arith-cbz-fusion",
-        .description = "CPU fuses arithmetic + cbz/cbnz operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ascend_store_address)] = .{
         .llvm_name = "ascend-store-address",
-        .description = "Schedule vector stores by ascending address",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.b16b16)] = .{
         .llvm_name = "b16b16",
-        .description = "Enable SVE2.1 or SME2.1 non-widening BFloat16 to BFloat16 instructions (FEAT_B16B16)",
         .dependencies = featureSet(&[_]Feature{
             .bf16,
         }),
     };
     result[@intFromEnum(Feature.balance_fp_ops)] = .{
         .llvm_name = "balance-fp-ops",
-        .description = "balance mix of odd and even D-registers for fp multiply(-accumulate) ops",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.bf16)] = .{
         .llvm_name = "bf16",
-        .description = "Enable BFloat16 Extension (FEAT_BF16)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.brbe)] = .{
         .llvm_name = "brbe",
-        .description = "Enable Branch Record Buffer Extension (FEAT_BRBE)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.bti)] = .{
         .llvm_name = "bti",
-        .description = "Enable Branch Target Identification (FEAT_BTI)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x10)] = .{
         .llvm_name = "call-saved-x10",
-        .description = "Make X10 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x11)] = .{
         .llvm_name = "call-saved-x11",
-        .description = "Make X11 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x12)] = .{
         .llvm_name = "call-saved-x12",
-        .description = "Make X12 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x13)] = .{
         .llvm_name = "call-saved-x13",
-        .description = "Make X13 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x14)] = .{
         .llvm_name = "call-saved-x14",
-        .description = "Make X14 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x15)] = .{
         .llvm_name = "call-saved-x15",
-        .description = "Make X15 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x18)] = .{
         .llvm_name = "call-saved-x18",
-        .description = "Make X18 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x8)] = .{
         .llvm_name = "call-saved-x8",
-        .description = "Make X8 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.call_saved_x9)] = .{
         .llvm_name = "call-saved-x9",
-        .description = "Make X9 callee saved.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ccdp)] = .{
         .llvm_name = "ccdp",
-        .description = "Enable v8.5 Cache Clean to Point of Deep Persistence (FEAT_DPB2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ccidx)] = .{
         .llvm_name = "ccidx",
-        .description = "Enable v8.3-A Extend of the CCSIDR number of sets (FEAT_CCIDX)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ccpp)] = .{
         .llvm_name = "ccpp",
-        .description = "Enable v8.2 data Cache Clean to Point of Persistence (FEAT_DPB)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.chk)] = .{
         .llvm_name = "chk",
-        .description = "Enable Armv8.0-A Check Feature Status Extension (FEAT_CHK)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.clrbhb)] = .{
         .llvm_name = "clrbhb",
-        .description = "Enable Clear BHB instruction (FEAT_CLRBHB)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cmp_bcc_fusion)] = .{
         .llvm_name = "cmp-bcc-fusion",
-        .description = "CPU fuses cmp+bcc operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.complxnum)] = .{
         .llvm_name = "complxnum",
-        .description = "Enable v8.3-A Floating-point complex number support (FEAT_FCMA)",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.contextidr_el2)] = .{
         .llvm_name = "CONTEXTIDREL2",
-        .description = "Enable RW operand Context ID Register (EL2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cortex_r82)] = .{
         .llvm_name = "cortex-r82",
-        .description = "Cortex-R82 ARM processors",
         .dependencies = featureSet(&[_]Feature{
             .use_postra_scheduler,
         }),
     };
     result[@intFromEnum(Feature.cpa)] = .{
         .llvm_name = "cpa",
-        .description = "Enable Armv9.5-A Checked Pointer Arithmetic (FEAT_CPA)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crc)] = .{
         .llvm_name = "crc",
-        .description = "Enable ARMv8 CRC-32 checksum instructions (FEAT_CRC32)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crypto)] = .{
         .llvm_name = "crypto",
-        .description = "Enable cryptographic instructions",
         .dependencies = featureSet(&[_]Feature{
             .aes,
             .sha2,
@@ -543,620 +498,504 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.cssc)] = .{
         .llvm_name = "cssc",
-        .description = "Enable Common Short Sequence Compression (CSSC) instructions (FEAT_CSSC)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.d128)] = .{
         .llvm_name = "d128",
-        .description = "Enable Armv9.4-A 128-bit Page Table Descriptors, System Registers and Instructions (FEAT_D128, FEAT_LVA3, FEAT_SYSREG128, FEAT_SYSINSTR128)",
         .dependencies = featureSet(&[_]Feature{
             .lse128,
         }),
     };
     result[@intFromEnum(Feature.disable_latency_sched_heuristic)] = .{
         .llvm_name = "disable-latency-sched-heuristic",
-        .description = "Disable latency scheduling heuristic",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.disable_ldp)] = .{
         .llvm_name = "disable-ldp",
-        .description = "Do not emit ldp",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.disable_stp)] = .{
         .llvm_name = "disable-stp",
-        .description = "Do not emit stp",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dit)] = .{
         .llvm_name = "dit",
-        .description = "Enable v8.4-A Data Independent Timing instructions (FEAT_DIT)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dotprod)] = .{
         .llvm_name = "dotprod",
-        .description = "Enable dot product support (FEAT_DotProd)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ecv)] = .{
         .llvm_name = "ecv",
-        .description = "Enable enhanced counter virtualization extension (FEAT_ECV)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.el2vmsa)] = .{
         .llvm_name = "el2vmsa",
-        .description = "Enable Exception Level 2 Virtual Memory System Architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.el3)] = .{
         .llvm_name = "el3",
-        .description = "Enable Exception Level 3",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.enable_select_opt)] = .{
         .llvm_name = "enable-select-opt",
-        .description = "Enable the select optimize pass for select loop heuristics",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ete)] = .{
         .llvm_name = "ete",
-        .description = "Enable Embedded Trace Extension (FEAT_ETE)",
         .dependencies = featureSet(&[_]Feature{
             .trbe,
         }),
     };
     result[@intFromEnum(Feature.exynos_cheap_as_move)] = .{
         .llvm_name = "exynos-cheap-as-move",
-        .description = "Use Exynos specific handling of cheap instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.f32mm)] = .{
         .llvm_name = "f32mm",
-        .description = "Enable Matrix Multiply FP32 Extension (FEAT_F32MM)",
         .dependencies = featureSet(&[_]Feature{
             .sve,
         }),
     };
     result[@intFromEnum(Feature.f64mm)] = .{
         .llvm_name = "f64mm",
-        .description = "Enable Matrix Multiply FP64 Extension (FEAT_F64MM)",
         .dependencies = featureSet(&[_]Feature{
             .sve,
         }),
     };
     result[@intFromEnum(Feature.faminmax)] = .{
         .llvm_name = "faminmax",
-        .description = "Enable FAMIN and FAMAX instructions (FEAT_FAMINMAX)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fgt)] = .{
         .llvm_name = "fgt",
-        .description = "Enable fine grained virtualization traps extension (FEAT_FGT)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fix_cortex_a53_835769)] = .{
         .llvm_name = "fix-cortex-a53-835769",
-        .description = "Mitigate Cortex-A53 Erratum 835769",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flagm)] = .{
         .llvm_name = "flagm",
-        .description = "Enable v8.4-A Flag Manipulation Instructions (FEAT_FlagM)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fmv)] = .{
         .llvm_name = "fmv",
-        .description = "Enable Function Multi Versioning support.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.force_32bit_jump_tables)] = .{
         .llvm_name = "force-32bit-jump-tables",
-        .description = "Force jump table entries to be 32-bits wide except at MinSize",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp16fml)] = .{
         .llvm_name = "fp16fml",
-        .description = "Enable FP16 FML instructions (FEAT_FHM)",
         .dependencies = featureSet(&[_]Feature{
             .fullfp16,
         }),
     };
     result[@intFromEnum(Feature.fp8)] = .{
         .llvm_name = "fp8",
-        .description = "Enable FP8 instructions (FEAT_FP8)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp8dot2)] = .{
         .llvm_name = "fp8dot2",
-        .description = "Enable fp8 2-way dot instructions (FEAT_FP8DOT2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp8dot4)] = .{
         .llvm_name = "fp8dot4",
-        .description = "Enable fp8 4-way dot instructions (FEAT_FP8DOT4)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp8fma)] = .{
         .llvm_name = "fp8fma",
-        .description = "Enable fp8 multiply-add instructions (FEAT_FP8FMA)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp_armv8)] = .{
         .llvm_name = "fp-armv8",
-        .description = "Enable ARMv8 FP (FEAT_FP)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpmr)] = .{
         .llvm_name = "fpmr",
-        .description = "Enable FPMR Register (FEAT_FPMR)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fptoint)] = .{
         .llvm_name = "fptoint",
-        .description = "Enable FRInt[32|64][Z|X] instructions that round a floating-point number to an integer (in FP format) forcing it to fit into a 32- or 64-bit int (FEAT_FRINTTS)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fullfp16)] = .{
         .llvm_name = "fullfp16",
-        .description = "Full FP16 (FEAT_FP16)",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8,
         }),
     };
     result[@intFromEnum(Feature.fuse_address)] = .{
         .llvm_name = "fuse-address",
-        .description = "CPU fuses address generation and memory operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_addsub_2reg_const1)] = .{
         .llvm_name = "fuse-addsub-2reg-const1",
-        .description = "CPU fuses (a + b + 1) and (a - b - 1)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_adrp_add)] = .{
         .llvm_name = "fuse-adrp-add",
-        .description = "CPU fuses adrp+add operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_aes)] = .{
         .llvm_name = "fuse-aes",
-        .description = "CPU fuses AES crypto operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_arith_logic)] = .{
         .llvm_name = "fuse-arith-logic",
-        .description = "CPU fuses arithmetic and logic operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_crypto_eor)] = .{
         .llvm_name = "fuse-crypto-eor",
-        .description = "CPU fuses AES/PMULL and EOR operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_csel)] = .{
         .llvm_name = "fuse-csel",
-        .description = "CPU fuses conditional select operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_literals)] = .{
         .llvm_name = "fuse-literals",
-        .description = "CPU fuses literal generation operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gcs)] = .{
         .llvm_name = "gcs",
-        .description = "Enable Armv9.4-A Guarded Call Stack Extension",
         .dependencies = featureSet(&[_]Feature{
             .chk,
         }),
     };
     result[@intFromEnum(Feature.harden_sls_blr)] = .{
         .llvm_name = "harden-sls-blr",
-        .description = "Harden against straight line speculation across BLR instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.harden_sls_nocomdat)] = .{
         .llvm_name = "harden-sls-nocomdat",
-        .description = "Generate thunk code for SLS mitigation in the normal text section",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.harden_sls_retbr)] = .{
         .llvm_name = "harden-sls-retbr",
-        .description = "Harden against straight line speculation across RET and BR instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hbc)] = .{
         .llvm_name = "hbc",
-        .description = "Enable Armv8.8-A Hinted Conditional Branches Extension (FEAT_HBC)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hcx)] = .{
         .llvm_name = "hcx",
-        .description = "Enable Armv8.7-A HCRX_EL2 system register (FEAT_HCX)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.i8mm)] = .{
         .llvm_name = "i8mm",
-        .description = "Enable Matrix Multiply Int8 Extension (FEAT_I8MM)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ite)] = .{
         .llvm_name = "ite",
-        .description = "Enable Armv9.4-A Instrumentation Extension FEAT_ITE",
         .dependencies = featureSet(&[_]Feature{
             .ete,
         }),
     };
     result[@intFromEnum(Feature.jsconv)] = .{
         .llvm_name = "jsconv",
-        .description = "Enable v8.3-A JavaScript FP conversion instructions (FEAT_JSCVT)",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8,
         }),
     };
     result[@intFromEnum(Feature.ldp_aligned_only)] = .{
         .llvm_name = "ldp-aligned-only",
-        .description = "In order to emit ldp, first check if the load will be aligned to 2 * element_size",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lor)] = .{
         .llvm_name = "lor",
-        .description = "Enables ARM v8.1 Limited Ordering Regions extension (FEAT_LOR)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ls64)] = .{
         .llvm_name = "ls64",
-        .description = "Enable Armv8.7-A LD64B/ST64B Accelerator Extension (FEAT_LS64, FEAT_LS64_V, FEAT_LS64_ACCDATA)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lse)] = .{
         .llvm_name = "lse",
-        .description = "Enable ARMv8.1 Large System Extension (LSE) atomic instructions (FEAT_LSE)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lse128)] = .{
         .llvm_name = "lse128",
-        .description = "Enable Armv9.4-A 128-bit Atomic Instructions (FEAT_LSE128)",
         .dependencies = featureSet(&[_]Feature{
             .lse,
         }),
     };
     result[@intFromEnum(Feature.lse2)] = .{
         .llvm_name = "lse2",
-        .description = "Enable ARMv8.4 Large System Extension 2 (LSE2) atomicity rules (FEAT_LSE2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lut)] = .{
         .llvm_name = "lut",
-        .description = "Enable Lookup Table instructions (FEAT_LUT)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mec)] = .{
         .llvm_name = "mec",
-        .description = "Enable Memory Encryption Contexts Extension",
         .dependencies = featureSet(&[_]Feature{
             .rme,
         }),
     };
     result[@intFromEnum(Feature.mops)] = .{
         .llvm_name = "mops",
-        .description = "Enable Armv8.8-A memcpy and memset acceleration instructions (FEAT_MOPS)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mpam)] = .{
         .llvm_name = "mpam",
-        .description = "Enable v8.4-A Memory system Partitioning and Monitoring extension (FEAT_MPAM)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mte)] = .{
         .llvm_name = "mte",
-        .description = "Enable Memory Tagging Extension (FEAT_MTE, FEAT_MTE2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.neon)] = .{
         .llvm_name = "neon",
-        .description = "Enable Advanced SIMD instructions (FEAT_AdvSIMD)",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8,
         }),
     };
     result[@intFromEnum(Feature.nmi)] = .{
         .llvm_name = "nmi",
-        .description = "Enable Armv8.8-A Non-maskable Interrupts (FEAT_NMI, FEAT_GICv3_NMI)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_bti_at_return_twice)] = .{
         .llvm_name = "no-bti-at-return-twice",
-        .description = "Don't place a BTI instruction after a return-twice",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_neg_immediates)] = .{
         .llvm_name = "no-neg-immediates",
-        .description = "Convert immediates and instructions to their negated or complemented equivalent when the immediate does not fit in the encoding.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_sve_fp_ld1r)] = .{
         .llvm_name = "no-sve-fp-ld1r",
-        .description = "Avoid using LD1RX instructions for FP",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_zcz_fp)] = .{
         .llvm_name = "no-zcz-fp",
-        .description = "Has no zero-cycle zeroing instructions for FP registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nv)] = .{
         .llvm_name = "nv",
-        .description = "Enable v8.4-A Nested Virtualization Enhancement (FEAT_NV, FEAT_NV2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.outline_atomics)] = .{
         .llvm_name = "outline-atomics",
-        .description = "Enable out of line atomics to support LSE instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pan)] = .{
         .llvm_name = "pan",
-        .description = "Enables ARM v8.1 Privileged Access-Never extension (FEAT_PAN)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pan_rwv)] = .{
         .llvm_name = "pan-rwv",
-        .description = "Enable v8.2 PAN s1e1R and s1e1W Variants (FEAT_PAN2)",
         .dependencies = featureSet(&[_]Feature{
             .pan,
         }),
     };
     result[@intFromEnum(Feature.pauth)] = .{
         .llvm_name = "pauth",
-        .description = "Enable v8.3-A Pointer Authentication extension (FEAT_PAuth)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pauth_lr)] = .{
         .llvm_name = "pauth-lr",
-        .description = "Enable Armv9.5-A PAC enhancements (FEAT_PAuth_LR)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.perfmon)] = .{
         .llvm_name = "perfmon",
-        .description = "Enable Code Generation for ARMv8 PMUv3 Performance Monitors extension (FEAT_PMUv3)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.predictable_select_expensive)] = .{
         .llvm_name = "predictable-select-expensive",
-        .description = "Prefer likely predicted branches over selects",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.predres)] = .{
         .llvm_name = "predres",
-        .description = "Enable v8.5a execution and data prediction invalidation instructions (FEAT_SPECRES)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prfm_slc_target)] = .{
         .llvm_name = "prfm-slc-target",
-        .description = "Enable SLC target for PRFM instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rand)] = .{
         .llvm_name = "rand",
-        .description = "Enable Random Number generation instructions (FEAT_RNG)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ras)] = .{
         .llvm_name = "ras",
-        .description = "Enable ARMv8 Reliability, Availability and Serviceability Extensions (FEAT_RAS, FEAT_RASv1p1)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rasv2)] = .{
         .llvm_name = "rasv2",
-        .description = "Enable ARMv8.9-A Reliability, Availability and Serviceability Extensions (FEAT_RASv2)",
         .dependencies = featureSet(&[_]Feature{
             .ras,
         }),
     };
     result[@intFromEnum(Feature.rcpc)] = .{
         .llvm_name = "rcpc",
-        .description = "Enable support for RCPC extension (FEAT_LRCPC)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rcpc3)] = .{
         .llvm_name = "rcpc3",
-        .description = "Enable Armv8.9-A RCPC instructions for A64 and Advanced SIMD and floating-point instruction set (FEAT_LRCPC3)",
         .dependencies = featureSet(&[_]Feature{
             .rcpc_immo,
         }),
     };
     result[@intFromEnum(Feature.rcpc_immo)] = .{
         .llvm_name = "rcpc-immo",
-        .description = "Enable v8.4-A RCPC instructions with Immediate Offsets (FEAT_LRCPC2)",
         .dependencies = featureSet(&[_]Feature{
             .rcpc,
         }),
     };
     result[@intFromEnum(Feature.rdm)] = .{
         .llvm_name = "rdm",
-        .description = "Enable ARMv8.1 Rounding Double Multiply Add/Subtract instructions (FEAT_RDM)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x1)] = .{
         .llvm_name = "reserve-x1",
-        .description = "Reserve X1, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x10)] = .{
         .llvm_name = "reserve-x10",
-        .description = "Reserve X10, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x11)] = .{
         .llvm_name = "reserve-x11",
-        .description = "Reserve X11, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x12)] = .{
         .llvm_name = "reserve-x12",
-        .description = "Reserve X12, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x13)] = .{
         .llvm_name = "reserve-x13",
-        .description = "Reserve X13, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x14)] = .{
         .llvm_name = "reserve-x14",
-        .description = "Reserve X14, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x15)] = .{
         .llvm_name = "reserve-x15",
-        .description = "Reserve X15, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x18)] = .{
         .llvm_name = "reserve-x18",
-        .description = "Reserve X18, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x2)] = .{
         .llvm_name = "reserve-x2",
-        .description = "Reserve X2, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x20)] = .{
         .llvm_name = "reserve-x20",
-        .description = "Reserve X20, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x21)] = .{
         .llvm_name = "reserve-x21",
-        .description = "Reserve X21, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x22)] = .{
         .llvm_name = "reserve-x22",
-        .description = "Reserve X22, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x23)] = .{
         .llvm_name = "reserve-x23",
-        .description = "Reserve X23, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x24)] = .{
         .llvm_name = "reserve-x24",
-        .description = "Reserve X24, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x25)] = .{
         .llvm_name = "reserve-x25",
-        .description = "Reserve X25, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x26)] = .{
         .llvm_name = "reserve-x26",
-        .description = "Reserve X26, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x27)] = .{
         .llvm_name = "reserve-x27",
-        .description = "Reserve X27, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x28)] = .{
         .llvm_name = "reserve-x28",
-        .description = "Reserve X28, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x3)] = .{
         .llvm_name = "reserve-x3",
-        .description = "Reserve X3, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x30)] = .{
         .llvm_name = "reserve-x30",
-        .description = "Reserve X30, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x4)] = .{
         .llvm_name = "reserve-x4",
-        .description = "Reserve X4, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x5)] = .{
         .llvm_name = "reserve-x5",
-        .description = "Reserve X5, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x6)] = .{
         .llvm_name = "reserve-x6",
-        .description = "Reserve X6, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x7)] = .{
         .llvm_name = "reserve-x7",
-        .description = "Reserve X7, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x9)] = .{
         .llvm_name = "reserve-x9",
-        .description = "Reserve X9, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rme)] = .{
         .llvm_name = "rme",
-        .description = "Enable Realm Management Extension (FEAT_RME)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sb)] = .{
         .llvm_name = "sb",
-        .description = "Enable v8.5 Speculation Barrier (FEAT_SB)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sel2)] = .{
         .llvm_name = "sel2",
-        .description = "Enable v8.4-A Secure Exception Level 2 extension (FEAT_SEL2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sha2)] = .{
         .llvm_name = "sha2",
-        .description = "Enable SHA1 and SHA256 support (FEAT_SHA1, FEAT_SHA256)",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.sha3)] = .{
         .llvm_name = "sha3",
-        .description = "Enable SHA512 and SHA3 support (FEAT_SHA3, FEAT_SHA512)",
         .dependencies = featureSet(&[_]Feature{
             .sha2,
         }),
     };
     result[@intFromEnum(Feature.slow_misaligned_128store)] = .{
         .llvm_name = "slow-misaligned-128store",
-        .description = "Misaligned 128 bit stores are slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_paired_128)] = .{
         .llvm_name = "slow-paired-128",
-        .description = "Paired 128 bit loads and stores are slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_strqro_store)] = .{
         .llvm_name = "slow-strqro-store",
-        .description = "STR of Q register with register offset is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm4)] = .{
         .llvm_name = "sm4",
-        .description = "Enable SM3 and SM4 support (FEAT_SM4, FEAT_SM3)",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.sme)] = .{
         .llvm_name = "sme",
-        .description = "Enable Scalable Matrix Extension (SME) (FEAT_SME)",
         .dependencies = featureSet(&[_]Feature{
             .bf16,
             .use_scalar_inc_vl,
@@ -1164,33 +1003,28 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sme2)] = .{
         .llvm_name = "sme2",
-        .description = "Enable Scalable Matrix Extension 2 (SME2) instructions",
         .dependencies = featureSet(&[_]Feature{
             .sme,
         }),
     };
     result[@intFromEnum(Feature.sme2p1)] = .{
         .llvm_name = "sme2p1",
-        .description = "Enable Scalable Matrix Extension 2.1 (FEAT_SME2p1) instructions",
         .dependencies = featureSet(&[_]Feature{
             .sme2,
         }),
     };
     result[@intFromEnum(Feature.sme_f16f16)] = .{
         .llvm_name = "sme-f16f16",
-        .description = "Enable SME2.1 non-widening Float16 instructions (FEAT_SME_F16F16)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sme_f64f64)] = .{
         .llvm_name = "sme-f64f64",
-        .description = "Enable Scalable Matrix Extension (SME) F64F64 instructions (FEAT_SME_F64F64)",
         .dependencies = featureSet(&[_]Feature{
             .sme,
         }),
     };
     result[@intFromEnum(Feature.sme_f8f16)] = .{
         .llvm_name = "sme-f8f16",
-        .description = "Enable Scalable Matrix Extension (SME) F8F16 instructions(FEAT_SME_F8F16)",
         .dependencies = featureSet(&[_]Feature{
             .fp8,
             .sme2,
@@ -1198,7 +1032,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sme_f8f32)] = .{
         .llvm_name = "sme-f8f32",
-        .description = "Enable Scalable Matrix Extension (SME) F8F32 instructions (FEAT_SME_F8F32)",
         .dependencies = featureSet(&[_]Feature{
             .fp8,
             .sme2,
@@ -1206,7 +1039,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sme_fa64)] = .{
         .llvm_name = "sme-fa64",
-        .description = "Enable the full A64 instruction set in streaming SVE mode (FEAT_SME_FA64)",
         .dependencies = featureSet(&[_]Feature{
             .sme,
             .sve2,
@@ -1214,89 +1046,74 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sme_i16i64)] = .{
         .llvm_name = "sme-i16i64",
-        .description = "Enable Scalable Matrix Extension (SME) I16I64 instructions (FEAT_SME_I16I64)",
         .dependencies = featureSet(&[_]Feature{
             .sme,
         }),
     };
     result[@intFromEnum(Feature.sme_lutv2)] = .{
         .llvm_name = "sme-lutv2",
-        .description = "Enable Scalable Matrix Extension (SME) LUTv2 instructions (FEAT_SME_LUTv2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.spe)] = .{
         .llvm_name = "spe",
-        .description = "Enable Statistical Profiling extension (FEAT_SPE)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.spe_eef)] = .{
         .llvm_name = "spe-eef",
-        .description = "Enable extra register in the Statistical Profiling Extension (FEAT_SPEv1p2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.specres2)] = .{
         .llvm_name = "specres2",
-        .description = "Enable Speculation Restriction Instruction (FEAT_SPECRES2)",
         .dependencies = featureSet(&[_]Feature{
             .predres,
         }),
     };
     result[@intFromEnum(Feature.specrestrict)] = .{
         .llvm_name = "specrestrict",
-        .description = "Enable architectural speculation restriction (FEAT_CSV2_2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ssbs)] = .{
         .llvm_name = "ssbs",
-        .description = "Enable Speculative Store Bypass Safe bit (FEAT_SSBS, FEAT_SSBS2)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ssve_fp8dot2)] = .{
         .llvm_name = "ssve-fp8dot2",
-        .description = "Enable SVE2 fp8 2-way dot product instructions (FEAT_SSVE_FP8DOT2)",
         .dependencies = featureSet(&[_]Feature{
             .sme2,
         }),
     };
     result[@intFromEnum(Feature.ssve_fp8dot4)] = .{
         .llvm_name = "ssve-fp8dot4",
-        .description = "Enable SVE2 fp8 4-way dot product instructions (FEAT_SSVE_FP8DOT4)",
         .dependencies = featureSet(&[_]Feature{
             .sme2,
         }),
     };
     result[@intFromEnum(Feature.ssve_fp8fma)] = .{
         .llvm_name = "ssve-fp8fma",
-        .description = "Enable SVE2 fp8 multiply-add instructions (FEAT_SSVE_FP8FMA)",
         .dependencies = featureSet(&[_]Feature{
             .sme2,
         }),
     };
     result[@intFromEnum(Feature.store_pair_suppress)] = .{
         .llvm_name = "store-pair-suppress",
-        .description = "Enable Store Pair Suppression heuristics",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.stp_aligned_only)] = .{
         .llvm_name = "stp-aligned-only",
-        .description = "In order to emit stp, first check if the store will be aligned to 2 * element_size",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.strict_align)] = .{
         .llvm_name = "strict-align",
-        .description = "Disallow all unaligned memory access",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sve)] = .{
         .llvm_name = "sve",
-        .description = "Enable Scalable Vector Extension (SVE) instructions (FEAT_SVE)",
         .dependencies = featureSet(&[_]Feature{
             .fullfp16,
         }),
     };
     result[@intFromEnum(Feature.sve2)] = .{
         .llvm_name = "sve2",
-        .description = "Enable Scalable Vector Extension 2 (SVE2) instructions (FEAT_SVE2)",
         .dependencies = featureSet(&[_]Feature{
             .sve,
             .use_scalar_inc_vl,
@@ -1304,7 +1121,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sve2_aes)] = .{
         .llvm_name = "sve2-aes",
-        .description = "Enable AES SVE2 instructions (FEAT_SVE_AES, FEAT_SVE_PMULL128)",
         .dependencies = featureSet(&[_]Feature{
             .aes,
             .sve2,
@@ -1312,14 +1128,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sve2_bitperm)] = .{
         .llvm_name = "sve2-bitperm",
-        .description = "Enable bit permutation SVE2 instructions (FEAT_SVE_BitPerm)",
         .dependencies = featureSet(&[_]Feature{
             .sve2,
         }),
     };
     result[@intFromEnum(Feature.sve2_sha3)] = .{
         .llvm_name = "sve2-sha3",
-        .description = "Enable SHA3 SVE2 instructions (FEAT_SVE_SHA3)",
         .dependencies = featureSet(&[_]Feature{
             .sha3,
             .sve2,
@@ -1327,7 +1141,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sve2_sm4)] = .{
         .llvm_name = "sve2-sm4",
-        .description = "Enable SM4 SVE2 instructions (FEAT_SVE_SM4)",
         .dependencies = featureSet(&[_]Feature{
             .sm4,
             .sve2,
@@ -1335,94 +1148,76 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sve2p1)] = .{
         .llvm_name = "sve2p1",
-        .description = "Enable Scalable Vector Extension 2.1 instructions",
         .dependencies = featureSet(&[_]Feature{
             .sve2,
         }),
     };
     result[@intFromEnum(Feature.tagged_globals)] = .{
         .llvm_name = "tagged-globals",
-        .description = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.the)] = .{
         .llvm_name = "the",
-        .description = "Enable Armv8.9-A Translation Hardening Extension (FEAT_THE)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tlb_rmi)] = .{
         .llvm_name = "tlb-rmi",
-        .description = "Enable v8.4-A TLB Range and Maintenance Instructions (FEAT_TLBIOS, FEAT_TLBIRANGE)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tlbiw)] = .{
         .llvm_name = "tlbiw",
-        .description = "Enable ARMv9.5-A TLBI VMALL for Dirty State (FEAT_TLBIW)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tme)] = .{
         .llvm_name = "tme",
-        .description = "Enable Transactional Memory Extension (FEAT_TME)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tpidr_el1)] = .{
         .llvm_name = "tpidr-el1",
-        .description = "Permit use of TPIDR_EL1 for the TLS base",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tpidr_el2)] = .{
         .llvm_name = "tpidr-el2",
-        .description = "Permit use of TPIDR_EL2 for the TLS base",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tpidr_el3)] = .{
         .llvm_name = "tpidr-el3",
-        .description = "Permit use of TPIDR_EL3 for the TLS base",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tpidrro_el0)] = .{
         .llvm_name = "tpidrro-el0",
-        .description = "Permit use of TPIDRRO_EL0 for the TLS base",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tracev8_4)] = .{
         .llvm_name = "tracev8.4",
-        .description = "Enable v8.4-A Trace extension (FEAT_TRF)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.trbe)] = .{
         .llvm_name = "trbe",
-        .description = "Enable Trace Buffer Extension (FEAT_TRBE)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.uaops)] = .{
         .llvm_name = "uaops",
-        .description = "Enable v8.2 UAO PState (FEAT_UAO)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_experimental_zeroing_pseudos)] = .{
         .llvm_name = "use-experimental-zeroing-pseudos",
-        .description = "Hint to the compiler that the MOVPRFX instruction is merged with destructive operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_postra_scheduler)] = .{
         .llvm_name = "use-postra-scheduler",
-        .description = "Schedule again after register allocation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_reciprocal_square_root)] = .{
         .llvm_name = "use-reciprocal-square-root",
-        .description = "Use the reciprocal square root approximation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_scalar_inc_vl)] = .{
         .llvm_name = "use-scalar-inc-vl",
-        .description = "Prefer inc/dec over add+cnt",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v8_1a)] = .{
         .llvm_name = "v8.1a",
-        .description = "Support ARM v8.1a instructions",
         .dependencies = featureSet(&[_]Feature{
             .crc,
             .lor,
@@ -1435,7 +1230,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_2a)] = .{
         .llvm_name = "v8.2a",
-        .description = "Support ARM v8.2a instructions",
         .dependencies = featureSet(&[_]Feature{
             .ccpp,
             .pan_rwv,
@@ -1446,7 +1240,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_3a)] = .{
         .llvm_name = "v8.3a",
-        .description = "Support ARM v8.3a instructions",
         .dependencies = featureSet(&[_]Feature{
             .ccidx,
             .complxnum,
@@ -1458,7 +1251,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_4a)] = .{
         .llvm_name = "v8.4a",
-        .description = "Support ARM v8.4a instructions",
         .dependencies = featureSet(&[_]Feature{
             .am,
             .dit,
@@ -1476,7 +1268,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_5a)] = .{
         .llvm_name = "v8.5a",
-        .description = "Support ARM v8.5a instructions",
         .dependencies = featureSet(&[_]Feature{
             .altnzcv,
             .bti,
@@ -1491,7 +1282,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_6a)] = .{
         .llvm_name = "v8.6a",
-        .description = "Support ARM v8.6a instructions",
         .dependencies = featureSet(&[_]Feature{
             .amvs,
             .bf16,
@@ -1503,7 +1293,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_7a)] = .{
         .llvm_name = "v8.7a",
-        .description = "Support ARM v8.7a instructions",
         .dependencies = featureSet(&[_]Feature{
             .hcx,
             .v8_6a,
@@ -1513,7 +1302,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_8a)] = .{
         .llvm_name = "v8.8a",
-        .description = "Support ARM v8.8a instructions",
         .dependencies = featureSet(&[_]Feature{
             .hbc,
             .mops,
@@ -1523,7 +1311,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_9a)] = .{
         .llvm_name = "v8.9a",
-        .description = "Support ARM v8.9a instructions",
         .dependencies = featureSet(&[_]Feature{
             .chk,
             .clrbhb,
@@ -1536,7 +1323,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8a)] = .{
         .llvm_name = "v8a",
-        .description = "Support ARM v8.0a instructions",
         .dependencies = featureSet(&[_]Feature{
             .el2vmsa,
             .el3,
@@ -1545,7 +1331,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8r)] = .{
         .llvm_name = "v8r",
-        .description = "Support ARM v8r instructions",
         .dependencies = featureSet(&[_]Feature{
             .ccidx,
             .ccpp,
@@ -1571,7 +1356,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_1a)] = .{
         .llvm_name = "v9.1a",
-        .description = "Support ARM v9.1a instructions",
         .dependencies = featureSet(&[_]Feature{
             .v8_6a,
             .v9a,
@@ -1579,7 +1363,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_2a)] = .{
         .llvm_name = "v9.2a",
-        .description = "Support ARM v9.2a instructions",
         .dependencies = featureSet(&[_]Feature{
             .v8_7a,
             .v9_1a,
@@ -1587,7 +1370,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_3a)] = .{
         .llvm_name = "v9.3a",
-        .description = "Support ARM v9.3a instructions",
         .dependencies = featureSet(&[_]Feature{
             .v8_8a,
             .v9_2a,
@@ -1595,7 +1377,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_4a)] = .{
         .llvm_name = "v9.4a",
-        .description = "Support ARM v9.4a instructions",
         .dependencies = featureSet(&[_]Feature{
             .v8_9a,
             .v9_3a,
@@ -1603,7 +1384,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_5a)] = .{
         .llvm_name = "v9.5a",
-        .description = "Support ARM v9.5a instructions",
         .dependencies = featureSet(&[_]Feature{
             .cpa,
             .v9_4a,
@@ -1611,7 +1391,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9a)] = .{
         .llvm_name = "v9a",
-        .description = "Support ARM v9a instructions",
         .dependencies = featureSet(&[_]Feature{
             .mec,
             .sve2,
@@ -1620,41 +1399,34 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vh)] = .{
         .llvm_name = "vh",
-        .description = "Enables ARM v8.1 Virtual Host extension (FEAT_VHE)",
         .dependencies = featureSet(&[_]Feature{
             .contextidr_el2,
         }),
     };
     result[@intFromEnum(Feature.wfxt)] = .{
         .llvm_name = "wfxt",
-        .description = "Enable Armv8.7-A WFET and WFIT instruction (FEAT_WFxT)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xs)] = .{
         .llvm_name = "xs",
-        .description = "Enable Armv8.7-A limited-TLB-maintenance instruction (FEAT_XS)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zcm)] = .{
         .llvm_name = "zcm",
-        .description = "Has zero-cycle register moves",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zcz)] = .{
         .llvm_name = "zcz",
-        .description = "Has zero-cycle zeroing instructions",
         .dependencies = featureSet(&[_]Feature{
             .zcz_gp,
         }),
     };
     result[@intFromEnum(Feature.zcz_fp_workaround)] = .{
         .llvm_name = "zcz-fp-workaround",
-        .description = "The zero-cycle floating-point zeroing instruction has a bug",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zcz_gp)] = .{
         .llvm_name = "zcz-gp",
-        .description = "Has zero-cycle zeroing instructions for generic registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -1662,6 +1434,240 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.a510)] = "Cortex-A510 ARM processors";
+    result[@intFromEnum(Feature.a520)] = "Cortex-A520 ARM processors";
+    result[@intFromEnum(Feature.a65)] = "Cortex-A65 ARM processors";
+    result[@intFromEnum(Feature.a710)] = "Cortex-A710 ARM processors";
+    result[@intFromEnum(Feature.a720)] = "Cortex-A720 ARM processors";
+    result[@intFromEnum(Feature.a76)] = "Cortex-A76 ARM processors";
+    result[@intFromEnum(Feature.a78)] = "Cortex-A78 ARM processors";
+    result[@intFromEnum(Feature.a78c)] = "Cortex-A78C ARM processors";
+    result[@intFromEnum(Feature.addr_lsl_fast)] = "Address operands with logical shift of up to 3 places are cheap";
+    result[@intFromEnum(Feature.aes)] = "Enable AES support (FEAT_AES, FEAT_PMULL)";
+    result[@intFromEnum(Feature.aggressive_fma)] = "Enable Aggressive FMA for floating-point.";
+    result[@intFromEnum(Feature.alternate_sextload_cvt_f32_pattern)] = "Use alternative pattern for sextload convert to f32";
+    result[@intFromEnum(Feature.altnzcv)] = "Enable alternative NZCV format for floating point comparisons (FEAT_FlagM2)";
+    result[@intFromEnum(Feature.alu_lsl_fast)] = "Add/Sub operations with lsl shift <= 4 are cheap";
+    result[@intFromEnum(Feature.am)] = "Enable v8.4-A Activity Monitors extension (FEAT_AMUv1)";
+    result[@intFromEnum(Feature.amvs)] = "Enable v8.6-A Activity Monitors Virtualization support (FEAT_AMUv1p1)";
+    result[@intFromEnum(Feature.arith_bcc_fusion)] = "CPU fuses arithmetic+bcc operations";
+    result[@intFromEnum(Feature.arith_cbz_fusion)] = "CPU fuses arithmetic + cbz/cbnz operations";
+    result[@intFromEnum(Feature.ascend_store_address)] = "Schedule vector stores by ascending address";
+    result[@intFromEnum(Feature.b16b16)] = "Enable SVE2.1 or SME2.1 non-widening BFloat16 to BFloat16 instructions (FEAT_B16B16)";
+    result[@intFromEnum(Feature.balance_fp_ops)] = "balance mix of odd and even D-registers for fp multiply(-accumulate) ops";
+    result[@intFromEnum(Feature.bf16)] = "Enable BFloat16 Extension (FEAT_BF16)";
+    result[@intFromEnum(Feature.brbe)] = "Enable Branch Record Buffer Extension (FEAT_BRBE)";
+    result[@intFromEnum(Feature.bti)] = "Enable Branch Target Identification (FEAT_BTI)";
+    result[@intFromEnum(Feature.call_saved_x10)] = "Make X10 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x11)] = "Make X11 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x12)] = "Make X12 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x13)] = "Make X13 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x14)] = "Make X14 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x15)] = "Make X15 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x18)] = "Make X18 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x8)] = "Make X8 callee saved.";
+    result[@intFromEnum(Feature.call_saved_x9)] = "Make X9 callee saved.";
+    result[@intFromEnum(Feature.ccdp)] = "Enable v8.5 Cache Clean to Point of Deep Persistence (FEAT_DPB2)";
+    result[@intFromEnum(Feature.ccidx)] = "Enable v8.3-A Extend of the CCSIDR number of sets (FEAT_CCIDX)";
+    result[@intFromEnum(Feature.ccpp)] = "Enable v8.2 data Cache Clean to Point of Persistence (FEAT_DPB)";
+    result[@intFromEnum(Feature.chk)] = "Enable Armv8.0-A Check Feature Status Extension (FEAT_CHK)";
+    result[@intFromEnum(Feature.clrbhb)] = "Enable Clear BHB instruction (FEAT_CLRBHB)";
+    result[@intFromEnum(Feature.cmp_bcc_fusion)] = "CPU fuses cmp+bcc operations";
+    result[@intFromEnum(Feature.complxnum)] = "Enable v8.3-A Floating-point complex number support (FEAT_FCMA)";
+    result[@intFromEnum(Feature.contextidr_el2)] = "Enable RW operand Context ID Register (EL2)";
+    result[@intFromEnum(Feature.cortex_r82)] = "Cortex-R82 ARM processors";
+    result[@intFromEnum(Feature.cpa)] = "Enable Armv9.5-A Checked Pointer Arithmetic (FEAT_CPA)";
+    result[@intFromEnum(Feature.crc)] = "Enable ARMv8 CRC-32 checksum instructions (FEAT_CRC32)";
+    result[@intFromEnum(Feature.crypto)] = "Enable cryptographic instructions";
+    result[@intFromEnum(Feature.cssc)] = "Enable Common Short Sequence Compression (CSSC) instructions (FEAT_CSSC)";
+    result[@intFromEnum(Feature.d128)] = "Enable Armv9.4-A 128-bit Page Table Descriptors, System Registers and Instructions (FEAT_D128, FEAT_LVA3, FEAT_SYSREG128, FEAT_SYSINSTR128)";
+    result[@intFromEnum(Feature.disable_latency_sched_heuristic)] = "Disable latency scheduling heuristic";
+    result[@intFromEnum(Feature.disable_ldp)] = "Do not emit ldp";
+    result[@intFromEnum(Feature.disable_stp)] = "Do not emit stp";
+    result[@intFromEnum(Feature.dit)] = "Enable v8.4-A Data Independent Timing instructions (FEAT_DIT)";
+    result[@intFromEnum(Feature.dotprod)] = "Enable dot product support (FEAT_DotProd)";
+    result[@intFromEnum(Feature.ecv)] = "Enable enhanced counter virtualization extension (FEAT_ECV)";
+    result[@intFromEnum(Feature.el2vmsa)] = "Enable Exception Level 2 Virtual Memory System Architecture";
+    result[@intFromEnum(Feature.el3)] = "Enable Exception Level 3";
+    result[@intFromEnum(Feature.enable_select_opt)] = "Enable the select optimize pass for select loop heuristics";
+    result[@intFromEnum(Feature.ete)] = "Enable Embedded Trace Extension (FEAT_ETE)";
+    result[@intFromEnum(Feature.exynos_cheap_as_move)] = "Use Exynos specific handling of cheap instructions";
+    result[@intFromEnum(Feature.f32mm)] = "Enable Matrix Multiply FP32 Extension (FEAT_F32MM)";
+    result[@intFromEnum(Feature.f64mm)] = "Enable Matrix Multiply FP64 Extension (FEAT_F64MM)";
+    result[@intFromEnum(Feature.faminmax)] = "Enable FAMIN and FAMAX instructions (FEAT_FAMINMAX)";
+    result[@intFromEnum(Feature.fgt)] = "Enable fine grained virtualization traps extension (FEAT_FGT)";
+    result[@intFromEnum(Feature.fix_cortex_a53_835769)] = "Mitigate Cortex-A53 Erratum 835769";
+    result[@intFromEnum(Feature.flagm)] = "Enable v8.4-A Flag Manipulation Instructions (FEAT_FlagM)";
+    result[@intFromEnum(Feature.fmv)] = "Enable Function Multi Versioning support.";
+    result[@intFromEnum(Feature.force_32bit_jump_tables)] = "Force jump table entries to be 32-bits wide except at MinSize";
+    result[@intFromEnum(Feature.fp16fml)] = "Enable FP16 FML instructions (FEAT_FHM)";
+    result[@intFromEnum(Feature.fp8)] = "Enable FP8 instructions (FEAT_FP8)";
+    result[@intFromEnum(Feature.fp8dot2)] = "Enable fp8 2-way dot instructions (FEAT_FP8DOT2)";
+    result[@intFromEnum(Feature.fp8dot4)] = "Enable fp8 4-way dot instructions (FEAT_FP8DOT4)";
+    result[@intFromEnum(Feature.fp8fma)] = "Enable fp8 multiply-add instructions (FEAT_FP8FMA)";
+    result[@intFromEnum(Feature.fp_armv8)] = "Enable ARMv8 FP (FEAT_FP)";
+    result[@intFromEnum(Feature.fpmr)] = "Enable FPMR Register (FEAT_FPMR)";
+    result[@intFromEnum(Feature.fptoint)] = "Enable FRInt[32|64][Z|X] instructions that round a floating-point number to an integer (in FP format) forcing it to fit into a 32- or 64-bit int (FEAT_FRINTTS)";
+    result[@intFromEnum(Feature.fullfp16)] = "Full FP16 (FEAT_FP16)";
+    result[@intFromEnum(Feature.fuse_address)] = "CPU fuses address generation and memory operations";
+    result[@intFromEnum(Feature.fuse_addsub_2reg_const1)] = "CPU fuses (a + b + 1) and (a - b - 1)";
+    result[@intFromEnum(Feature.fuse_adrp_add)] = "CPU fuses adrp+add operations";
+    result[@intFromEnum(Feature.fuse_aes)] = "CPU fuses AES crypto operations";
+    result[@intFromEnum(Feature.fuse_arith_logic)] = "CPU fuses arithmetic and logic operations";
+    result[@intFromEnum(Feature.fuse_crypto_eor)] = "CPU fuses AES/PMULL and EOR operations";
+    result[@intFromEnum(Feature.fuse_csel)] = "CPU fuses conditional select operations";
+    result[@intFromEnum(Feature.fuse_literals)] = "CPU fuses literal generation operations";
+    result[@intFromEnum(Feature.gcs)] = "Enable Armv9.4-A Guarded Call Stack Extension";
+    result[@intFromEnum(Feature.harden_sls_blr)] = "Harden against straight line speculation across BLR instructions";
+    result[@intFromEnum(Feature.harden_sls_nocomdat)] = "Generate thunk code for SLS mitigation in the normal text section";
+    result[@intFromEnum(Feature.harden_sls_retbr)] = "Harden against straight line speculation across RET and BR instructions";
+    result[@intFromEnum(Feature.hbc)] = "Enable Armv8.8-A Hinted Conditional Branches Extension (FEAT_HBC)";
+    result[@intFromEnum(Feature.hcx)] = "Enable Armv8.7-A HCRX_EL2 system register (FEAT_HCX)";
+    result[@intFromEnum(Feature.i8mm)] = "Enable Matrix Multiply Int8 Extension (FEAT_I8MM)";
+    result[@intFromEnum(Feature.ite)] = "Enable Armv9.4-A Instrumentation Extension FEAT_ITE";
+    result[@intFromEnum(Feature.jsconv)] = "Enable v8.3-A JavaScript FP conversion instructions (FEAT_JSCVT)";
+    result[@intFromEnum(Feature.ldp_aligned_only)] = "In order to emit ldp, first check if the load will be aligned to 2 * element_size";
+    result[@intFromEnum(Feature.lor)] = "Enables ARM v8.1 Limited Ordering Regions extension (FEAT_LOR)";
+    result[@intFromEnum(Feature.ls64)] = "Enable Armv8.7-A LD64B/ST64B Accelerator Extension (FEAT_LS64, FEAT_LS64_V, FEAT_LS64_ACCDATA)";
+    result[@intFromEnum(Feature.lse)] = "Enable ARMv8.1 Large System Extension (LSE) atomic instructions (FEAT_LSE)";
+    result[@intFromEnum(Feature.lse128)] = "Enable Armv9.4-A 128-bit Atomic Instructions (FEAT_LSE128)";
+    result[@intFromEnum(Feature.lse2)] = "Enable ARMv8.4 Large System Extension 2 (LSE2) atomicity rules (FEAT_LSE2)";
+    result[@intFromEnum(Feature.lut)] = "Enable Lookup Table instructions (FEAT_LUT)";
+    result[@intFromEnum(Feature.mec)] = "Enable Memory Encryption Contexts Extension";
+    result[@intFromEnum(Feature.mops)] = "Enable Armv8.8-A memcpy and memset acceleration instructions (FEAT_MOPS)";
+    result[@intFromEnum(Feature.mpam)] = "Enable v8.4-A Memory system Partitioning and Monitoring extension (FEAT_MPAM)";
+    result[@intFromEnum(Feature.mte)] = "Enable Memory Tagging Extension (FEAT_MTE, FEAT_MTE2)";
+    result[@intFromEnum(Feature.neon)] = "Enable Advanced SIMD instructions (FEAT_AdvSIMD)";
+    result[@intFromEnum(Feature.nmi)] = "Enable Armv8.8-A Non-maskable Interrupts (FEAT_NMI, FEAT_GICv3_NMI)";
+    result[@intFromEnum(Feature.no_bti_at_return_twice)] = "Don't place a BTI instruction after a return-twice";
+    result[@intFromEnum(Feature.no_neg_immediates)] = "Convert immediates and instructions to their negated or complemented equivalent when the immediate does not fit in the encoding.";
+    result[@intFromEnum(Feature.no_sve_fp_ld1r)] = "Avoid using LD1RX instructions for FP";
+    result[@intFromEnum(Feature.no_zcz_fp)] = "Has no zero-cycle zeroing instructions for FP registers";
+    result[@intFromEnum(Feature.nv)] = "Enable v8.4-A Nested Virtualization Enchancement (FEAT_NV, FEAT_NV2)";
+    result[@intFromEnum(Feature.outline_atomics)] = "Enable out of line atomics to support LSE instructions";
+    result[@intFromEnum(Feature.pan)] = "Enables ARM v8.1 Privileged Access-Never extension (FEAT_PAN)";
+    result[@intFromEnum(Feature.pan_rwv)] = "Enable v8.2 PAN s1e1R and s1e1W Variants (FEAT_PAN2)";
+    result[@intFromEnum(Feature.pauth)] = "Enable v8.3-A Pointer Authentication extension (FEAT_PAuth)";
+    result[@intFromEnum(Feature.pauth_lr)] = "Enable Armv9.5-A PAC enhancements (FEAT_PAuth_LR)";
+    result[@intFromEnum(Feature.perfmon)] = "Enable Code Generation for ARMv8 PMUv3 Performance Monitors extension (FEAT_PMUv3)";
+    result[@intFromEnum(Feature.predictable_select_expensive)] = "Prefer likely predicted branches over selects";
+    result[@intFromEnum(Feature.predres)] = "Enable v8.5a execution and data prediction invalidation instructions (FEAT_SPECRES)";
+    result[@intFromEnum(Feature.prfm_slc_target)] = "Enable SLC target for PRFM instruction";
+    result[@intFromEnum(Feature.rand)] = "Enable Random Number generation instructions (FEAT_RNG)";
+    result[@intFromEnum(Feature.ras)] = "Enable ARMv8 Reliability, Availability and Serviceability Extensions (FEAT_RAS, FEAT_RASv1p1)";
+    result[@intFromEnum(Feature.rasv2)] = "Enable ARMv8.9-A Reliability, Availability and Serviceability Extensions (FEAT_RASv2)";
+    result[@intFromEnum(Feature.rcpc)] = "Enable support for RCPC extension (FEAT_LRCPC)";
+    result[@intFromEnum(Feature.rcpc3)] = "Enable Armv8.9-A RCPC instructions for A64 and Advanced SIMD and floating-point instruction set (FEAT_LRCPC3)";
+    result[@intFromEnum(Feature.rcpc_immo)] = "Enable v8.4-A RCPC instructions with Immediate Offsets (FEAT_LRCPC2)";
+    result[@intFromEnum(Feature.rdm)] = "Enable ARMv8.1 Rounding Double Multiply Add/Subtract instructions (FEAT_RDM)";
+    result[@intFromEnum(Feature.reserve_x1)] = "Reserve X1, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x10)] = "Reserve X10, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x11)] = "Reserve X11, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x12)] = "Reserve X12, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x13)] = "Reserve X13, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x14)] = "Reserve X14, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x15)] = "Reserve X15, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x18)] = "Reserve X18, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x2)] = "Reserve X2, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x20)] = "Reserve X20, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x21)] = "Reserve X21, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x22)] = "Reserve X22, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x23)] = "Reserve X23, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x24)] = "Reserve X24, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x25)] = "Reserve X25, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x26)] = "Reserve X26, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x27)] = "Reserve X27, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x28)] = "Reserve X28, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x3)] = "Reserve X3, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x30)] = "Reserve X30, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x4)] = "Reserve X4, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x5)] = "Reserve X5, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x6)] = "Reserve X6, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x7)] = "Reserve X7, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_x9)] = "Reserve X9, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.rme)] = "Enable Realm Management Extension (FEAT_RME)";
+    result[@intFromEnum(Feature.sb)] = "Enable v8.5 Speculation Barrier (FEAT_SB)";
+    result[@intFromEnum(Feature.sel2)] = "Enable v8.4-A Secure Exception Level 2 extension (FEAT_SEL2)";
+    result[@intFromEnum(Feature.sha2)] = "Enable SHA1 and SHA256 support (FEAT_SHA1, FEAT_SHA256)";
+    result[@intFromEnum(Feature.sha3)] = "Enable SHA512 and SHA3 support (FEAT_SHA3, FEAT_SHA512)";
+    result[@intFromEnum(Feature.slow_misaligned_128store)] = "Misaligned 128 bit stores are slow";
+    result[@intFromEnum(Feature.slow_paired_128)] = "Paired 128 bit loads and stores are slow";
+    result[@intFromEnum(Feature.slow_strqro_store)] = "STR of Q register with register offset is slow";
+    result[@intFromEnum(Feature.sm4)] = "Enable SM3 and SM4 support (FEAT_SM4, FEAT_SM3)";
+    result[@intFromEnum(Feature.sme)] = "Enable Scalable Matrix Extension (SME) (FEAT_SME)";
+    result[@intFromEnum(Feature.sme2)] = "Enable Scalable Matrix Extension 2 (SME2) instructions";
+    result[@intFromEnum(Feature.sme2p1)] = "Enable Scalable Matrix Extension 2.1 (FEAT_SME2p1) instructions";
+    result[@intFromEnum(Feature.sme_f16f16)] = "Enable SME2.1 non-widening Float16 instructions (FEAT_SME_F16F16)";
+    result[@intFromEnum(Feature.sme_f64f64)] = "Enable Scalable Matrix Extension (SME) F64F64 instructions (FEAT_SME_F64F64)";
+    result[@intFromEnum(Feature.sme_f8f16)] = "Enable Scalable Matrix Extension (SME) F8F16 instructions(FEAT_SME_F8F16)";
+    result[@intFromEnum(Feature.sme_f8f32)] = "Enable Scalable Matrix Extension (SME) F8F32 instructions (FEAT_SME_F8F32)";
+    result[@intFromEnum(Feature.sme_fa64)] = "Enable the full A64 instruction set in streaming SVE mode (FEAT_SME_FA64)";
+    result[@intFromEnum(Feature.sme_i16i64)] = "Enable Scalable Matrix Extension (SME) I16I64 instructions (FEAT_SME_I16I64)";
+    result[@intFromEnum(Feature.sme_lutv2)] = "Enable Scalable Matrix Extension (SME) LUTv2 instructions (FEAT_SME_LUTv2)";
+    result[@intFromEnum(Feature.spe)] = "Enable Statistical Profiling extension (FEAT_SPE)";
+    result[@intFromEnum(Feature.spe_eef)] = "Enable extra register in the Statistical Profiling Extension (FEAT_SPEv1p2)";
+    result[@intFromEnum(Feature.specres2)] = "Enable Speculation Restriction Instruction (FEAT_SPECRES2)";
+    result[@intFromEnum(Feature.specrestrict)] = "Enable architectural speculation restriction (FEAT_CSV2_2)";
+    result[@intFromEnum(Feature.ssbs)] = "Enable Speculative Store Bypass Safe bit (FEAT_SSBS, FEAT_SSBS2)";
+    result[@intFromEnum(Feature.ssve_fp8dot2)] = "Enable SVE2 fp8 2-way dot product instructions (FEAT_SSVE_FP8DOT2)";
+    result[@intFromEnum(Feature.ssve_fp8dot4)] = "Enable SVE2 fp8 4-way dot product instructions (FEAT_SSVE_FP8DOT4)";
+    result[@intFromEnum(Feature.ssve_fp8fma)] = "Enable SVE2 fp8 multiply-add instructions (FEAT_SSVE_FP8FMA)";
+    result[@intFromEnum(Feature.store_pair_suppress)] = "Enable Store Pair Suppression heuristics";
+    result[@intFromEnum(Feature.stp_aligned_only)] = "In order to emit stp, first check if the store will be aligned to 2 * element_size";
+    result[@intFromEnum(Feature.strict_align)] = "Disallow all unaligned memory access";
+    result[@intFromEnum(Feature.sve)] = "Enable Scalable Vector Extension (SVE) instructions (FEAT_SVE)";
+    result[@intFromEnum(Feature.sve2)] = "Enable Scalable Vector Extension 2 (SVE2) instructions (FEAT_SVE2)";
+    result[@intFromEnum(Feature.sve2_aes)] = "Enable AES SVE2 instructions (FEAT_SVE_AES, FEAT_SVE_PMULL128)";
+    result[@intFromEnum(Feature.sve2_bitperm)] = "Enable bit permutation SVE2 instructions (FEAT_SVE_BitPerm)";
+    result[@intFromEnum(Feature.sve2_sha3)] = "Enable SHA3 SVE2 instructions (FEAT_SVE_SHA3)";
+    result[@intFromEnum(Feature.sve2_sm4)] = "Enable SM4 SVE2 instructions (FEAT_SVE_SM4)";
+    result[@intFromEnum(Feature.sve2p1)] = "Enable Scalable Vector Extension 2.1 instructions";
+    result[@intFromEnum(Feature.tagged_globals)] = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits";
+    result[@intFromEnum(Feature.the)] = "Enable Armv8.9-A Translation Hardening Extension (FEAT_THE)";
+    result[@intFromEnum(Feature.tlb_rmi)] = "Enable v8.4-A TLB Range and Maintenance Instructions (FEAT_TLBIOS, FEAT_TLBIRANGE)";
+    result[@intFromEnum(Feature.tlbiw)] = "Enable ARMv9.5-A TLBI VMALL for Dirty State (FEAT_TLBIW)";
+    result[@intFromEnum(Feature.tme)] = "Enable Transactional Memory Extension (FEAT_TME)";
+    result[@intFromEnum(Feature.tpidr_el1)] = "Permit use of TPIDR_EL1 for the TLS base";
+    result[@intFromEnum(Feature.tpidr_el2)] = "Permit use of TPIDR_EL2 for the TLS base";
+    result[@intFromEnum(Feature.tpidr_el3)] = "Permit use of TPIDR_EL3 for the TLS base";
+    result[@intFromEnum(Feature.tpidrro_el0)] = "Permit use of TPIDRRO_EL0 for the TLS base";
+    result[@intFromEnum(Feature.tracev8_4)] = "Enable v8.4-A Trace extension (FEAT_TRF)";
+    result[@intFromEnum(Feature.trbe)] = "Enable Trace Buffer Extension (FEAT_TRBE)";
+    result[@intFromEnum(Feature.uaops)] = "Enable v8.2 UAO PState (FEAT_UAO)";
+    result[@intFromEnum(Feature.use_experimental_zeroing_pseudos)] = "Hint to the compiler that the MOVPRFX instruction is merged with destructive operations";
+    result[@intFromEnum(Feature.use_postra_scheduler)] = "Schedule again after register allocation";
+    result[@intFromEnum(Feature.use_reciprocal_square_root)] = "Use the reciprocal square root approximation";
+    result[@intFromEnum(Feature.use_scalar_inc_vl)] = "Prefer inc/dec over add+cnt";
+    result[@intFromEnum(Feature.v8_1a)] = "Support ARM v8.1a instructions";
+    result[@intFromEnum(Feature.v8_2a)] = "Support ARM v8.2a instructions";
+    result[@intFromEnum(Feature.v8_3a)] = "Support ARM v8.3a instructions";
+    result[@intFromEnum(Feature.v8_4a)] = "Support ARM v8.4a instructions";
+    result[@intFromEnum(Feature.v8_5a)] = "Support ARM v8.5a instructions";
+    result[@intFromEnum(Feature.v8_6a)] = "Support ARM v8.6a instructions";
+    result[@intFromEnum(Feature.v8_7a)] = "Support ARM v8.7a instructions";
+    result[@intFromEnum(Feature.v8_8a)] = "Support ARM v8.8a instructions";
+    result[@intFromEnum(Feature.v8_9a)] = "Support ARM v8.9a instructions";
+    result[@intFromEnum(Feature.v8a)] = "Support ARM v8.0a instructions";
+    result[@intFromEnum(Feature.v8r)] = "Support ARM v8r instructions";
+    result[@intFromEnum(Feature.v9_1a)] = "Support ARM v9.1a instructions";
+    result[@intFromEnum(Feature.v9_2a)] = "Support ARM v9.2a instructions";
+    result[@intFromEnum(Feature.v9_3a)] = "Support ARM v9.3a instructions";
+    result[@intFromEnum(Feature.v9_4a)] = "Support ARM v9.4a instructions";
+    result[@intFromEnum(Feature.v9_5a)] = "Support ARM v9.5a instructions";
+    result[@intFromEnum(Feature.v9a)] = "Support ARM v9a instructions";
+    result[@intFromEnum(Feature.vh)] = "Enables ARM v8.1 Virtual Host extension (FEAT_VHE)";
+    result[@intFromEnum(Feature.wfxt)] = "Enable Armv8.7-A WFET and WFIT instruction (FEAT_WFxT)";
+    result[@intFromEnum(Feature.xs)] = "Enable Armv8.7-A limited-TLB-maintenance instruction (FEAT_XS)";
+    result[@intFromEnum(Feature.zcm)] = "Has zero-cycle register moves";
+    result[@intFromEnum(Feature.zcz)] = "Has zero-cycle zeroing instructions";
+    result[@intFromEnum(Feature.zcz_fp_workaround)] = "The zero-cycle floating-point zeroing instruction has a bug";
+    result[@intFromEnum(Feature.zcz_gp)] = "Has zero-cycle zeroing instructions for generic registers";
     break :blk result;
 };
 

--- a/lib/std/Target/amdgpu.zig
+++ b/lib/std/Target/amdgpu.zig
@@ -188,317 +188,256 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"16_bit_insts")] = .{
         .llvm_name = "16-bit-insts",
-        .description = "Has i16/f16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.a16)] = .{
         .llvm_name = "a16",
-        .description = "Support A16 for 16-bit coordinates/gradients/lod/clamp/mip image operands",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.add_no_carry_insts)] = .{
         .llvm_name = "add-no-carry-insts",
-        .description = "Have VALU add/sub instructions without carry out",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aperture_regs)] = .{
         .llvm_name = "aperture-regs",
-        .description = "Has Memory Aperture Base and Size Registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.architected_flat_scratch)] = .{
         .llvm_name = "architected-flat-scratch",
-        .description = "Flat Scratch register is a readonly SPI initialized architected register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.architected_sgprs)] = .{
         .llvm_name = "architected-sgprs",
-        .description = "Enable the architected SGPRs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.atomic_buffer_global_pk_add_f16_insts)] = .{
         .llvm_name = "atomic-buffer-global-pk-add-f16-insts",
-        .description = "Has buffer_atomic_pk_add_f16 and global_atomic_pk_add_f16 instructions that can return original value",
         .dependencies = featureSet(&[_]Feature{
             .flat_global_insts,
         }),
     };
     result[@intFromEnum(Feature.atomic_buffer_global_pk_add_f16_no_rtn_insts)] = .{
         .llvm_name = "atomic-buffer-global-pk-add-f16-no-rtn-insts",
-        .description = "Has buffer_atomic_pk_add_f16 and global_atomic_pk_add_f16 instructions that don't return original value",
         .dependencies = featureSet(&[_]Feature{
             .flat_global_insts,
         }),
     };
     result[@intFromEnum(Feature.atomic_csub_no_rtn_insts)] = .{
         .llvm_name = "atomic-csub-no-rtn-insts",
-        .description = "Has buffer_atomic_csub and global_atomic_csub instructions that don't return original value",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.atomic_ds_pk_add_16_insts)] = .{
         .llvm_name = "atomic-ds-pk-add-16-insts",
-        .description = "Has ds_pk_add_bf16, ds_pk_add_f16, ds_pk_add_rtn_bf16, ds_pk_add_rtn_f16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.atomic_fadd_no_rtn_insts)] = .{
         .llvm_name = "atomic-fadd-no-rtn-insts",
-        .description = "Has buffer_atomic_add_f32 and global_atomic_add_f32 instructions that don't return original value",
         .dependencies = featureSet(&[_]Feature{
             .flat_global_insts,
         }),
     };
     result[@intFromEnum(Feature.atomic_fadd_rtn_insts)] = .{
         .llvm_name = "atomic-fadd-rtn-insts",
-        .description = "Has buffer_atomic_add_f32 and global_atomic_add_f32 instructions that return original value",
         .dependencies = featureSet(&[_]Feature{
             .flat_global_insts,
         }),
     };
     result[@intFromEnum(Feature.atomic_flat_pk_add_16_insts)] = .{
         .llvm_name = "atomic-flat-pk-add-16-insts",
-        .description = "Has flat_atomic_pk_add_f16 and flat_atomic_pk_add_bf16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.atomic_global_pk_add_bf16_inst)] = .{
         .llvm_name = "atomic-global-pk-add-bf16-inst",
-        .description = "Has global_atomic_pk_add_bf16 instruction",
         .dependencies = featureSet(&[_]Feature{
             .flat_global_insts,
         }),
     };
     result[@intFromEnum(Feature.auto_waitcnt_before_barrier)] = .{
         .llvm_name = "auto-waitcnt-before-barrier",
-        .description = "Hardware automatically inserts waitcnt before barrier",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.back_off_barrier)] = .{
         .llvm_name = "back-off-barrier",
-        .description = "Hardware supports backing off s_barrier if an exception occurs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ci_insts)] = .{
         .llvm_name = "ci-insts",
-        .description = "Additional instructions for CI+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cumode)] = .{
         .llvm_name = "cumode",
-        .description = "Enable CU wavefront execution mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.default_component_broadcast)] = .{
         .llvm_name = "default-component-broadcast",
-        .description = "BUFFER/IMAGE store instructions set unspecified components to x component (GFX12)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.default_component_zero)] = .{
         .llvm_name = "default-component-zero",
-        .description = "BUFFER/IMAGE store instructions set unspecified components to zero (before GFX12)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dl_insts)] = .{
         .llvm_name = "dl-insts",
-        .description = "Has v_fmac_f32 and v_xnor_b32 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot10_insts)] = .{
         .llvm_name = "dot10-insts",
-        .description = "Has v_dot2_f32_f16 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot1_insts)] = .{
         .llvm_name = "dot1-insts",
-        .description = "Has v_dot4_i32_i8 and v_dot8_i32_i4 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot2_insts)] = .{
         .llvm_name = "dot2-insts",
-        .description = "Has v_dot2_i32_i16, v_dot2_u32_u16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot3_insts)] = .{
         .llvm_name = "dot3-insts",
-        .description = "Has v_dot8c_i32_i4 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot4_insts)] = .{
         .llvm_name = "dot4-insts",
-        .description = "Has v_dot2c_i32_i16 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot5_insts)] = .{
         .llvm_name = "dot5-insts",
-        .description = "Has v_dot2c_f32_f16 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot6_insts)] = .{
         .llvm_name = "dot6-insts",
-        .description = "Has v_dot4c_i32_i8 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot7_insts)] = .{
         .llvm_name = "dot7-insts",
-        .description = "Has v_dot4_u32_u8, v_dot8_u32_u4 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot8_insts)] = .{
         .llvm_name = "dot8-insts",
-        .description = "Has v_dot4_i32_iu8, v_dot8_i32_iu4 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dot9_insts)] = .{
         .llvm_name = "dot9-insts",
-        .description = "Has v_dot2_f16_f16, v_dot2_bf16_bf16, v_dot2_f32_bf16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dpp)] = .{
         .llvm_name = "dpp",
-        .description = "Support DPP (Data Parallel Primitives) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dpp8)] = .{
         .llvm_name = "dpp8",
-        .description = "Support DPP8 (Data Parallel Primitives) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dpp_64bit)] = .{
         .llvm_name = "dpp-64bit",
-        .description = "Support DPP (Data Parallel Primitives) extension in DP ALU",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dpp_src1_sgpr)] = .{
         .llvm_name = "dpp-src1-sgpr",
-        .description = "Support SGPR for Src1 of DPP instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ds128)] = .{
         .llvm_name = "enable-ds128",
-        .description = "Use ds_{read|write}_b128",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ds_src2_insts)] = .{
         .llvm_name = "ds-src2-insts",
-        .description = "Has ds_*_src2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.extended_image_insts)] = .{
         .llvm_name = "extended-image-insts",
-        .description = "Support mips != 0, lod != 0, gather4, and get_lod",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_denormal_f32)] = .{
         .llvm_name = "fast-denormal-f32",
-        .description = "Enabling denormals does not cause f32 instructions to run at f64 rates",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_fmaf)] = .{
         .llvm_name = "fast-fmaf",
-        .description = "Assuming f32 fma is at least as fast as mul + add",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_address_space)] = .{
         .llvm_name = "flat-address-space",
-        .description = "Support flat address space",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_atomic_fadd_f32_inst)] = .{
         .llvm_name = "flat-atomic-fadd-f32-inst",
-        .description = "Has flat_atomic_add_f32 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_for_global)] = .{
         .llvm_name = "flat-for-global",
-        .description = "Force to generate flat instruction for global",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_global_insts)] = .{
         .llvm_name = "flat-global-insts",
-        .description = "Have global_* flat memory instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_inst_offsets)] = .{
         .llvm_name = "flat-inst-offsets",
-        .description = "Flat instructions have immediate offset addressing mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_scratch)] = .{
         .llvm_name = "enable-flat-scratch",
-        .description = "Use scratch_* flat memory instructions to access scratch",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_scratch_insts)] = .{
         .llvm_name = "flat-scratch-insts",
-        .description = "Have scratch_* flat memory instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.flat_segment_offset_bug)] = .{
         .llvm_name = "flat-segment-offset-bug",
-        .description = "GFX10 bug where inst_offset is ignored when flat instructions access global memory",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fma_mix_insts)] = .{
         .llvm_name = "fma-mix-insts",
-        .description = "Has v_fma_mix_f32, v_fma_mixlo_f16, v_fma_mixhi_f16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fmacf64_inst)] = .{
         .llvm_name = "fmacf64-inst",
-        .description = "Has v_fmac_f64 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fmaf)] = .{
         .llvm_name = "fmaf",
-        .description = "Enable single precision FMA (not as fast as mul+add, but fused)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.force_store_sc0_sc1)] = .{
         .llvm_name = "force-store-sc0-sc1",
-        .description = "Has SC0 and SC1 on stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp64)] = .{
         .llvm_name = "fp64",
-        .description = "Enable double precision operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp8_conversion_insts)] = .{
         .llvm_name = "fp8-conversion-insts",
-        .description = "Has fp8 and bf8 conversion instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp8_insts)] = .{
         .llvm_name = "fp8-insts",
-        .description = "Has fp8 and bf8 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.full_rate_64_ops)] = .{
         .llvm_name = "full-rate-64-ops",
-        .description = "Most fp64 instructions are full rate",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.g16)] = .{
         .llvm_name = "g16",
-        .description = "Support G16 for 16-bit gradient image operands",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gcn3_encoding)] = .{
         .llvm_name = "gcn3-encoding",
-        .description = "Encoding format for VI",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gds)] = .{
         .llvm_name = "gds",
-        .description = "Has Global Data Share",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.get_wave_id_inst)] = .{
         .llvm_name = "get-wave-id-inst",
-        .description = "Has s_get_waveid_in_workgroup instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx10)] = .{
         .llvm_name = "gfx10",
-        .description = "GFX10 GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .@"16_bit_insts",
             .a16,
@@ -547,27 +486,22 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.gfx10_3_insts)] = .{
         .llvm_name = "gfx10-3-insts",
-        .description = "Additional instructions for GFX10.3",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx10_a_encoding)] = .{
         .llvm_name = "gfx10_a-encoding",
-        .description = "Has BVH ray tracing instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx10_b_encoding)] = .{
         .llvm_name = "gfx10_b-encoding",
-        .description = "Encoding format GFX10_B",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx10_insts)] = .{
         .llvm_name = "gfx10-insts",
-        .description = "Additional instructions for GFX10+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx11)] = .{
         .llvm_name = "gfx11",
-        .description = "GFX11 GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .@"16_bit_insts",
             .a16,
@@ -615,17 +549,14 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.gfx11_full_vgprs)] = .{
         .llvm_name = "gfx11-full-vgprs",
-        .description = "GFX11 with 50% more physical VGPRs and 50% larger allocation granule than GFX10",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx11_insts)] = .{
         .llvm_name = "gfx11-insts",
-        .description = "Additional instructions for GFX11+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx12)] = .{
         .llvm_name = "gfx12",
-        .description = "GFX12 GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .@"16_bit_insts",
             .a16,
@@ -671,22 +602,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.gfx12_insts)] = .{
         .llvm_name = "gfx12-insts",
-        .description = "Additional instructions for GFX12+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx7_gfx8_gfx9_insts)] = .{
         .llvm_name = "gfx7-gfx8-gfx9-insts",
-        .description = "Instructions shared in GFX7, GFX8, GFX9",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx8_insts)] = .{
         .llvm_name = "gfx8-insts",
-        .description = "Additional instructions for GFX8+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx9)] = .{
         .llvm_name = "gfx9",
-        .description = "GFX9 GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .@"16_bit_insts",
             .a16,
@@ -731,312 +658,250 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.gfx90a_insts)] = .{
         .llvm_name = "gfx90a-insts",
-        .description = "Additional instructions for GFX90A+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx940_insts)] = .{
         .llvm_name = "gfx940-insts",
-        .description = "Additional instructions for GFX940+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfx9_insts)] = .{
         .llvm_name = "gfx9-insts",
-        .description = "Additional instructions for GFX9+",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gws)] = .{
         .llvm_name = "gws",
-        .description = "Has Global Wave Sync",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.half_rate_64_ops)] = .{
         .llvm_name = "half-rate-64-ops",
-        .description = "Most fp64 instructions are half rate instead of quarter",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.image_gather4_d16_bug)] = .{
         .llvm_name = "image-gather4-d16-bug",
-        .description = "Image Gather4 D16 hardware bug",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.image_insts)] = .{
         .llvm_name = "image-insts",
-        .description = "Support image instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.image_store_d16_bug)] = .{
         .llvm_name = "image-store-d16-bug",
-        .description = "Image Store D16 hardware bug",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.inst_fwd_prefetch_bug)] = .{
         .llvm_name = "inst-fwd-prefetch-bug",
-        .description = "S_INST_PREFETCH instruction causes shader to hang",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.int_clamp_insts)] = .{
         .llvm_name = "int-clamp-insts",
-        .description = "Support clamp for integer destination",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.inv_2pi_inline_imm)] = .{
         .llvm_name = "inv-2pi-inline-imm",
-        .description = "Has 1 / (2 * pi) as inline immediate",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.kernarg_preload)] = .{
         .llvm_name = "kernarg-preload",
-        .description = "Hardware supports preloading of kernel arguments in user SGPRs.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lds_branch_vmem_war_hazard)] = .{
         .llvm_name = "lds-branch-vmem-war-hazard",
-        .description = "Switching between LDS and VMEM-tex not waiting VM_VSRC=0",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lds_misaligned_bug)] = .{
         .llvm_name = "lds-misaligned-bug",
-        .description = "Some GFX10 bug with multi-dword LDS and flat access that is not naturally aligned in WGP mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ldsbankcount16)] = .{
         .llvm_name = "ldsbankcount16",
-        .description = "The number of LDS banks per compute unit.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ldsbankcount32)] = .{
         .llvm_name = "ldsbankcount32",
-        .description = "The number of LDS banks per compute unit.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.load_store_opt)] = .{
         .llvm_name = "load-store-opt",
-        .description = "Enable SI load/store optimizer pass",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.localmemorysize32768)] = .{
         .llvm_name = "localmemorysize32768",
-        .description = "The size of local memory in bytes",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.localmemorysize65536)] = .{
         .llvm_name = "localmemorysize65536",
-        .description = "The size of local memory in bytes",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mad_intra_fwd_bug)] = .{
         .llvm_name = "mad-intra-fwd-bug",
-        .description = "MAD_U64/I64 intra instruction forwarding bug",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mad_mac_f32_insts)] = .{
         .llvm_name = "mad-mac-f32-insts",
-        .description = "Has v_mad_f32/v_mac_f32/v_madak_f32/v_madmk_f32 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mad_mix_insts)] = .{
         .llvm_name = "mad-mix-insts",
-        .description = "Has v_mad_mix_f32, v_mad_mixlo_f16, v_mad_mixhi_f16 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mai_insts)] = .{
         .llvm_name = "mai-insts",
-        .description = "Has mAI instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.max_private_element_size_16)] = .{
         .llvm_name = "max-private-element-size-16",
-        .description = "Maximum private access size may be 16",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.max_private_element_size_4)] = .{
         .llvm_name = "max-private-element-size-4",
-        .description = "Maximum private access size may be 4",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.max_private_element_size_8)] = .{
         .llvm_name = "max-private-element-size-8",
-        .description = "Maximum private access size may be 8",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mfma_inline_literal_bug)] = .{
         .llvm_name = "mfma-inline-literal-bug",
-        .description = "MFMA cannot use inline literal as SrcC",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mimg_r128)] = .{
         .llvm_name = "mimg-r128",
-        .description = "Support 128-bit texture resources",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.movrel)] = .{
         .llvm_name = "movrel",
-        .description = "Has v_movrel*_b32 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.msaa_load_dst_sel_bug)] = .{
         .llvm_name = "msaa-load-dst-sel-bug",
-        .description = "MSAA loads not honoring dst_sel bug",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.negative_scratch_offset_bug)] = .{
         .llvm_name = "negative-scratch-offset-bug",
-        .description = "Negative immediate offsets in scratch instructions with an SGPR offset page fault on GFX9",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.negative_unaligned_scratch_offset_bug)] = .{
         .llvm_name = "negative-unaligned-scratch-offset-bug",
-        .description = "Scratch instructions with a VGPR offset and a negative immediate offset that is not a multiple of 4 read wrong memory on GFX10",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_data_dep_hazard)] = .{
         .llvm_name = "no-data-dep-hazard",
-        .description = "Does not need SW waitstates",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_sdst_cmpx)] = .{
         .llvm_name = "no-sdst-cmpx",
-        .description = "V_CMPX does not write VCC/SGPR in addition to EXEC",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nsa_clause_bug)] = .{
         .llvm_name = "nsa-clause-bug",
-        .description = "MIMG-NSA in a hard clause has unpredictable results on GFX10.1",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nsa_encoding)] = .{
         .llvm_name = "nsa-encoding",
-        .description = "Support NSA encoding for image instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nsa_to_vmem_bug)] = .{
         .llvm_name = "nsa-to-vmem-bug",
-        .description = "MIMG-NSA followed by VMEM fail if EXEC_LO or EXEC_HI equals zero",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.offset_3f_bug)] = .{
         .llvm_name = "offset-3f-bug",
-        .description = "Branch offset of 3f hardware bug",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.packed_fp32_ops)] = .{
         .llvm_name = "packed-fp32-ops",
-        .description = "Support packed fp32 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.packed_tid)] = .{
         .llvm_name = "packed-tid",
-        .description = "Workitem IDs are packed into v0 at kernel launch",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.partial_nsa_encoding)] = .{
         .llvm_name = "partial-nsa-encoding",
-        .description = "Support partial NSA encoding for image instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pk_fmac_f16_inst)] = .{
         .llvm_name = "pk-fmac-f16-inst",
-        .description = "Has v_pk_fmac_f16 instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.promote_alloca)] = .{
         .llvm_name = "promote-alloca",
-        .description = "Enable promote alloca pass",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prt_strict_null)] = .{
         .llvm_name = "enable-prt-strict-null",
-        .description = "Enable zeroing of result registers for sparse texture fetches",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pseudo_scalar_trans)] = .{
         .llvm_name = "pseudo-scalar-trans",
-        .description = "Has Pseudo Scalar Transcendental instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.r128_a16)] = .{
         .llvm_name = "r128-a16",
-        .description = "Support gfx9-style A16 for 16-bit coordinates/gradients/lod/clamp/mip image operands, where a16 is aliased with r128",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.real_true16)] = .{
         .llvm_name = "real-true16",
-        .description = "Use true 16-bit registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.restricted_soffset)] = .{
         .llvm_name = "restricted-soffset",
-        .description = "Has restricted SOffset (immediate not supported).",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.s_memrealtime)] = .{
         .llvm_name = "s-memrealtime",
-        .description = "Has s_memrealtime instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.s_memtime_inst)] = .{
         .llvm_name = "s-memtime-inst",
-        .description = "Has s_memtime instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.salu_float)] = .{
         .llvm_name = "salu-float",
-        .description = "Has SALU floating point instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.scalar_atomics)] = .{
         .llvm_name = "scalar-atomics",
-        .description = "Has atomic scalar memory instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.scalar_dwordx3_loads)] = .{
         .llvm_name = "scalar-dwordx3-loads",
-        .description = "Has 96-bit scalar load instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.scalar_flat_scratch_insts)] = .{
         .llvm_name = "scalar-flat-scratch-insts",
-        .description = "Have s_scratch_* flat memory instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.scalar_stores)] = .{
         .llvm_name = "scalar-stores",
-        .description = "Has store scalar memory instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sdwa)] = .{
         .llvm_name = "sdwa",
-        .description = "Support SDWA (Sub-DWORD Addressing) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sdwa_mav)] = .{
         .llvm_name = "sdwa-mav",
-        .description = "Support v_mac_f32/f16 with SDWA (Sub-DWORD Addressing) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sdwa_omod)] = .{
         .llvm_name = "sdwa-omod",
-        .description = "Support OMod with SDWA (Sub-DWORD Addressing) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sdwa_out_mods_vopc)] = .{
         .llvm_name = "sdwa-out-mods-vopc",
-        .description = "Support clamp for VOPC with SDWA (Sub-DWORD Addressing) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sdwa_scalar)] = .{
         .llvm_name = "sdwa-scalar",
-        .description = "Support scalar register with SDWA (Sub-DWORD Addressing) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sdwa_sdst)] = .{
         .llvm_name = "sdwa-sdst",
-        .description = "Support scalar dst for VOPC with SDWA (Sub-DWORD Addressing) extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sea_islands)] = .{
         .llvm_name = "sea-islands",
-        .description = "SEA_ISLANDS GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .ci_insts,
             .default_component_zero,
@@ -1060,32 +925,26 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sgpr_init_bug)] = .{
         .llvm_name = "sgpr-init-bug",
-        .description = "VI SGPR initialization bug requiring a fixed SGPR allocation size",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.shader_cycles_hi_lo_registers)] = .{
         .llvm_name = "shader-cycles-hi-lo-registers",
-        .description = "Has SHADER_CYCLES_HI/LO hardware registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.shader_cycles_register)] = .{
         .llvm_name = "shader-cycles-register",
-        .description = "Has SHADER_CYCLES hardware register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.si_scheduler)] = .{
         .llvm_name = "si-scheduler",
-        .description = "Enable SI Machine Scheduler",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.smem_to_vector_write_hazard)] = .{
         .llvm_name = "smem-to-vector-write-hazard",
-        .description = "s_load_dword followed by v_cmp page faults",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.southern_islands)] = .{
         .llvm_name = "southern-islands",
-        .description = "SOUTHERN_ISLANDS GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .default_component_zero,
             .ds_src2_insts,
@@ -1106,102 +965,82 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.sramecc)] = .{
         .llvm_name = "sramecc",
-        .description = "Enable SRAMECC",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sramecc_support)] = .{
         .llvm_name = "sramecc-support",
-        .description = "Hardware supports SRAMECC",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tgsplit)] = .{
         .llvm_name = "tgsplit",
-        .description = "Enable threadgroup split execution",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.trap_handler)] = .{
         .llvm_name = "trap-handler",
-        .description = "Trap handler support",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.trig_reduced_range)] = .{
         .llvm_name = "trig-reduced-range",
-        .description = "Requires use of fract on arguments to trig instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.true16)] = .{
         .llvm_name = "true16",
-        .description = "True 16-bit operand instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unaligned_access_mode)] = .{
         .llvm_name = "unaligned-access-mode",
-        .description = "Enable unaligned global, local and region loads and stores if the hardware supports it",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unaligned_buffer_access)] = .{
         .llvm_name = "unaligned-buffer-access",
-        .description = "Hardware supports unaligned global loads and stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unaligned_ds_access)] = .{
         .llvm_name = "unaligned-ds-access",
-        .description = "Hardware supports unaligned local and region loads and stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unaligned_scratch_access)] = .{
         .llvm_name = "unaligned-scratch-access",
-        .description = "Support unaligned scratch loads and stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unpacked_d16_vmem)] = .{
         .llvm_name = "unpacked-d16-vmem",
-        .description = "Has unpacked d16 vmem instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unsafe_ds_offset_folding)] = .{
         .llvm_name = "unsafe-ds-offset-folding",
-        .description = "Force using DS instruction immediate offsets on SI",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.user_sgpr_init16_bug)] = .{
         .llvm_name = "user-sgpr-init16-bug",
-        .description = "Bug requiring at least 16 user+system SGPRs to be enabled",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.valu_trans_use_hazard)] = .{
         .llvm_name = "valu-trans-use-hazard",
-        .description = "Hazard when TRANS instructions are closely followed by a use of the result",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vcmpx_exec_war_hazard)] = .{
         .llvm_name = "vcmpx-exec-war-hazard",
-        .description = "V_CMPX WAR hazard on EXEC (V_CMPX issue ONLY)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vcmpx_permlane_hazard)] = .{
         .llvm_name = "vcmpx-permlane-hazard",
-        .description = "TODO: describe me",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vgpr_index_mode)] = .{
         .llvm_name = "vgpr-index-mode",
-        .description = "Has VGPR mode register indexing",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vgpr_singleuse_hint)] = .{
         .llvm_name = "vgpr-singleuse-hint",
-        .description = "Has single-use VGPR hint instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vmem_to_scalar_write_hazard)] = .{
         .llvm_name = "vmem-to-scalar-write-hazard",
-        .description = "VMEM instruction followed by scalar writing to EXEC mask, M0 or SGPR leads to incorrect execution.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.volcanic_islands)] = .{
         .llvm_name = "volcanic-islands",
-        .description = "VOLCANIC_ISLANDS GPU generation",
         .dependencies = featureSet(&[_]Feature{
             .@"16_bit_insts",
             .ci_insts,
@@ -1238,47 +1077,38 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vop3_literal)] = .{
         .llvm_name = "vop3-literal",
-        .description = "Can use one literal in VOP3",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vop3p)] = .{
         .llvm_name = "vop3p",
-        .description = "Has VOP3P packed instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vopd)] = .{
         .llvm_name = "vopd",
-        .description = "Has VOPD dual issue wave32 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vscnt)] = .{
         .llvm_name = "vscnt",
-        .description = "Has separate store vscnt counter",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.wavefrontsize16)] = .{
         .llvm_name = "wavefrontsize16",
-        .description = "The number of threads per wavefront",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.wavefrontsize32)] = .{
         .llvm_name = "wavefrontsize32",
-        .description = "The number of threads per wavefront",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.wavefrontsize64)] = .{
         .llvm_name = "wavefrontsize64",
-        .description = "The number of threads per wavefront",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xnack)] = .{
         .llvm_name = "xnack",
-        .description = "Enable XNACK support",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xnack_support)] = .{
         .llvm_name = "xnack-support",
-        .description = "Hardware supports XNACK",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -1286,6 +1116,182 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"16_bit_insts")] = "Has i16/f16 instructions";
+    result[@intFromEnum(Feature.a16)] = "Support A16 for 16-bit coordinates/gradients/lod/clamp/mip image operands";
+    result[@intFromEnum(Feature.add_no_carry_insts)] = "Have VALU add/sub instructions without carry out";
+    result[@intFromEnum(Feature.aperture_regs)] = "Has Memory Aperture Base and Size Registers";
+    result[@intFromEnum(Feature.architected_flat_scratch)] = "Flat Scratch register is a readonly SPI initialized architected register";
+    result[@intFromEnum(Feature.architected_sgprs)] = "Enable the architected SGPRs";
+    result[@intFromEnum(Feature.atomic_buffer_global_pk_add_f16_insts)] = "Has buffer_atomic_pk_add_f16 and global_atomic_pk_add_f16 instructions that can return original value";
+    result[@intFromEnum(Feature.atomic_buffer_global_pk_add_f16_no_rtn_insts)] = "Has buffer_atomic_pk_add_f16 and global_atomic_pk_add_f16 instructions that don't return original value";
+    result[@intFromEnum(Feature.atomic_csub_no_rtn_insts)] = "Has buffer_atomic_csub and global_atomic_csub instructions that don't return original value";
+    result[@intFromEnum(Feature.atomic_ds_pk_add_16_insts)] = "Has ds_pk_add_bf16, ds_pk_add_f16, ds_pk_add_rtn_bf16, ds_pk_add_rtn_f16 instructions";
+    result[@intFromEnum(Feature.atomic_fadd_no_rtn_insts)] = "Has buffer_atomic_add_f32 and global_atomic_add_f32 instructions that don't return original value";
+    result[@intFromEnum(Feature.atomic_fadd_rtn_insts)] = "Has buffer_atomic_add_f32 and global_atomic_add_f32 instructions that return original value";
+    result[@intFromEnum(Feature.atomic_flat_pk_add_16_insts)] = "Has flat_atomic_pk_add_f16 and flat_atomic_pk_add_bf16 instructions";
+    result[@intFromEnum(Feature.atomic_global_pk_add_bf16_inst)] = "Has global_atomic_pk_add_bf16 instruction";
+    result[@intFromEnum(Feature.auto_waitcnt_before_barrier)] = "Hardware automatically inserts waitcnt before barrier";
+    result[@intFromEnum(Feature.back_off_barrier)] = "Hardware supports backing off s_barrier if an exception occurs";
+    result[@intFromEnum(Feature.ci_insts)] = "Additional instructions for CI+";
+    result[@intFromEnum(Feature.cumode)] = "Enable CU wavefront execution mode";
+    result[@intFromEnum(Feature.default_component_broadcast)] = "BUFFER/IMAGE store instructions set unspecified components to x component (GFX12)";
+    result[@intFromEnum(Feature.default_component_zero)] = "BUFFER/IMAGE store instructions set unspecified components to zero (before GFX12)";
+    result[@intFromEnum(Feature.dl_insts)] = "Has v_fmac_f32 and v_xnor_b32 instructions";
+    result[@intFromEnum(Feature.dot10_insts)] = "Has v_dot2_f32_f16 instruction";
+    result[@intFromEnum(Feature.dot1_insts)] = "Has v_dot4_i32_i8 and v_dot8_i32_i4 instructions";
+    result[@intFromEnum(Feature.dot2_insts)] = "Has v_dot2_i32_i16, v_dot2_u32_u16 instructions";
+    result[@intFromEnum(Feature.dot3_insts)] = "Has v_dot8c_i32_i4 instruction";
+    result[@intFromEnum(Feature.dot4_insts)] = "Has v_dot2c_i32_i16 instruction";
+    result[@intFromEnum(Feature.dot5_insts)] = "Has v_dot2c_f32_f16 instruction";
+    result[@intFromEnum(Feature.dot6_insts)] = "Has v_dot4c_i32_i8 instruction";
+    result[@intFromEnum(Feature.dot7_insts)] = "Has v_dot4_u32_u8, v_dot8_u32_u4 instructions";
+    result[@intFromEnum(Feature.dot8_insts)] = "Has v_dot4_i32_iu8, v_dot8_i32_iu4 instructions";
+    result[@intFromEnum(Feature.dot9_insts)] = "Has v_dot2_f16_f16, v_dot2_bf16_bf16, v_dot2_f32_bf16 instructions";
+    result[@intFromEnum(Feature.dpp)] = "Support DPP (Data Parallel Primitives) extension";
+    result[@intFromEnum(Feature.dpp8)] = "Support DPP8 (Data Parallel Primitives) extension";
+    result[@intFromEnum(Feature.dpp_64bit)] = "Support DPP (Data Parallel Primitives) extension in DP ALU";
+    result[@intFromEnum(Feature.dpp_src1_sgpr)] = "Support SGPR for Src1 of DPP instructions";
+    result[@intFromEnum(Feature.ds128)] = "Use ds_{read|write}_b128";
+    result[@intFromEnum(Feature.ds_src2_insts)] = "Has ds_*_src2 instructions";
+    result[@intFromEnum(Feature.extended_image_insts)] = "Support mips != 0, lod != 0, gather4, and get_lod";
+    result[@intFromEnum(Feature.fast_denormal_f32)] = "Enabling denormals does not cause f32 instructions to run at f64 rates";
+    result[@intFromEnum(Feature.fast_fmaf)] = "Assuming f32 fma is at least as fast as mul + add";
+    result[@intFromEnum(Feature.flat_address_space)] = "Support flat address space";
+    result[@intFromEnum(Feature.flat_atomic_fadd_f32_inst)] = "Has flat_atomic_add_f32 instruction";
+    result[@intFromEnum(Feature.flat_for_global)] = "Force to generate flat instruction for global";
+    result[@intFromEnum(Feature.flat_global_insts)] = "Have global_* flat memory instructions";
+    result[@intFromEnum(Feature.flat_inst_offsets)] = "Flat instructions have immediate offset addressing mode";
+    result[@intFromEnum(Feature.flat_scratch)] = "Use scratch_* flat memory instructions to access scratch";
+    result[@intFromEnum(Feature.flat_scratch_insts)] = "Have scratch_* flat memory instructions";
+    result[@intFromEnum(Feature.flat_segment_offset_bug)] = "GFX10 bug where inst_offset is ignored when flat instructions access global memory";
+    result[@intFromEnum(Feature.fma_mix_insts)] = "Has v_fma_mix_f32, v_fma_mixlo_f16, v_fma_mixhi_f16 instructions";
+    result[@intFromEnum(Feature.fmacf64_inst)] = "Has v_fmac_f64 instruction";
+    result[@intFromEnum(Feature.fmaf)] = "Enable single precision FMA (not as fast as mul+add, but fused)";
+    result[@intFromEnum(Feature.force_store_sc0_sc1)] = "Has SC0 and SC1 on stores";
+    result[@intFromEnum(Feature.fp64)] = "Enable double precision operations";
+    result[@intFromEnum(Feature.fp8_conversion_insts)] = "Has fp8 and bf8 conversion instructions";
+    result[@intFromEnum(Feature.fp8_insts)] = "Has fp8 and bf8 instructions";
+    result[@intFromEnum(Feature.full_rate_64_ops)] = "Most fp64 instructions are full rate";
+    result[@intFromEnum(Feature.g16)] = "Support G16 for 16-bit gradient image operands";
+    result[@intFromEnum(Feature.gcn3_encoding)] = "Encoding format for VI";
+    result[@intFromEnum(Feature.gds)] = "Has Global Data Share";
+    result[@intFromEnum(Feature.get_wave_id_inst)] = "Has s_get_waveid_in_workgroup instruction";
+    result[@intFromEnum(Feature.gfx10)] = "GFX10 GPU generation";
+    result[@intFromEnum(Feature.gfx10_3_insts)] = "Additional instructions for GFX10.3";
+    result[@intFromEnum(Feature.gfx10_a_encoding)] = "Has BVH ray tracing instructions";
+    result[@intFromEnum(Feature.gfx10_b_encoding)] = "Encoding format GFX10_B";
+    result[@intFromEnum(Feature.gfx10_insts)] = "Additional instructions for GFX10+";
+    result[@intFromEnum(Feature.gfx11)] = "GFX11 GPU generation";
+    result[@intFromEnum(Feature.gfx11_full_vgprs)] = "GFX11 with 50% more physical VGPRs and 50% larger allocation granule than GFX10";
+    result[@intFromEnum(Feature.gfx11_insts)] = "Additional instructions for GFX11+";
+    result[@intFromEnum(Feature.gfx12)] = "GFX12 GPU generation";
+    result[@intFromEnum(Feature.gfx12_insts)] = "Additional instructions for GFX12+";
+    result[@intFromEnum(Feature.gfx7_gfx8_gfx9_insts)] = "Instructions shared in GFX7, GFX8, GFX9";
+    result[@intFromEnum(Feature.gfx8_insts)] = "Additional instructions for GFX8+";
+    result[@intFromEnum(Feature.gfx9)] = "GFX9 GPU generation";
+    result[@intFromEnum(Feature.gfx90a_insts)] = "Additional instructions for GFX90A+";
+    result[@intFromEnum(Feature.gfx940_insts)] = "Additional instructions for GFX940+";
+    result[@intFromEnum(Feature.gfx9_insts)] = "Additional instructions for GFX9+";
+    result[@intFromEnum(Feature.gws)] = "Has Global Wave Sync";
+    result[@intFromEnum(Feature.half_rate_64_ops)] = "Most fp64 instructions are half rate instead of quarter";
+    result[@intFromEnum(Feature.image_gather4_d16_bug)] = "Image Gather4 D16 hardware bug";
+    result[@intFromEnum(Feature.image_insts)] = "Support image instructions";
+    result[@intFromEnum(Feature.image_store_d16_bug)] = "Image Store D16 hardware bug";
+    result[@intFromEnum(Feature.inst_fwd_prefetch_bug)] = "S_INST_PREFETCH instruction causes shader to hang";
+    result[@intFromEnum(Feature.int_clamp_insts)] = "Support clamp for integer destination";
+    result[@intFromEnum(Feature.inv_2pi_inline_imm)] = "Has 1 / (2 * pi) as inline immediate";
+    result[@intFromEnum(Feature.kernarg_preload)] = "Hardware supports preloading of kernel arguments in user SGPRs.";
+    result[@intFromEnum(Feature.lds_branch_vmem_war_hazard)] = "Switching between LDS and VMEM-tex not waiting VM_VSRC=0";
+    result[@intFromEnum(Feature.lds_misaligned_bug)] = "Some GFX10 bug with multi-dword LDS and flat access that is not naturally aligned in WGP mode";
+    result[@intFromEnum(Feature.ldsbankcount16)] = "The number of LDS banks per compute unit.";
+    result[@intFromEnum(Feature.ldsbankcount32)] = "The number of LDS banks per compute unit.";
+    result[@intFromEnum(Feature.load_store_opt)] = "Enable SI load/store optimizer pass";
+    result[@intFromEnum(Feature.localmemorysize32768)] = "The size of local memory in bytes";
+    result[@intFromEnum(Feature.localmemorysize65536)] = "The size of local memory in bytes";
+    result[@intFromEnum(Feature.mad_intra_fwd_bug)] = "MAD_U64/I64 intra instruction forwarding bug";
+    result[@intFromEnum(Feature.mad_mac_f32_insts)] = "Has v_mad_f32/v_mac_f32/v_madak_f32/v_madmk_f32 instructions";
+    result[@intFromEnum(Feature.mad_mix_insts)] = "Has v_mad_mix_f32, v_mad_mixlo_f16, v_mad_mixhi_f16 instructions";
+    result[@intFromEnum(Feature.mai_insts)] = "Has mAI instructions";
+    result[@intFromEnum(Feature.max_private_element_size_16)] = "Maximum private access size may be 16";
+    result[@intFromEnum(Feature.max_private_element_size_4)] = "Maximum private access size may be 4";
+    result[@intFromEnum(Feature.max_private_element_size_8)] = "Maximum private access size may be 8";
+    result[@intFromEnum(Feature.mfma_inline_literal_bug)] = "MFMA cannot use inline literal as SrcC";
+    result[@intFromEnum(Feature.mimg_r128)] = "Support 128-bit texture resources";
+    result[@intFromEnum(Feature.movrel)] = "Has v_movrel*_b32 instructions";
+    result[@intFromEnum(Feature.msaa_load_dst_sel_bug)] = "MSAA loads not honoring dst_sel bug";
+    result[@intFromEnum(Feature.negative_scratch_offset_bug)] = "Negative immediate offsets in scratch instructions with an SGPR offset page fault on GFX9";
+    result[@intFromEnum(Feature.negative_unaligned_scratch_offset_bug)] = "Scratch instructions with a VGPR offset and a negative immediate offset that is not a multiple of 4 read wrong memory on GFX10";
+    result[@intFromEnum(Feature.no_data_dep_hazard)] = "Does not need SW waitstates";
+    result[@intFromEnum(Feature.no_sdst_cmpx)] = "V_CMPX does not write VCC/SGPR in addition to EXEC";
+    result[@intFromEnum(Feature.nsa_clause_bug)] = "MIMG-NSA in a hard clause has unpredictable results on GFX10.1";
+    result[@intFromEnum(Feature.nsa_encoding)] = "Support NSA encoding for image instructions";
+    result[@intFromEnum(Feature.nsa_to_vmem_bug)] = "MIMG-NSA followed by VMEM fail if EXEC_LO or EXEC_HI equals zero";
+    result[@intFromEnum(Feature.offset_3f_bug)] = "Branch offset of 3f hardware bug";
+    result[@intFromEnum(Feature.packed_fp32_ops)] = "Support packed fp32 instructions";
+    result[@intFromEnum(Feature.packed_tid)] = "Workitem IDs are packed into v0 at kernel launch";
+    result[@intFromEnum(Feature.partial_nsa_encoding)] = "Support partial NSA encoding for image instructions";
+    result[@intFromEnum(Feature.pk_fmac_f16_inst)] = "Has v_pk_fmac_f16 instruction";
+    result[@intFromEnum(Feature.promote_alloca)] = "Enable promote alloca pass";
+    result[@intFromEnum(Feature.prt_strict_null)] = "Enable zeroing of result registers for sparse texture fetches";
+    result[@intFromEnum(Feature.pseudo_scalar_trans)] = "Has Pseudo Scalar Transcendental instructions";
+    result[@intFromEnum(Feature.r128_a16)] = "Support gfx9-style A16 for 16-bit coordinates/gradients/lod/clamp/mip image operands, where a16 is aliased with r128";
+    result[@intFromEnum(Feature.real_true16)] = "Use true 16-bit registers";
+    result[@intFromEnum(Feature.restricted_soffset)] = "Has restricted SOffset (immediate not supported).";
+    result[@intFromEnum(Feature.s_memrealtime)] = "Has s_memrealtime instruction";
+    result[@intFromEnum(Feature.s_memtime_inst)] = "Has s_memtime instruction";
+    result[@intFromEnum(Feature.salu_float)] = "Has SALU floating point instructions";
+    result[@intFromEnum(Feature.scalar_atomics)] = "Has atomic scalar memory instructions";
+    result[@intFromEnum(Feature.scalar_dwordx3_loads)] = "Has 96-bit scalar load instructions";
+    result[@intFromEnum(Feature.scalar_flat_scratch_insts)] = "Have s_scratch_* flat memory instructions";
+    result[@intFromEnum(Feature.scalar_stores)] = "Has store scalar memory instructions";
+    result[@intFromEnum(Feature.sdwa)] = "Support SDWA (Sub-DWORD Addressing) extension";
+    result[@intFromEnum(Feature.sdwa_mav)] = "Support v_mac_f32/f16 with SDWA (Sub-DWORD Addressing) extension";
+    result[@intFromEnum(Feature.sdwa_omod)] = "Support OMod with SDWA (Sub-DWORD Addressing) extension";
+    result[@intFromEnum(Feature.sdwa_out_mods_vopc)] = "Support clamp for VOPC with SDWA (Sub-DWORD Addressing) extension";
+    result[@intFromEnum(Feature.sdwa_scalar)] = "Support scalar register with SDWA (Sub-DWORD Addressing) extension";
+    result[@intFromEnum(Feature.sdwa_sdst)] = "Support scalar dst for VOPC with SDWA (Sub-DWORD Addressing) extension";
+    result[@intFromEnum(Feature.sea_islands)] = "SEA_ISLANDS GPU generation";
+    result[@intFromEnum(Feature.sgpr_init_bug)] = "VI SGPR initialization bug requiring a fixed SGPR allocation size";
+    result[@intFromEnum(Feature.shader_cycles_hi_lo_registers)] = "Has SHADER_CYCLES_HI/LO hardware registers";
+    result[@intFromEnum(Feature.shader_cycles_register)] = "Has SHADER_CYCLES hardware register";
+    result[@intFromEnum(Feature.si_scheduler)] = "Enable SI Machine Scheduler";
+    result[@intFromEnum(Feature.smem_to_vector_write_hazard)] = "s_load_dword followed by v_cmp page faults";
+    result[@intFromEnum(Feature.southern_islands)] = "SOUTHERN_ISLANDS GPU generation";
+    result[@intFromEnum(Feature.sramecc)] = "Enable SRAMECC";
+    result[@intFromEnum(Feature.sramecc_support)] = "Hardware supports SRAMECC";
+    result[@intFromEnum(Feature.tgsplit)] = "Enable threadgroup split execution";
+    result[@intFromEnum(Feature.trap_handler)] = "Trap handler support";
+    result[@intFromEnum(Feature.trig_reduced_range)] = "Requires use of fract on arguments to trig instructions";
+    result[@intFromEnum(Feature.true16)] = "True 16-bit operand instructions";
+    result[@intFromEnum(Feature.unaligned_access_mode)] = "Enable unaligned global, local and region loads and stores if the hardware supports it";
+    result[@intFromEnum(Feature.unaligned_buffer_access)] = "Hardware supports unaligned global loads and stores";
+    result[@intFromEnum(Feature.unaligned_ds_access)] = "Hardware supports unaligned local and region loads and stores";
+    result[@intFromEnum(Feature.unaligned_scratch_access)] = "Support unaligned scratch loads and stores";
+    result[@intFromEnum(Feature.unpacked_d16_vmem)] = "Has unpacked d16 vmem instructions";
+    result[@intFromEnum(Feature.unsafe_ds_offset_folding)] = "Force using DS instruction immediate offsets on SI";
+    result[@intFromEnum(Feature.user_sgpr_init16_bug)] = "Bug requiring at least 16 user+system SGPRs to be enabled";
+    result[@intFromEnum(Feature.valu_trans_use_hazard)] = "Hazard when TRANS instructions are closely followed by a use of the result";
+    result[@intFromEnum(Feature.vcmpx_exec_war_hazard)] = "V_CMPX WAR hazard on EXEC (V_CMPX issue ONLY)";
+    result[@intFromEnum(Feature.vcmpx_permlane_hazard)] = "TODO: describe me";
+    result[@intFromEnum(Feature.vgpr_index_mode)] = "Has VGPR mode register indexing";
+    result[@intFromEnum(Feature.vgpr_singleuse_hint)] = "Has single-use VGPR hint instructions";
+    result[@intFromEnum(Feature.vmem_to_scalar_write_hazard)] = "VMEM instruction followed by scalar writing to EXEC mask, M0 or SGPR leads to incorrect execution.";
+    result[@intFromEnum(Feature.volcanic_islands)] = "VOLCANIC_ISLANDS GPU generation";
+    result[@intFromEnum(Feature.vop3_literal)] = "Can use one literal in VOP3";
+    result[@intFromEnum(Feature.vop3p)] = "Has VOP3P packed instructions";
+    result[@intFromEnum(Feature.vopd)] = "Has VOPD dual issue wave32 instructions";
+    result[@intFromEnum(Feature.vscnt)] = "Has separate store vscnt counter";
+    result[@intFromEnum(Feature.wavefrontsize16)] = "The number of threads per wavefront";
+    result[@intFromEnum(Feature.wavefrontsize32)] = "The number of threads per wavefront";
+    result[@intFromEnum(Feature.wavefrontsize64)] = "The number of threads per wavefront";
+    result[@intFromEnum(Feature.xnack)] = "Enable XNACK support";
+    result[@intFromEnum(Feature.xnack_support)] = "Hardware supports XNACK";
     break :blk result;
 };
 

--- a/lib/std/Target/arc.zig
+++ b/lib/std/Target/arc.zig
@@ -19,7 +19,6 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.norm)] = .{
         .llvm_name = "norm",
-        .description = "Enable support for norm instruction.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -27,6 +26,13 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.norm)] = "Enable support for norm instruction.";
     break :blk result;
 };
 

--- a/lib/std/Target/arm.zig
+++ b/lib/std/Target/arm.zig
@@ -220,156 +220,130 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"32bit")] = .{
         .llvm_name = "32bit",
-        .description = "Prefer 32-bit Thumb instrs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"8msecext")] = .{
         .llvm_name = "8msecext",
-        .description = "Enable support for ARMv8-M Security Extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.a76)] = .{
         .llvm_name = "a76",
-        .description = "Cortex-A76 ARM processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aapcs_frame_chain)] = .{
         .llvm_name = "aapcs-frame-chain",
-        .description = "Create an AAPCS compliant frame chain",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aapcs_frame_chain_leaf)] = .{
         .llvm_name = "aapcs-frame-chain-leaf",
-        .description = "Create an AAPCS compliant frame chain for leaf functions",
         .dependencies = featureSet(&[_]Feature{
             .aapcs_frame_chain,
         }),
     };
     result[@intFromEnum(Feature.aclass)] = .{
         .llvm_name = "aclass",
-        .description = "Is application profile ('A' series)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.acquire_release)] = .{
         .llvm_name = "acquire-release",
-        .description = "Has v8 acquire/release (lda/ldaex  etc) instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aes)] = .{
         .llvm_name = "aes",
-        .description = "Enable AES support",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.atomics_32)] = .{
         .llvm_name = "atomics-32",
-        .description = "Assume that lock-free 32-bit atomics are available",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.avoid_movs_shop)] = .{
         .llvm_name = "avoid-movs-shop",
-        .description = "Avoid movs instructions with shifter operand",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.avoid_partial_cpsr)] = .{
         .llvm_name = "avoid-partial-cpsr",
-        .description = "Avoid CPSR partial update for OOO execution",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.bf16)] = .{
         .llvm_name = "bf16",
-        .description = "Enable support for BFloat16 instructions",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.big_endian_instructions)] = .{
         .llvm_name = "big-endian-instructions",
-        .description = "Expect instructions to be stored big-endian.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cde)] = .{
         .llvm_name = "cde",
-        .description = "Support CDE instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8m_main,
         }),
     };
     result[@intFromEnum(Feature.cdecp0)] = .{
         .llvm_name = "cdecp0",
-        .description = "Coprocessor 0 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp1)] = .{
         .llvm_name = "cdecp1",
-        .description = "Coprocessor 1 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp2)] = .{
         .llvm_name = "cdecp2",
-        .description = "Coprocessor 2 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp3)] = .{
         .llvm_name = "cdecp3",
-        .description = "Coprocessor 3 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp4)] = .{
         .llvm_name = "cdecp4",
-        .description = "Coprocessor 4 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp5)] = .{
         .llvm_name = "cdecp5",
-        .description = "Coprocessor 5 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp6)] = .{
         .llvm_name = "cdecp6",
-        .description = "Coprocessor 6 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cdecp7)] = .{
         .llvm_name = "cdecp7",
-        .description = "Coprocessor 7 ISA is CDEv1",
         .dependencies = featureSet(&[_]Feature{
             .cde,
         }),
     };
     result[@intFromEnum(Feature.cheap_predicable_cpsr)] = .{
         .llvm_name = "cheap-predicable-cpsr",
-        .description = "Disable +1 predication cost for instructions updating CPSR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.clrbhb)] = .{
         .llvm_name = "clrbhb",
-        .description = "Enable Clear BHB instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crc)] = .{
         .llvm_name = "crc",
-        .description = "Enable support for CRC instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crypto)] = .{
         .llvm_name = "crypto",
-        .description = "Enable support for Cryptography extensions",
         .dependencies = featureSet(&[_]Feature{
             .aes,
             .sha2,
@@ -377,54 +351,44 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.d32)] = .{
         .llvm_name = "d32",
-        .description = "Extend FP to 32 double registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.db)] = .{
         .llvm_name = "db",
-        .description = "Has data barrier (dmb/dsb) instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dfb)] = .{
         .llvm_name = "dfb",
-        .description = "Has full data barrier (dfb) instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.disable_postra_scheduler)] = .{
         .llvm_name = "disable-postra-scheduler",
-        .description = "Don't schedule again after register allocation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dont_widen_vmovs)] = .{
         .llvm_name = "dont-widen-vmovs",
-        .description = "Don't widen VMOVS to VMOVD",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dotprod)] = .{
         .llvm_name = "dotprod",
-        .description = "Enable support for dot product instructions",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.dsp)] = .{
         .llvm_name = "dsp",
-        .description = "Supports DSP instructions in ARM and/or Thumb2",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.execute_only)] = .{
         .llvm_name = "execute-only",
-        .description = "Enable the generation of execute only code.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.expand_fp_mlx)] = .{
         .llvm_name = "expand-fp-mlx",
-        .description = "Expand VFP/NEON MLA/MLS instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.exynos)] = .{
         .llvm_name = "exynos",
-        .description = "Samsung Exynos processors",
         .dependencies = featureSet(&[_]Feature{
             .crc,
             .crypto,
@@ -447,36 +411,30 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.fix_cmse_cve_2021_35465)] = .{
         .llvm_name = "fix-cmse-cve-2021-35465",
-        .description = "Mitigate against the cve-2021-35465 security vulnerability",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fix_cortex_a57_aes_1742098)] = .{
         .llvm_name = "fix-cortex-a57-aes-1742098",
-        .description = "Work around Cortex-A57 Erratum 1742098 / Cortex-A72 Erratum 1655431 (AES)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp16)] = .{
         .llvm_name = "fp16",
-        .description = "Enable half-precision floating point",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp16fml)] = .{
         .llvm_name = "fp16fml",
-        .description = "Enable full half-precision floating point fml instructions",
         .dependencies = featureSet(&[_]Feature{
             .fullfp16,
         }),
     };
     result[@intFromEnum(Feature.fp64)] = .{
         .llvm_name = "fp64",
-        .description = "Floating point unit supports double precision",
         .dependencies = featureSet(&[_]Feature{
             .fpregs64,
         }),
     };
     result[@intFromEnum(Feature.fp_armv8)] = .{
         .llvm_name = "fp-armv8",
-        .description = "Enable ARMv8 FP",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8d16,
             .fp_armv8sp,
@@ -485,7 +443,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.fp_armv8d16)] = .{
         .llvm_name = "fp-armv8d16",
-        .description = "Enable ARMv8 FP with only 16 d-registers",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8d16sp,
             .vfp4d16,
@@ -493,14 +450,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.fp_armv8d16sp)] = .{
         .llvm_name = "fp-armv8d16sp",
-        .description = "Enable ARMv8 FP with only 16 d-registers and no double precision",
         .dependencies = featureSet(&[_]Feature{
             .vfp4d16sp,
         }),
     };
     result[@intFromEnum(Feature.fp_armv8sp)] = .{
         .llvm_name = "fp-armv8sp",
-        .description = "Enable ARMv8 FP with no double precision",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8d16sp,
             .vfp4sp,
@@ -508,31 +463,26 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.fpao)] = .{
         .llvm_name = "fpao",
-        .description = "Enable fast computation of positive address offsets",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpregs)] = .{
         .llvm_name = "fpregs",
-        .description = "Enable FP registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpregs16)] = .{
         .llvm_name = "fpregs16",
-        .description = "Enable 16-bit FP registers",
         .dependencies = featureSet(&[_]Feature{
             .fpregs,
         }),
     };
     result[@intFromEnum(Feature.fpregs64)] = .{
         .llvm_name = "fpregs64",
-        .description = "Enable 64-bit FP registers",
         .dependencies = featureSet(&[_]Feature{
             .fpregs,
         }),
     };
     result[@intFromEnum(Feature.fullfp16)] = .{
         .llvm_name = "fullfp16",
-        .description = "Enable full half-precision floating point",
         .dependencies = featureSet(&[_]Feature{
             .fp_armv8d16sp,
             .fpregs16,
@@ -540,72 +490,60 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.fuse_aes)] = .{
         .llvm_name = "fuse-aes",
-        .description = "CPU fuses AES crypto operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fuse_literals)] = .{
         .llvm_name = "fuse-literals",
-        .description = "CPU fuses literal generation operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.harden_sls_blr)] = .{
         .llvm_name = "harden-sls-blr",
-        .description = "Harden against straight line speculation across indirect calls",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.harden_sls_nocomdat)] = .{
         .llvm_name = "harden-sls-nocomdat",
-        .description = "Generate thunk code for SLS mitigation in the normal text section",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.harden_sls_retbr)] = .{
         .llvm_name = "harden-sls-retbr",
-        .description = "Harden against straight line speculation across RETurn and BranchRegister instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.has_v4t)] = .{
         .llvm_name = "v4t",
-        .description = "Support ARM v4T instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.has_v5t)] = .{
         .llvm_name = "v5t",
-        .description = "Support ARM v5T instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v4t,
         }),
     };
     result[@intFromEnum(Feature.has_v5te)] = .{
         .llvm_name = "v5te",
-        .description = "Support ARM v5TE, v5TEj, and v5TExp instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v5t,
         }),
     };
     result[@intFromEnum(Feature.has_v6)] = .{
         .llvm_name = "v6",
-        .description = "Support ARM v6 instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v5te,
         }),
     };
     result[@intFromEnum(Feature.has_v6k)] = .{
         .llvm_name = "v6k",
-        .description = "Support ARM v6k instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v6,
         }),
     };
     result[@intFromEnum(Feature.has_v6m)] = .{
         .llvm_name = "v6m",
-        .description = "Support ARM v6M instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v6,
         }),
     };
     result[@intFromEnum(Feature.has_v6t2)] = .{
         .llvm_name = "v6t2",
-        .description = "Support ARM v6t2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v6k,
             .has_v8m,
@@ -614,7 +552,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v7)] = .{
         .llvm_name = "v7",
-        .description = "Support ARM v7 instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v6t2,
             .has_v7clrex,
@@ -622,12 +559,10 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v7clrex)] = .{
         .llvm_name = "v7clrex",
-        .description = "Has v7 clrex instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.has_v8)] = .{
         .llvm_name = "v8",
-        .description = "Support ARM v8 instructions",
         .dependencies = featureSet(&[_]Feature{
             .acquire_release,
             .has_v7,
@@ -636,35 +571,30 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v8_1a)] = .{
         .llvm_name = "v8.1a",
-        .description = "Support ARM v8.1a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8,
         }),
     };
     result[@intFromEnum(Feature.has_v8_1m_main)] = .{
         .llvm_name = "v8.1m.main",
-        .description = "Support ARM v8-1M Mainline instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8m_main,
         }),
     };
     result[@intFromEnum(Feature.has_v8_2a)] = .{
         .llvm_name = "v8.2a",
-        .description = "Support ARM v8.2a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_1a,
         }),
     };
     result[@intFromEnum(Feature.has_v8_3a)] = .{
         .llvm_name = "v8.3a",
-        .description = "Support ARM v8.3a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_2a,
         }),
     };
     result[@intFromEnum(Feature.has_v8_4a)] = .{
         .llvm_name = "v8.4a",
-        .description = "Support ARM v8.4a instructions",
         .dependencies = featureSet(&[_]Feature{
             .dotprod,
             .has_v8_3a,
@@ -672,7 +602,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v8_5a)] = .{
         .llvm_name = "v8.5a",
-        .description = "Support ARM v8.5a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_4a,
             .sb,
@@ -680,7 +609,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v8_6a)] = .{
         .llvm_name = "v8.6a",
-        .description = "Support ARM v8.6a instructions",
         .dependencies = featureSet(&[_]Feature{
             .bf16,
             .has_v8_5a,
@@ -689,21 +617,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v8_7a)] = .{
         .llvm_name = "v8.7a",
-        .description = "Support ARM v8.7a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_6a,
         }),
     };
     result[@intFromEnum(Feature.has_v8_8a)] = .{
         .llvm_name = "v8.8a",
-        .description = "Support ARM v8.8a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_7a,
         }),
     };
     result[@intFromEnum(Feature.has_v8_9a)] = .{
         .llvm_name = "v8.9a",
-        .description = "Support ARM v8.9a instructions",
         .dependencies = featureSet(&[_]Feature{
             .clrbhb,
             .has_v8_8a,
@@ -711,21 +636,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v8m)] = .{
         .llvm_name = "v8m",
-        .description = "Support ARM v8M Baseline instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v6m,
         }),
     };
     result[@intFromEnum(Feature.has_v8m_main)] = .{
         .llvm_name = "v8m.main",
-        .description = "Support ARM v8M Mainline instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v7,
         }),
     };
     result[@intFromEnum(Feature.has_v9_1a)] = .{
         .llvm_name = "v9.1a",
-        .description = "Support ARM v9.1a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_6a,
             .has_v9a,
@@ -733,7 +655,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v9_2a)] = .{
         .llvm_name = "v9.2a",
-        .description = "Support ARM v9.2a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_7a,
             .has_v9_1a,
@@ -741,7 +662,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v9_3a)] = .{
         .llvm_name = "v9.3a",
-        .description = "Support ARM v9.3a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_8a,
             .has_v9_2a,
@@ -749,7 +669,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v9_4a)] = .{
         .llvm_name = "v9.4a",
-        .description = "Support ARM v9.4a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_9a,
             .has_v9_3a,
@@ -757,87 +676,72 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.has_v9_5a)] = .{
         .llvm_name = "v9.5a",
-        .description = "Support ARM v9.5a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v9_4a,
         }),
     };
     result[@intFromEnum(Feature.has_v9a)] = .{
         .llvm_name = "v9a",
-        .description = "Support ARM v9a instructions",
         .dependencies = featureSet(&[_]Feature{
             .has_v8_5a,
         }),
     };
     result[@intFromEnum(Feature.hwdiv)] = .{
         .llvm_name = "hwdiv",
-        .description = "Enable divide instructions in Thumb",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hwdiv_arm)] = .{
         .llvm_name = "hwdiv-arm",
-        .description = "Enable divide instructions in ARM mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.i8mm)] = .{
         .llvm_name = "i8mm",
-        .description = "Enable Matrix Multiply Int8 Extension",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.iwmmxt)] = .{
         .llvm_name = "iwmmxt",
-        .description = "ARMv5te architecture",
         .dependencies = featureSet(&[_]Feature{
             .v5te,
         }),
     };
     result[@intFromEnum(Feature.iwmmxt2)] = .{
         .llvm_name = "iwmmxt2",
-        .description = "ARMv5te architecture",
         .dependencies = featureSet(&[_]Feature{
             .v5te,
         }),
     };
     result[@intFromEnum(Feature.lob)] = .{
         .llvm_name = "lob",
-        .description = "Enable Low Overhead Branch extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.long_calls)] = .{
         .llvm_name = "long-calls",
-        .description = "Generate calls via indirect call instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.loop_align)] = .{
         .llvm_name = "loop-align",
-        .description = "Prefer 32-bit alignment for loops",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.m3)] = .{
         .llvm_name = "m3",
-        .description = "Cortex-M3 ARM processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mclass)] = .{
         .llvm_name = "mclass",
-        .description = "Is microcontroller profile ('M' series)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mp)] = .{
         .llvm_name = "mp",
-        .description = "Supports Multiprocessing extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.muxed_units)] = .{
         .llvm_name = "muxed-units",
-        .description = "Has muxed AGU and NEON/FPU",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mve)] = .{
         .llvm_name = "mve",
-        .description = "Support M-Class Vector Extension with integer ops",
         .dependencies = featureSet(&[_]Feature{
             .dsp,
             .fpregs16,
@@ -847,22 +751,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mve1beat)] = .{
         .llvm_name = "mve1beat",
-        .description = "Model MVE instructions as a 1 beat per tick architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mve2beat)] = .{
         .llvm_name = "mve2beat",
-        .description = "Model MVE instructions as a 2 beats per tick architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mve4beat)] = .{
         .llvm_name = "mve4beat",
-        .description = "Model MVE instructions as a 4 beats per tick architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mve_fp)] = .{
         .llvm_name = "mve.fp",
-        .description = "Support M-Class Vector Extension with integer and floating ops",
         .dependencies = featureSet(&[_]Feature{
             .fullfp16,
             .mve,
@@ -870,253 +770,206 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.nacl_trap)] = .{
         .llvm_name = "nacl-trap",
-        .description = "NaCl trap",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.neon)] = .{
         .llvm_name = "neon",
-        .description = "Enable NEON instructions",
         .dependencies = featureSet(&[_]Feature{
             .vfp3,
         }),
     };
     result[@intFromEnum(Feature.neon_fpmovs)] = .{
         .llvm_name = "neon-fpmovs",
-        .description = "Convert VMOVSR, VMOVRS, VMOVS to NEON",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.neonfp)] = .{
         .llvm_name = "neonfp",
-        .description = "Use NEON for single precision FP",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_branch_predictor)] = .{
         .llvm_name = "no-branch-predictor",
-        .description = "Has no branch predictor",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_bti_at_return_twice)] = .{
         .llvm_name = "no-bti-at-return-twice",
-        .description = "Don't place a BTI instruction after a return-twice",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_movt)] = .{
         .llvm_name = "no-movt",
-        .description = "Don't use movt/movw pairs for 32-bit imms",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_neg_immediates)] = .{
         .llvm_name = "no-neg-immediates",
-        .description = "Convert immediates and instructions to their negated or complemented equivalent when the immediate does not fit in the encoding.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.noarm)] = .{
         .llvm_name = "noarm",
-        .description = "Does not support ARM mode execution",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nonpipelined_vfp)] = .{
         .llvm_name = "nonpipelined-vfp",
-        .description = "VFP instructions are not pipelined",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pacbti)] = .{
         .llvm_name = "pacbti",
-        .description = "Enable Pointer Authentication and Branch Target Identification",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.perfmon)] = .{
         .llvm_name = "perfmon",
-        .description = "Enable support for Performance Monitor extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_ishst)] = .{
         .llvm_name = "prefer-ishst",
-        .description = "Prefer ISHST barriers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_vmovsr)] = .{
         .llvm_name = "prefer-vmovsr",
-        .description = "Prefer VMOVSR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prof_unpr)] = .{
         .llvm_name = "prof-unpr",
-        .description = "Is profitable to unpredicate",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.r4)] = .{
         .llvm_name = "r4",
-        .description = "Cortex-R4 ARM processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ras)] = .{
         .llvm_name = "ras",
-        .description = "Enable Reliability, Availability and Serviceability extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rclass)] = .{
         .llvm_name = "rclass",
-        .description = "Is realtime profile ('R' series)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.read_tp_tpidrprw)] = .{
         .llvm_name = "read-tp-tpidrprw",
-        .description = "Reading thread pointer from TPIDRPRW register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.read_tp_tpidruro)] = .{
         .llvm_name = "read-tp-tpidruro",
-        .description = "Reading thread pointer from TPIDRURO register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.read_tp_tpidrurw)] = .{
         .llvm_name = "read-tp-tpidrurw",
-        .description = "Reading thread pointer from TPIDRURW register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_r9)] = .{
         .llvm_name = "reserve-r9",
-        .description = "Reserve R9, making it unavailable as GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ret_addr_stack)] = .{
         .llvm_name = "ret-addr-stack",
-        .description = "Has return address stack",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sb)] = .{
         .llvm_name = "sb",
-        .description = "Enable v8.5a Speculation Barrier",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sha2)] = .{
         .llvm_name = "sha2",
-        .description = "Enable SHA1 and SHA256 support",
         .dependencies = featureSet(&[_]Feature{
             .neon,
         }),
     };
     result[@intFromEnum(Feature.slow_fp_brcc)] = .{
         .llvm_name = "slow-fp-brcc",
-        .description = "FP compare + branch is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_load_D_subreg)] = .{
         .llvm_name = "slow-load-D-subreg",
-        .description = "Loading into D subregs is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_odd_reg)] = .{
         .llvm_name = "slow-odd-reg",
-        .description = "VLDM/VSTM starting with an odd register is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_vdup32)] = .{
         .llvm_name = "slow-vdup32",
-        .description = "Has slow VDUP32 - prefer VMOV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_vgetlni32)] = .{
         .llvm_name = "slow-vgetlni32",
-        .description = "Has slow VGETLNi32 - prefer VMOV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slowfpvfmx)] = .{
         .llvm_name = "slowfpvfmx",
-        .description = "Disable VFP / NEON FMA instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slowfpvmlx)] = .{
         .llvm_name = "slowfpvmlx",
-        .description = "Disable VFP / NEON MAC instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.soft_float)] = .{
         .llvm_name = "soft-float",
-        .description = "Use software floating point features.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.splat_vfp_neon)] = .{
         .llvm_name = "splat-vfp-neon",
-        .description = "Splat register from VFP to NEON",
         .dependencies = featureSet(&[_]Feature{
             .dont_widen_vmovs,
         }),
     };
     result[@intFromEnum(Feature.strict_align)] = .{
         .llvm_name = "strict-align",
-        .description = "Disallow all unaligned memory access",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.swift)] = .{
         .llvm_name = "swift",
-        .description = "Swift ARM processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.thumb2)] = .{
         .llvm_name = "thumb2",
-        .description = "Enable Thumb2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.thumb_mode)] = .{
         .llvm_name = "thumb-mode",
-        .description = "Thumb mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.trustzone)] = .{
         .llvm_name = "trustzone",
-        .description = "Enable support for TrustZone security extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_mipipeliner)] = .{
         .llvm_name = "use-mipipeliner",
-        .description = "Use the MachinePipeliner",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_misched)] = .{
         .llvm_name = "use-misched",
-        .description = "Use the MachineScheduler",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v2)] = .{
         .llvm_name = null,
-        .description = "ARMv2 architecture",
         .dependencies = featureSet(&[_]Feature{
             .strict_align,
         }),
     };
     result[@intFromEnum(Feature.v2a)] = .{
         .llvm_name = null,
-        .description = "ARMv2a architecture",
         .dependencies = featureSet(&[_]Feature{
             .strict_align,
         }),
     };
     result[@intFromEnum(Feature.v3)] = .{
         .llvm_name = null,
-        .description = "ARMv3 architecture",
         .dependencies = featureSet(&[_]Feature{
             .strict_align,
         }),
     };
     result[@intFromEnum(Feature.v3m)] = .{
         .llvm_name = null,
-        .description = "ARMv3m architecture",
         .dependencies = featureSet(&[_]Feature{
             .strict_align,
         }),
     };
     result[@intFromEnum(Feature.v4)] = .{
         .llvm_name = "armv4",
-        .description = "ARMv4 architecture",
         .dependencies = featureSet(&[_]Feature{
             .strict_align,
         }),
     };
     result[@intFromEnum(Feature.v4t)] = .{
         .llvm_name = "armv4t",
-        .description = "ARMv4t architecture",
         .dependencies = featureSet(&[_]Feature{
             .has_v4t,
             .strict_align,
@@ -1124,7 +977,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v5t)] = .{
         .llvm_name = "armv5t",
-        .description = "ARMv5t architecture",
         .dependencies = featureSet(&[_]Feature{
             .has_v5t,
             .strict_align,
@@ -1132,7 +984,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v5te)] = .{
         .llvm_name = "armv5te",
-        .description = "ARMv5te architecture",
         .dependencies = featureSet(&[_]Feature{
             .has_v5te,
             .strict_align,
@@ -1140,7 +991,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v5tej)] = .{
         .llvm_name = "armv5tej",
-        .description = "ARMv5tej architecture",
         .dependencies = featureSet(&[_]Feature{
             .has_v5te,
             .strict_align,
@@ -1148,7 +998,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v6)] = .{
         .llvm_name = "armv6",
-        .description = "ARMv6 architecture",
         .dependencies = featureSet(&[_]Feature{
             .dsp,
             .has_v6,
@@ -1156,21 +1005,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v6j)] = .{
         .llvm_name = "armv6j",
-        .description = "ARMv7a architecture",
         .dependencies = featureSet(&[_]Feature{
             .v6,
         }),
     };
     result[@intFromEnum(Feature.v6k)] = .{
         .llvm_name = "armv6k",
-        .description = "ARMv6k architecture",
         .dependencies = featureSet(&[_]Feature{
             .has_v6k,
         }),
     };
     result[@intFromEnum(Feature.v6kz)] = .{
         .llvm_name = "armv6kz",
-        .description = "ARMv6kz architecture",
         .dependencies = featureSet(&[_]Feature{
             .has_v6k,
             .trustzone,
@@ -1178,7 +1024,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v6m)] = .{
         .llvm_name = "armv6-m",
-        .description = "ARMv6m architecture",
         .dependencies = featureSet(&[_]Feature{
             .db,
             .has_v6m,
@@ -1190,7 +1035,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v6sm)] = .{
         .llvm_name = "armv6s-m",
-        .description = "ARMv6sm architecture",
         .dependencies = featureSet(&[_]Feature{
             .db,
             .has_v6m,
@@ -1202,7 +1046,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v6t2)] = .{
         .llvm_name = "armv6t2",
-        .description = "ARMv6t2 architecture",
         .dependencies = featureSet(&[_]Feature{
             .dsp,
             .has_v6t2,
@@ -1210,7 +1053,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v7a)] = .{
         .llvm_name = "armv7-a",
-        .description = "ARMv7a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .db,
@@ -1222,7 +1064,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v7em)] = .{
         .llvm_name = "armv7e-m",
-        .description = "ARMv7em architecture",
         .dependencies = featureSet(&[_]Feature{
             .db,
             .dsp,
@@ -1235,14 +1076,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v7k)] = .{
         .llvm_name = "armv7k",
-        .description = "ARMv7a architecture",
         .dependencies = featureSet(&[_]Feature{
             .v7a,
         }),
     };
     result[@intFromEnum(Feature.v7m)] = .{
         .llvm_name = "armv7-m",
-        .description = "ARMv7m architecture",
         .dependencies = featureSet(&[_]Feature{
             .db,
             .has_v7,
@@ -1254,7 +1093,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v7r)] = .{
         .llvm_name = "armv7-r",
-        .description = "ARMv7r architecture",
         .dependencies = featureSet(&[_]Feature{
             .db,
             .dsp,
@@ -1266,14 +1104,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v7s)] = .{
         .llvm_name = "armv7s",
-        .description = "ARMv7a architecture",
         .dependencies = featureSet(&[_]Feature{
             .v7a,
         }),
     };
     result[@intFromEnum(Feature.v7ve)] = .{
         .llvm_name = "armv7ve",
-        .description = "ARMv7ve architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .db,
@@ -1288,7 +1124,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_1a)] = .{
         .llvm_name = "armv8.1-a",
-        .description = "ARMv81a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1304,7 +1139,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_1m_main)] = .{
         .llvm_name = "armv8.1-m.main",
-        .description = "ARMv81mMainline architecture",
         .dependencies = featureSet(&[_]Feature{
             .@"8msecext",
             .acquire_release,
@@ -1320,7 +1154,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_2a)] = .{
         .llvm_name = "armv8.2-a",
-        .description = "ARMv82a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1337,7 +1170,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_3a)] = .{
         .llvm_name = "armv8.3-a",
-        .description = "ARMv83a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1354,7 +1186,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_4a)] = .{
         .llvm_name = "armv8.4-a",
-        .description = "ARMv84a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1371,7 +1202,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_5a)] = .{
         .llvm_name = "armv8.5-a",
-        .description = "ARMv85a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1388,7 +1218,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_6a)] = .{
         .llvm_name = "armv8.6-a",
-        .description = "ARMv86a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1405,7 +1234,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_7a)] = .{
         .llvm_name = "armv8.7-a",
-        .description = "ARMv87a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1422,7 +1250,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_8a)] = .{
         .llvm_name = "armv8.8-a",
-        .description = "ARMv88a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1439,7 +1266,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8_9a)] = .{
         .llvm_name = "armv8.9-a",
-        .description = "ARMv89a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1456,7 +1282,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8a)] = .{
         .llvm_name = "armv8-a",
-        .description = "ARMv8a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1472,7 +1297,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8m)] = .{
         .llvm_name = "armv8-m.base",
-        .description = "ARMv8mBaseline architecture",
         .dependencies = featureSet(&[_]Feature{
             .@"8msecext",
             .acquire_release,
@@ -1488,7 +1312,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8m_main)] = .{
         .llvm_name = "armv8-m.main",
-        .description = "ARMv8mMainline architecture",
         .dependencies = featureSet(&[_]Feature{
             .@"8msecext",
             .acquire_release,
@@ -1502,7 +1325,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v8r)] = .{
         .llvm_name = "armv8-r",
-        .description = "ARMv8r architecture",
         .dependencies = featureSet(&[_]Feature{
             .crc,
             .db,
@@ -1518,7 +1340,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_1a)] = .{
         .llvm_name = "armv9.1-a",
-        .description = "ARMv91a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1534,7 +1355,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_2a)] = .{
         .llvm_name = "armv9.2-a",
-        .description = "ARMv92a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1550,7 +1370,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_3a)] = .{
         .llvm_name = "armv9.3-a",
-        .description = "ARMv93a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1567,7 +1386,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_4a)] = .{
         .llvm_name = "armv9.4-a",
-        .description = "ARMv94a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1583,7 +1401,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9_5a)] = .{
         .llvm_name = "armv9.5-a",
-        .description = "ARMv95a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1599,7 +1416,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.v9a)] = .{
         .llvm_name = "armv9-a",
-        .description = "ARMv9a architecture",
         .dependencies = featureSet(&[_]Feature{
             .aclass,
             .crc,
@@ -1615,7 +1431,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp2)] = .{
         .llvm_name = "vfp2",
-        .description = "Enable VFP2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .fp64,
             .vfp2sp,
@@ -1623,14 +1438,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp2sp)] = .{
         .llvm_name = "vfp2sp",
-        .description = "Enable VFP2 instructions with no double precision",
         .dependencies = featureSet(&[_]Feature{
             .fpregs,
         }),
     };
     result[@intFromEnum(Feature.vfp3)] = .{
         .llvm_name = "vfp3",
-        .description = "Enable VFP3 instructions",
         .dependencies = featureSet(&[_]Feature{
             .vfp3d16,
             .vfp3sp,
@@ -1638,7 +1451,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp3d16)] = .{
         .llvm_name = "vfp3d16",
-        .description = "Enable VFP3 instructions with only 16 d-registers",
         .dependencies = featureSet(&[_]Feature{
             .vfp2,
             .vfp3d16sp,
@@ -1646,14 +1458,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp3d16sp)] = .{
         .llvm_name = "vfp3d16sp",
-        .description = "Enable VFP3 instructions with only 16 d-registers and no double precision",
         .dependencies = featureSet(&[_]Feature{
             .vfp2sp,
         }),
     };
     result[@intFromEnum(Feature.vfp3sp)] = .{
         .llvm_name = "vfp3sp",
-        .description = "Enable VFP3 instructions with no double precision",
         .dependencies = featureSet(&[_]Feature{
             .d32,
             .vfp3d16sp,
@@ -1661,7 +1471,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp4)] = .{
         .llvm_name = "vfp4",
-        .description = "Enable VFP4 instructions",
         .dependencies = featureSet(&[_]Feature{
             .vfp3,
             .vfp4d16,
@@ -1670,7 +1479,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp4d16)] = .{
         .llvm_name = "vfp4d16",
-        .description = "Enable VFP4 instructions with only 16 d-registers",
         .dependencies = featureSet(&[_]Feature{
             .vfp3d16,
             .vfp4d16sp,
@@ -1678,7 +1486,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp4d16sp)] = .{
         .llvm_name = "vfp4d16sp",
-        .description = "Enable VFP4 instructions with only 16 d-registers and no double precision",
         .dependencies = featureSet(&[_]Feature{
             .fp16,
             .vfp3d16sp,
@@ -1686,7 +1493,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vfp4sp)] = .{
         .llvm_name = "vfp4sp",
-        .description = "Enable VFP4 instructions with no double precision",
         .dependencies = featureSet(&[_]Feature{
             .vfp3sp,
             .vfp4d16sp,
@@ -1694,7 +1500,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.virtualization)] = .{
         .llvm_name = "virtualization",
-        .description = "Supports Virtualization extension",
         .dependencies = featureSet(&[_]Feature{
             .hwdiv,
             .hwdiv_arm,
@@ -1702,34 +1507,28 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vldn_align)] = .{
         .llvm_name = "vldn-align",
-        .description = "Check for VLDn unaligned access",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vmlx_forwarding)] = .{
         .llvm_name = "vmlx-forwarding",
-        .description = "Has multiplier accumulator forwarding",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vmlx_hazards)] = .{
         .llvm_name = "vmlx-hazards",
-        .description = "Has VMLx hazards",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.wide_stride_vfp)] = .{
         .llvm_name = "wide-stride-vfp",
-        .description = "Use a wide stride when allocating VFP registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xscale)] = .{
         .llvm_name = "xscale",
-        .description = "ARMv5te architecture",
         .dependencies = featureSet(&[_]Feature{
             .v5te,
         }),
     };
     result[@intFromEnum(Feature.zcz)] = .{
         .llvm_name = "zcz",
-        .description = "Has zero-cycle zeroing instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -1737,6 +1536,213 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"32bit")] = "Prefer 32-bit Thumb instrs";
+    result[@intFromEnum(Feature.@"8msecext")] = "Enable support for ARMv8-M Security Extensions";
+    result[@intFromEnum(Feature.a76)] = "Cortex-A76 ARM processors";
+    result[@intFromEnum(Feature.aapcs_frame_chain)] = "Create an AAPCS compliant frame chain";
+    result[@intFromEnum(Feature.aapcs_frame_chain_leaf)] = "Create an AAPCS compliant frame chain for leaf functions";
+    result[@intFromEnum(Feature.aclass)] = "Is application profile ('A' series)";
+    result[@intFromEnum(Feature.acquire_release)] = "Has v8 acquire/release (lda/ldaex  etc) instructions";
+    result[@intFromEnum(Feature.aes)] = "Enable AES support";
+    result[@intFromEnum(Feature.atomics_32)] = "Assume that lock-free 32-bit atomics are available";
+    result[@intFromEnum(Feature.avoid_movs_shop)] = "Avoid movs instructions with shifter operand";
+    result[@intFromEnum(Feature.avoid_partial_cpsr)] = "Avoid CPSR partial update for OOO execution";
+    result[@intFromEnum(Feature.bf16)] = "Enable support for BFloat16 instructions";
+    result[@intFromEnum(Feature.big_endian_instructions)] = "Expect instructions to be stored big-endian.";
+    result[@intFromEnum(Feature.cde)] = "Support CDE instructions";
+    result[@intFromEnum(Feature.cdecp0)] = "Coprocessor 0 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp1)] = "Coprocessor 1 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp2)] = "Coprocessor 2 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp3)] = "Coprocessor 3 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp4)] = "Coprocessor 4 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp5)] = "Coprocessor 5 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp6)] = "Coprocessor 6 ISA is CDEv1";
+    result[@intFromEnum(Feature.cdecp7)] = "Coprocessor 7 ISA is CDEv1";
+    result[@intFromEnum(Feature.cheap_predicable_cpsr)] = "Disable +1 predication cost for instructions updating CPSR";
+    result[@intFromEnum(Feature.clrbhb)] = "Enable Clear BHB instruction";
+    result[@intFromEnum(Feature.crc)] = "Enable support for CRC instructions";
+    result[@intFromEnum(Feature.crypto)] = "Enable support for Cryptography extensions";
+    result[@intFromEnum(Feature.d32)] = "Extend FP to 32 double registers";
+    result[@intFromEnum(Feature.db)] = "Has data barrier (dmb/dsb) instructions";
+    result[@intFromEnum(Feature.dfb)] = "Has full data barrier (dfb) instruction";
+    result[@intFromEnum(Feature.disable_postra_scheduler)] = "Don't schedule again after register allocation";
+    result[@intFromEnum(Feature.dont_widen_vmovs)] = "Don't widen VMOVS to VMOVD";
+    result[@intFromEnum(Feature.dotprod)] = "Enable support for dot product instructions";
+    result[@intFromEnum(Feature.dsp)] = "Supports DSP instructions in ARM and/or Thumb2";
+    result[@intFromEnum(Feature.execute_only)] = "Enable the generation of execute only code.";
+    result[@intFromEnum(Feature.expand_fp_mlx)] = "Expand VFP/NEON MLA/MLS instructions";
+    result[@intFromEnum(Feature.exynos)] = "Samsung Exynos processors";
+    result[@intFromEnum(Feature.fix_cmse_cve_2021_35465)] = "Mitigate against the cve-2021-35465 security vulnurability";
+    result[@intFromEnum(Feature.fix_cortex_a57_aes_1742098)] = "Work around Cortex-A57 Erratum 1742098 / Cortex-A72 Erratum 1655431 (AES)";
+    result[@intFromEnum(Feature.fp16)] = "Enable half-precision floating point";
+    result[@intFromEnum(Feature.fp16fml)] = "Enable full half-precision floating point fml instructions";
+    result[@intFromEnum(Feature.fp64)] = "Floating point unit supports double precision";
+    result[@intFromEnum(Feature.fp_armv8)] = "Enable ARMv8 FP";
+    result[@intFromEnum(Feature.fp_armv8d16)] = "Enable ARMv8 FP with only 16 d-registers";
+    result[@intFromEnum(Feature.fp_armv8d16sp)] = "Enable ARMv8 FP with only 16 d-registers and no double precision";
+    result[@intFromEnum(Feature.fp_armv8sp)] = "Enable ARMv8 FP with no double precision";
+    result[@intFromEnum(Feature.fpao)] = "Enable fast computation of positive address offsets";
+    result[@intFromEnum(Feature.fpregs)] = "Enable FP registers";
+    result[@intFromEnum(Feature.fpregs16)] = "Enable 16-bit FP registers";
+    result[@intFromEnum(Feature.fpregs64)] = "Enable 64-bit FP registers";
+    result[@intFromEnum(Feature.fullfp16)] = "Enable full half-precision floating point";
+    result[@intFromEnum(Feature.fuse_aes)] = "CPU fuses AES crypto operations";
+    result[@intFromEnum(Feature.fuse_literals)] = "CPU fuses literal generation operations";
+    result[@intFromEnum(Feature.harden_sls_blr)] = "Harden against straight line speculation across indirect calls";
+    result[@intFromEnum(Feature.harden_sls_nocomdat)] = "Generate thunk code for SLS mitigation in the normal text section";
+    result[@intFromEnum(Feature.harden_sls_retbr)] = "Harden against straight line speculation across RETurn and BranchRegister instructions";
+    result[@intFromEnum(Feature.has_v4t)] = "Support ARM v4T instructions";
+    result[@intFromEnum(Feature.has_v5t)] = "Support ARM v5T instructions";
+    result[@intFromEnum(Feature.has_v5te)] = "Support ARM v5TE, v5TEj, and v5TExp instructions";
+    result[@intFromEnum(Feature.has_v6)] = "Support ARM v6 instructions";
+    result[@intFromEnum(Feature.has_v6k)] = "Support ARM v6k instructions";
+    result[@intFromEnum(Feature.has_v6m)] = "Support ARM v6M instructions";
+    result[@intFromEnum(Feature.has_v6t2)] = "Support ARM v6t2 instructions";
+    result[@intFromEnum(Feature.has_v7)] = "Support ARM v7 instructions";
+    result[@intFromEnum(Feature.has_v7clrex)] = "Has v7 clrex instruction";
+    result[@intFromEnum(Feature.has_v8)] = "Support ARM v8 instructions";
+    result[@intFromEnum(Feature.has_v8_1a)] = "Support ARM v8.1a instructions";
+    result[@intFromEnum(Feature.has_v8_1m_main)] = "Support ARM v8-1M Mainline instructions";
+    result[@intFromEnum(Feature.has_v8_2a)] = "Support ARM v8.2a instructions";
+    result[@intFromEnum(Feature.has_v8_3a)] = "Support ARM v8.3a instructions";
+    result[@intFromEnum(Feature.has_v8_4a)] = "Support ARM v8.4a instructions";
+    result[@intFromEnum(Feature.has_v8_5a)] = "Support ARM v8.5a instructions";
+    result[@intFromEnum(Feature.has_v8_6a)] = "Support ARM v8.6a instructions";
+    result[@intFromEnum(Feature.has_v8_7a)] = "Support ARM v8.7a instructions";
+    result[@intFromEnum(Feature.has_v8_8a)] = "Support ARM v8.8a instructions";
+    result[@intFromEnum(Feature.has_v8_9a)] = "Support ARM v8.9a instructions";
+    result[@intFromEnum(Feature.has_v8m)] = "Support ARM v8M Baseline instructions";
+    result[@intFromEnum(Feature.has_v8m_main)] = "Support ARM v8M Mainline instructions";
+    result[@intFromEnum(Feature.has_v9_1a)] = "Support ARM v9.1a instructions";
+    result[@intFromEnum(Feature.has_v9_2a)] = "Support ARM v9.2a instructions";
+    result[@intFromEnum(Feature.has_v9_3a)] = "Support ARM v9.3a instructions";
+    result[@intFromEnum(Feature.has_v9_4a)] = "Support ARM v9.4a instructions";
+    result[@intFromEnum(Feature.has_v9_5a)] = "Support ARM v9.5a instructions";
+    result[@intFromEnum(Feature.has_v9a)] = "Support ARM v9a instructions";
+    result[@intFromEnum(Feature.hwdiv)] = "Enable divide instructions in Thumb";
+    result[@intFromEnum(Feature.hwdiv_arm)] = "Enable divide instructions in ARM mode";
+    result[@intFromEnum(Feature.i8mm)] = "Enable Matrix Multiply Int8 Extension";
+    result[@intFromEnum(Feature.iwmmxt)] = "ARMv5te architecture";
+    result[@intFromEnum(Feature.iwmmxt2)] = "ARMv5te architecture";
+    result[@intFromEnum(Feature.lob)] = "Enable Low Overhead Branch extensions";
+    result[@intFromEnum(Feature.long_calls)] = "Generate calls via indirect call instructions";
+    result[@intFromEnum(Feature.loop_align)] = "Prefer 32-bit alignment for loops";
+    result[@intFromEnum(Feature.m3)] = "Cortex-M3 ARM processors";
+    result[@intFromEnum(Feature.mclass)] = "Is microcontroller profile ('M' series)";
+    result[@intFromEnum(Feature.mp)] = "Supports Multiprocessing extension";
+    result[@intFromEnum(Feature.muxed_units)] = "Has muxed AGU and NEON/FPU";
+    result[@intFromEnum(Feature.mve)] = "Support M-Class Vector Extension with integer ops";
+    result[@intFromEnum(Feature.mve1beat)] = "Model MVE instructions as a 1 beat per tick architecture";
+    result[@intFromEnum(Feature.mve2beat)] = "Model MVE instructions as a 2 beats per tick architecture";
+    result[@intFromEnum(Feature.mve4beat)] = "Model MVE instructions as a 4 beats per tick architecture";
+    result[@intFromEnum(Feature.mve_fp)] = "Support M-Class Vector Extension with integer and floating ops";
+    result[@intFromEnum(Feature.nacl_trap)] = "NaCl trap";
+    result[@intFromEnum(Feature.neon)] = "Enable NEON instructions";
+    result[@intFromEnum(Feature.neon_fpmovs)] = "Convert VMOVSR, VMOVRS, VMOVS to NEON";
+    result[@intFromEnum(Feature.neonfp)] = "Use NEON for single precision FP";
+    result[@intFromEnum(Feature.no_branch_predictor)] = "Has no branch predictor";
+    result[@intFromEnum(Feature.no_bti_at_return_twice)] = "Don't place a BTI instruction after a return-twice";
+    result[@intFromEnum(Feature.no_movt)] = "Don't use movt/movw pairs for 32-bit imms";
+    result[@intFromEnum(Feature.no_neg_immediates)] = "Convert immediates and instructions to their negated or complemented equivalent when the immediate does not fit in the encoding.";
+    result[@intFromEnum(Feature.noarm)] = "Does not support ARM mode execution";
+    result[@intFromEnum(Feature.nonpipelined_vfp)] = "VFP instructions are not pipelined";
+    result[@intFromEnum(Feature.pacbti)] = "Enable Pointer Authentication and Branch Target Identification";
+    result[@intFromEnum(Feature.perfmon)] = "Enable support for Performance Monitor extensions";
+    result[@intFromEnum(Feature.prefer_ishst)] = "Prefer ISHST barriers";
+    result[@intFromEnum(Feature.prefer_vmovsr)] = "Prefer VMOVSR";
+    result[@intFromEnum(Feature.prof_unpr)] = "Is profitable to unpredicate";
+    result[@intFromEnum(Feature.r4)] = "Cortex-R4 ARM processors";
+    result[@intFromEnum(Feature.ras)] = "Enable Reliability, Availability and Serviceability extensions";
+    result[@intFromEnum(Feature.rclass)] = "Is realtime profile ('R' series)";
+    result[@intFromEnum(Feature.read_tp_tpidrprw)] = "Reading thread pointer from TPIDRPRW register";
+    result[@intFromEnum(Feature.read_tp_tpidruro)] = "Reading thread pointer from TPIDRURO register";
+    result[@intFromEnum(Feature.read_tp_tpidrurw)] = "Reading thread pointer from TPIDRURW register";
+    result[@intFromEnum(Feature.reserve_r9)] = "Reserve R9, making it unavailable as GPR";
+    result[@intFromEnum(Feature.ret_addr_stack)] = "Has return address stack";
+    result[@intFromEnum(Feature.sb)] = "Enable v8.5a Speculation Barrier";
+    result[@intFromEnum(Feature.sha2)] = "Enable SHA1 and SHA256 support";
+    result[@intFromEnum(Feature.slow_fp_brcc)] = "FP compare + branch is slow";
+    result[@intFromEnum(Feature.slow_load_D_subreg)] = "Loading into D subregs is slow";
+    result[@intFromEnum(Feature.slow_odd_reg)] = "VLDM/VSTM starting with an odd register is slow";
+    result[@intFromEnum(Feature.slow_vdup32)] = "Has slow VDUP32 - prefer VMOV";
+    result[@intFromEnum(Feature.slow_vgetlni32)] = "Has slow VGETLNi32 - prefer VMOV";
+    result[@intFromEnum(Feature.slowfpvfmx)] = "Disable VFP / NEON FMA instructions";
+    result[@intFromEnum(Feature.slowfpvmlx)] = "Disable VFP / NEON MAC instructions";
+    result[@intFromEnum(Feature.soft_float)] = "Use software floating point features.";
+    result[@intFromEnum(Feature.splat_vfp_neon)] = "Splat register from VFP to NEON";
+    result[@intFromEnum(Feature.strict_align)] = "Disallow all unaligned memory access";
+    result[@intFromEnum(Feature.swift)] = "Swift ARM processors";
+    result[@intFromEnum(Feature.thumb2)] = "Enable Thumb2 instructions";
+    result[@intFromEnum(Feature.thumb_mode)] = "Thumb mode";
+    result[@intFromEnum(Feature.trustzone)] = "Enable support for TrustZone security extensions";
+    result[@intFromEnum(Feature.use_mipipeliner)] = "Use the MachinePipeliner";
+    result[@intFromEnum(Feature.use_misched)] = "Use the MachineScheduler";
+    result[@intFromEnum(Feature.v2)] = "ARMv2 architecture";
+    result[@intFromEnum(Feature.v2a)] = "ARMv2a architecture";
+    result[@intFromEnum(Feature.v3)] = "ARMv3 architecture";
+    result[@intFromEnum(Feature.v3m)] = "ARMv3m architecture";
+    result[@intFromEnum(Feature.v4)] = "ARMv4 architecture";
+    result[@intFromEnum(Feature.v4t)] = "ARMv4t architecture";
+    result[@intFromEnum(Feature.v5t)] = "ARMv5t architecture";
+    result[@intFromEnum(Feature.v5te)] = "ARMv5te architecture";
+    result[@intFromEnum(Feature.v5tej)] = "ARMv5tej architecture";
+    result[@intFromEnum(Feature.v6)] = "ARMv6 architecture";
+    result[@intFromEnum(Feature.v6j)] = "ARMv7a architecture";
+    result[@intFromEnum(Feature.v6k)] = "ARMv6k architecture";
+    result[@intFromEnum(Feature.v6kz)] = "ARMv6kz architecture";
+    result[@intFromEnum(Feature.v6m)] = "ARMv6m architecture";
+    result[@intFromEnum(Feature.v6sm)] = "ARMv6sm architecture";
+    result[@intFromEnum(Feature.v6t2)] = "ARMv6t2 architecture";
+    result[@intFromEnum(Feature.v7a)] = "ARMv7a architecture";
+    result[@intFromEnum(Feature.v7em)] = "ARMv7em architecture";
+    result[@intFromEnum(Feature.v7k)] = "ARMv7a architecture";
+    result[@intFromEnum(Feature.v7m)] = "ARMv7m architecture";
+    result[@intFromEnum(Feature.v7r)] = "ARMv7r architecture";
+    result[@intFromEnum(Feature.v7s)] = "ARMv7a architecture";
+    result[@intFromEnum(Feature.v7ve)] = "ARMv7ve architecture";
+    result[@intFromEnum(Feature.v8_1a)] = "ARMv81a architecture";
+    result[@intFromEnum(Feature.v8_1m_main)] = "ARMv81mMainline architecture";
+    result[@intFromEnum(Feature.v8_2a)] = "ARMv82a architecture";
+    result[@intFromEnum(Feature.v8_3a)] = "ARMv83a architecture";
+    result[@intFromEnum(Feature.v8_4a)] = "ARMv84a architecture";
+    result[@intFromEnum(Feature.v8_5a)] = "ARMv85a architecture";
+    result[@intFromEnum(Feature.v8_6a)] = "ARMv86a architecture";
+    result[@intFromEnum(Feature.v8_7a)] = "ARMv87a architecture";
+    result[@intFromEnum(Feature.v8_8a)] = "ARMv88a architecture";
+    result[@intFromEnum(Feature.v8_9a)] = "ARMv89a architecture";
+    result[@intFromEnum(Feature.v8a)] = "ARMv8a architecture";
+    result[@intFromEnum(Feature.v8m)] = "ARMv8mBaseline architecture";
+    result[@intFromEnum(Feature.v8m_main)] = "ARMv8mMainline architecture";
+    result[@intFromEnum(Feature.v8r)] = "ARMv8r architecture";
+    result[@intFromEnum(Feature.v9_1a)] = "ARMv91a architecture";
+    result[@intFromEnum(Feature.v9_2a)] = "ARMv92a architecture";
+    result[@intFromEnum(Feature.v9_3a)] = "ARMv93a architecture";
+    result[@intFromEnum(Feature.v9_4a)] = "ARMv94a architecture";
+    result[@intFromEnum(Feature.v9_5a)] = "ARMv95a architecture";
+    result[@intFromEnum(Feature.v9a)] = "ARMv9a architecture";
+    result[@intFromEnum(Feature.vfp2)] = "Enable VFP2 instructions";
+    result[@intFromEnum(Feature.vfp2sp)] = "Enable VFP2 instructions with no double precision";
+    result[@intFromEnum(Feature.vfp3)] = "Enable VFP3 instructions";
+    result[@intFromEnum(Feature.vfp3d16)] = "Enable VFP3 instructions with only 16 d-registers";
+    result[@intFromEnum(Feature.vfp3d16sp)] = "Enable VFP3 instructions with only 16 d-registers and no double precision";
+    result[@intFromEnum(Feature.vfp3sp)] = "Enable VFP3 instructions with no double precision";
+    result[@intFromEnum(Feature.vfp4)] = "Enable VFP4 instructions";
+    result[@intFromEnum(Feature.vfp4d16)] = "Enable VFP4 instructions with only 16 d-registers";
+    result[@intFromEnum(Feature.vfp4d16sp)] = "Enable VFP4 instructions with only 16 d-registers and no double precision";
+    result[@intFromEnum(Feature.vfp4sp)] = "Enable VFP4 instructions with no double precision";
+    result[@intFromEnum(Feature.virtualization)] = "Supports Virtualization extension";
+    result[@intFromEnum(Feature.vldn_align)] = "Check for VLDn unaligned access";
+    result[@intFromEnum(Feature.vmlx_forwarding)] = "Has multiplier accumulator forwarding";
+    result[@intFromEnum(Feature.vmlx_hazards)] = "Has VMLx hazards";
+    result[@intFromEnum(Feature.wide_stride_vfp)] = "Use a wide stride when allocating VFP registers";
+    result[@intFromEnum(Feature.xscale)] = "ARMv5te architecture";
+    result[@intFromEnum(Feature.zcz)] = "Has zero-cycle zeroing instructions";
     break :blk result;
 };
 

--- a/lib/std/Target/avr.zig
+++ b/lib/std/Target/avr.zig
@@ -54,17 +54,14 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.addsubiw)] = .{
         .llvm_name = "addsubiw",
-        .description = "Enable 16-bit register-immediate addition and subtraction instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.avr0)] = .{
         .llvm_name = "avr0",
-        .description = "The device is a part of the avr0 family",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.avr1)] = .{
         .llvm_name = "avr1",
-        .description = "The device is a part of the avr1 family",
         .dependencies = featureSet(&[_]Feature{
             .avr0,
             .lpm,
@@ -73,7 +70,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr2)] = .{
         .llvm_name = "avr2",
-        .description = "The device is a part of the avr2 family",
         .dependencies = featureSet(&[_]Feature{
             .addsubiw,
             .avr1,
@@ -83,7 +79,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr25)] = .{
         .llvm_name = "avr25",
-        .description = "The device is a part of the avr25 family",
         .dependencies = featureSet(&[_]Feature{
             .avr2,
             .@"break",
@@ -94,7 +89,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr3)] = .{
         .llvm_name = "avr3",
-        .description = "The device is a part of the avr3 family",
         .dependencies = featureSet(&[_]Feature{
             .avr2,
             .jmpcall,
@@ -102,7 +96,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr31)] = .{
         .llvm_name = "avr31",
-        .description = "The device is a part of the avr31 family",
         .dependencies = featureSet(&[_]Feature{
             .avr3,
             .elpm,
@@ -110,7 +103,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr35)] = .{
         .llvm_name = "avr35",
-        .description = "The device is a part of the avr35 family",
         .dependencies = featureSet(&[_]Feature{
             .avr3,
             .@"break",
@@ -121,7 +113,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr4)] = .{
         .llvm_name = "avr4",
-        .description = "The device is a part of the avr4 family",
         .dependencies = featureSet(&[_]Feature{
             .avr2,
             .@"break",
@@ -133,7 +124,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr5)] = .{
         .llvm_name = "avr5",
-        .description = "The device is a part of the avr5 family",
         .dependencies = featureSet(&[_]Feature{
             .avr3,
             .@"break",
@@ -145,7 +135,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr51)] = .{
         .llvm_name = "avr51",
-        .description = "The device is a part of the avr51 family",
         .dependencies = featureSet(&[_]Feature{
             .avr5,
             .elpm,
@@ -154,7 +143,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avr6)] = .{
         .llvm_name = "avr6",
-        .description = "The device is a part of the avr6 family",
         .dependencies = featureSet(&[_]Feature{
             .avr51,
             .eijmpcall,
@@ -162,7 +150,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avrtiny)] = .{
         .llvm_name = "avrtiny",
-        .description = "The device is a part of the avrtiny family",
         .dependencies = featureSet(&[_]Feature{
             .avr0,
             .@"break",
@@ -173,82 +160,66 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.@"break")] = .{
         .llvm_name = "break",
-        .description = "The device supports the `BREAK` debugging instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.des)] = .{
         .llvm_name = "des",
-        .description = "The device supports the `DES k` encryption instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.eijmpcall)] = .{
         .llvm_name = "eijmpcall",
-        .description = "The device supports the `EIJMP`/`EICALL` instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.elpm)] = .{
         .llvm_name = "elpm",
-        .description = "The device supports the ELPM instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.elpmx)] = .{
         .llvm_name = "elpmx",
-        .description = "The device supports the `ELPM Rd, Z[+]` instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ijmpcall)] = .{
         .llvm_name = "ijmpcall",
-        .description = "The device supports `IJMP`/`ICALL`instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.jmpcall)] = .{
         .llvm_name = "jmpcall",
-        .description = "The device supports the `JMP` and `CALL` instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lowbytefirst)] = .{
         .llvm_name = "lowbytefirst",
-        .description = "Do the low byte first when writing a 16-bit port or storing a 16-bit word",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lpm)] = .{
         .llvm_name = "lpm",
-        .description = "The device supports the `LPM` instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lpmx)] = .{
         .llvm_name = "lpmx",
-        .description = "The device supports the `LPM Rd, Z[+]` instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.memmappedregs)] = .{
         .llvm_name = "memmappedregs",
-        .description = "The device has CPU registers mapped in data address space",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.movw)] = .{
         .llvm_name = "movw",
-        .description = "The device supports the 16-bit MOVW instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mul)] = .{
         .llvm_name = "mul",
-        .description = "The device supports the multiplication instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rmw)] = .{
         .llvm_name = "rmw",
-        .description = "The device supports the read-write-modify instructions: XCH, LAS, LAC, LAT",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.smallstack)] = .{
         .llvm_name = "smallstack",
-        .description = "The device has an 8-bit stack pointer",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.special)] = .{
         .llvm_name = "special",
-        .description = "Enable use of the entire instruction set - used for debugging",
         .dependencies = featureSet(&[_]Feature{
             .addsubiw,
             .@"break",
@@ -271,27 +242,22 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.spm)] = .{
         .llvm_name = "spm",
-        .description = "The device supports the `SPM` instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.spmx)] = .{
         .llvm_name = "spmx",
-        .description = "The device supports the `SPM Z+` instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sram)] = .{
         .llvm_name = "sram",
-        .description = "The device has random access memory",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tinyencoding)] = .{
         .llvm_name = "tinyencoding",
-        .description = "The device has Tiny core specific instruction encodings",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xmega)] = .{
         .llvm_name = "xmega",
-        .description = "The device is a part of the xmega family",
         .dependencies = featureSet(&[_]Feature{
             .addsubiw,
             .avr0,
@@ -314,7 +280,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.xmega3)] = .{
         .llvm_name = "xmega3",
-        .description = "The device is a part of the xmega3 family",
         .dependencies = featureSet(&[_]Feature{
             .addsubiw,
             .avr0,
@@ -331,7 +296,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.xmegau)] = .{
         .llvm_name = "xmegau",
-        .description = "The device is a part of the xmegau family",
         .dependencies = featureSet(&[_]Feature{
             .rmw,
             .xmega,
@@ -342,6 +306,48 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.addsubiw)] = "Enable 16-bit register-immediate addition and subtraction instructions";
+    result[@intFromEnum(Feature.avr0)] = "The device is a part of the avr0 family";
+    result[@intFromEnum(Feature.avr1)] = "The device is a part of the avr1 family";
+    result[@intFromEnum(Feature.avr2)] = "The device is a part of the avr2 family";
+    result[@intFromEnum(Feature.avr25)] = "The device is a part of the avr25 family";
+    result[@intFromEnum(Feature.avr3)] = "The device is a part of the avr3 family";
+    result[@intFromEnum(Feature.avr31)] = "The device is a part of the avr31 family";
+    result[@intFromEnum(Feature.avr35)] = "The device is a part of the avr35 family";
+    result[@intFromEnum(Feature.avr4)] = "The device is a part of the avr4 family";
+    result[@intFromEnum(Feature.avr5)] = "The device is a part of the avr5 family";
+    result[@intFromEnum(Feature.avr51)] = "The device is a part of the avr51 family";
+    result[@intFromEnum(Feature.avr6)] = "The device is a part of the avr6 family";
+    result[@intFromEnum(Feature.avrtiny)] = "The device is a part of the avrtiny family";
+    result[@intFromEnum(Feature.@"break")] = "The device supports the `BREAK` debugging instruction";
+    result[@intFromEnum(Feature.des)] = "The device supports the `DES k` encryption instruction";
+    result[@intFromEnum(Feature.eijmpcall)] = "The device supports the `EIJMP`/`EICALL` instructions";
+    result[@intFromEnum(Feature.elpm)] = "The device supports the ELPM instruction";
+    result[@intFromEnum(Feature.elpmx)] = "The device supports the `ELPM Rd, Z[+]` instructions";
+    result[@intFromEnum(Feature.ijmpcall)] = "The device supports `IJMP`/`ICALL`instructions";
+    result[@intFromEnum(Feature.jmpcall)] = "The device supports the `JMP` and `CALL` instructions";
+    result[@intFromEnum(Feature.lowbytefirst)] = "Do the low byte first when writing a 16-bit port or storing a 16-bit word";
+    result[@intFromEnum(Feature.lpm)] = "The device supports the `LPM` instruction";
+    result[@intFromEnum(Feature.lpmx)] = "The device supports the `LPM Rd, Z[+]` instruction";
+    result[@intFromEnum(Feature.memmappedregs)] = "The device has CPU registers mapped in data address space";
+    result[@intFromEnum(Feature.movw)] = "The device supports the 16-bit MOVW instruction";
+    result[@intFromEnum(Feature.mul)] = "The device supports the multiplication instructions";
+    result[@intFromEnum(Feature.rmw)] = "The device supports the read-write-modify instructions: XCH, LAS, LAC, LAT";
+    result[@intFromEnum(Feature.smallstack)] = "The device has an 8-bit stack pointer";
+    result[@intFromEnum(Feature.special)] = "Enable use of the entire instruction set - used for debugging";
+    result[@intFromEnum(Feature.spm)] = "The device supports the `SPM` instruction";
+    result[@intFromEnum(Feature.spmx)] = "The device supports the `SPM Z+` instruction";
+    result[@intFromEnum(Feature.sram)] = "The device has random access memory";
+    result[@intFromEnum(Feature.tinyencoding)] = "The device has Tiny core specific instruction encodings";
+    result[@intFromEnum(Feature.xmega)] = "The device is a part of the xmega family";
+    result[@intFromEnum(Feature.xmega3)] = "The device is a part of the xmega3 family";
+    result[@intFromEnum(Feature.xmegau)] = "The device is a part of the xmegau family";
     break :blk result;
 };
 

--- a/lib/std/Target/bpf.zig
+++ b/lib/std/Target/bpf.zig
@@ -21,17 +21,14 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.alu32)] = .{
         .llvm_name = "alu32",
-        .description = "Enable ALU32 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dummy)] = .{
         .llvm_name = "dummy",
-        .description = "unused feature",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dwarfris)] = .{
         .llvm_name = "dwarfris",
-        .description = "Disable MCAsmInfo DwarfUsesRelocationsAcrossSections",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -39,6 +36,15 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.alu32)] = "Enable ALU32 instructions";
+    result[@intFromEnum(Feature.dummy)] = "unused feature";
+    result[@intFromEnum(Feature.dwarfris)] = "Disable MCAsmInfo DwarfUsesRelocationsAcrossSections";
     break :blk result;
 };
 

--- a/lib/std/Target/csky.zig
+++ b/lib/std/Target/csky.zig
@@ -81,26 +81,22 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"10e60")] = .{
         .llvm_name = "10e60",
-        .description = "Support CSKY 10e60 instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"7e10",
         }),
     };
     result[@intFromEnum(Feature.@"2e3")] = .{
         .llvm_name = "2e3",
-        .description = "Support CSKY 2e3 instructions",
         .dependencies = featureSet(&[_]Feature{
             .e2,
         }),
     };
     result[@intFromEnum(Feature.@"3e3r1")] = .{
         .llvm_name = "3e3r1",
-        .description = "Support CSKY 3e3r1 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"3e3r2")] = .{
         .llvm_name = "3e3r2",
-        .description = "Support CSKY 3e3r2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"3e3r1",
             .doloop,
@@ -108,311 +104,252 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.@"3e3r3")] = .{
         .llvm_name = "3e3r3",
-        .description = "Support CSKY 3e3r3 instructions",
         .dependencies = featureSet(&[_]Feature{
             .doloop,
         }),
     };
     result[@intFromEnum(Feature.@"3e7")] = .{
         .llvm_name = "3e7",
-        .description = "Support CSKY 3e7 instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"2e3",
         }),
     };
     result[@intFromEnum(Feature.@"7e10")] = .{
         .llvm_name = "7e10",
-        .description = "Support CSKY 7e10 instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"3e7",
         }),
     };
     result[@intFromEnum(Feature.btst16)] = .{
         .llvm_name = "btst16",
-        .description = "Use the 16-bit btsti instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cache)] = .{
         .llvm_name = "cache",
-        .description = "Enable cache",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ccrt)] = .{
         .llvm_name = "ccrt",
-        .description = "Use CSKY compiler runtime",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck801)] = .{
         .llvm_name = "ck801",
-        .description = "CSKY ck801 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck802)] = .{
         .llvm_name = "ck802",
-        .description = "CSKY ck802 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck803)] = .{
         .llvm_name = "ck803",
-        .description = "CSKY ck803 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck803s)] = .{
         .llvm_name = "ck803s",
-        .description = "CSKY ck803s processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck804)] = .{
         .llvm_name = "ck804",
-        .description = "CSKY ck804 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck805)] = .{
         .llvm_name = "ck805",
-        .description = "CSKY ck805 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck807)] = .{
         .llvm_name = "ck807",
-        .description = "CSKY ck807 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck810)] = .{
         .llvm_name = "ck810",
-        .description = "CSKY ck810 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck810v)] = .{
         .llvm_name = "ck810v",
-        .description = "CSKY ck810v processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck860)] = .{
         .llvm_name = "ck860",
-        .description = "CSKY ck860 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ck860v)] = .{
         .llvm_name = "ck860v",
-        .description = "CSKY ck860v processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.constpool)] = .{
         .llvm_name = "constpool",
-        .description = "Dump the constant pool by compiler",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.doloop)] = .{
         .llvm_name = "doloop",
-        .description = "Enable doloop instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dsp1e2)] = .{
         .llvm_name = "dsp1e2",
-        .description = "Support CSKY dsp1e2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dsp_silan)] = .{
         .llvm_name = "dsp_silan",
-        .description = "Enable DSP Silan instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dspe60)] = .{
         .llvm_name = "dspe60",
-        .description = "Support CSKY dspe60 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dspv2)] = .{
         .llvm_name = "dspv2",
-        .description = "Enable DSP V2.0 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.e1)] = .{
         .llvm_name = "e1",
-        .description = "Support CSKY e1 instructions",
         .dependencies = featureSet(&[_]Feature{
             .elrw,
         }),
     };
     result[@intFromEnum(Feature.e2)] = .{
         .llvm_name = "e2",
-        .description = "Support CSKY e2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .e1,
         }),
     };
     result[@intFromEnum(Feature.edsp)] = .{
         .llvm_name = "edsp",
-        .description = "Enable DSP instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.elrw)] = .{
         .llvm_name = "elrw",
-        .description = "Use the extend LRW instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fdivdu)] = .{
         .llvm_name = "fdivdu",
-        .description = "Enable float divide instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.float1e2)] = .{
         .llvm_name = "float1e2",
-        .description = "Support CSKY float1e2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.float1e3)] = .{
         .llvm_name = "float1e3",
-        .description = "Support CSKY float1e3 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.float3e4)] = .{
         .llvm_name = "float3e4",
-        .description = "Support CSKY float3e4 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.float7e60)] = .{
         .llvm_name = "float7e60",
-        .description = "Support CSKY float7e60 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.floate1)] = .{
         .llvm_name = "floate1",
-        .description = "Support CSKY floate1 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpuv2_df)] = .{
         .llvm_name = "fpuv2_df",
-        .description = "Enable FPUv2 double float instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpuv2_sf)] = .{
         .llvm_name = "fpuv2_sf",
-        .description = "Enable FPUv2 single float instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpuv3_df)] = .{
         .llvm_name = "fpuv3_df",
-        .description = "Enable FPUv3 double float instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpuv3_hf)] = .{
         .llvm_name = "fpuv3_hf",
-        .description = "Enable FPUv3 half precision operate instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpuv3_hi)] = .{
         .llvm_name = "fpuv3_hi",
-        .description = "Enable FPUv3 half word converting instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpuv3_sf)] = .{
         .llvm_name = "fpuv3_sf",
-        .description = "Enable FPUv3 single float instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hard_float)] = .{
         .llvm_name = "hard-float",
-        .description = "Use hard floating point features",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hard_float_abi)] = .{
         .llvm_name = "hard-float-abi",
-        .description = "Use hard floating point ABI to pass args",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hard_tp)] = .{
         .llvm_name = "hard-tp",
-        .description = "Enable TLS Pointer register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.high_registers)] = .{
         .llvm_name = "high-registers",
-        .description = "Enable r16-r31 registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hwdiv)] = .{
         .llvm_name = "hwdiv",
-        .description = "Enable divide instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.istack)] = .{
         .llvm_name = "istack",
-        .description = "Enable interrupt attribute",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.java)] = .{
         .llvm_name = "java",
-        .description = "Enable java instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mp)] = .{
         .llvm_name = "mp",
-        .description = "Support CSKY mp instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"2e3",
         }),
     };
     result[@intFromEnum(Feature.mp1e2)] = .{
         .llvm_name = "mp1e2",
-        .description = "Support CSKY mp1e2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"3e7",
         }),
     };
     result[@intFromEnum(Feature.multiple_stld)] = .{
         .llvm_name = "multiple_stld",
-        .description = "Enable multiple load/store instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nvic)] = .{
         .llvm_name = "nvic",
-        .description = "Enable NVIC",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pushpop)] = .{
         .llvm_name = "pushpop",
-        .description = "Enable push/pop instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.smart)] = .{
         .llvm_name = "smart",
-        .description = "Let CPU work in Smart Mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.soft_tp)] = .{
         .llvm_name = "soft-tp",
-        .description = "Disable TLS Pointer register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.stack_size)] = .{
         .llvm_name = "stack-size",
-        .description = "Output stack size information",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.trust)] = .{
         .llvm_name = "trust",
-        .description = "Enable trust instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vdsp2e3)] = .{
         .llvm_name = "vdsp2e3",
-        .description = "Support CSKY vdsp2e3 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vdsp2e60f)] = .{
         .llvm_name = "vdsp2e60f",
-        .description = "Support CSKY vdsp2e60f instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vdspv1)] = .{
         .llvm_name = "vdspv1",
-        .description = "Enable 128bit vdsp-v1 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vdspv2)] = .{
         .llvm_name = "vdspv2",
-        .description = "Enable vdsp-v2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -420,6 +357,75 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"10e60")] = "Support CSKY 10e60 instructions";
+    result[@intFromEnum(Feature.@"2e3")] = "Support CSKY 2e3 instructions";
+    result[@intFromEnum(Feature.@"3e3r1")] = "Support CSKY 3e3r1 instructions";
+    result[@intFromEnum(Feature.@"3e3r2")] = "Support CSKY 3e3r2 instructions";
+    result[@intFromEnum(Feature.@"3e3r3")] = "Support CSKY 3e3r3 instructions";
+    result[@intFromEnum(Feature.@"3e7")] = "Support CSKY 3e7 instructions";
+    result[@intFromEnum(Feature.@"7e10")] = "Support CSKY 7e10 instructions";
+    result[@intFromEnum(Feature.btst16)] = "Use the 16-bit btsti instruction";
+    result[@intFromEnum(Feature.cache)] = "Enable cache";
+    result[@intFromEnum(Feature.ccrt)] = "Use CSKY compiler runtime";
+    result[@intFromEnum(Feature.ck801)] = "CSKY ck801 processors";
+    result[@intFromEnum(Feature.ck802)] = "CSKY ck802 processors";
+    result[@intFromEnum(Feature.ck803)] = "CSKY ck803 processors";
+    result[@intFromEnum(Feature.ck803s)] = "CSKY ck803s processors";
+    result[@intFromEnum(Feature.ck804)] = "CSKY ck804 processors";
+    result[@intFromEnum(Feature.ck805)] = "CSKY ck805 processors";
+    result[@intFromEnum(Feature.ck807)] = "CSKY ck807 processors";
+    result[@intFromEnum(Feature.ck810)] = "CSKY ck810 processors";
+    result[@intFromEnum(Feature.ck810v)] = "CSKY ck810v processors";
+    result[@intFromEnum(Feature.ck860)] = "CSKY ck860 processors";
+    result[@intFromEnum(Feature.ck860v)] = "CSKY ck860v processors";
+    result[@intFromEnum(Feature.constpool)] = "Dump the constant pool by compiler";
+    result[@intFromEnum(Feature.doloop)] = "Enable doloop instructions";
+    result[@intFromEnum(Feature.dsp1e2)] = "Support CSKY dsp1e2 instructions";
+    result[@intFromEnum(Feature.dsp_silan)] = "Enable DSP Silan instrutions";
+    result[@intFromEnum(Feature.dspe60)] = "Support CSKY dspe60 instructions";
+    result[@intFromEnum(Feature.dspv2)] = "Enable DSP V2.0 instrutions";
+    result[@intFromEnum(Feature.e1)] = "Support CSKY e1 instructions";
+    result[@intFromEnum(Feature.e2)] = "Support CSKY e2 instructions";
+    result[@intFromEnum(Feature.edsp)] = "Enable DSP instrutions";
+    result[@intFromEnum(Feature.elrw)] = "Use the extend LRW instruction";
+    result[@intFromEnum(Feature.fdivdu)] = "Enable float divide instructions";
+    result[@intFromEnum(Feature.float1e2)] = "Support CSKY float1e2 instructions";
+    result[@intFromEnum(Feature.float1e3)] = "Support CSKY float1e3 instructions";
+    result[@intFromEnum(Feature.float3e4)] = "Support CSKY float3e4 instructions";
+    result[@intFromEnum(Feature.float7e60)] = "Support CSKY float7e60 instructions";
+    result[@intFromEnum(Feature.floate1)] = "Support CSKY floate1 instructions";
+    result[@intFromEnum(Feature.fpuv2_df)] = "Enable FPUv2 double float instructions";
+    result[@intFromEnum(Feature.fpuv2_sf)] = "Enable FPUv2 single float instructions";
+    result[@intFromEnum(Feature.fpuv3_df)] = "Enable FPUv3 double float instructions";
+    result[@intFromEnum(Feature.fpuv3_hf)] = "Enable FPUv3 half precision operate instructions";
+    result[@intFromEnum(Feature.fpuv3_hi)] = "Enable FPUv3 half word converting instructions";
+    result[@intFromEnum(Feature.fpuv3_sf)] = "Enable FPUv3 single float instructions";
+    result[@intFromEnum(Feature.hard_float)] = "Use hard floating point features";
+    result[@intFromEnum(Feature.hard_float_abi)] = "Use hard floating point ABI to pass args";
+    result[@intFromEnum(Feature.hard_tp)] = "Enable TLS Pointer register";
+    result[@intFromEnum(Feature.high_registers)] = "Enable r16-r31 registers";
+    result[@intFromEnum(Feature.hwdiv)] = "Enable divide instrutions";
+    result[@intFromEnum(Feature.istack)] = "Enable interrput attribute";
+    result[@intFromEnum(Feature.java)] = "Enable java instructions";
+    result[@intFromEnum(Feature.mp)] = "Support CSKY mp instructions";
+    result[@intFromEnum(Feature.mp1e2)] = "Support CSKY mp1e2 instructions";
+    result[@intFromEnum(Feature.multiple_stld)] = "Enable multiple load/store instrutions";
+    result[@intFromEnum(Feature.nvic)] = "Enable NVIC";
+    result[@intFromEnum(Feature.pushpop)] = "Enable push/pop instrutions";
+    result[@intFromEnum(Feature.smart)] = "Let CPU work in Smart Mode";
+    result[@intFromEnum(Feature.soft_tp)] = "Disable TLS Pointer register";
+    result[@intFromEnum(Feature.stack_size)] = "Output stack size information";
+    result[@intFromEnum(Feature.trust)] = "Enable trust instructions";
+    result[@intFromEnum(Feature.vdsp2e3)] = "Support CSKY vdsp2e3 instructions";
+    result[@intFromEnum(Feature.vdsp2e60f)] = "Support CSKY vdsp2e60f instructions";
+    result[@intFromEnum(Feature.vdspv1)] = "Enable 128bit vdsp-v1 instructions";
+    result[@intFromEnum(Feature.vdspv2)] = "Enable vdsp-v2 instructions";
     break :blk result;
 };
 

--- a/lib/std/Target/hexagon.zig
+++ b/lib/std/Target/hexagon.zig
@@ -60,77 +60,64 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.audio)] = .{
         .llvm_name = "audio",
-        .description = "Hexagon Audio extension instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cabac)] = .{
         .llvm_name = "cabac",
-        .description = "Emit the CABAC instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.compound)] = .{
         .llvm_name = "compound",
-        .description = "Use compound instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.duplex)] = .{
         .llvm_name = "duplex",
-        .description = "Enable generation of duplex instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hvx)] = .{
         .llvm_name = "hvx",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hvx_ieee_fp)] = .{
         .llvm_name = "hvx-ieee-fp",
-        .description = "Hexagon HVX IEEE floating point instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hvx_length128b)] = .{
         .llvm_name = "hvx-length128b",
-        .description = "Hexagon HVX 128B instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvx,
         }),
     };
     result[@intFromEnum(Feature.hvx_length64b)] = .{
         .llvm_name = "hvx-length64b",
-        .description = "Hexagon HVX 64B instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvx,
         }),
     };
     result[@intFromEnum(Feature.hvx_qfloat)] = .{
         .llvm_name = "hvx-qfloat",
-        .description = "Hexagon HVX QFloating point instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hvxv60)] = .{
         .llvm_name = "hvxv60",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvx,
         }),
     };
     result[@intFromEnum(Feature.hvxv62)] = .{
         .llvm_name = "hvxv62",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv60,
         }),
     };
     result[@intFromEnum(Feature.hvxv65)] = .{
         .llvm_name = "hvxv65",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv62,
         }),
     };
     result[@intFromEnum(Feature.hvxv66)] = .{
         .llvm_name = "hvxv66",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv65,
             .zreg,
@@ -138,161 +125,132 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.hvxv67)] = .{
         .llvm_name = "hvxv67",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv66,
         }),
     };
     result[@intFromEnum(Feature.hvxv68)] = .{
         .llvm_name = "hvxv68",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv67,
         }),
     };
     result[@intFromEnum(Feature.hvxv69)] = .{
         .llvm_name = "hvxv69",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv68,
         }),
     };
     result[@intFromEnum(Feature.hvxv71)] = .{
         .llvm_name = "hvxv71",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv69,
         }),
     };
     result[@intFromEnum(Feature.hvxv73)] = .{
         .llvm_name = "hvxv73",
-        .description = "Hexagon HVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .hvxv71,
         }),
     };
     result[@intFromEnum(Feature.long_calls)] = .{
         .llvm_name = "long-calls",
-        .description = "Use constant-extended calls",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mem_noshuf)] = .{
         .llvm_name = "mem_noshuf",
-        .description = "Supports mem_noshuf feature",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.memops)] = .{
         .llvm_name = "memops",
-        .description = "Use memop instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.noreturn_stack_elim)] = .{
         .llvm_name = "noreturn-stack-elim",
-        .description = "Eliminate stack allocation in a noreturn function when possible",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nvj)] = .{
         .llvm_name = "nvj",
-        .description = "Support for new-value jumps",
         .dependencies = featureSet(&[_]Feature{
             .packets,
         }),
     };
     result[@intFromEnum(Feature.nvs)] = .{
         .llvm_name = "nvs",
-        .description = "Support for new-value stores",
         .dependencies = featureSet(&[_]Feature{
             .packets,
         }),
     };
     result[@intFromEnum(Feature.packets)] = .{
         .llvm_name = "packets",
-        .description = "Support for instruction packets",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prev65)] = .{
         .llvm_name = "prev65",
-        .description = "Support features deprecated in v65",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserved_r19)] = .{
         .llvm_name = "reserved-r19",
-        .description = "Reserve register R19",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.small_data)] = .{
         .llvm_name = "small-data",
-        .description = "Allow GP-relative addressing of global variables",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tinycore)] = .{
         .llvm_name = "tinycore",
-        .description = "Hexagon Tiny Core",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unsafe_fp)] = .{
         .llvm_name = "unsafe-fp",
-        .description = "Use unsafe FP math",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v5)] = .{
         .llvm_name = "v5",
-        .description = "Enable Hexagon V5 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v55)] = .{
         .llvm_name = "v55",
-        .description = "Enable Hexagon V55 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v60)] = .{
         .llvm_name = "v60",
-        .description = "Enable Hexagon V60 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v62)] = .{
         .llvm_name = "v62",
-        .description = "Enable Hexagon V62 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v65)] = .{
         .llvm_name = "v65",
-        .description = "Enable Hexagon V65 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v66)] = .{
         .llvm_name = "v66",
-        .description = "Enable Hexagon V66 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v67)] = .{
         .llvm_name = "v67",
-        .description = "Enable Hexagon V67 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v68)] = .{
         .llvm_name = "v68",
-        .description = "Enable Hexagon V68 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v69)] = .{
         .llvm_name = "v69",
-        .description = "Enable Hexagon V69 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v71)] = .{
         .llvm_name = "v71",
-        .description = "Enable Hexagon V71 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v73)] = .{
         .llvm_name = "v73",
-        .description = "Enable Hexagon V73 architecture",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zreg)] = .{
         .llvm_name = "zreg",
-        .description = "Hexagon ZReg extension instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -300,6 +258,54 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.audio)] = "Hexagon Audio extension instructions";
+    result[@intFromEnum(Feature.cabac)] = "Emit the CABAC instruction";
+    result[@intFromEnum(Feature.compound)] = "Use compound instructions";
+    result[@intFromEnum(Feature.duplex)] = "Enable generation of duplex instruction";
+    result[@intFromEnum(Feature.hvx)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvx_ieee_fp)] = "Hexagon HVX IEEE floating point instructions";
+    result[@intFromEnum(Feature.hvx_length128b)] = "Hexagon HVX 128B instructions";
+    result[@intFromEnum(Feature.hvx_length64b)] = "Hexagon HVX 64B instructions";
+    result[@intFromEnum(Feature.hvx_qfloat)] = "Hexagon HVX QFloating point instructions";
+    result[@intFromEnum(Feature.hvxv60)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv62)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv65)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv66)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv67)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv68)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv69)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv71)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.hvxv73)] = "Hexagon HVX instructions";
+    result[@intFromEnum(Feature.long_calls)] = "Use constant-extended calls";
+    result[@intFromEnum(Feature.mem_noshuf)] = "Supports mem_noshuf feature";
+    result[@intFromEnum(Feature.memops)] = "Use memop instructions";
+    result[@intFromEnum(Feature.noreturn_stack_elim)] = "Eliminate stack allocation in a noreturn function when possible";
+    result[@intFromEnum(Feature.nvj)] = "Support for new-value jumps";
+    result[@intFromEnum(Feature.nvs)] = "Support for new-value stores";
+    result[@intFromEnum(Feature.packets)] = "Support for instruction packets";
+    result[@intFromEnum(Feature.prev65)] = "Support features deprecated in v65";
+    result[@intFromEnum(Feature.reserved_r19)] = "Reserve register R19";
+    result[@intFromEnum(Feature.small_data)] = "Allow GP-relative addressing of global variables";
+    result[@intFromEnum(Feature.tinycore)] = "Hexagon Tiny Core";
+    result[@intFromEnum(Feature.unsafe_fp)] = "Use unsafe FP math";
+    result[@intFromEnum(Feature.v5)] = "Enable Hexagon V5 architecture";
+    result[@intFromEnum(Feature.v55)] = "Enable Hexagon V55 architecture";
+    result[@intFromEnum(Feature.v60)] = "Enable Hexagon V60 architecture";
+    result[@intFromEnum(Feature.v62)] = "Enable Hexagon V62 architecture";
+    result[@intFromEnum(Feature.v65)] = "Enable Hexagon V65 architecture";
+    result[@intFromEnum(Feature.v66)] = "Enable Hexagon V66 architecture";
+    result[@intFromEnum(Feature.v67)] = "Enable Hexagon V67 architecture";
+    result[@intFromEnum(Feature.v68)] = "Enable Hexagon V68 architecture";
+    result[@intFromEnum(Feature.v69)] = "Enable Hexagon V69 architecture";
+    result[@intFromEnum(Feature.v71)] = "Enable Hexagon V71 architecture";
+    result[@intFromEnum(Feature.v73)] = "Enable Hexagon V73 architecture";
+    result[@intFromEnum(Feature.zreg)] = "Hexagon ZReg extension instructions";
     break :blk result;
 };
 

--- a/lib/std/Target/loongarch.zig
+++ b/lib/std/Target/loongarch.zig
@@ -33,83 +33,68 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"32bit")] = .{
         .llvm_name = "32bit",
-        .description = "LA32 Basic Integer and Privilege Instruction Set",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"64bit")] = .{
         .llvm_name = "64bit",
-        .description = "LA64 Basic Integer and Privilege Instruction Set",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.auto_vec)] = .{
         .llvm_name = "auto-vec",
-        .description = "Experimental auto vectorization",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.d)] = .{
         .llvm_name = "d",
-        .description = "'D' (Double-Precision Floating-Point)",
         .dependencies = featureSet(&[_]Feature{
             .f,
         }),
     };
     result[@intFromEnum(Feature.f)] = .{
         .llvm_name = "f",
-        .description = "'F' (Single-Precision Floating-Point)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.frecipe)] = .{
         .llvm_name = "frecipe",
-        .description = "Support frecipe.{s/d} and frsqrte.{s/d} instructions.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.la_global_with_abs)] = .{
         .llvm_name = "la-global-with-abs",
-        .description = "Expand la.global as la.abs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.la_global_with_pcrel)] = .{
         .llvm_name = "la-global-with-pcrel",
-        .description = "Expand la.global as la.pcrel",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.la_local_with_abs)] = .{
         .llvm_name = "la-local-with-abs",
-        .description = "Expand la.local as la.abs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lasx)] = .{
         .llvm_name = "lasx",
-        .description = "'LASX' (Loongson Advanced SIMD Extension)",
         .dependencies = featureSet(&[_]Feature{
             .lsx,
         }),
     };
     result[@intFromEnum(Feature.lbt)] = .{
         .llvm_name = "lbt",
-        .description = "'LBT' (Loongson Binary Translation Extension)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lsx)] = .{
         .llvm_name = "lsx",
-        .description = "'LSX' (Loongson SIMD Extension)",
         .dependencies = featureSet(&[_]Feature{
             .d,
         }),
     };
     result[@intFromEnum(Feature.lvz)] = .{
         .llvm_name = "lvz",
-        .description = "'LVZ' (Loongson Virtualization Extension)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.relax)] = .{
         .llvm_name = "relax",
-        .description = "Enable Linker relaxation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ual)] = .{
         .llvm_name = "ual",
-        .description = "Allow memory accesses to be unaligned",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -117,6 +102,27 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"32bit")] = "LA32 Basic Integer and Privilege Instruction Set";
+    result[@intFromEnum(Feature.@"64bit")] = "LA64 Basic Integer and Privilege Instruction Set";
+    result[@intFromEnum(Feature.auto_vec)] = "Experimental auto vectorization";
+    result[@intFromEnum(Feature.d)] = "'D' (Double-Precision Floating-Point)";
+    result[@intFromEnum(Feature.f)] = "'F' (Single-Precision Floating-Point)";
+    result[@intFromEnum(Feature.frecipe)] = "Support frecipe.{s/d} and frsqrte.{s/d} instructions.";
+    result[@intFromEnum(Feature.la_global_with_abs)] = "Expand la.global as la.abs";
+    result[@intFromEnum(Feature.la_global_with_pcrel)] = "Expand la.global as la.pcrel";
+    result[@intFromEnum(Feature.la_local_with_abs)] = "Expand la.local as la.abs";
+    result[@intFromEnum(Feature.lasx)] = "'LASX' (Loongson Advanced SIMD Extension)";
+    result[@intFromEnum(Feature.lbt)] = "'LBT' (Loongson Binary Translation Extension)";
+    result[@intFromEnum(Feature.lsx)] = "'LSX' (Loongson SIMD Extension)";
+    result[@intFromEnum(Feature.lvz)] = "'LVZ' (Loongson Virtualization Extension)";
+    result[@intFromEnum(Feature.relax)] = "Enable Linker relaxation";
+    result[@intFromEnum(Feature.ual)] = "Allow memory accesses to be unaligned";
     break :blk result;
 };
 

--- a/lib/std/Target/m68k.zig
+++ b/lib/std/Target/m68k.zig
@@ -41,33 +41,28 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.isa_68000)] = .{
         .llvm_name = "isa-68000",
-        .description = "Is M68000 ISA supported",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.isa_68010)] = .{
         .llvm_name = "isa-68010",
-        .description = "Is M68010 ISA supported",
         .dependencies = featureSet(&[_]Feature{
             .isa_68000,
         }),
     };
     result[@intFromEnum(Feature.isa_68020)] = .{
         .llvm_name = "isa-68020",
-        .description = "Is M68020 ISA supported",
         .dependencies = featureSet(&[_]Feature{
             .isa_68010,
         }),
     };
     result[@intFromEnum(Feature.isa_68030)] = .{
         .llvm_name = "isa-68030",
-        .description = "Is M68030 ISA supported",
         .dependencies = featureSet(&[_]Feature{
             .isa_68020,
         }),
     };
     result[@intFromEnum(Feature.isa_68040)] = .{
         .llvm_name = "isa-68040",
-        .description = "Is M68040 ISA supported",
         .dependencies = featureSet(&[_]Feature{
             .isa_68030,
             .isa_68882,
@@ -75,96 +70,78 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.isa_68060)] = .{
         .llvm_name = "isa-68060",
-        .description = "Is M68060 ISA supported",
         .dependencies = featureSet(&[_]Feature{
             .isa_68040,
         }),
     };
     result[@intFromEnum(Feature.isa_68881)] = .{
         .llvm_name = "isa-68881",
-        .description = "Is M68881 (FPU) ISA supported",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.isa_68882)] = .{
         .llvm_name = "isa-68882",
-        .description = "Is M68882 (FPU) ISA supported",
         .dependencies = featureSet(&[_]Feature{
             .isa_68881,
         }),
     };
     result[@intFromEnum(Feature.reserve_a0)] = .{
         .llvm_name = "reserve-a0",
-        .description = "Reserve A0 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_a1)] = .{
         .llvm_name = "reserve-a1",
-        .description = "Reserve A1 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_a2)] = .{
         .llvm_name = "reserve-a2",
-        .description = "Reserve A2 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_a3)] = .{
         .llvm_name = "reserve-a3",
-        .description = "Reserve A3 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_a4)] = .{
         .llvm_name = "reserve-a4",
-        .description = "Reserve A4 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_a5)] = .{
         .llvm_name = "reserve-a5",
-        .description = "Reserve A5 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_a6)] = .{
         .llvm_name = "reserve-a6",
-        .description = "Reserve A6 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d0)] = .{
         .llvm_name = "reserve-d0",
-        .description = "Reserve D0 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d1)] = .{
         .llvm_name = "reserve-d1",
-        .description = "Reserve D1 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d2)] = .{
         .llvm_name = "reserve-d2",
-        .description = "Reserve D2 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d3)] = .{
         .llvm_name = "reserve-d3",
-        .description = "Reserve D3 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d4)] = .{
         .llvm_name = "reserve-d4",
-        .description = "Reserve D4 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d5)] = .{
         .llvm_name = "reserve-d5",
-        .description = "Reserve D5 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d6)] = .{
         .llvm_name = "reserve-d6",
-        .description = "Reserve D6 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_d7)] = .{
         .llvm_name = "reserve-d7",
-        .description = "Reserve D7 register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -172,6 +149,35 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.isa_68000)] = "Is M68000 ISA supported";
+    result[@intFromEnum(Feature.isa_68010)] = "Is M68010 ISA supported";
+    result[@intFromEnum(Feature.isa_68020)] = "Is M68020 ISA supported";
+    result[@intFromEnum(Feature.isa_68030)] = "Is M68030 ISA supported";
+    result[@intFromEnum(Feature.isa_68040)] = "Is M68040 ISA supported";
+    result[@intFromEnum(Feature.isa_68060)] = "Is M68060 ISA supported";
+    result[@intFromEnum(Feature.isa_68881)] = "Is M68881 (FPU) ISA supported";
+    result[@intFromEnum(Feature.isa_68882)] = "Is M68882 (FPU) ISA supported";
+    result[@intFromEnum(Feature.reserve_a0)] = "Reserve A0 register";
+    result[@intFromEnum(Feature.reserve_a1)] = "Reserve A1 register";
+    result[@intFromEnum(Feature.reserve_a2)] = "Reserve A2 register";
+    result[@intFromEnum(Feature.reserve_a3)] = "Reserve A3 register";
+    result[@intFromEnum(Feature.reserve_a4)] = "Reserve A4 register";
+    result[@intFromEnum(Feature.reserve_a5)] = "Reserve A5 register";
+    result[@intFromEnum(Feature.reserve_a6)] = "Reserve A6 register";
+    result[@intFromEnum(Feature.reserve_d0)] = "Reserve D0 register";
+    result[@intFromEnum(Feature.reserve_d1)] = "Reserve D1 register";
+    result[@intFromEnum(Feature.reserve_d2)] = "Reserve D2 register";
+    result[@intFromEnum(Feature.reserve_d3)] = "Reserve D3 register";
+    result[@intFromEnum(Feature.reserve_d4)] = "Reserve D4 register";
+    result[@intFromEnum(Feature.reserve_d5)] = "Reserve D5 register";
+    result[@intFromEnum(Feature.reserve_d6)] = "Reserve D6 register";
+    result[@intFromEnum(Feature.reserve_d7)] = "Reserve D7 register";
     break :blk result;
 };
 

--- a/lib/std/Target/mips.zig
+++ b/lib/std/Target/mips.zig
@@ -70,102 +70,84 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.abs2008)] = .{
         .llvm_name = "abs2008",
-        .description = "Disable IEEE 754-2008 abs.fmt mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cnmips)] = .{
         .llvm_name = "cnmips",
-        .description = "Octeon cnMIPS Support",
         .dependencies = featureSet(&[_]Feature{
             .mips64r2,
         }),
     };
     result[@intFromEnum(Feature.cnmipsp)] = .{
         .llvm_name = "cnmipsp",
-        .description = "Octeon+ cnMIPS Support",
         .dependencies = featureSet(&[_]Feature{
             .cnmips,
         }),
     };
     result[@intFromEnum(Feature.crc)] = .{
         .llvm_name = "crc",
-        .description = "Mips R6 CRC ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dsp)] = .{
         .llvm_name = "dsp",
-        .description = "Mips DSP ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dspr2)] = .{
         .llvm_name = "dspr2",
-        .description = "Mips DSP-R2 ASE",
         .dependencies = featureSet(&[_]Feature{
             .dsp,
         }),
     };
     result[@intFromEnum(Feature.dspr3)] = .{
         .llvm_name = "dspr3",
-        .description = "Mips DSP-R3 ASE",
         .dependencies = featureSet(&[_]Feature{
             .dspr2,
         }),
     };
     result[@intFromEnum(Feature.eva)] = .{
         .llvm_name = "eva",
-        .description = "Mips EVA ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp64)] = .{
         .llvm_name = "fp64",
-        .description = "Support 64-bit FP registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fpxx)] = .{
         .llvm_name = "fpxx",
-        .description = "Support for FPXX",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ginv)] = .{
         .llvm_name = "ginv",
-        .description = "Mips Global Invalidate ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gp64)] = .{
         .llvm_name = "gp64",
-        .description = "General Purpose Registers are 64-bit wide",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.long_calls)] = .{
         .llvm_name = "long-calls",
-        .description = "Disable use of the jal instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.micromips)] = .{
         .llvm_name = "micromips",
-        .description = "microMips mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips1)] = .{
         .llvm_name = "mips1",
-        .description = "Mips I ISA Support [highly experimental]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips16)] = .{
         .llvm_name = "mips16",
-        .description = "Mips16 mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips2)] = .{
         .llvm_name = "mips2",
-        .description = "Mips II ISA Support [highly experimental]",
         .dependencies = featureSet(&[_]Feature{
             .mips1,
         }),
     };
     result[@intFromEnum(Feature.mips3)] = .{
         .llvm_name = "mips3",
-        .description = "MIPS III ISA Support [highly experimental]",
         .dependencies = featureSet(&[_]Feature{
             .fp64,
             .gp64,
@@ -176,7 +158,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips32)] = .{
         .llvm_name = "mips32",
-        .description = "Mips32 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips2,
             .mips3_32,
@@ -185,7 +166,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips32r2)] = .{
         .llvm_name = "mips32r2",
-        .description = "Mips32r2 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32,
             .mips3_32r2,
@@ -195,21 +175,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips32r3)] = .{
         .llvm_name = "mips32r3",
-        .description = "Mips32r3 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32r2,
         }),
     };
     result[@intFromEnum(Feature.mips32r5)] = .{
         .llvm_name = "mips32r5",
-        .description = "Mips32r5 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32r3,
         }),
     };
     result[@intFromEnum(Feature.mips32r6)] = .{
         .llvm_name = "mips32r6",
-        .description = "Mips32r6 ISA Support [experimental]",
         .dependencies = featureSet(&[_]Feature{
             .abs2008,
             .fp64,
@@ -219,22 +196,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips3_32)] = .{
         .llvm_name = "mips3_32",
-        .description = "Subset of MIPS-III that is also in MIPS32 [highly experimental]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips3_32r2)] = .{
         .llvm_name = "mips3_32r2",
-        .description = "Subset of MIPS-III that is also in MIPS32r2 [highly experimental]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips3d)] = .{
         .llvm_name = "mips3d",
-        .description = "Mips 3D ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips4)] = .{
         .llvm_name = "mips4",
-        .description = "MIPS IV ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips3,
             .mips4_32,
@@ -243,17 +216,14 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips4_32)] = .{
         .llvm_name = "mips4_32",
-        .description = "Subset of MIPS-IV that is also in MIPS32 [highly experimental]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips4_32r2)] = .{
         .llvm_name = "mips4_32r2",
-        .description = "Subset of MIPS-IV that is also in MIPS32r2 [highly experimental]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips5)] = .{
         .llvm_name = "mips5",
-        .description = "MIPS V ISA Support [highly experimental]",
         .dependencies = featureSet(&[_]Feature{
             .mips4,
             .mips5_32r2,
@@ -261,12 +231,10 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips5_32r2)] = .{
         .llvm_name = "mips5_32r2",
-        .description = "Subset of MIPS-V that is also in MIPS32r2 [highly experimental]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mips64)] = .{
         .llvm_name = "mips64",
-        .description = "Mips64 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32,
             .mips5,
@@ -274,7 +242,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips64r2)] = .{
         .llvm_name = "mips64r2",
-        .description = "Mips64r2 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32r2,
             .mips64,
@@ -282,7 +249,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips64r3)] = .{
         .llvm_name = "mips64r3",
-        .description = "Mips64r3 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32r3,
             .mips64r2,
@@ -290,7 +256,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips64r5)] = .{
         .llvm_name = "mips64r5",
-        .description = "Mips64r5 ISA Support",
         .dependencies = featureSet(&[_]Feature{
             .mips32r5,
             .mips64r3,
@@ -298,7 +263,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.mips64r6)] = .{
         .llvm_name = "mips64r6",
-        .description = "Mips64r6 ISA Support [experimental]",
         .dependencies = featureSet(&[_]Feature{
             .mips32r6,
             .mips64r5,
@@ -306,84 +270,68 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.msa)] = .{
         .llvm_name = "msa",
-        .description = "Mips MSA ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mt)] = .{
         .llvm_name = "mt",
-        .description = "Mips MT ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nan2008)] = .{
         .llvm_name = "nan2008",
-        .description = "IEEE 754-2008 NaN encoding",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.noabicalls)] = .{
         .llvm_name = "noabicalls",
-        .description = "Disable SVR4-style position-independent code",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nomadd4)] = .{
         .llvm_name = "nomadd4",
-        .description = "Disable 4-operand madd.fmt and related instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nooddspreg)] = .{
         .llvm_name = "nooddspreg",
-        .description = "Disable odd numbered single-precision registers",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.p5600)] = .{
         .llvm_name = "p5600",
-        .description = "The P5600 Processor",
         .dependencies = featureSet(&[_]Feature{
             .mips32r5,
         }),
     };
     result[@intFromEnum(Feature.ptr64)] = .{
         .llvm_name = "ptr64",
-        .description = "Pointers are 64-bit wide",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.single_float)] = .{
         .llvm_name = "single-float",
-        .description = "Only supports single precision float",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.soft_float)] = .{
         .llvm_name = "soft-float",
-        .description = "Does not support floating point instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sym32)] = .{
         .llvm_name = "sym32",
-        .description = "Symbols are 32 bit on Mips64",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_indirect_jump_hazard)] = .{
         .llvm_name = "use-indirect-jump-hazard",
-        .description = "Use indirect jump guards to prevent certain speculation based attacks",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_tcc_in_div)] = .{
         .llvm_name = "use-tcc-in-div",
-        .description = "Force the assembler to use trapping",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vfpu)] = .{
         .llvm_name = "vfpu",
-        .description = "Enable vector FPU instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.virt)] = .{
         .llvm_name = "virt",
-        .description = "Mips Virtualization ASE",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xgot)] = .{
         .llvm_name = "xgot",
-        .description = "Assume 32-bit GOT",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -391,6 +339,64 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.abs2008)] = "Disable IEEE 754-2008 abs.fmt mode";
+    result[@intFromEnum(Feature.cnmips)] = "Octeon cnMIPS Support";
+    result[@intFromEnum(Feature.cnmipsp)] = "Octeon+ cnMIPS Support";
+    result[@intFromEnum(Feature.crc)] = "Mips R6 CRC ASE";
+    result[@intFromEnum(Feature.dsp)] = "Mips DSP ASE";
+    result[@intFromEnum(Feature.dspr2)] = "Mips DSP-R2 ASE";
+    result[@intFromEnum(Feature.dspr3)] = "Mips DSP-R3 ASE";
+    result[@intFromEnum(Feature.eva)] = "Mips EVA ASE";
+    result[@intFromEnum(Feature.fp64)] = "Support 64-bit FP registers";
+    result[@intFromEnum(Feature.fpxx)] = "Support for FPXX";
+    result[@intFromEnum(Feature.ginv)] = "Mips Global Invalidate ASE";
+    result[@intFromEnum(Feature.gp64)] = "General Purpose Registers are 64-bit wide";
+    result[@intFromEnum(Feature.long_calls)] = "Disable use of the jal instruction";
+    result[@intFromEnum(Feature.micromips)] = "microMips mode";
+    result[@intFromEnum(Feature.mips1)] = "Mips I ISA Support [highly experimental]";
+    result[@intFromEnum(Feature.mips16)] = "Mips16 mode";
+    result[@intFromEnum(Feature.mips2)] = "Mips II ISA Support [highly experimental]";
+    result[@intFromEnum(Feature.mips3)] = "MIPS III ISA Support [highly experimental]";
+    result[@intFromEnum(Feature.mips32)] = "Mips32 ISA Support";
+    result[@intFromEnum(Feature.mips32r2)] = "Mips32r2 ISA Support";
+    result[@intFromEnum(Feature.mips32r3)] = "Mips32r3 ISA Support";
+    result[@intFromEnum(Feature.mips32r5)] = "Mips32r5 ISA Support";
+    result[@intFromEnum(Feature.mips32r6)] = "Mips32r6 ISA Support [experimental]";
+    result[@intFromEnum(Feature.mips3_32)] = "Subset of MIPS-III that is also in MIPS32 [highly experimental]";
+    result[@intFromEnum(Feature.mips3_32r2)] = "Subset of MIPS-III that is also in MIPS32r2 [highly experimental]";
+    result[@intFromEnum(Feature.mips3d)] = "Mips 3D ASE";
+    result[@intFromEnum(Feature.mips4)] = "MIPS IV ISA Support";
+    result[@intFromEnum(Feature.mips4_32)] = "Subset of MIPS-IV that is also in MIPS32 [highly experimental]";
+    result[@intFromEnum(Feature.mips4_32r2)] = "Subset of MIPS-IV that is also in MIPS32r2 [highly experimental]";
+    result[@intFromEnum(Feature.mips5)] = "MIPS V ISA Support [highly experimental]";
+    result[@intFromEnum(Feature.mips5_32r2)] = "Subset of MIPS-V that is also in MIPS32r2 [highly experimental]";
+    result[@intFromEnum(Feature.mips64)] = "Mips64 ISA Support";
+    result[@intFromEnum(Feature.mips64r2)] = "Mips64r2 ISA Support";
+    result[@intFromEnum(Feature.mips64r3)] = "Mips64r3 ISA Support";
+    result[@intFromEnum(Feature.mips64r5)] = "Mips64r5 ISA Support";
+    result[@intFromEnum(Feature.mips64r6)] = "Mips64r6 ISA Support [experimental]";
+    result[@intFromEnum(Feature.msa)] = "Mips MSA ASE";
+    result[@intFromEnum(Feature.mt)] = "Mips MT ASE";
+    result[@intFromEnum(Feature.nan2008)] = "IEEE 754-2008 NaN encoding";
+    result[@intFromEnum(Feature.noabicalls)] = "Disable SVR4-style position-independent code";
+    result[@intFromEnum(Feature.nomadd4)] = "Disable 4-operand madd.fmt and related instructions";
+    result[@intFromEnum(Feature.nooddspreg)] = "Disable odd numbered single-precision registers";
+    result[@intFromEnum(Feature.p5600)] = "The P5600 Processor";
+    result[@intFromEnum(Feature.ptr64)] = "Pointers are 64-bit wide";
+    result[@intFromEnum(Feature.single_float)] = "Only supports single precision float";
+    result[@intFromEnum(Feature.soft_float)] = "Does not support floating point instructions";
+    result[@intFromEnum(Feature.sym32)] = "Symbols are 32 bit on Mips64";
+    result[@intFromEnum(Feature.use_indirect_jump_hazard)] = "Use indirect jump guards to prevent certain speculation based attacks";
+    result[@intFromEnum(Feature.use_tcc_in_div)] = "Force the assembler to use trapping";
+    result[@intFromEnum(Feature.vfpu)] = "Enable vector FPU instructions";
+    result[@intFromEnum(Feature.virt)] = "Mips Virtualization ASE";
+    result[@intFromEnum(Feature.xgot)] = "Assume 32-bit GOT";
     break :blk result;
 };
 

--- a/lib/std/Target/msp430.zig
+++ b/lib/std/Target/msp430.zig
@@ -22,22 +22,18 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.ext)] = .{
         .llvm_name = "ext",
-        .description = "Enable MSP430-X extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hwmult16)] = .{
         .llvm_name = "hwmult16",
-        .description = "Enable 16-bit hardware multiplier",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hwmult32)] = .{
         .llvm_name = "hwmult32",
-        .description = "Enable 32-bit hardware multiplier",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hwmultf5)] = .{
         .llvm_name = "hwmultf5",
-        .description = "Enable F5 series hardware multiplier",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -45,6 +41,16 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.ext)] = "Enable MSP430-X extensions";
+    result[@intFromEnum(Feature.hwmult16)] = "Enable 16-bit hardware multiplier";
+    result[@intFromEnum(Feature.hwmult32)] = "Enable 32-bit hardware multiplier";
+    result[@intFromEnum(Feature.hwmultf5)] = "Enable F5 series hardware multiplier";
     break :blk result;
 };
 

--- a/lib/std/Target/nvptx.zig
+++ b/lib/std/Target/nvptx.zig
@@ -63,227 +63,182 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.ptx32)] = .{
         .llvm_name = "ptx32",
-        .description = "Use PTX version 32",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx40)] = .{
         .llvm_name = "ptx40",
-        .description = "Use PTX version 40",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx41)] = .{
         .llvm_name = "ptx41",
-        .description = "Use PTX version 41",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx42)] = .{
         .llvm_name = "ptx42",
-        .description = "Use PTX version 42",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx43)] = .{
         .llvm_name = "ptx43",
-        .description = "Use PTX version 43",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx50)] = .{
         .llvm_name = "ptx50",
-        .description = "Use PTX version 50",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx60)] = .{
         .llvm_name = "ptx60",
-        .description = "Use PTX version 60",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx61)] = .{
         .llvm_name = "ptx61",
-        .description = "Use PTX version 61",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx63)] = .{
         .llvm_name = "ptx63",
-        .description = "Use PTX version 63",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx64)] = .{
         .llvm_name = "ptx64",
-        .description = "Use PTX version 64",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx65)] = .{
         .llvm_name = "ptx65",
-        .description = "Use PTX version 65",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx70)] = .{
         .llvm_name = "ptx70",
-        .description = "Use PTX version 70",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx71)] = .{
         .llvm_name = "ptx71",
-        .description = "Use PTX version 71",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx72)] = .{
         .llvm_name = "ptx72",
-        .description = "Use PTX version 72",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx73)] = .{
         .llvm_name = "ptx73",
-        .description = "Use PTX version 73",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx74)] = .{
         .llvm_name = "ptx74",
-        .description = "Use PTX version 74",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx75)] = .{
         .llvm_name = "ptx75",
-        .description = "Use PTX version 75",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx76)] = .{
         .llvm_name = "ptx76",
-        .description = "Use PTX version 76",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx77)] = .{
         .llvm_name = "ptx77",
-        .description = "Use PTX version 77",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx78)] = .{
         .llvm_name = "ptx78",
-        .description = "Use PTX version 78",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx80)] = .{
         .llvm_name = "ptx80",
-        .description = "Use PTX version 80",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx81)] = .{
         .llvm_name = "ptx81",
-        .description = "Use PTX version 81",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx82)] = .{
         .llvm_name = "ptx82",
-        .description = "Use PTX version 82",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptx83)] = .{
         .llvm_name = "ptx83",
-        .description = "Use PTX version 83",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_20)] = .{
         .llvm_name = "sm_20",
-        .description = "Target SM 20",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_21)] = .{
         .llvm_name = "sm_21",
-        .description = "Target SM 21",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_30)] = .{
         .llvm_name = "sm_30",
-        .description = "Target SM 30",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_32)] = .{
         .llvm_name = "sm_32",
-        .description = "Target SM 32",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_35)] = .{
         .llvm_name = "sm_35",
-        .description = "Target SM 35",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_37)] = .{
         .llvm_name = "sm_37",
-        .description = "Target SM 37",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_50)] = .{
         .llvm_name = "sm_50",
-        .description = "Target SM 50",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_52)] = .{
         .llvm_name = "sm_52",
-        .description = "Target SM 52",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_53)] = .{
         .llvm_name = "sm_53",
-        .description = "Target SM 53",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_60)] = .{
         .llvm_name = "sm_60",
-        .description = "Target SM 60",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_61)] = .{
         .llvm_name = "sm_61",
-        .description = "Target SM 61",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_62)] = .{
         .llvm_name = "sm_62",
-        .description = "Target SM 62",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_70)] = .{
         .llvm_name = "sm_70",
-        .description = "Target SM 70",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_72)] = .{
         .llvm_name = "sm_72",
-        .description = "Target SM 72",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_75)] = .{
         .llvm_name = "sm_75",
-        .description = "Target SM 75",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_80)] = .{
         .llvm_name = "sm_80",
-        .description = "Target SM 80",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_86)] = .{
         .llvm_name = "sm_86",
-        .description = "Target SM 86",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_87)] = .{
         .llvm_name = "sm_87",
-        .description = "Target SM 87",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_89)] = .{
         .llvm_name = "sm_89",
-        .description = "Target SM 89",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_90)] = .{
         .llvm_name = "sm_90",
-        .description = "Target SM 90",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm_90a)] = .{
         .llvm_name = "sm_90a",
-        .description = "Target SM 90a",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -291,6 +246,57 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.ptx32)] = "Use PTX version 32";
+    result[@intFromEnum(Feature.ptx40)] = "Use PTX version 40";
+    result[@intFromEnum(Feature.ptx41)] = "Use PTX version 41";
+    result[@intFromEnum(Feature.ptx42)] = "Use PTX version 42";
+    result[@intFromEnum(Feature.ptx43)] = "Use PTX version 43";
+    result[@intFromEnum(Feature.ptx50)] = "Use PTX version 50";
+    result[@intFromEnum(Feature.ptx60)] = "Use PTX version 60";
+    result[@intFromEnum(Feature.ptx61)] = "Use PTX version 61";
+    result[@intFromEnum(Feature.ptx63)] = "Use PTX version 63";
+    result[@intFromEnum(Feature.ptx64)] = "Use PTX version 64";
+    result[@intFromEnum(Feature.ptx65)] = "Use PTX version 65";
+    result[@intFromEnum(Feature.ptx70)] = "Use PTX version 70";
+    result[@intFromEnum(Feature.ptx71)] = "Use PTX version 71";
+    result[@intFromEnum(Feature.ptx72)] = "Use PTX version 72";
+    result[@intFromEnum(Feature.ptx73)] = "Use PTX version 73";
+    result[@intFromEnum(Feature.ptx74)] = "Use PTX version 74";
+    result[@intFromEnum(Feature.ptx75)] = "Use PTX version 75";
+    result[@intFromEnum(Feature.ptx76)] = "Use PTX version 76";
+    result[@intFromEnum(Feature.ptx77)] = "Use PTX version 77";
+    result[@intFromEnum(Feature.ptx78)] = "Use PTX version 78";
+    result[@intFromEnum(Feature.ptx80)] = "Use PTX version 80";
+    result[@intFromEnum(Feature.ptx81)] = "Use PTX version 81";
+    result[@intFromEnum(Feature.ptx82)] = "Use PTX version 82";
+    result[@intFromEnum(Feature.ptx83)] = "Use PTX version 83";
+    result[@intFromEnum(Feature.sm_20)] = "Target SM 20";
+    result[@intFromEnum(Feature.sm_21)] = "Target SM 21";
+    result[@intFromEnum(Feature.sm_30)] = "Target SM 30";
+    result[@intFromEnum(Feature.sm_32)] = "Target SM 32";
+    result[@intFromEnum(Feature.sm_35)] = "Target SM 35";
+    result[@intFromEnum(Feature.sm_37)] = "Target SM 37";
+    result[@intFromEnum(Feature.sm_50)] = "Target SM 50";
+    result[@intFromEnum(Feature.sm_52)] = "Target SM 52";
+    result[@intFromEnum(Feature.sm_53)] = "Target SM 53";
+    result[@intFromEnum(Feature.sm_60)] = "Target SM 60";
+    result[@intFromEnum(Feature.sm_61)] = "Target SM 61";
+    result[@intFromEnum(Feature.sm_62)] = "Target SM 62";
+    result[@intFromEnum(Feature.sm_70)] = "Target SM 70";
+    result[@intFromEnum(Feature.sm_72)] = "Target SM 72";
+    result[@intFromEnum(Feature.sm_75)] = "Target SM 75";
+    result[@intFromEnum(Feature.sm_80)] = "Target SM 80";
+    result[@intFromEnum(Feature.sm_86)] = "Target SM 86";
+    result[@intFromEnum(Feature.sm_87)] = "Target SM 87";
+    result[@intFromEnum(Feature.sm_89)] = "Target SM 89";
+    result[@intFromEnum(Feature.sm_90)] = "Target SM 90";
+    result[@intFromEnum(Feature.sm_90a)] = "Target SM 90a";
     break :blk result;
 };
 

--- a/lib/std/Target/powerpc.zig
+++ b/lib/std/Target/powerpc.zig
@@ -100,334 +100,280 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"64bit")] = .{
         .llvm_name = "64bit",
-        .description = "Enable 64-bit instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"64bitregs")] = .{
         .llvm_name = "64bitregs",
-        .description = "Enable 64-bit registers usage for ppc32 [beta]",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aix)] = .{
         .llvm_name = "aix",
-        .description = "AIX OS",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aix_small_local_exec_tls)] = .{
         .llvm_name = "aix-small-local-exec-tls",
-        .description = "Produce a TOC-free local-exec TLS sequence for this function for 64-bit AIX",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.allow_unaligned_fp_access)] = .{
         .llvm_name = "allow-unaligned-fp-access",
-        .description = "CPU does not trap on unaligned FP access",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.altivec)] = .{
         .llvm_name = "altivec",
-        .description = "Enable Altivec instructions",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.booke)] = .{
         .llvm_name = "booke",
-        .description = "Enable Book E instructions",
         .dependencies = featureSet(&[_]Feature{
             .icbt,
         }),
     };
     result[@intFromEnum(Feature.bpermd)] = .{
         .llvm_name = "bpermd",
-        .description = "Enable the bpermd instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cmpb)] = .{
         .llvm_name = "cmpb",
-        .description = "Enable the cmpb instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crbits)] = .{
         .llvm_name = "crbits",
-        .description = "Use condition-register bits individually",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crypto)] = .{
         .llvm_name = "crypto",
-        .description = "Enable POWER8 Crypto instructions",
         .dependencies = featureSet(&[_]Feature{
             .power8_altivec,
         }),
     };
     result[@intFromEnum(Feature.direct_move)] = .{
         .llvm_name = "direct-move",
-        .description = "Enable Power8 direct move instructions",
         .dependencies = featureSet(&[_]Feature{
             .vsx,
         }),
     };
     result[@intFromEnum(Feature.e500)] = .{
         .llvm_name = "e500",
-        .description = "Enable E500/E500mc instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.efpu2)] = .{
         .llvm_name = "efpu2",
-        .description = "Enable Embedded Floating-Point APU 2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .spe,
         }),
     };
     result[@intFromEnum(Feature.extdiv)] = .{
         .llvm_name = "extdiv",
-        .description = "Enable extended divide instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_MFLR)] = .{
         .llvm_name = "fast-MFLR",
-        .description = "MFLR is a fast instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fcpsgn)] = .{
         .llvm_name = "fcpsgn",
-        .description = "Enable the fcpsgn instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.float128)] = .{
         .llvm_name = "float128",
-        .description = "Enable the __float128 data type for IEEE-754R Binary128.",
         .dependencies = featureSet(&[_]Feature{
             .vsx,
         }),
     };
     result[@intFromEnum(Feature.fpcvt)] = .{
         .llvm_name = "fpcvt",
-        .description = "Enable fc[ft]* (unsigned and single-precision) and lfiwzx instructions",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.fprnd)] = .{
         .llvm_name = "fprnd",
-        .description = "Enable the fri[mnpz] instructions",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.fpu)] = .{
         .llvm_name = "fpu",
-        .description = "Enable classic FPU instructions",
         .dependencies = featureSet(&[_]Feature{
             .hard_float,
         }),
     };
     result[@intFromEnum(Feature.fre)] = .{
         .llvm_name = "fre",
-        .description = "Enable the fre instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.fres)] = .{
         .llvm_name = "fres",
-        .description = "Enable the fres instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.frsqrte)] = .{
         .llvm_name = "frsqrte",
-        .description = "Enable the frsqrte instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.frsqrtes)] = .{
         .llvm_name = "frsqrtes",
-        .description = "Enable the frsqrtes instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.fsqrt)] = .{
         .llvm_name = "fsqrt",
-        .description = "Enable the fsqrt instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.fuse_add_logical)] = .{
         .llvm_name = "fuse-add-logical",
-        .description = "Target supports Add with Logical Operations fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_addi_load)] = .{
         .llvm_name = "fuse-addi-load",
-        .description = "Power8 Addi-Load fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_addis_load)] = .{
         .llvm_name = "fuse-addis-load",
-        .description = "Power8 Addis-Load fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_arith_add)] = .{
         .llvm_name = "fuse-arith-add",
-        .description = "Target supports Arithmetic Operations with Add fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_back2back)] = .{
         .llvm_name = "fuse-back2back",
-        .description = "Target supports general back to back fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_cmp)] = .{
         .llvm_name = "fuse-cmp",
-        .description = "Target supports Comparison Operations fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_logical)] = .{
         .llvm_name = "fuse-logical",
-        .description = "Target supports Logical Operations fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_logical_add)] = .{
         .llvm_name = "fuse-logical-add",
-        .description = "Target supports Logical with Add Operations fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_sha3)] = .{
         .llvm_name = "fuse-sha3",
-        .description = "Target supports SHA3 assist fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_store)] = .{
         .llvm_name = "fuse-store",
-        .description = "Target supports store clustering",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_wideimm)] = .{
         .llvm_name = "fuse-wideimm",
-        .description = "Target supports Wide-Immediate fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fuse_zeromove)] = .{
         .llvm_name = "fuse-zeromove",
-        .description = "Target supports move to SPR with branch fusion",
         .dependencies = featureSet(&[_]Feature{
             .fusion,
         }),
     };
     result[@intFromEnum(Feature.fusion)] = .{
         .llvm_name = "fusion",
-        .description = "Target supports instruction fusion",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hard_float)] = .{
         .llvm_name = "hard-float",
-        .description = "Enable floating-point instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.htm)] = .{
         .llvm_name = "htm",
-        .description = "Enable Hardware Transactional Memory instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.icbt)] = .{
         .llvm_name = "icbt",
-        .description = "Enable icbt instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.invariant_function_descriptors)] = .{
         .llvm_name = "invariant-function-descriptors",
-        .description = "Assume function descriptors are invariant",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.isa_future_instructions)] = .{
         .llvm_name = "isa-future-instructions",
-        .description = "Enable instructions for Future ISA.",
         .dependencies = featureSet(&[_]Feature{
             .isa_v31_instructions,
         }),
     };
     result[@intFromEnum(Feature.isa_v206_instructions)] = .{
         .llvm_name = "isa-v206-instructions",
-        .description = "Enable instructions in ISA 2.06.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.isa_v207_instructions)] = .{
         .llvm_name = "isa-v207-instructions",
-        .description = "Enable instructions in ISA 2.07.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.isa_v30_instructions)] = .{
         .llvm_name = "isa-v30-instructions",
-        .description = "Enable instructions in ISA 3.0.",
         .dependencies = featureSet(&[_]Feature{
             .isa_v207_instructions,
         }),
     };
     result[@intFromEnum(Feature.isa_v31_instructions)] = .{
         .llvm_name = "isa-v31-instructions",
-        .description = "Enable instructions in ISA 3.1.",
         .dependencies = featureSet(&[_]Feature{
             .isa_v30_instructions,
         }),
     };
     result[@intFromEnum(Feature.isel)] = .{
         .llvm_name = "isel",
-        .description = "Enable the isel instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ldbrx)] = .{
         .llvm_name = "ldbrx",
-        .description = "Enable the ldbrx instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lfiwax)] = .{
         .llvm_name = "lfiwax",
-        .description = "Enable the lfiwax instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.longcall)] = .{
         .llvm_name = "longcall",
-        .description = "Always use indirect calls",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mfocrf)] = .{
         .llvm_name = "mfocrf",
-        .description = "Enable the MFOCRF instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mma)] = .{
         .llvm_name = "mma",
-        .description = "Enable MMA instructions",
         .dependencies = featureSet(&[_]Feature{
             .paired_vector_memops,
             .power8_vector,
@@ -436,43 +382,36 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.modern_aix_as)] = .{
         .llvm_name = "modern-aix-as",
-        .description = "AIX system assembler is modern enough to support new mnes",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.msync)] = .{
         .llvm_name = "msync",
-        .description = "Has only the msync instruction instead of sync",
         .dependencies = featureSet(&[_]Feature{
             .booke,
         }),
     };
     result[@intFromEnum(Feature.paired_vector_memops)] = .{
         .llvm_name = "paired-vector-memops",
-        .description = "32Byte load and store instructions",
         .dependencies = featureSet(&[_]Feature{
             .isa_v30_instructions,
         }),
     };
     result[@intFromEnum(Feature.partword_atomics)] = .{
         .llvm_name = "partword-atomics",
-        .description = "Enable l[bh]arx and st[bh]cx.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pcrelative_memops)] = .{
         .llvm_name = "pcrelative-memops",
-        .description = "Enable PC relative Memory Ops",
         .dependencies = featureSet(&[_]Feature{
             .prefix_instrs,
         }),
     };
     result[@intFromEnum(Feature.popcntd)] = .{
         .llvm_name = "popcntd",
-        .description = "Enable the popcnt[dw] instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.power10_vector)] = .{
         .llvm_name = "power10-vector",
-        .description = "Enable POWER10 vector instructions",
         .dependencies = featureSet(&[_]Feature{
             .isa_v31_instructions,
             .power9_vector,
@@ -480,14 +419,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.power8_altivec)] = .{
         .llvm_name = "power8-altivec",
-        .description = "Enable POWER8 Altivec instructions",
         .dependencies = featureSet(&[_]Feature{
             .altivec,
         }),
     };
     result[@intFromEnum(Feature.power8_vector)] = .{
         .llvm_name = "power8-vector",
-        .description = "Enable POWER8 vector instructions",
         .dependencies = featureSet(&[_]Feature{
             .power8_altivec,
             .vsx,
@@ -495,7 +432,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.power9_altivec)] = .{
         .llvm_name = "power9-altivec",
-        .description = "Enable POWER9 Altivec instructions",
         .dependencies = featureSet(&[_]Feature{
             .isa_v30_instructions,
             .power8_altivec,
@@ -503,7 +439,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.power9_vector)] = .{
         .llvm_name = "power9-vector",
-        .description = "Enable POWER9 vector instructions",
         .dependencies = featureSet(&[_]Feature{
             .power8_vector,
             .power9_altivec,
@@ -511,32 +446,26 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.ppc4xx)] = .{
         .llvm_name = "ppc4xx",
-        .description = "Enable PPC 4xx instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ppc6xx)] = .{
         .llvm_name = "ppc6xx",
-        .description = "Enable PPC 6xx instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ppc_postra_sched)] = .{
         .llvm_name = "ppc-postra-sched",
-        .description = "Use PowerPC post-RA scheduling strategy",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ppc_prera_sched)] = .{
         .llvm_name = "ppc-prera-sched",
-        .description = "Use PowerPC pre-RA scheduling strategy",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.predictable_select_expensive)] = .{
         .llvm_name = "predictable-select-expensive",
-        .description = "Prefer likely predicted branches over selects",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefix_instrs)] = .{
         .llvm_name = "prefix-instrs",
-        .description = "Enable prefixed instructions",
         .dependencies = featureSet(&[_]Feature{
             .power8_vector,
             .power9_altivec,
@@ -544,61 +473,50 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.privileged)] = .{
         .llvm_name = "privileged",
-        .description = "Add privileged instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.quadword_atomics)] = .{
         .llvm_name = "quadword-atomics",
-        .description = "Enable lqarx and stqcx.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.recipprec)] = .{
         .llvm_name = "recipprec",
-        .description = "Assume higher precision reciprocal estimates",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rop_protect)] = .{
         .llvm_name = "rop-protect",
-        .description = "Add ROP protect",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.secure_plt)] = .{
         .llvm_name = "secure-plt",
-        .description = "Enable secure plt mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_popcntd)] = .{
         .llvm_name = "slow-popcntd",
-        .description = "Has slow popcnt[dw] instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.spe)] = .{
         .llvm_name = "spe",
-        .description = "Enable SPE instructions",
         .dependencies = featureSet(&[_]Feature{
             .hard_float,
         }),
     };
     result[@intFromEnum(Feature.stfiwx)] = .{
         .llvm_name = "stfiwx",
-        .description = "Enable the stfiwx instruction",
         .dependencies = featureSet(&[_]Feature{
             .fpu,
         }),
     };
     result[@intFromEnum(Feature.two_const_nr)] = .{
         .llvm_name = "two-const-nr",
-        .description = "Requires two constant Newton-Raphson computation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vectors_use_two_units)] = .{
         .llvm_name = "vectors-use-two-units",
-        .description = "Vectors use two units",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vsx)] = .{
         .llvm_name = "vsx",
-        .description = "Enable VSX instructions",
         .dependencies = featureSet(&[_]Feature{
             .altivec,
         }),
@@ -608,6 +526,94 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"64bit")] = "Enable 64-bit instructions";
+    result[@intFromEnum(Feature.@"64bitregs")] = "Enable 64-bit registers usage for ppc32 [beta]";
+    result[@intFromEnum(Feature.aix)] = "AIX OS";
+    result[@intFromEnum(Feature.aix_small_local_exec_tls)] = "Produce a TOC-free local-exec TLS sequence for this function for 64-bit AIX";
+    result[@intFromEnum(Feature.allow_unaligned_fp_access)] = "CPU does not trap on unaligned FP access";
+    result[@intFromEnum(Feature.altivec)] = "Enable Altivec instructions";
+    result[@intFromEnum(Feature.booke)] = "Enable Book E instructions";
+    result[@intFromEnum(Feature.bpermd)] = "Enable the bpermd instruction";
+    result[@intFromEnum(Feature.cmpb)] = "Enable the cmpb instruction";
+    result[@intFromEnum(Feature.crbits)] = "Use condition-register bits individually";
+    result[@intFromEnum(Feature.crypto)] = "Enable POWER8 Crypto instructions";
+    result[@intFromEnum(Feature.direct_move)] = "Enable Power8 direct move instructions";
+    result[@intFromEnum(Feature.e500)] = "Enable E500/E500mc instructions";
+    result[@intFromEnum(Feature.efpu2)] = "Enable Embedded Floating-Point APU 2 instructions";
+    result[@intFromEnum(Feature.extdiv)] = "Enable extended divide instructions";
+    result[@intFromEnum(Feature.fast_MFLR)] = "MFLR is a fast instruction";
+    result[@intFromEnum(Feature.fcpsgn)] = "Enable the fcpsgn instruction";
+    result[@intFromEnum(Feature.float128)] = "Enable the __float128 data type for IEEE-754R Binary128.";
+    result[@intFromEnum(Feature.fpcvt)] = "Enable fc[ft]* (unsigned and single-precision) and lfiwzx instructions";
+    result[@intFromEnum(Feature.fprnd)] = "Enable the fri[mnpz] instructions";
+    result[@intFromEnum(Feature.fpu)] = "Enable classic FPU instructions";
+    result[@intFromEnum(Feature.fre)] = "Enable the fre instruction";
+    result[@intFromEnum(Feature.fres)] = "Enable the fres instruction";
+    result[@intFromEnum(Feature.frsqrte)] = "Enable the frsqrte instruction";
+    result[@intFromEnum(Feature.frsqrtes)] = "Enable the frsqrtes instruction";
+    result[@intFromEnum(Feature.fsqrt)] = "Enable the fsqrt instruction";
+    result[@intFromEnum(Feature.fuse_add_logical)] = "Target supports Add with Logical Operations fusion";
+    result[@intFromEnum(Feature.fuse_addi_load)] = "Power8 Addi-Load fusion";
+    result[@intFromEnum(Feature.fuse_addis_load)] = "Power8 Addis-Load fusion";
+    result[@intFromEnum(Feature.fuse_arith_add)] = "Target supports Arithmetic Operations with Add fusion";
+    result[@intFromEnum(Feature.fuse_back2back)] = "Target supports general back to back fusion";
+    result[@intFromEnum(Feature.fuse_cmp)] = "Target supports Comparison Operations fusion";
+    result[@intFromEnum(Feature.fuse_logical)] = "Target supports Logical Operations fusion";
+    result[@intFromEnum(Feature.fuse_logical_add)] = "Target supports Logical with Add Operations fusion";
+    result[@intFromEnum(Feature.fuse_sha3)] = "Target supports SHA3 assist fusion";
+    result[@intFromEnum(Feature.fuse_store)] = "Target supports store clustering";
+    result[@intFromEnum(Feature.fuse_wideimm)] = "Target supports Wide-Immediate fusion";
+    result[@intFromEnum(Feature.fuse_zeromove)] = "Target supports move to SPR with branch fusion";
+    result[@intFromEnum(Feature.fusion)] = "Target supports instruction fusion";
+    result[@intFromEnum(Feature.hard_float)] = "Enable floating-point instructions";
+    result[@intFromEnum(Feature.htm)] = "Enable Hardware Transactional Memory instructions";
+    result[@intFromEnum(Feature.icbt)] = "Enable icbt instruction";
+    result[@intFromEnum(Feature.invariant_function_descriptors)] = "Assume function descriptors are invariant";
+    result[@intFromEnum(Feature.isa_future_instructions)] = "Enable instructions for Future ISA.";
+    result[@intFromEnum(Feature.isa_v206_instructions)] = "Enable instructions in ISA 2.06.";
+    result[@intFromEnum(Feature.isa_v207_instructions)] = "Enable instructions in ISA 2.07.";
+    result[@intFromEnum(Feature.isa_v30_instructions)] = "Enable instructions in ISA 3.0.";
+    result[@intFromEnum(Feature.isa_v31_instructions)] = "Enable instructions in ISA 3.1.";
+    result[@intFromEnum(Feature.isel)] = "Enable the isel instruction";
+    result[@intFromEnum(Feature.ldbrx)] = "Enable the ldbrx instruction";
+    result[@intFromEnum(Feature.lfiwax)] = "Enable the lfiwax instruction";
+    result[@intFromEnum(Feature.longcall)] = "Always use indirect calls";
+    result[@intFromEnum(Feature.mfocrf)] = "Enable the MFOCRF instruction";
+    result[@intFromEnum(Feature.mma)] = "Enable MMA instructions";
+    result[@intFromEnum(Feature.modern_aix_as)] = "AIX system assembler is modern enough to support new mnes";
+    result[@intFromEnum(Feature.msync)] = "Has only the msync instruction instead of sync";
+    result[@intFromEnum(Feature.paired_vector_memops)] = "32Byte load and store instructions";
+    result[@intFromEnum(Feature.partword_atomics)] = "Enable l[bh]arx and st[bh]cx.";
+    result[@intFromEnum(Feature.pcrelative_memops)] = "Enable PC relative Memory Ops";
+    result[@intFromEnum(Feature.popcntd)] = "Enable the popcnt[dw] instructions";
+    result[@intFromEnum(Feature.power10_vector)] = "Enable POWER10 vector instructions";
+    result[@intFromEnum(Feature.power8_altivec)] = "Enable POWER8 Altivec instructions";
+    result[@intFromEnum(Feature.power8_vector)] = "Enable POWER8 vector instructions";
+    result[@intFromEnum(Feature.power9_altivec)] = "Enable POWER9 Altivec instructions";
+    result[@intFromEnum(Feature.power9_vector)] = "Enable POWER9 vector instructions";
+    result[@intFromEnum(Feature.ppc4xx)] = "Enable PPC 4xx instructions";
+    result[@intFromEnum(Feature.ppc6xx)] = "Enable PPC 6xx instructions";
+    result[@intFromEnum(Feature.ppc_postra_sched)] = "Use PowerPC post-RA scheduling strategy";
+    result[@intFromEnum(Feature.ppc_prera_sched)] = "Use PowerPC pre-RA scheduling strategy";
+    result[@intFromEnum(Feature.predictable_select_expensive)] = "Prefer likely predicted branches over selects";
+    result[@intFromEnum(Feature.prefix_instrs)] = "Enable prefixed instructions";
+    result[@intFromEnum(Feature.privileged)] = "Add privileged instructions";
+    result[@intFromEnum(Feature.quadword_atomics)] = "Enable lqarx and stqcx.";
+    result[@intFromEnum(Feature.recipprec)] = "Assume higher precision reciprocal estimates";
+    result[@intFromEnum(Feature.rop_protect)] = "Add ROP protect";
+    result[@intFromEnum(Feature.secure_plt)] = "Enable secure plt mode";
+    result[@intFromEnum(Feature.slow_popcntd)] = "Has slow popcnt[dw] instructions";
+    result[@intFromEnum(Feature.spe)] = "Enable SPE instructions";
+    result[@intFromEnum(Feature.stfiwx)] = "Enable the stfiwx instruction";
+    result[@intFromEnum(Feature.two_const_nr)] = "Requires two constant Newton-Raphson computation";
+    result[@intFromEnum(Feature.vectors_use_two_units)] = "Vectors use two units";
+    result[@intFromEnum(Feature.vsx)] = "Enable VSX instructions";
     break :blk result;
 };
 

--- a/lib/std/Target/riscv.zig
+++ b/lib/std/Target/riscv.zig
@@ -206,83 +206,68 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"32bit")] = .{
         .llvm_name = "32bit",
-        .description = "Implements RV32",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"64bit")] = .{
         .llvm_name = "64bit",
-        .description = "Implements RV64",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.a)] = .{
         .llvm_name = "a",
-        .description = "'A' (Atomic Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.auipc_addi_fusion)] = .{
         .llvm_name = "auipc-addi-fusion",
-        .description = "Enable AUIPC+ADDI macrofusion",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.c)] = .{
         .llvm_name = "c",
-        .description = "'C' (Compressed Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.conditional_cmv_fusion)] = .{
         .llvm_name = "conditional-cmv-fusion",
-        .description = "Enable branch+c.mv fusion",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.d)] = .{
         .llvm_name = "d",
-        .description = "'D' (Double-Precision Floating-Point)",
         .dependencies = featureSet(&[_]Feature{
             .f,
         }),
     };
     result[@intFromEnum(Feature.dlen_factor_2)] = .{
         .llvm_name = "dlen-factor-2",
-        .description = "Vector unit DLEN(data path width) is half of VLEN",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.e)] = .{
         .llvm_name = "e",
-        .description = "Implements RV{32,64}E (provides 16 rather than 32 GPRs)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.experimental)] = .{
         .llvm_name = "experimental",
-        .description = "Experimental intrinsics",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.experimental_zacas)] = .{
         .llvm_name = "experimental-zacas",
-        .description = "'Zacas' (Atomic Compare-And-Swap Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.experimental_zcmop)] = .{
         .llvm_name = "experimental-zcmop",
-        .description = "'Zcmop' (Compressed May-Be-Operations)",
         .dependencies = featureSet(&[_]Feature{
             .zca,
         }),
     };
     result[@intFromEnum(Feature.experimental_zfbfmin)] = .{
         .llvm_name = "experimental-zfbfmin",
-        .description = "'Zfbfmin' (Scalar BF16 Converts)",
         .dependencies = featureSet(&[_]Feature{
             .f,
         }),
     };
     result[@intFromEnum(Feature.experimental_zicfilp)] = .{
         .llvm_name = "experimental-zicfilp",
-        .description = "'Zicfilp' (Landing pad)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.experimental_zicfiss)] = .{
         .llvm_name = "experimental-zicfiss",
-        .description = "'Zicfiss' (Shadow stack)",
         .dependencies = featureSet(&[_]Feature{
             .experimental_zimop,
             .zicsr,
@@ -290,24 +275,20 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.experimental_zimop)] = .{
         .llvm_name = "experimental-zimop",
-        .description = "'Zimop' (May-Be-Operations)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.experimental_ztso)] = .{
         .llvm_name = "experimental-ztso",
-        .description = "'Ztso' (Memory Model - Total Store Order)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.experimental_zvfbfmin)] = .{
         .llvm_name = "experimental-zvfbfmin",
-        .description = "'Zvbfmin' (Vector BF16 Converts)",
         .dependencies = featureSet(&[_]Feature{
             .zve32f,
         }),
     };
     result[@intFromEnum(Feature.experimental_zvfbfwma)] = .{
         .llvm_name = "experimental-zvfbfwma",
-        .description = "'Zvfbfwma' (Vector BF16 widening mul-add)",
         .dependencies = featureSet(&[_]Feature{
             .experimental_zfbfmin,
             .experimental_zvfbfmin,
@@ -315,289 +296,232 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.f)] = .{
         .llvm_name = "f",
-        .description = "'F' (Single-Precision Floating-Point)",
         .dependencies = featureSet(&[_]Feature{
             .zicsr,
         }),
     };
     result[@intFromEnum(Feature.fast_unaligned_access)] = .{
         .llvm_name = "fast-unaligned-access",
-        .description = "Has reasonably performant unaligned loads and stores (both scalar and vector)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.forced_atomics)] = .{
         .llvm_name = "forced-atomics",
-        .description = "Assume that lock-free native-width atomics are available",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.h)] = .{
         .llvm_name = "h",
-        .description = "'H' (Hypervisor)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.i)] = .{
         .llvm_name = "i",
-        .description = "'I' (Base Integer Instruction Set)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ld_add_fusion)] = .{
         .llvm_name = "ld-add-fusion",
-        .description = "Enable LD+ADD macrofusion",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lui_addi_fusion)] = .{
         .llvm_name = "lui-addi-fusion",
-        .description = "Enable LUI+ADDI macro fusion",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.m)] = .{
         .llvm_name = "m",
-        .description = "'M' (Integer Multiplication and Division)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_default_unroll)] = .{
         .llvm_name = "no-default-unroll",
-        .description = "Disable default unroll preference.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_optimized_zero_stride_load)] = .{
         .llvm_name = "no-optimized-zero-stride-load",
-        .description = "Hasn't optimized (perform fewer memory operations)zero-stride vector load",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_rvc_hints)] = .{
         .llvm_name = "no-rvc-hints",
-        .description = "Disable RVC Hint Instructions.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.relax)] = .{
         .llvm_name = "relax",
-        .description = "Enable Linker relaxation.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x1)] = .{
         .llvm_name = "reserve-x1",
-        .description = "Reserve X1",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x10)] = .{
         .llvm_name = "reserve-x10",
-        .description = "Reserve X10",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x11)] = .{
         .llvm_name = "reserve-x11",
-        .description = "Reserve X11",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x12)] = .{
         .llvm_name = "reserve-x12",
-        .description = "Reserve X12",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x13)] = .{
         .llvm_name = "reserve-x13",
-        .description = "Reserve X13",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x14)] = .{
         .llvm_name = "reserve-x14",
-        .description = "Reserve X14",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x15)] = .{
         .llvm_name = "reserve-x15",
-        .description = "Reserve X15",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x16)] = .{
         .llvm_name = "reserve-x16",
-        .description = "Reserve X16",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x17)] = .{
         .llvm_name = "reserve-x17",
-        .description = "Reserve X17",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x18)] = .{
         .llvm_name = "reserve-x18",
-        .description = "Reserve X18",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x19)] = .{
         .llvm_name = "reserve-x19",
-        .description = "Reserve X19",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x2)] = .{
         .llvm_name = "reserve-x2",
-        .description = "Reserve X2",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x20)] = .{
         .llvm_name = "reserve-x20",
-        .description = "Reserve X20",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x21)] = .{
         .llvm_name = "reserve-x21",
-        .description = "Reserve X21",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x22)] = .{
         .llvm_name = "reserve-x22",
-        .description = "Reserve X22",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x23)] = .{
         .llvm_name = "reserve-x23",
-        .description = "Reserve X23",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x24)] = .{
         .llvm_name = "reserve-x24",
-        .description = "Reserve X24",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x25)] = .{
         .llvm_name = "reserve-x25",
-        .description = "Reserve X25",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x26)] = .{
         .llvm_name = "reserve-x26",
-        .description = "Reserve X26",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x27)] = .{
         .llvm_name = "reserve-x27",
-        .description = "Reserve X27",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x28)] = .{
         .llvm_name = "reserve-x28",
-        .description = "Reserve X28",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x29)] = .{
         .llvm_name = "reserve-x29",
-        .description = "Reserve X29",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x3)] = .{
         .llvm_name = "reserve-x3",
-        .description = "Reserve X3",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x30)] = .{
         .llvm_name = "reserve-x30",
-        .description = "Reserve X30",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x31)] = .{
         .llvm_name = "reserve-x31",
-        .description = "Reserve X31",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x4)] = .{
         .llvm_name = "reserve-x4",
-        .description = "Reserve X4",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x5)] = .{
         .llvm_name = "reserve-x5",
-        .description = "Reserve X5",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x6)] = .{
         .llvm_name = "reserve-x6",
-        .description = "Reserve X6",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x7)] = .{
         .llvm_name = "reserve-x7",
-        .description = "Reserve X7",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x8)] = .{
         .llvm_name = "reserve-x8",
-        .description = "Reserve X8",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_x9)] = .{
         .llvm_name = "reserve-x9",
-        .description = "Reserve X9",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.save_restore)] = .{
         .llvm_name = "save-restore",
-        .description = "Enable save/restore.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.seq_cst_trailing_fence)] = .{
         .llvm_name = "seq-cst-trailing-fence",
-        .description = "Enable trailing fence for seq-cst store.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.shifted_zextw_fusion)] = .{
         .llvm_name = "shifted-zextw-fusion",
-        .description = "Enable SLLI+SRLI to be fused when computing (shifted) word zero extension",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.short_forward_branch_opt)] = .{
         .llvm_name = "short-forward-branch-opt",
-        .description = "Enable short forward branch optimization",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.smaia)] = .{
         .llvm_name = "smaia",
-        .description = "'Smaia' (Advanced Interrupt Architecture Machine Level)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.smepmp)] = .{
         .llvm_name = "smepmp",
-        .description = "'Smepmp' (Enhanced Physical Memory Protection)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ssaia)] = .{
         .llvm_name = "ssaia",
-        .description = "'Ssaia' (Advanced Interrupt Architecture Supervisor Level)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.svinval)] = .{
         .llvm_name = "svinval",
-        .description = "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.svnapot)] = .{
         .llvm_name = "svnapot",
-        .description = "'Svnapot' (NAPOT Translation Contiguity)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.svpbmt)] = .{
         .llvm_name = "svpbmt",
-        .description = "'Svpbmt' (Page-Based Memory Types)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tagged_globals)] = .{
         .llvm_name = "tagged-globals",
-        .description = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.unaligned_scalar_mem)] = .{
         .llvm_name = "unaligned-scalar-mem",
-        .description = "Has reasonably performant unaligned scalar loads and stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_postra_scheduler)] = .{
         .llvm_name = "use-postra-scheduler",
-        .description = "Schedule again after register allocation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v)] = .{
         .llvm_name = "v",
-        .description = "'V' (Vector Extension for Application Processors)",
         .dependencies = featureSet(&[_]Feature{
             .zve64d,
             .zvl128b,
@@ -605,215 +529,176 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.ventana_veyron)] = .{
         .llvm_name = "ventana-veyron",
-        .description = "Ventana Veyron-Series processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvalu)] = .{
         .llvm_name = "xcvalu",
-        .description = "'XCValu' (CORE-V ALU Operations)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvbi)] = .{
         .llvm_name = "xcvbi",
-        .description = "'XCVbi' (CORE-V Immediate Branching)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvbitmanip)] = .{
         .llvm_name = "xcvbitmanip",
-        .description = "'XCVbitmanip' (CORE-V Bit Manipulation)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvelw)] = .{
         .llvm_name = "xcvelw",
-        .description = "'XCVelw' (CORE-V Event Load Word)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvmac)] = .{
         .llvm_name = "xcvmac",
-        .description = "'XCVmac' (CORE-V Multiply-Accumulate)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvmem)] = .{
         .llvm_name = "xcvmem",
-        .description = "'XCVmem' (CORE-V Post-incrementing Load & Store)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xcvsimd)] = .{
         .llvm_name = "xcvsimd",
-        .description = "'XCVsimd' (CORE-V SIMD ALU)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xsfvcp)] = .{
         .llvm_name = "xsfvcp",
-        .description = "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)",
         .dependencies = featureSet(&[_]Feature{
             .zve32x,
         }),
     };
     result[@intFromEnum(Feature.xsfvfnrclipxfqf)] = .{
         .llvm_name = "xsfvfnrclipxfqf",
-        .description = "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)",
         .dependencies = featureSet(&[_]Feature{
             .zve32f,
         }),
     };
     result[@intFromEnum(Feature.xsfvfwmaccqqq)] = .{
         .llvm_name = "xsfvfwmaccqqq",
-        .description = "'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4))",
         .dependencies = featureSet(&[_]Feature{
             .experimental_zvfbfmin,
         }),
     };
     result[@intFromEnum(Feature.xsfvqmaccdod)] = .{
         .llvm_name = "xsfvqmaccdod",
-        .description = "'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2))",
         .dependencies = featureSet(&[_]Feature{
             .zve32x,
         }),
     };
     result[@intFromEnum(Feature.xsfvqmaccqoq)] = .{
         .llvm_name = "xsfvqmaccqoq",
-        .description = "'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4))",
         .dependencies = featureSet(&[_]Feature{
             .zve32x,
         }),
     };
     result[@intFromEnum(Feature.xtheadba)] = .{
         .llvm_name = "xtheadba",
-        .description = "'xtheadba' (T-Head address calculation instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadbb)] = .{
         .llvm_name = "xtheadbb",
-        .description = "'xtheadbb' (T-Head basic bit-manipulation instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadbs)] = .{
         .llvm_name = "xtheadbs",
-        .description = "'xtheadbs' (T-Head single-bit instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadcmo)] = .{
         .llvm_name = "xtheadcmo",
-        .description = "'xtheadcmo' (T-Head cache management instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadcondmov)] = .{
         .llvm_name = "xtheadcondmov",
-        .description = "'xtheadcondmov' (T-Head conditional move instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadfmemidx)] = .{
         .llvm_name = "xtheadfmemidx",
-        .description = "'xtheadfmemidx' (T-Head FP Indexed Memory Operations)",
         .dependencies = featureSet(&[_]Feature{
             .f,
         }),
     };
     result[@intFromEnum(Feature.xtheadmac)] = .{
         .llvm_name = "xtheadmac",
-        .description = "'xtheadmac' (T-Head Multiply-Accumulate Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadmemidx)] = .{
         .llvm_name = "xtheadmemidx",
-        .description = "'xtheadmemidx' (T-Head Indexed Memory Operations)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadmempair)] = .{
         .llvm_name = "xtheadmempair",
-        .description = "'xtheadmempair' (T-Head two-GPR Memory Operations)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadsync)] = .{
         .llvm_name = "xtheadsync",
-        .description = "'xtheadsync' (T-Head multicore synchronization instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xtheadvdot)] = .{
         .llvm_name = "xtheadvdot",
-        .description = "'xtheadvdot' (T-Head Vector Extensions for Dot)",
         .dependencies = featureSet(&[_]Feature{
             .v,
         }),
     };
     result[@intFromEnum(Feature.xventanacondops)] = .{
         .llvm_name = "xventanacondops",
-        .description = "'XVentanaCondOps' (Ventana Conditional Ops)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.za128rs)] = .{
         .llvm_name = "za128rs",
-        .description = "'Za128rs' (Reservation Set Size of at Most 128 Bytes)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.za64rs)] = .{
         .llvm_name = "za64rs",
-        .description = "'Za64rs' (Reservation Set Size of at Most 64 Bytes)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zawrs)] = .{
         .llvm_name = "zawrs",
-        .description = "'Zawrs' (Wait on Reservation Set)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zba)] = .{
         .llvm_name = "zba",
-        .description = "'Zba' (Address Generation Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zbb)] = .{
         .llvm_name = "zbb",
-        .description = "'Zbb' (Basic Bit-Manipulation)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zbc)] = .{
         .llvm_name = "zbc",
-        .description = "'Zbc' (Carry-Less Multiplication)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zbkb)] = .{
         .llvm_name = "zbkb",
-        .description = "'Zbkb' (Bitmanip instructions for Cryptography)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zbkc)] = .{
         .llvm_name = "zbkc",
-        .description = "'Zbkc' (Carry-less multiply instructions for Cryptography)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zbkx)] = .{
         .llvm_name = "zbkx",
-        .description = "'Zbkx' (Crossbar permutation instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zbs)] = .{
         .llvm_name = "zbs",
-        .description = "'Zbs' (Single-Bit Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zca)] = .{
         .llvm_name = "zca",
-        .description = "'Zca' (part of the C extension, excluding compressed floating point loads/stores)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zcb)] = .{
         .llvm_name = "zcb",
-        .description = "'Zcb' (Compressed basic bit manipulation instructions)",
         .dependencies = featureSet(&[_]Feature{
             .zca,
         }),
     };
     result[@intFromEnum(Feature.zcd)] = .{
         .llvm_name = "zcd",
-        .description = "'Zcd' (Compressed Double-Precision Floating-Point Instructions)",
         .dependencies = featureSet(&[_]Feature{
             .zca,
         }),
     };
     result[@intFromEnum(Feature.zce)] = .{
         .llvm_name = "zce",
-        .description = "'Zce' (Compressed extensions for microcontrollers)",
         .dependencies = featureSet(&[_]Feature{
             .zcb,
             .zcmp,
@@ -822,21 +707,18 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zcf)] = .{
         .llvm_name = "zcf",
-        .description = "'Zcf' (Compressed Single-Precision Floating-Point Instructions)",
         .dependencies = featureSet(&[_]Feature{
             .zca,
         }),
     };
     result[@intFromEnum(Feature.zcmp)] = .{
         .llvm_name = "zcmp",
-        .description = "'Zcmp' (sequenced instructions for code-size reduction)",
         .dependencies = featureSet(&[_]Feature{
             .zca,
         }),
     };
     result[@intFromEnum(Feature.zcmt)] = .{
         .llvm_name = "zcmt",
-        .description = "'Zcmt' (table jump instructions for code-size reduction)",
         .dependencies = featureSet(&[_]Feature{
             .zca,
             .zicsr,
@@ -844,145 +726,120 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zdinx)] = .{
         .llvm_name = "zdinx",
-        .description = "'Zdinx' (Double in Integer)",
         .dependencies = featureSet(&[_]Feature{
             .zfinx,
         }),
     };
     result[@intFromEnum(Feature.zexth_fusion)] = .{
         .llvm_name = "zexth-fusion",
-        .description = "Enable SLLI+SRLI to be fused to zero extension of halfword",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zextw_fusion)] = .{
         .llvm_name = "zextw-fusion",
-        .description = "Enable SLLI+SRLI to be fused to zero extension of word",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zfa)] = .{
         .llvm_name = "zfa",
-        .description = "'Zfa' (Additional Floating-Point)",
         .dependencies = featureSet(&[_]Feature{
             .f,
         }),
     };
     result[@intFromEnum(Feature.zfh)] = .{
         .llvm_name = "zfh",
-        .description = "'Zfh' (Half-Precision Floating-Point)",
         .dependencies = featureSet(&[_]Feature{
             .zfhmin,
         }),
     };
     result[@intFromEnum(Feature.zfhmin)] = .{
         .llvm_name = "zfhmin",
-        .description = "'Zfhmin' (Half-Precision Floating-Point Minimal)",
         .dependencies = featureSet(&[_]Feature{
             .f,
         }),
     };
     result[@intFromEnum(Feature.zfinx)] = .{
         .llvm_name = "zfinx",
-        .description = "'Zfinx' (Float in Integer)",
         .dependencies = featureSet(&[_]Feature{
             .zicsr,
         }),
     };
     result[@intFromEnum(Feature.zhinx)] = .{
         .llvm_name = "zhinx",
-        .description = "'Zhinx' (Half Float in Integer)",
         .dependencies = featureSet(&[_]Feature{
             .zhinxmin,
         }),
     };
     result[@intFromEnum(Feature.zhinxmin)] = .{
         .llvm_name = "zhinxmin",
-        .description = "'Zhinxmin' (Half Float in Integer Minimal)",
         .dependencies = featureSet(&[_]Feature{
             .zfinx,
         }),
     };
     result[@intFromEnum(Feature.zic64b)] = .{
         .llvm_name = "zic64b",
-        .description = "'Zic64b' (Cache Block Size Is 64 Bytes)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zicbom)] = .{
         .llvm_name = "zicbom",
-        .description = "'Zicbom' (Cache-Block Management Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zicbop)] = .{
         .llvm_name = "zicbop",
-        .description = "'Zicbop' (Cache-Block Prefetch Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zicboz)] = .{
         .llvm_name = "zicboz",
-        .description = "'Zicboz' (Cache-Block Zero Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ziccamoa)] = .{
         .llvm_name = "ziccamoa",
-        .description = "'Ziccamoa' (Main Memory Supports All Atomics in A)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ziccif)] = .{
         .llvm_name = "ziccif",
-        .description = "'Ziccif' (Main Memory Supports Instruction Fetch with Atomicity Requirement)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zicclsm)] = .{
         .llvm_name = "zicclsm",
-        .description = "'Zicclsm' (Main Memory Supports Misaligned Loads/Stores)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ziccrse)] = .{
         .llvm_name = "ziccrse",
-        .description = "'Ziccrse' (Main Memory Supports Forward Progress on LR/SC Sequences)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zicntr)] = .{
         .llvm_name = "zicntr",
-        .description = "'Zicntr' (Base Counters and Timers)",
         .dependencies = featureSet(&[_]Feature{
             .zicsr,
         }),
     };
     result[@intFromEnum(Feature.zicond)] = .{
         .llvm_name = "zicond",
-        .description = "'Zicond' (Integer Conditional Operations)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zicsr)] = .{
         .llvm_name = "zicsr",
-        .description = "'zicsr' (CSRs)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zifencei)] = .{
         .llvm_name = "zifencei",
-        .description = "'Zifencei' (fence.i)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zihintntl)] = .{
         .llvm_name = "zihintntl",
-        .description = "'Zihintntl' (Non-Temporal Locality Hints)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zihintpause)] = .{
         .llvm_name = "zihintpause",
-        .description = "'Zihintpause' (Pause Hint)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zihpm)] = .{
         .llvm_name = "zihpm",
-        .description = "'Zihpm' (Hardware Performance Counters)",
         .dependencies = featureSet(&[_]Feature{
             .zicsr,
         }),
     };
     result[@intFromEnum(Feature.zk)] = .{
         .llvm_name = "zk",
-        .description = "'Zk' (Standard scalar cryptography extension)",
         .dependencies = featureSet(&[_]Feature{
             .zkn,
             .zkr,
@@ -991,7 +848,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zkn)] = .{
         .llvm_name = "zkn",
-        .description = "'Zkn' (NIST Algorithm Suite)",
         .dependencies = featureSet(&[_]Feature{
             .zbkb,
             .zbkc,
@@ -1003,27 +859,22 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zknd)] = .{
         .llvm_name = "zknd",
-        .description = "'Zknd' (NIST Suite: AES Decryption)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zkne)] = .{
         .llvm_name = "zkne",
-        .description = "'Zkne' (NIST Suite: AES Encryption)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zknh)] = .{
         .llvm_name = "zknh",
-        .description = "'Zknh' (NIST Suite: Hash Function Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zkr)] = .{
         .llvm_name = "zkr",
-        .description = "'Zkr' (Entropy Source Extension)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zks)] = .{
         .llvm_name = "zks",
-        .description = "'Zks' (ShangMi Algorithm Suite)",
         .dependencies = featureSet(&[_]Feature{
             .zbkb,
             .zbkc,
@@ -1034,39 +885,32 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zksed)] = .{
         .llvm_name = "zksed",
-        .description = "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zksh)] = .{
         .llvm_name = "zksh",
-        .description = "'Zksh' (ShangMi Suite: SM3 Hash Function Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zkt)] = .{
         .llvm_name = "zkt",
-        .description = "'Zkt' (Data Independent Execution Latency)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zmmul)] = .{
         .llvm_name = "zmmul",
-        .description = "'Zmmul' (Integer Multiplication)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvbb)] = .{
         .llvm_name = "zvbb",
-        .description = "'Zvbb' (Vector basic bit-manipulation instructions)",
         .dependencies = featureSet(&[_]Feature{
             .zvkb,
         }),
     };
     result[@intFromEnum(Feature.zvbc)] = .{
         .llvm_name = "zvbc",
-        .description = "'Zvbc' (Vector Carryless Multiplication)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zve32f)] = .{
         .llvm_name = "zve32f",
-        .description = "'Zve32f' (Vector Extensions for Embedded Processors with maximal 32 EEW and F extension)",
         .dependencies = featureSet(&[_]Feature{
             .f,
             .zve32x,
@@ -1074,7 +918,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zve32x)] = .{
         .llvm_name = "zve32x",
-        .description = "'Zve32x' (Vector Extensions for Embedded Processors with maximal 32 EEW)",
         .dependencies = featureSet(&[_]Feature{
             .zicsr,
             .zvl32b,
@@ -1082,7 +925,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zve64d)] = .{
         .llvm_name = "zve64d",
-        .description = "'Zve64d' (Vector Extensions for Embedded Processors with maximal 64 EEW, F and D extension)",
         .dependencies = featureSet(&[_]Feature{
             .d,
             .zve64f,
@@ -1090,7 +932,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zve64f)] = .{
         .llvm_name = "zve64f",
-        .description = "'Zve64f' (Vector Extensions for Embedded Processors with maximal 64 EEW and F extension)",
         .dependencies = featureSet(&[_]Feature{
             .zve32f,
             .zve64x,
@@ -1098,7 +939,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zve64x)] = .{
         .llvm_name = "zve64x",
-        .description = "'Zve64x' (Vector Extensions for Embedded Processors with maximal 64 EEW)",
         .dependencies = featureSet(&[_]Feature{
             .zve32x,
             .zvl64b,
@@ -1106,7 +946,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvfh)] = .{
         .llvm_name = "zvfh",
-        .description = "'Zvfh' (Vector Half-Precision Floating-Point)",
         .dependencies = featureSet(&[_]Feature{
             .zfhmin,
             .zvfhmin,
@@ -1114,24 +953,20 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvfhmin)] = .{
         .llvm_name = "zvfhmin",
-        .description = "'Zvfhmin' (Vector Half-Precision Floating-Point Minimal)",
         .dependencies = featureSet(&[_]Feature{
             .zve32f,
         }),
     };
     result[@intFromEnum(Feature.zvkb)] = .{
         .llvm_name = "zvkb",
-        .description = "'Zvkb' (Vector Bit-manipulation used in Cryptography)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvkg)] = .{
         .llvm_name = "zvkg",
-        .description = "'Zvkg' (Vector GCM instructions for Cryptography)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvkn)] = .{
         .llvm_name = "zvkn",
-        .description = "'Zvkn' (shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and 'Zvkt')",
         .dependencies = featureSet(&[_]Feature{
             .zvkb,
             .zvkned,
@@ -1141,7 +976,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvknc)] = .{
         .llvm_name = "zvknc",
-        .description = "'Zvknc' (shorthand for 'Zvknc' and 'Zvbc')",
         .dependencies = featureSet(&[_]Feature{
             .zvbc,
             .zvkn,
@@ -1149,12 +983,10 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvkned)] = .{
         .llvm_name = "zvkned",
-        .description = "'Zvkned' (Vector AES Encryption & Decryption (Single Round))",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvkng)] = .{
         .llvm_name = "zvkng",
-        .description = "'zvkng' (shorthand for 'Zvkn' and 'Zvkg')",
         .dependencies = featureSet(&[_]Feature{
             .zvkg,
             .zvkn,
@@ -1162,19 +994,16 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvknha)] = .{
         .llvm_name = "zvknha",
-        .description = "'Zvknha' (Vector SHA-2 (SHA-256 only))",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvknhb)] = .{
         .llvm_name = "zvknhb",
-        .description = "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))",
         .dependencies = featureSet(&[_]Feature{
             .zve64x,
         }),
     };
     result[@intFromEnum(Feature.zvks)] = .{
         .llvm_name = "zvks",
-        .description = "'Zvks' (shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and 'Zvkt')",
         .dependencies = featureSet(&[_]Feature{
             .zvkb,
             .zvksed,
@@ -1184,7 +1013,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvksc)] = .{
         .llvm_name = "zvksc",
-        .description = "'Zvksc' (shorthand for 'Zvks' and 'Zvbc')",
         .dependencies = featureSet(&[_]Feature{
             .zvbc,
             .zvks,
@@ -1192,12 +1020,10 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvksed)] = .{
         .llvm_name = "zvksed",
-        .description = "'Zvksed' (SM4 Block Cipher Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvksg)] = .{
         .llvm_name = "zvksg",
-        .description = "'Zvksg' (shorthand for 'Zvks' and 'Zvkg')",
         .dependencies = featureSet(&[_]Feature{
             .zvkg,
             .zvks,
@@ -1205,92 +1031,78 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.zvksh)] = .{
         .llvm_name = "zvksh",
-        .description = "'Zvksh' (SM3 Hash Function Instructions)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvkt)] = .{
         .llvm_name = "zvkt",
-        .description = "'Zvkt' (Vector Data-Independent Execution Latency)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvl1024b)] = .{
         .llvm_name = "zvl1024b",
-        .description = "'Zvl' (Minimum Vector Length) 1024",
         .dependencies = featureSet(&[_]Feature{
             .zvl512b,
         }),
     };
     result[@intFromEnum(Feature.zvl128b)] = .{
         .llvm_name = "zvl128b",
-        .description = "'Zvl' (Minimum Vector Length) 128",
         .dependencies = featureSet(&[_]Feature{
             .zvl64b,
         }),
     };
     result[@intFromEnum(Feature.zvl16384b)] = .{
         .llvm_name = "zvl16384b",
-        .description = "'Zvl' (Minimum Vector Length) 16384",
         .dependencies = featureSet(&[_]Feature{
             .zvl8192b,
         }),
     };
     result[@intFromEnum(Feature.zvl2048b)] = .{
         .llvm_name = "zvl2048b",
-        .description = "'Zvl' (Minimum Vector Length) 2048",
         .dependencies = featureSet(&[_]Feature{
             .zvl1024b,
         }),
     };
     result[@intFromEnum(Feature.zvl256b)] = .{
         .llvm_name = "zvl256b",
-        .description = "'Zvl' (Minimum Vector Length) 256",
         .dependencies = featureSet(&[_]Feature{
             .zvl128b,
         }),
     };
     result[@intFromEnum(Feature.zvl32768b)] = .{
         .llvm_name = "zvl32768b",
-        .description = "'Zvl' (Minimum Vector Length) 32768",
         .dependencies = featureSet(&[_]Feature{
             .zvl16384b,
         }),
     };
     result[@intFromEnum(Feature.zvl32b)] = .{
         .llvm_name = "zvl32b",
-        .description = "'Zvl' (Minimum Vector Length) 32",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.zvl4096b)] = .{
         .llvm_name = "zvl4096b",
-        .description = "'Zvl' (Minimum Vector Length) 4096",
         .dependencies = featureSet(&[_]Feature{
             .zvl2048b,
         }),
     };
     result[@intFromEnum(Feature.zvl512b)] = .{
         .llvm_name = "zvl512b",
-        .description = "'Zvl' (Minimum Vector Length) 512",
         .dependencies = featureSet(&[_]Feature{
             .zvl256b,
         }),
     };
     result[@intFromEnum(Feature.zvl64b)] = .{
         .llvm_name = "zvl64b",
-        .description = "'Zvl' (Minimum Vector Length) 64",
         .dependencies = featureSet(&[_]Feature{
             .zvl32b,
         }),
     };
     result[@intFromEnum(Feature.zvl65536b)] = .{
         .llvm_name = "zvl65536b",
-        .description = "'Zvl' (Minimum Vector Length) 65536",
         .dependencies = featureSet(&[_]Feature{
             .zvl32768b,
         }),
     };
     result[@intFromEnum(Feature.zvl8192b)] = .{
         .llvm_name = "zvl8192b",
-        .description = "'Zvl' (Minimum Vector Length) 8192",
         .dependencies = featureSet(&[_]Feature{
             .zvl4096b,
         }),
@@ -1300,6 +1112,200 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"32bit")] = "Implements RV32";
+    result[@intFromEnum(Feature.@"64bit")] = "Implements RV64";
+    result[@intFromEnum(Feature.a)] = "'A' (Atomic Instructions)";
+    result[@intFromEnum(Feature.auipc_addi_fusion)] = "Enable AUIPC+ADDI macrofusion";
+    result[@intFromEnum(Feature.c)] = "'C' (Compressed Instructions)";
+    result[@intFromEnum(Feature.conditional_cmv_fusion)] = "Enable branch+c.mv fusion";
+    result[@intFromEnum(Feature.d)] = "'D' (Double-Precision Floating-Point)";
+    result[@intFromEnum(Feature.dlen_factor_2)] = "Vector unit DLEN(data path width) is half of VLEN";
+    result[@intFromEnum(Feature.e)] = "Implements RV{32,64}E (provides 16 rather than 32 GPRs)";
+    result[@intFromEnum(Feature.experimental)] = "Experimental intrinsics";
+    result[@intFromEnum(Feature.experimental_zacas)] = "'Zacas' (Atomic Compare-And-Swap Instructions)";
+    result[@intFromEnum(Feature.experimental_zcmop)] = "'Zcmop' (Compressed May-Be-Operations)";
+    result[@intFromEnum(Feature.experimental_zfbfmin)] = "'Zfbfmin' (Scalar BF16 Converts)";
+    result[@intFromEnum(Feature.experimental_zicfilp)] = "'Zicfilp' (Landing pad)";
+    result[@intFromEnum(Feature.experimental_zicfiss)] = "'Zicfiss' (Shadow stack)";
+    result[@intFromEnum(Feature.experimental_zimop)] = "'Zimop' (May-Be-Operations)";
+    result[@intFromEnum(Feature.experimental_ztso)] = "'Ztso' (Memory Model - Total Store Order)";
+    result[@intFromEnum(Feature.experimental_zvfbfmin)] = "'Zvbfmin' (Vector BF16 Converts)";
+    result[@intFromEnum(Feature.experimental_zvfbfwma)] = "'Zvfbfwma' (Vector BF16 widening mul-add)";
+    result[@intFromEnum(Feature.f)] = "'F' (Single-Precision Floating-Point)";
+    result[@intFromEnum(Feature.fast_unaligned_access)] = "Has reasonably performant unaligned loads and stores (both scalar and vector)";
+    result[@intFromEnum(Feature.forced_atomics)] = "Assume that lock-free native-width atomics are available";
+    result[@intFromEnum(Feature.h)] = "'H' (Hypervisor)";
+    result[@intFromEnum(Feature.i)] = "'I' (Base Integer Instruction Set)";
+    result[@intFromEnum(Feature.ld_add_fusion)] = "Enable LD+ADD macrofusion";
+    result[@intFromEnum(Feature.lui_addi_fusion)] = "Enable LUI+ADDI macro fusion";
+    result[@intFromEnum(Feature.m)] = "'M' (Integer Multiplication and Division)";
+    result[@intFromEnum(Feature.no_default_unroll)] = "Disable default unroll preference.";
+    result[@intFromEnum(Feature.no_optimized_zero_stride_load)] = "Hasn't optimized (perform fewer memory operations)zero-stride vector load";
+    result[@intFromEnum(Feature.no_rvc_hints)] = "Disable RVC Hint Instructions.";
+    result[@intFromEnum(Feature.relax)] = "Enable Linker relaxation.";
+    result[@intFromEnum(Feature.reserve_x1)] = "Reserve X1";
+    result[@intFromEnum(Feature.reserve_x10)] = "Reserve X10";
+    result[@intFromEnum(Feature.reserve_x11)] = "Reserve X11";
+    result[@intFromEnum(Feature.reserve_x12)] = "Reserve X12";
+    result[@intFromEnum(Feature.reserve_x13)] = "Reserve X13";
+    result[@intFromEnum(Feature.reserve_x14)] = "Reserve X14";
+    result[@intFromEnum(Feature.reserve_x15)] = "Reserve X15";
+    result[@intFromEnum(Feature.reserve_x16)] = "Reserve X16";
+    result[@intFromEnum(Feature.reserve_x17)] = "Reserve X17";
+    result[@intFromEnum(Feature.reserve_x18)] = "Reserve X18";
+    result[@intFromEnum(Feature.reserve_x19)] = "Reserve X19";
+    result[@intFromEnum(Feature.reserve_x2)] = "Reserve X2";
+    result[@intFromEnum(Feature.reserve_x20)] = "Reserve X20";
+    result[@intFromEnum(Feature.reserve_x21)] = "Reserve X21";
+    result[@intFromEnum(Feature.reserve_x22)] = "Reserve X22";
+    result[@intFromEnum(Feature.reserve_x23)] = "Reserve X23";
+    result[@intFromEnum(Feature.reserve_x24)] = "Reserve X24";
+    result[@intFromEnum(Feature.reserve_x25)] = "Reserve X25";
+    result[@intFromEnum(Feature.reserve_x26)] = "Reserve X26";
+    result[@intFromEnum(Feature.reserve_x27)] = "Reserve X27";
+    result[@intFromEnum(Feature.reserve_x28)] = "Reserve X28";
+    result[@intFromEnum(Feature.reserve_x29)] = "Reserve X29";
+    result[@intFromEnum(Feature.reserve_x3)] = "Reserve X3";
+    result[@intFromEnum(Feature.reserve_x30)] = "Reserve X30";
+    result[@intFromEnum(Feature.reserve_x31)] = "Reserve X31";
+    result[@intFromEnum(Feature.reserve_x4)] = "Reserve X4";
+    result[@intFromEnum(Feature.reserve_x5)] = "Reserve X5";
+    result[@intFromEnum(Feature.reserve_x6)] = "Reserve X6";
+    result[@intFromEnum(Feature.reserve_x7)] = "Reserve X7";
+    result[@intFromEnum(Feature.reserve_x8)] = "Reserve X8";
+    result[@intFromEnum(Feature.reserve_x9)] = "Reserve X9";
+    result[@intFromEnum(Feature.save_restore)] = "Enable save/restore.";
+    result[@intFromEnum(Feature.seq_cst_trailing_fence)] = "Enable trailing fence for seq-cst store.";
+    result[@intFromEnum(Feature.shifted_zextw_fusion)] = "Enable SLLI+SRLI to be fused when computing (shifted) word zero extension";
+    result[@intFromEnum(Feature.short_forward_branch_opt)] = "Enable short forward branch optimization";
+    result[@intFromEnum(Feature.smaia)] = "'Smaia' (Advanced Interrupt Architecture Machine Level)";
+    result[@intFromEnum(Feature.smepmp)] = "'Smepmp' (Enhanced Physical Memory Protection)";
+    result[@intFromEnum(Feature.ssaia)] = "'Ssaia' (Advanced Interrupt Architecture Supervisor Level)";
+    result[@intFromEnum(Feature.svinval)] = "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)";
+    result[@intFromEnum(Feature.svnapot)] = "'Svnapot' (NAPOT Translation Contiguity)";
+    result[@intFromEnum(Feature.svpbmt)] = "'Svpbmt' (Page-Based Memory Types)";
+    result[@intFromEnum(Feature.tagged_globals)] = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits";
+    result[@intFromEnum(Feature.unaligned_scalar_mem)] = "Has reasonably performant unaligned scalar loads and stores";
+    result[@intFromEnum(Feature.use_postra_scheduler)] = "Schedule again after register allocation";
+    result[@intFromEnum(Feature.v)] = "'V' (Vector Extension for Application Processors)";
+    result[@intFromEnum(Feature.ventana_veyron)] = "Ventana Veyron-Series processors";
+    result[@intFromEnum(Feature.xcvalu)] = "'XCValu' (CORE-V ALU Operations)";
+    result[@intFromEnum(Feature.xcvbi)] = "'XCVbi' (CORE-V Immediate Branching)";
+    result[@intFromEnum(Feature.xcvbitmanip)] = "'XCVbitmanip' (CORE-V Bit Manipulation)";
+    result[@intFromEnum(Feature.xcvelw)] = "'XCVelw' (CORE-V Event Load Word)";
+    result[@intFromEnum(Feature.xcvmac)] = "'XCVmac' (CORE-V Multiply-Accumulate)";
+    result[@intFromEnum(Feature.xcvmem)] = "'XCVmem' (CORE-V Post-incrementing Load & Store)";
+    result[@intFromEnum(Feature.xcvsimd)] = "'XCVsimd' (CORE-V SIMD ALU)";
+    result[@intFromEnum(Feature.xsfvcp)] = "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)";
+    result[@intFromEnum(Feature.xsfvfnrclipxfqf)] = "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)";
+    result[@intFromEnum(Feature.xsfvfwmaccqqq)] = "'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4))";
+    result[@intFromEnum(Feature.xsfvqmaccdod)] = "'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2))";
+    result[@intFromEnum(Feature.xsfvqmaccqoq)] = "'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4))";
+    result[@intFromEnum(Feature.xtheadba)] = "'xtheadba' (T-Head address calculation instructions)";
+    result[@intFromEnum(Feature.xtheadbb)] = "'xtheadbb' (T-Head basic bit-manipulation instructions)";
+    result[@intFromEnum(Feature.xtheadbs)] = "'xtheadbs' (T-Head single-bit instructions)";
+    result[@intFromEnum(Feature.xtheadcmo)] = "'xtheadcmo' (T-Head cache management instructions)";
+    result[@intFromEnum(Feature.xtheadcondmov)] = "'xtheadcondmov' (T-Head conditional move instructions)";
+    result[@intFromEnum(Feature.xtheadfmemidx)] = "'xtheadfmemidx' (T-Head FP Indexed Memory Operations)";
+    result[@intFromEnum(Feature.xtheadmac)] = "'xtheadmac' (T-Head Multiply-Accumulate Instructions)";
+    result[@intFromEnum(Feature.xtheadmemidx)] = "'xtheadmemidx' (T-Head Indexed Memory Operations)";
+    result[@intFromEnum(Feature.xtheadmempair)] = "'xtheadmempair' (T-Head two-GPR Memory Operations)";
+    result[@intFromEnum(Feature.xtheadsync)] = "'xtheadsync' (T-Head multicore synchronization instructions)";
+    result[@intFromEnum(Feature.xtheadvdot)] = "'xtheadvdot' (T-Head Vector Extensions for Dot)";
+    result[@intFromEnum(Feature.xventanacondops)] = "'XVentanaCondOps' (Ventana Conditional Ops)";
+    result[@intFromEnum(Feature.za128rs)] = "'Za128rs' (Reservation Set Size of at Most 128 Bytes)";
+    result[@intFromEnum(Feature.za64rs)] = "'Za64rs' (Reservation Set Size of at Most 64 Bytes)";
+    result[@intFromEnum(Feature.zawrs)] = "'Zawrs' (Wait on Reservation Set)";
+    result[@intFromEnum(Feature.zba)] = "'Zba' (Address Generation Instructions)";
+    result[@intFromEnum(Feature.zbb)] = "'Zbb' (Basic Bit-Manipulation)";
+    result[@intFromEnum(Feature.zbc)] = "'Zbc' (Carry-Less Multiplication)";
+    result[@intFromEnum(Feature.zbkb)] = "'Zbkb' (Bitmanip instructions for Cryptography)";
+    result[@intFromEnum(Feature.zbkc)] = "'Zbkc' (Carry-less multiply instructions for Cryptography)";
+    result[@intFromEnum(Feature.zbkx)] = "'Zbkx' (Crossbar permutation instructions)";
+    result[@intFromEnum(Feature.zbs)] = "'Zbs' (Single-Bit Instructions)";
+    result[@intFromEnum(Feature.zca)] = "'Zca' (part of the C extension, excluding compressed floating point loads/stores)";
+    result[@intFromEnum(Feature.zcb)] = "'Zcb' (Compressed basic bit manipulation instructions)";
+    result[@intFromEnum(Feature.zcd)] = "'Zcd' (Compressed Double-Precision Floating-Point Instructions)";
+    result[@intFromEnum(Feature.zce)] = "'Zce' (Compressed extensions for microcontrollers)";
+    result[@intFromEnum(Feature.zcf)] = "'Zcf' (Compressed Single-Precision Floating-Point Instructions)";
+    result[@intFromEnum(Feature.zcmp)] = "'Zcmp' (sequenced instuctions for code-size reduction)";
+    result[@intFromEnum(Feature.zcmt)] = "'Zcmt' (table jump instuctions for code-size reduction)";
+    result[@intFromEnum(Feature.zdinx)] = "'Zdinx' (Double in Integer)";
+    result[@intFromEnum(Feature.zexth_fusion)] = "Enable SLLI+SRLI to be fused to zero extension of halfword";
+    result[@intFromEnum(Feature.zextw_fusion)] = "Enable SLLI+SRLI to be fused to zero extension of word";
+    result[@intFromEnum(Feature.zfa)] = "'Zfa' (Additional Floating-Point)";
+    result[@intFromEnum(Feature.zfh)] = "'Zfh' (Half-Precision Floating-Point)";
+    result[@intFromEnum(Feature.zfhmin)] = "'Zfhmin' (Half-Precision Floating-Point Minimal)";
+    result[@intFromEnum(Feature.zfinx)] = "'Zfinx' (Float in Integer)";
+    result[@intFromEnum(Feature.zhinx)] = "'Zhinx' (Half Float in Integer)";
+    result[@intFromEnum(Feature.zhinxmin)] = "'Zhinxmin' (Half Float in Integer Minimal)";
+    result[@intFromEnum(Feature.zic64b)] = "'Zic64b' (Cache Block Size Is 64 Bytes)";
+    result[@intFromEnum(Feature.zicbom)] = "'Zicbom' (Cache-Block Management Instructions)";
+    result[@intFromEnum(Feature.zicbop)] = "'Zicbop' (Cache-Block Prefetch Instructions)";
+    result[@intFromEnum(Feature.zicboz)] = "'Zicboz' (Cache-Block Zero Instructions)";
+    result[@intFromEnum(Feature.ziccamoa)] = "'Ziccamoa' (Main Memory Supports All Atomics in A)";
+    result[@intFromEnum(Feature.ziccif)] = "'Ziccif' (Main Memory Supports Instruction Fetch with Atomicity Requirement)";
+    result[@intFromEnum(Feature.zicclsm)] = "'Zicclsm' (Main Memory Supports Misaligned Loads/Stores)";
+    result[@intFromEnum(Feature.ziccrse)] = "'Ziccrse' (Main Memory Supports Forward Progress on LR/SC Sequences)";
+    result[@intFromEnum(Feature.zicntr)] = "'Zicntr' (Base Counters and Timers)";
+    result[@intFromEnum(Feature.zicond)] = "'Zicond' (Integer Conditional Operations)";
+    result[@intFromEnum(Feature.zicsr)] = "'zicsr' (CSRs)";
+    result[@intFromEnum(Feature.zifencei)] = "'Zifencei' (fence.i)";
+    result[@intFromEnum(Feature.zihintntl)] = "'Zihintntl' (Non-Temporal Locality Hints)";
+    result[@intFromEnum(Feature.zihintpause)] = "'Zihintpause' (Pause Hint)";
+    result[@intFromEnum(Feature.zihpm)] = "'Zihpm' (Hardware Performance Counters)";
+    result[@intFromEnum(Feature.zk)] = "'Zk' (Standard scalar cryptography extension)";
+    result[@intFromEnum(Feature.zkn)] = "'Zkn' (NIST Algorithm Suite)";
+    result[@intFromEnum(Feature.zknd)] = "'Zknd' (NIST Suite: AES Decryption)";
+    result[@intFromEnum(Feature.zkne)] = "'Zkne' (NIST Suite: AES Encryption)";
+    result[@intFromEnum(Feature.zknh)] = "'Zknh' (NIST Suite: Hash Function Instructions)";
+    result[@intFromEnum(Feature.zkr)] = "'Zkr' (Entropy Source Extension)";
+    result[@intFromEnum(Feature.zks)] = "'Zks' (ShangMi Algorithm Suite)";
+    result[@intFromEnum(Feature.zksed)] = "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)";
+    result[@intFromEnum(Feature.zksh)] = "'Zksh' (ShangMi Suite: SM3 Hash Function Instructions)";
+    result[@intFromEnum(Feature.zkt)] = "'Zkt' (Data Independent Execution Latency)";
+    result[@intFromEnum(Feature.zmmul)] = "'Zmmul' (Integer Multiplication)";
+    result[@intFromEnum(Feature.zvbb)] = "'Zvbb' (Vector basic bit-manipulation instructions)";
+    result[@intFromEnum(Feature.zvbc)] = "'Zvbc' (Vector Carryless Multiplication)";
+    result[@intFromEnum(Feature.zve32f)] = "'Zve32f' (Vector Extensions for Embedded Processors with maximal 32 EEW and F extension)";
+    result[@intFromEnum(Feature.zve32x)] = "'Zve32x' (Vector Extensions for Embedded Processors with maximal 32 EEW)";
+    result[@intFromEnum(Feature.zve64d)] = "'Zve64d' (Vector Extensions for Embedded Processors with maximal 64 EEW, F and D extension)";
+    result[@intFromEnum(Feature.zve64f)] = "'Zve64f' (Vector Extensions for Embedded Processors with maximal 64 EEW and F extension)";
+    result[@intFromEnum(Feature.zve64x)] = "'Zve64x' (Vector Extensions for Embedded Processors with maximal 64 EEW)";
+    result[@intFromEnum(Feature.zvfh)] = "'Zvfh' (Vector Half-Precision Floating-Point)";
+    result[@intFromEnum(Feature.zvfhmin)] = "'Zvfhmin' (Vector Half-Precision Floating-Point Minimal)";
+    result[@intFromEnum(Feature.zvkb)] = "'Zvkb' (Vector Bit-manipulation used in Cryptography)";
+    result[@intFromEnum(Feature.zvkg)] = "'Zvkg' (Vector GCM instructions for Cryptography)";
+    result[@intFromEnum(Feature.zvkn)] = "'Zvkn' (shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and 'Zvkt')";
+    result[@intFromEnum(Feature.zvknc)] = "'Zvknc' (shorthand for 'Zvknc' and 'Zvbc')";
+    result[@intFromEnum(Feature.zvkned)] = "'Zvkned' (Vector AES Encryption & Decryption (Single Round))";
+    result[@intFromEnum(Feature.zvkng)] = "'zvkng' (shorthand for 'Zvkn' and 'Zvkg')";
+    result[@intFromEnum(Feature.zvknha)] = "'Zvknha' (Vector SHA-2 (SHA-256 only))";
+    result[@intFromEnum(Feature.zvknhb)] = "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))";
+    result[@intFromEnum(Feature.zvks)] = "'Zvks' (shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and 'Zvkt')";
+    result[@intFromEnum(Feature.zvksc)] = "'Zvksc' (shorthand for 'Zvks' and 'Zvbc')";
+    result[@intFromEnum(Feature.zvksed)] = "'Zvksed' (SM4 Block Cipher Instructions)";
+    result[@intFromEnum(Feature.zvksg)] = "'Zvksg' (shorthand for 'Zvks' and 'Zvkg')";
+    result[@intFromEnum(Feature.zvksh)] = "'Zvksh' (SM3 Hash Function Instructions)";
+    result[@intFromEnum(Feature.zvkt)] = "'Zvkt' (Vector Data-Independent Execution Latency)";
+    result[@intFromEnum(Feature.zvl1024b)] = "'Zvl' (Minimum Vector Length) 1024";
+    result[@intFromEnum(Feature.zvl128b)] = "'Zvl' (Minimum Vector Length) 128";
+    result[@intFromEnum(Feature.zvl16384b)] = "'Zvl' (Minimum Vector Length) 16384";
+    result[@intFromEnum(Feature.zvl2048b)] = "'Zvl' (Minimum Vector Length) 2048";
+    result[@intFromEnum(Feature.zvl256b)] = "'Zvl' (Minimum Vector Length) 256";
+    result[@intFromEnum(Feature.zvl32768b)] = "'Zvl' (Minimum Vector Length) 32768";
+    result[@intFromEnum(Feature.zvl32b)] = "'Zvl' (Minimum Vector Length) 32";
+    result[@intFromEnum(Feature.zvl4096b)] = "'Zvl' (Minimum Vector Length) 4096";
+    result[@intFromEnum(Feature.zvl512b)] = "'Zvl' (Minimum Vector Length) 512";
+    result[@intFromEnum(Feature.zvl64b)] = "'Zvl' (Minimum Vector Length) 64";
+    result[@intFromEnum(Feature.zvl65536b)] = "'Zvl' (Minimum Vector Length) 65536";
+    result[@intFromEnum(Feature.zvl8192b)] = "'Zvl' (Minimum Vector Length) 8192";
     break :blk result;
 };
 

--- a/lib/std/Target/s390x.zig
+++ b/lib/std/Target/s390x.zig
@@ -60,212 +60,170 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.backchain)] = .{
         .llvm_name = "backchain",
-        .description = "Store the address of the caller's frame into the callee's stack frame",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.bear_enhancement)] = .{
         .llvm_name = "bear-enhancement",
-        .description = "Assume that the BEAR-enhancement facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.deflate_conversion)] = .{
         .llvm_name = "deflate-conversion",
-        .description = "Assume that the deflate-conversion facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dfp_packed_conversion)] = .{
         .llvm_name = "dfp-packed-conversion",
-        .description = "Assume that the DFP packed-conversion facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.dfp_zoned_conversion)] = .{
         .llvm_name = "dfp-zoned-conversion",
-        .description = "Assume that the DFP zoned-conversion facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.distinct_ops)] = .{
         .llvm_name = "distinct-ops",
-        .description = "Assume that the distinct-operands facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.enhanced_dat_2)] = .{
         .llvm_name = "enhanced-dat-2",
-        .description = "Assume that the enhanced-DAT facility 2 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.enhanced_sort)] = .{
         .llvm_name = "enhanced-sort",
-        .description = "Assume that the enhanced-sort facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.execution_hint)] = .{
         .llvm_name = "execution-hint",
-        .description = "Assume that the execution-hint facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_serialization)] = .{
         .llvm_name = "fast-serialization",
-        .description = "Assume that the fast-serialization facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fp_extension)] = .{
         .llvm_name = "fp-extension",
-        .description = "Assume that the floating-point extension facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.guarded_storage)] = .{
         .llvm_name = "guarded-storage",
-        .description = "Assume that the guarded-storage facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.high_word)] = .{
         .llvm_name = "high-word",
-        .description = "Assume that the high-word facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.insert_reference_bits_multiple)] = .{
         .llvm_name = "insert-reference-bits-multiple",
-        .description = "Assume that the insert-reference-bits-multiple facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.interlocked_access1)] = .{
         .llvm_name = "interlocked-access1",
-        .description = "Assume that interlocked-access facility 1 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.load_and_trap)] = .{
         .llvm_name = "load-and-trap",
-        .description = "Assume that the load-and-trap facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.load_and_zero_rightmost_byte)] = .{
         .llvm_name = "load-and-zero-rightmost-byte",
-        .description = "Assume that the load-and-zero-rightmost-byte facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.load_store_on_cond)] = .{
         .llvm_name = "load-store-on-cond",
-        .description = "Assume that the load/store-on-condition facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.load_store_on_cond_2)] = .{
         .llvm_name = "load-store-on-cond-2",
-        .description = "Assume that the load/store-on-condition facility 2 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.message_security_assist_extension3)] = .{
         .llvm_name = "message-security-assist-extension3",
-        .description = "Assume that the message-security-assist extension facility 3 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.message_security_assist_extension4)] = .{
         .llvm_name = "message-security-assist-extension4",
-        .description = "Assume that the message-security-assist extension facility 4 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.message_security_assist_extension5)] = .{
         .llvm_name = "message-security-assist-extension5",
-        .description = "Assume that the message-security-assist extension facility 5 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.message_security_assist_extension7)] = .{
         .llvm_name = "message-security-assist-extension7",
-        .description = "Assume that the message-security-assist extension facility 7 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.message_security_assist_extension8)] = .{
         .llvm_name = "message-security-assist-extension8",
-        .description = "Assume that the message-security-assist extension facility 8 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.message_security_assist_extension9)] = .{
         .llvm_name = "message-security-assist-extension9",
-        .description = "Assume that the message-security-assist extension facility 9 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.miscellaneous_extensions)] = .{
         .llvm_name = "miscellaneous-extensions",
-        .description = "Assume that the miscellaneous-extensions facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.miscellaneous_extensions_2)] = .{
         .llvm_name = "miscellaneous-extensions-2",
-        .description = "Assume that the miscellaneous-extensions facility 2 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.miscellaneous_extensions_3)] = .{
         .llvm_name = "miscellaneous-extensions-3",
-        .description = "Assume that the miscellaneous-extensions facility 3 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nnp_assist)] = .{
         .llvm_name = "nnp-assist",
-        .description = "Assume that the NNP-assist facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.population_count)] = .{
         .llvm_name = "population-count",
-        .description = "Assume that the population-count facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.processor_activity_instrumentation)] = .{
         .llvm_name = "processor-activity-instrumentation",
-        .description = "Assume that the processor-activity-instrumentation facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.processor_assist)] = .{
         .llvm_name = "processor-assist",
-        .description = "Assume that the processor-assist facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reset_dat_protection)] = .{
         .llvm_name = "reset-dat-protection",
-        .description = "Assume that the reset-DAT-protection facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reset_reference_bits_multiple)] = .{
         .llvm_name = "reset-reference-bits-multiple",
-        .description = "Assume that the reset-reference-bits-multiple facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.soft_float)] = .{
         .llvm_name = "soft-float",
-        .description = "Use software emulation for floating point",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.transactional_execution)] = .{
         .llvm_name = "transactional-execution",
-        .description = "Assume that the transactional-execution facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vector)] = .{
         .llvm_name = "vector",
-        .description = "Assume that the vectory facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vector_enhancements_1)] = .{
         .llvm_name = "vector-enhancements-1",
-        .description = "Assume that the vector enhancements facility 1 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vector_enhancements_2)] = .{
         .llvm_name = "vector-enhancements-2",
-        .description = "Assume that the vector enhancements facility 2 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vector_packed_decimal)] = .{
         .llvm_name = "vector-packed-decimal",
-        .description = "Assume that the vector packed decimal facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vector_packed_decimal_enhancement)] = .{
         .llvm_name = "vector-packed-decimal-enhancement",
-        .description = "Assume that the vector packed decimal enhancement facility is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vector_packed_decimal_enhancement_2)] = .{
         .llvm_name = "vector-packed-decimal-enhancement-2",
-        .description = "Assume that the vector packed decimal enhancement facility 2 is installed",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -273,6 +231,54 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.backchain)] = "Store the address of the caller's frame into the callee's stack frame";
+    result[@intFromEnum(Feature.bear_enhancement)] = "Assume that the BEAR-enhancement facility is installed";
+    result[@intFromEnum(Feature.deflate_conversion)] = "Assume that the deflate-conversion facility is installed";
+    result[@intFromEnum(Feature.dfp_packed_conversion)] = "Assume that the DFP packed-conversion facility is installed";
+    result[@intFromEnum(Feature.dfp_zoned_conversion)] = "Assume that the DFP zoned-conversion facility is installed";
+    result[@intFromEnum(Feature.distinct_ops)] = "Assume that the distinct-operands facility is installed";
+    result[@intFromEnum(Feature.enhanced_dat_2)] = "Assume that the enhanced-DAT facility 2 is installed";
+    result[@intFromEnum(Feature.enhanced_sort)] = "Assume that the enhanced-sort facility is installed";
+    result[@intFromEnum(Feature.execution_hint)] = "Assume that the execution-hint facility is installed";
+    result[@intFromEnum(Feature.fast_serialization)] = "Assume that the fast-serialization facility is installed";
+    result[@intFromEnum(Feature.fp_extension)] = "Assume that the floating-point extension facility is installed";
+    result[@intFromEnum(Feature.guarded_storage)] = "Assume that the guarded-storage facility is installed";
+    result[@intFromEnum(Feature.high_word)] = "Assume that the high-word facility is installed";
+    result[@intFromEnum(Feature.insert_reference_bits_multiple)] = "Assume that the insert-reference-bits-multiple facility is installed";
+    result[@intFromEnum(Feature.interlocked_access1)] = "Assume that interlocked-access facility 1 is installed";
+    result[@intFromEnum(Feature.load_and_trap)] = "Assume that the load-and-trap facility is installed";
+    result[@intFromEnum(Feature.load_and_zero_rightmost_byte)] = "Assume that the load-and-zero-rightmost-byte facility is installed";
+    result[@intFromEnum(Feature.load_store_on_cond)] = "Assume that the load/store-on-condition facility is installed";
+    result[@intFromEnum(Feature.load_store_on_cond_2)] = "Assume that the load/store-on-condition facility 2 is installed";
+    result[@intFromEnum(Feature.message_security_assist_extension3)] = "Assume that the message-security-assist extension facility 3 is installed";
+    result[@intFromEnum(Feature.message_security_assist_extension4)] = "Assume that the message-security-assist extension facility 4 is installed";
+    result[@intFromEnum(Feature.message_security_assist_extension5)] = "Assume that the message-security-assist extension facility 5 is installed";
+    result[@intFromEnum(Feature.message_security_assist_extension7)] = "Assume that the message-security-assist extension facility 7 is installed";
+    result[@intFromEnum(Feature.message_security_assist_extension8)] = "Assume that the message-security-assist extension facility 8 is installed";
+    result[@intFromEnum(Feature.message_security_assist_extension9)] = "Assume that the message-security-assist extension facility 9 is installed";
+    result[@intFromEnum(Feature.miscellaneous_extensions)] = "Assume that the miscellaneous-extensions facility is installed";
+    result[@intFromEnum(Feature.miscellaneous_extensions_2)] = "Assume that the miscellaneous-extensions facility 2 is installed";
+    result[@intFromEnum(Feature.miscellaneous_extensions_3)] = "Assume that the miscellaneous-extensions facility 3 is installed";
+    result[@intFromEnum(Feature.nnp_assist)] = "Assume that the NNP-assist facility is installed";
+    result[@intFromEnum(Feature.population_count)] = "Assume that the population-count facility is installed";
+    result[@intFromEnum(Feature.processor_activity_instrumentation)] = "Assume that the processor-activity-instrumentation facility is installed";
+    result[@intFromEnum(Feature.processor_assist)] = "Assume that the processor-assist facility is installed";
+    result[@intFromEnum(Feature.reset_dat_protection)] = "Assume that the reset-DAT-protection facility is installed";
+    result[@intFromEnum(Feature.reset_reference_bits_multiple)] = "Assume that the reset-reference-bits-multiple facility is installed";
+    result[@intFromEnum(Feature.soft_float)] = "Use software emulation for floating point";
+    result[@intFromEnum(Feature.transactional_execution)] = "Assume that the transactional-execution facility is installed";
+    result[@intFromEnum(Feature.vector)] = "Assume that the vectory facility is installed";
+    result[@intFromEnum(Feature.vector_enhancements_1)] = "Assume that the vector enhancements facility 1 is installed";
+    result[@intFromEnum(Feature.vector_enhancements_2)] = "Assume that the vector enhancements facility 2 is installed";
+    result[@intFromEnum(Feature.vector_packed_decimal)] = "Assume that the vector packed decimal facility is installed";
+    result[@intFromEnum(Feature.vector_packed_decimal_enhancement)] = "Assume that the vector packed decimal enhancement facility is installed";
+    result[@intFromEnum(Feature.vector_packed_decimal_enhancement_2)] = "Assume that the vector packed decimal enhancement facility 2 is installed";
     break :blk result;
 };
 

--- a/lib/std/Target/sparc.zig
+++ b/lib/std/Target/sparc.zig
@@ -65,239 +65,192 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.deprecated_v8)] = .{
         .llvm_name = "deprecated-v8",
-        .description = "Enable deprecated V8 instructions in V9 mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.detectroundchange)] = .{
         .llvm_name = "detectroundchange",
-        .description = "LEON3 erratum detection: Detects any rounding mode change request: use only the round-to-nearest rounding mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fixallfdivsqrt)] = .{
         .llvm_name = "fixallfdivsqrt",
-        .description = "LEON erratum fix: Fix FDIVS/FDIVD/FSQRTS/FSQRTD instructions with NOPs and floating-point store",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hard_quad_float)] = .{
         .llvm_name = "hard-quad-float",
-        .description = "Enable quad-word floating point instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hasleoncasa)] = .{
         .llvm_name = "hasleoncasa",
-        .description = "Enable CASA instruction for LEON3 and LEON4 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hasumacsmac)] = .{
         .llvm_name = "hasumacsmac",
-        .description = "Enable UMAC and SMAC for LEON3 and LEON4 processors",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.insertnopload)] = .{
         .llvm_name = "insertnopload",
-        .description = "LEON3 erratum fix: Insert a NOP instruction after every single-cycle load instruction when the next instruction is another load/store instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.leon)] = .{
         .llvm_name = "leon",
-        .description = "Enable LEON extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.leoncyclecounter)] = .{
         .llvm_name = "leoncyclecounter",
-        .description = "Use the Leon cycle counter register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.leonpwrpsr)] = .{
         .llvm_name = "leonpwrpsr",
-        .description = "Enable the PWRPSR instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_fmuls)] = .{
         .llvm_name = "no-fmuls",
-        .description = "Disable the fmuls instruction.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_fsmuld)] = .{
         .llvm_name = "no-fsmuld",
-        .description = "Disable the fsmuld instruction.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.popc)] = .{
         .llvm_name = "popc",
-        .description = "Use the popc (population count) instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g1)] = .{
         .llvm_name = "reserve-g1",
-        .description = "Reserve G1, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g2)] = .{
         .llvm_name = "reserve-g2",
-        .description = "Reserve G2, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g3)] = .{
         .llvm_name = "reserve-g3",
-        .description = "Reserve G3, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g4)] = .{
         .llvm_name = "reserve-g4",
-        .description = "Reserve G4, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g5)] = .{
         .llvm_name = "reserve-g5",
-        .description = "Reserve G5, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g6)] = .{
         .llvm_name = "reserve-g6",
-        .description = "Reserve G6, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_g7)] = .{
         .llvm_name = "reserve-g7",
-        .description = "Reserve G7, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_i0)] = .{
         .llvm_name = "reserve-i0",
-        .description = "Reserve I0, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_i1)] = .{
         .llvm_name = "reserve-i1",
-        .description = "Reserve I1, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_i2)] = .{
         .llvm_name = "reserve-i2",
-        .description = "Reserve I2, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_i3)] = .{
         .llvm_name = "reserve-i3",
-        .description = "Reserve I3, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_i4)] = .{
         .llvm_name = "reserve-i4",
-        .description = "Reserve I4, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_i5)] = .{
         .llvm_name = "reserve-i5",
-        .description = "Reserve I5, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l0)] = .{
         .llvm_name = "reserve-l0",
-        .description = "Reserve L0, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l1)] = .{
         .llvm_name = "reserve-l1",
-        .description = "Reserve L1, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l2)] = .{
         .llvm_name = "reserve-l2",
-        .description = "Reserve L2, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l3)] = .{
         .llvm_name = "reserve-l3",
-        .description = "Reserve L3, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l4)] = .{
         .llvm_name = "reserve-l4",
-        .description = "Reserve L4, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l5)] = .{
         .llvm_name = "reserve-l5",
-        .description = "Reserve L5, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l6)] = .{
         .llvm_name = "reserve-l6",
-        .description = "Reserve L6, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_l7)] = .{
         .llvm_name = "reserve-l7",
-        .description = "Reserve L7, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_o0)] = .{
         .llvm_name = "reserve-o0",
-        .description = "Reserve O0, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_o1)] = .{
         .llvm_name = "reserve-o1",
-        .description = "Reserve O1, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_o2)] = .{
         .llvm_name = "reserve-o2",
-        .description = "Reserve O2, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_o3)] = .{
         .llvm_name = "reserve-o3",
-        .description = "Reserve O3, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_o4)] = .{
         .llvm_name = "reserve-o4",
-        .description = "Reserve O4, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reserve_o5)] = .{
         .llvm_name = "reserve-o5",
-        .description = "Reserve O5, making it unavailable as a GPR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_rdpc)] = .{
         .llvm_name = "slow-rdpc",
-        .description = "rd %pc, %XX is slow",
         .dependencies = featureSet(&[_]Feature{
             .v9,
         }),
     };
     result[@intFromEnum(Feature.soft_float)] = .{
         .llvm_name = "soft-float",
-        .description = "Use software emulation for floating point",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.soft_mul_div)] = .{
         .llvm_name = "soft-mul-div",
-        .description = "Use software emulation for integer multiply and divide",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v9)] = .{
         .llvm_name = "v9",
-        .description = "Enable SPARC-V9 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vis)] = .{
         .llvm_name = "vis",
-        .description = "Enable UltraSPARC Visual Instruction Set extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vis2)] = .{
         .llvm_name = "vis2",
-        .description = "Enable Visual Instruction Set extensions II",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vis3)] = .{
         .llvm_name = "vis3",
-        .description = "Enable Visual Instruction Set extensions III",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -305,6 +258,59 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.deprecated_v8)] = "Enable deprecated V8 instructions in V9 mode";
+    result[@intFromEnum(Feature.detectroundchange)] = "LEON3 erratum detection: Detects any rounding mode change request: use only the round-to-nearest rounding mode";
+    result[@intFromEnum(Feature.fixallfdivsqrt)] = "LEON erratum fix: Fix FDIVS/FDIVD/FSQRTS/FSQRTD instructions with NOPs and floating-point store";
+    result[@intFromEnum(Feature.hard_quad_float)] = "Enable quad-word floating point instructions";
+    result[@intFromEnum(Feature.hasleoncasa)] = "Enable CASA instruction for LEON3 and LEON4 processors";
+    result[@intFromEnum(Feature.hasumacsmac)] = "Enable UMAC and SMAC for LEON3 and LEON4 processors";
+    result[@intFromEnum(Feature.insertnopload)] = "LEON3 erratum fix: Insert a NOP instruction after every single-cycle load instruction when the next instruction is another load/store instruction";
+    result[@intFromEnum(Feature.leon)] = "Enable LEON extensions";
+    result[@intFromEnum(Feature.leoncyclecounter)] = "Use the Leon cycle counter register";
+    result[@intFromEnum(Feature.leonpwrpsr)] = "Enable the PWRPSR instruction";
+    result[@intFromEnum(Feature.no_fmuls)] = "Disable the fmuls instruction.";
+    result[@intFromEnum(Feature.no_fsmuld)] = "Disable the fsmuld instruction.";
+    result[@intFromEnum(Feature.popc)] = "Use the popc (population count) instruction";
+    result[@intFromEnum(Feature.reserve_g1)] = "Reserve G1, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_g2)] = "Reserve G2, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_g3)] = "Reserve G3, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_g4)] = "Reserve G4, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_g5)] = "Reserve G5, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_g6)] = "Reserve G6, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_g7)] = "Reserve G7, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_i0)] = "Reserve I0, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_i1)] = "Reserve I1, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_i2)] = "Reserve I2, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_i3)] = "Reserve I3, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_i4)] = "Reserve I4, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_i5)] = "Reserve I5, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l0)] = "Reserve L0, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l1)] = "Reserve L1, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l2)] = "Reserve L2, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l3)] = "Reserve L3, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l4)] = "Reserve L4, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l5)] = "Reserve L5, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l6)] = "Reserve L6, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_l7)] = "Reserve L7, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_o0)] = "Reserve O0, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_o1)] = "Reserve O1, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_o2)] = "Reserve O2, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_o3)] = "Reserve O3, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_o4)] = "Reserve O4, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.reserve_o5)] = "Reserve O5, making it unavailable as a GPR";
+    result[@intFromEnum(Feature.slow_rdpc)] = "rd %pc, %XX is slow";
+    result[@intFromEnum(Feature.soft_float)] = "Use software emulation for floating point";
+    result[@intFromEnum(Feature.soft_mul_div)] = "Use software emulation for integer multiply and divide";
+    result[@intFromEnum(Feature.v9)] = "Enable SPARC-V9 instructions";
+    result[@intFromEnum(Feature.vis)] = "Enable UltraSPARC Visual Instruction Set extensions";
+    result[@intFromEnum(Feature.vis2)] = "Enable Visual Instruction Set extensions II";
+    result[@intFromEnum(Feature.vis3)] = "Enable Visual Instruction Set extensions III";
     break :blk result;
 };
 

--- a/lib/std/Target/spirv.zig
+++ b/lib/std/Target/spirv.zig
@@ -13,85 +13,85 @@ pub const Feature = enum {
     v1_3,
     v1_4,
     v1_5,
-    SPV_AMD_shader_fragment_mask,
-    SPV_AMD_gpu_shader_int16,
-    SPV_AMD_gpu_shader_half_float,
-    SPV_AMD_texture_gather_bias_lod,
-    SPV_AMD_shader_ballot,
     SPV_AMD_gcn_shader,
-    SPV_AMD_shader_image_load_store_lod,
-    SPV_AMD_shader_explicit_vertex_parameter,
-    SPV_AMD_shader_trinary_minmax,
+    SPV_AMD_gpu_shader_half_float,
     SPV_AMD_gpu_shader_half_float_fetch,
-    SPV_GOOGLE_hlsl_functionality1,
-    SPV_GOOGLE_user_type,
-    SPV_GOOGLE_decorate_string,
+    SPV_AMD_gpu_shader_int16,
+    SPV_AMD_shader_ballot,
+    SPV_AMD_shader_explicit_vertex_parameter,
+    SPV_AMD_shader_fragment_mask,
+    SPV_AMD_shader_image_load_store_lod,
+    SPV_AMD_shader_trinary_minmax,
+    SPV_AMD_texture_gather_bias_lod,
     SPV_EXT_demote_to_helper_invocation,
     SPV_EXT_descriptor_indexing,
     SPV_EXT_fragment_fully_covered,
-    SPV_EXT_shader_stencil_export,
+    SPV_EXT_fragment_invocation_density,
+    SPV_EXT_fragment_shader_interlock,
     SPV_EXT_physical_storage_buffer,
     SPV_EXT_shader_atomic_float_add,
     SPV_EXT_shader_atomic_float_min_max,
     SPV_EXT_shader_image_int64,
-    SPV_EXT_fragment_shader_interlock,
-    SPV_EXT_fragment_invocation_density,
+    SPV_EXT_shader_stencil_export,
     SPV_EXT_shader_viewport_index_layer,
-    SPV_INTEL_loop_fuse,
-    SPV_INTEL_fpga_dsp_control,
-    SPV_INTEL_fpga_reg,
-    SPV_INTEL_fpga_memory_accesses,
-    SPV_INTEL_fpga_loop_controls,
-    SPV_INTEL_io_pipes,
-    SPV_INTEL_unstructured_loop_controls,
+    SPV_GOOGLE_decorate_string,
+    SPV_GOOGLE_hlsl_functionality1,
+    SPV_GOOGLE_user_type,
+    SPV_INTEL_arbitrary_precision_integers,
     SPV_INTEL_blocking_pipes,
     SPV_INTEL_device_side_avc_motion_estimation,
+    SPV_INTEL_fpga_cluster_attributes,
+    SPV_INTEL_fpga_dsp_control,
+    SPV_INTEL_fpga_loop_controls,
+    SPV_INTEL_fpga_memory_accesses,
     SPV_INTEL_fpga_memory_attributes,
+    SPV_INTEL_fpga_reg,
     SPV_INTEL_fp_fast_math_mode,
+    SPV_INTEL_io_pipes,
+    SPV_INTEL_kernel_attributes,
+    SPV_INTEL_loop_fuse,
     SPV_INTEL_media_block_io,
     SPV_INTEL_shader_integer_functions2,
     SPV_INTEL_subgroups,
-    SPV_INTEL_fpga_cluster_attributes,
-    SPV_INTEL_kernel_attributes,
-    SPV_INTEL_arbitrary_precision_integers,
-    SPV_KHR_8bit_storage,
-    SPV_KHR_shader_clock,
-    SPV_KHR_device_group,
+    SPV_INTEL_unstructured_loop_controls,
     SPV_KHR_16bit_storage,
-    SPV_KHR_variable_pointers,
-    SPV_KHR_no_integer_wrap_decoration,
-    SPV_KHR_subgroup_vote,
-    SPV_KHR_multiview,
-    SPV_KHR_shader_ballot,
-    SPV_KHR_vulkan_memory_model,
-    SPV_KHR_physical_storage_buffer,
-    SPV_KHR_workgroup_memory_explicit_layout,
+    SPV_KHR_8bit_storage,
+    SPV_KHR_device_group,
+    SPV_KHR_expect_assume,
+    SPV_KHR_float_controls,
     SPV_KHR_fragment_shading_rate,
+    SPV_KHR_linkonce_odr,
+    SPV_KHR_multiview,
+    SPV_KHR_non_semantic_info,
+    SPV_KHR_no_integer_wrap_decoration,
+    SPV_KHR_physical_storage_buffer,
+    SPV_KHR_post_depth_coverage,
+    SPV_KHR_ray_query,
+    SPV_KHR_ray_tracing,
     SPV_KHR_shader_atomic_counter_ops,
+    SPV_KHR_shader_ballot,
+    SPV_KHR_shader_clock,
     SPV_KHR_shader_draw_parameters,
     SPV_KHR_storage_buffer_storage_class,
-    SPV_KHR_linkonce_odr,
+    SPV_KHR_subgroup_vote,
     SPV_KHR_terminate_invocation,
-    SPV_KHR_non_semantic_info,
-    SPV_KHR_post_depth_coverage,
-    SPV_KHR_expect_assume,
-    SPV_KHR_ray_tracing,
-    SPV_KHR_ray_query,
-    SPV_KHR_float_controls,
-    SPV_NV_viewport_array2,
-    SPV_NV_shader_subgroup_partitioned,
+    SPV_KHR_variable_pointers,
+    SPV_KHR_vulkan_memory_model,
+    SPV_KHR_workgroup_memory_explicit_layout,
     SPV_NVX_multiview_per_view_attributes,
+    SPV_NV_compute_shader_derivatives,
+    SPV_NV_cooperative_matrix,
+    SPV_NV_fragment_shader_barycentric,
+    SPV_NV_geometry_shader_passthrough,
+    SPV_NV_mesh_shader,
     SPV_NV_ray_tracing,
+    SPV_NV_sample_mask_override_coverage,
     SPV_NV_shader_image_footprint,
+    SPV_NV_shader_sm_builtins,
+    SPV_NV_shader_subgroup_partitioned,
     SPV_NV_shading_rate,
     SPV_NV_stereo_view_rendering,
-    SPV_NV_compute_shader_derivatives,
-    SPV_NV_shader_sm_builtins,
-    SPV_NV_mesh_shader,
-    SPV_NV_geometry_shader_passthrough,
-    SPV_NV_fragment_shader_barycentric,
-    SPV_NV_cooperative_matrix,
-    SPV_NV_sample_mask_override_coverage,
+    SPV_NV_viewport_array2,
     Matrix,
     Shader,
     Geometry,
@@ -306,803 +306,662 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.v1_1)] = .{
         .llvm_name = null,
-        .description = "SPIR-V version 1.1",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.v1_2)] = .{
         .llvm_name = null,
-        .description = "SPIR-V version 1.2",
         .dependencies = featureSet(&[_]Feature{
             .v1_1,
         }),
     };
     result[@intFromEnum(Feature.v1_3)] = .{
         .llvm_name = null,
-        .description = "SPIR-V version 1.3",
         .dependencies = featureSet(&[_]Feature{
             .v1_2,
         }),
     };
     result[@intFromEnum(Feature.v1_4)] = .{
         .llvm_name = null,
-        .description = "SPIR-V version 1.4",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.v1_5)] = .{
         .llvm_name = null,
-        .description = "SPIR-V version 1.5",
         .dependencies = featureSet(&[_]Feature{
             .v1_4,
         }),
     };
-    result[@intFromEnum(Feature.SPV_AMD_shader_fragment_mask)] = .{
+    result[@intFromEnum(Feature.SPV_AMD_gcn_shader)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_shader_fragment_mask",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_gpu_shader_int16)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_gpu_shader_int16",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_AMD_gpu_shader_half_float)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_gpu_shader_half_float",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_texture_gather_bias_lod)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_texture_gather_bias_lod",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_shader_ballot)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_shader_ballot",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_gcn_shader)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_gcn_shader",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_shader_image_load_store_lod)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_shader_image_load_store_lod",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_shader_explicit_vertex_parameter)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_shader_explicit_vertex_parameter",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_AMD_shader_trinary_minmax)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_shader_trinary_minmax",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_AMD_gpu_shader_half_float_fetch)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_AMD_gpu_shader_half_float_fetch",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_GOOGLE_hlsl_functionality1)] = .{
+    result[@intFromEnum(Feature.SPV_AMD_gpu_shader_int16)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_GOOGLE_hlsl_functionality1",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_GOOGLE_user_type)] = .{
+    result[@intFromEnum(Feature.SPV_AMD_shader_ballot)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_GOOGLE_user_type",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_GOOGLE_decorate_string)] = .{
+    result[@intFromEnum(Feature.SPV_AMD_shader_explicit_vertex_parameter)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_GOOGLE_decorate_string",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_AMD_shader_fragment_mask)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_AMD_shader_image_load_store_lod)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_AMD_shader_trinary_minmax)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_AMD_texture_gather_bias_lod)] = .{
+        .llvm_name = null,
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_EXT_demote_to_helper_invocation)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_demote_to_helper_invocation",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_EXT_descriptor_indexing)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_descriptor_indexing",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_EXT_fragment_fully_covered)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_fragment_fully_covered",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_EXT_shader_stencil_export)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_shader_stencil_export",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_EXT_physical_storage_buffer)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_physical_storage_buffer",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_EXT_shader_atomic_float_add)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_shader_atomic_float_add",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_EXT_shader_atomic_float_min_max)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_shader_atomic_float_min_max",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_EXT_shader_image_int64)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_shader_image_int64",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_EXT_fragment_shader_interlock)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_fragment_shader_interlock",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_EXT_fragment_invocation_density)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_fragment_invocation_density",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_EXT_fragment_shader_interlock)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_EXT_physical_storage_buffer)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_EXT_shader_atomic_float_add)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_EXT_shader_atomic_float_min_max)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_EXT_shader_image_int64)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_EXT_shader_stencil_export)] = .{
+        .llvm_name = null,
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_EXT_shader_viewport_index_layer)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_EXT_shader_viewport_index_layer",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_INTEL_loop_fuse)] = .{
+    result[@intFromEnum(Feature.SPV_GOOGLE_decorate_string)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_loop_fuse",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_INTEL_fpga_dsp_control)] = .{
+    result[@intFromEnum(Feature.SPV_GOOGLE_hlsl_functionality1)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fpga_dsp_control",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_INTEL_fpga_reg)] = .{
+    result[@intFromEnum(Feature.SPV_GOOGLE_user_type)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fpga_reg",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_fpga_memory_accesses)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fpga_memory_accesses",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_fpga_loop_controls)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fpga_loop_controls",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_io_pipes)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_io_pipes",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_unstructured_loop_controls)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_unstructured_loop_controls",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_blocking_pipes)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_blocking_pipes",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_device_side_avc_motion_estimation)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_device_side_avc_motion_estimation",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_fpga_memory_attributes)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fpga_memory_attributes",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_fp_fast_math_mode)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fp_fast_math_mode",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_media_block_io)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_media_block_io",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_shader_integer_functions2)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_shader_integer_functions2",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_subgroups)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_subgroups",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_fpga_cluster_attributes)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_fpga_cluster_attributes",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_INTEL_kernel_attributes)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_kernel_attributes",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_INTEL_arbitrary_precision_integers)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_INTEL_arbitrary_precision_integers",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_KHR_8bit_storage)] = .{
+    result[@intFromEnum(Feature.SPV_INTEL_blocking_pipes)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_8bit_storage",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_KHR_shader_clock)] = .{
+    result[@intFromEnum(Feature.SPV_INTEL_device_side_avc_motion_estimation)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_shader_clock",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_KHR_device_group)] = .{
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_cluster_attributes)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_device_group",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_dsp_control)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_loop_controls)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_memory_accesses)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_memory_attributes)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_reg)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_fp_fast_math_mode)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_io_pipes)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_kernel_attributes)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_loop_fuse)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_media_block_io)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_shader_integer_functions2)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_subgroups)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_INTEL_unstructured_loop_controls)] = .{
+        .llvm_name = null,
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_KHR_16bit_storage)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_16bit_storage",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_KHR_variable_pointers)] = .{
+    result[@intFromEnum(Feature.SPV_KHR_8bit_storage)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_variable_pointers",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_KHR_no_integer_wrap_decoration)] = .{
+    result[@intFromEnum(Feature.SPV_KHR_device_group)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_no_integer_wrap_decoration",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_subgroup_vote)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_subgroup_vote",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_multiview)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_multiview",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_shader_ballot)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_shader_ballot",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_vulkan_memory_model)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_vulkan_memory_model",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_physical_storage_buffer)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_physical_storage_buffer",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_workgroup_memory_explicit_layout)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_workgroup_memory_explicit_layout",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_fragment_shading_rate)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_fragment_shading_rate",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_shader_atomic_counter_ops)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_shader_atomic_counter_ops",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_shader_draw_parameters)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_shader_draw_parameters",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_storage_buffer_storage_class)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_storage_buffer_storage_class",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_linkonce_odr)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_linkonce_odr",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_terminate_invocation)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_terminate_invocation",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_non_semantic_info)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_non_semantic_info",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_post_depth_coverage)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_post_depth_coverage",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_KHR_expect_assume)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_expect_assume",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_ray_tracing)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_ray_tracing",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_KHR_ray_query)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_ray_query",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_KHR_float_controls)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_KHR_float_controls",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_NV_viewport_array2)] = .{
+    result[@intFromEnum(Feature.SPV_KHR_fragment_shading_rate)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_viewport_array2",
         .dependencies = featureSet(&[_]Feature{}),
     };
-    result[@intFromEnum(Feature.SPV_NV_shader_subgroup_partitioned)] = .{
+    result[@intFromEnum(Feature.SPV_KHR_linkonce_odr)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_shader_subgroup_partitioned",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_multiview)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_non_semantic_info)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_no_integer_wrap_decoration)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_physical_storage_buffer)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_post_depth_coverage)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_ray_query)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_ray_tracing)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_shader_atomic_counter_ops)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_shader_ballot)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_shader_clock)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_shader_draw_parameters)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_storage_buffer_storage_class)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_subgroup_vote)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_terminate_invocation)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_variable_pointers)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_vulkan_memory_model)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_KHR_workgroup_memory_explicit_layout)] = .{
+        .llvm_name = null,
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_NVX_multiview_per_view_attributes)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_NVX_multiview_per_view_attributes",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_ray_tracing)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_ray_tracing",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_shader_image_footprint)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_shader_image_footprint",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_shading_rate)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_shading_rate",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_stereo_view_rendering)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_stereo_view_rendering",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_NV_compute_shader_derivatives)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_compute_shader_derivatives",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_shader_sm_builtins)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_shader_sm_builtins",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_mesh_shader)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_mesh_shader",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_geometry_shader_passthrough)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_geometry_shader_passthrough",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.SPV_NV_fragment_shader_barycentric)] = .{
-        .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_fragment_shader_barycentric",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_NV_cooperative_matrix)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_cooperative_matrix",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_fragment_shader_barycentric)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_geometry_shader_passthrough)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_mesh_shader)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_ray_tracing)] = .{
+        .llvm_name = null,
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SPV_NV_sample_mask_override_coverage)] = .{
         .llvm_name = null,
-        .description = "SPIR-V extension SPV_NV_sample_mask_override_coverage",
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_shader_image_footprint)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_shader_sm_builtins)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_shader_subgroup_partitioned)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_shading_rate)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_stereo_view_rendering)] = .{
+        .llvm_name = null,
+        .dependencies = featureSet(&[_]Feature{}),
+    };
+    result[@intFromEnum(Feature.SPV_NV_viewport_array2)] = .{
+        .llvm_name = null,
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Matrix)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Matrix",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Shader)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Shader",
         .dependencies = featureSet(&[_]Feature{
             .Matrix,
         }),
     };
     result[@intFromEnum(Feature.Geometry)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Geometry",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.Tessellation)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Tessellation",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.Addresses)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Addresses",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Linkage)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Linkage",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Kernel)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Kernel",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Vector16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Vector16",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.Float16Buffer)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Float16Buffer",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.Float16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Float16",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Float64)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Float64",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Int64)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Int64",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Int64Atomics)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Int64Atomics",
         .dependencies = featureSet(&[_]Feature{
             .Int64,
         }),
     };
     result[@intFromEnum(Feature.ImageBasic)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageBasic",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.ImageReadWrite)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageReadWrite",
         .dependencies = featureSet(&[_]Feature{
             .ImageBasic,
         }),
     };
     result[@intFromEnum(Feature.ImageMipmap)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageMipmap",
         .dependencies = featureSet(&[_]Feature{
             .ImageBasic,
         }),
     };
     result[@intFromEnum(Feature.Pipes)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Pipes",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.Groups)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Groups",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.DeviceEnqueue)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DeviceEnqueue",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.LiteralSampler)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability LiteralSampler",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.AtomicStorage)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicStorage",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.Int16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Int16",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.TessellationPointSize)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability TessellationPointSize",
         .dependencies = featureSet(&[_]Feature{
             .Tessellation,
         }),
     };
     result[@intFromEnum(Feature.GeometryPointSize)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GeometryPointSize",
         .dependencies = featureSet(&[_]Feature{
             .Geometry,
         }),
     };
     result[@intFromEnum(Feature.ImageGatherExtended)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageGatherExtended",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.StorageImageMultisample)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageMultisample",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.UniformBufferArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformBufferArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SampledImageArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampledImageArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.StorageBufferArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageBufferArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.StorageImageArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ClipDistance)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ClipDistance",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.CullDistance)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability CullDistance",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ImageCubeArray)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageCubeArray",
         .dependencies = featureSet(&[_]Feature{
             .SampledCubeArray,
         }),
     };
     result[@intFromEnum(Feature.SampleRateShading)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampleRateShading",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ImageRect)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageRect",
         .dependencies = featureSet(&[_]Feature{
             .SampledRect,
         }),
     };
     result[@intFromEnum(Feature.SampledRect)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampledRect",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.GenericPointer)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GenericPointer",
         .dependencies = featureSet(&[_]Feature{
             .Addresses,
         }),
     };
     result[@intFromEnum(Feature.Int8)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Int8",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.InputAttachment)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability InputAttachment",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SparseResidency)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SparseResidency",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.MinLod)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability MinLod",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.Sampled1D)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Sampled1D",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.Image1D)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Image1D",
         .dependencies = featureSet(&[_]Feature{
             .Sampled1D,
         }),
     };
     result[@intFromEnum(Feature.SampledCubeArray)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampledCubeArray",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SampledBuffer)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampledBuffer",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ImageBuffer)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageBuffer",
         .dependencies = featureSet(&[_]Feature{
             .SampledBuffer,
         }),
     };
     result[@intFromEnum(Feature.ImageMSArray)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageMSArray",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.StorageImageExtendedFormats)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageExtendedFormats",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ImageQuery)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageQuery",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.DerivativeControl)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DerivativeControl",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.InterpolationFunction)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability InterpolationFunction",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.TransformFeedback)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability TransformFeedback",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.GeometryStreams)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GeometryStreams",
         .dependencies = featureSet(&[_]Feature{
             .Geometry,
         }),
     };
     result[@intFromEnum(Feature.StorageImageReadWithoutFormat)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageReadWithoutFormat",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.StorageImageWriteWithoutFormat)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageWriteWithoutFormat",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.MultiViewport)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability MultiViewport",
         .dependencies = featureSet(&[_]Feature{
             .Geometry,
         }),
     };
     result[@intFromEnum(Feature.SubgroupDispatch)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupDispatch",
         .dependencies = featureSet(&[_]Feature{
             .v1_1,
             .DeviceEnqueue,
@@ -1110,7 +969,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.NamedBarrier)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability NamedBarrier",
         .dependencies = featureSet(&[_]Feature{
             .v1_1,
             .Kernel,
@@ -1118,7 +976,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.PipeStorage)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability PipeStorage",
         .dependencies = featureSet(&[_]Feature{
             .v1_1,
             .Pipes,
@@ -1126,14 +983,12 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniform)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniform",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.GroupNonUniformVote)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformVote",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1141,7 +996,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniformArithmetic)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformArithmetic",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1149,7 +1003,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniformBallot)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformBallot",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1157,7 +1010,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniformShuffle)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformShuffle",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1165,7 +1017,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniformShuffleRelative)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformShuffleRelative",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1173,7 +1024,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniformClustered)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformClustered",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1181,7 +1031,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.GroupNonUniformQuad)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformQuad",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .GroupNonUniform,
@@ -1189,33 +1038,28 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.ShaderLayer)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderLayer",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.ShaderViewportIndex)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderViewportIndex",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.FragmentShadingRateKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentShadingRateKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SubgroupBallotKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupBallotKHR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.DrawParameters)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DrawParameters",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .Shader,
@@ -1223,47 +1067,40 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.WorkgroupMemoryExplicitLayoutKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability WorkgroupMemoryExplicitLayoutKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.WorkgroupMemoryExplicitLayout8BitAccessKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability WorkgroupMemoryExplicitLayout8BitAccessKHR",
         .dependencies = featureSet(&[_]Feature{
             .WorkgroupMemoryExplicitLayoutKHR,
         }),
     };
     result[@intFromEnum(Feature.WorkgroupMemoryExplicitLayout16BitAccessKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability WorkgroupMemoryExplicitLayout16BitAccessKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SubgroupVoteKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupVoteKHR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.StorageBuffer16BitAccess)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageBuffer16BitAccess",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.StorageUniformBufferBlock16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageUniformBufferBlock16",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.UniformAndStorageBuffer16BitAccess)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformAndStorageBuffer16BitAccess",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .StorageBuffer16BitAccess,
@@ -1272,7 +1109,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageUniform16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageUniform16",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .StorageBuffer16BitAccess,
@@ -1281,28 +1117,24 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StoragePushConstant16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StoragePushConstant16",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.StorageInputOutput16)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageInputOutput16",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.DeviceGroup)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DeviceGroup",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
         }),
     };
     result[@intFromEnum(Feature.MultiView)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability MultiView",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .Shader,
@@ -1310,7 +1142,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.VariablePointersStorageBuffer)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VariablePointersStorageBuffer",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .Shader,
@@ -1318,7 +1149,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.VariablePointers)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VariablePointers",
         .dependencies = featureSet(&[_]Feature{
             .v1_3,
             .VariablePointersStorageBuffer,
@@ -1326,24 +1156,20 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.AtomicStorageOps)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicStorageOps",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SampleMaskPostDepthCoverage)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampleMaskPostDepthCoverage",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.StorageBuffer8BitAccess)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageBuffer8BitAccess",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.UniformAndStorageBuffer8BitAccess)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformAndStorageBuffer8BitAccess",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .StorageBuffer8BitAccess,
@@ -1351,63 +1177,54 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StoragePushConstant8)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StoragePushConstant8",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.DenormPreserve)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DenormPreserve",
         .dependencies = featureSet(&[_]Feature{
             .v1_4,
         }),
     };
     result[@intFromEnum(Feature.DenormFlushToZero)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DenormFlushToZero",
         .dependencies = featureSet(&[_]Feature{
             .v1_4,
         }),
     };
     result[@intFromEnum(Feature.SignedZeroInfNanPreserve)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SignedZeroInfNanPreserve",
         .dependencies = featureSet(&[_]Feature{
             .v1_4,
         }),
     };
     result[@intFromEnum(Feature.RoundingModeRTE)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RoundingModeRTE",
         .dependencies = featureSet(&[_]Feature{
             .v1_4,
         }),
     };
     result[@intFromEnum(Feature.RoundingModeRTZ)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RoundingModeRTZ",
         .dependencies = featureSet(&[_]Feature{
             .v1_4,
         }),
     };
     result[@intFromEnum(Feature.RayQueryProvisionalKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RayQueryProvisionalKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.RayQueryKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RayQueryKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.RayTraversalPrimitiveCullingKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RayTraversalPrimitiveCullingKHR",
         .dependencies = featureSet(&[_]Feature{
             .RayQueryKHR,
             .RayTracingKHR,
@@ -1415,160 +1232,136 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.RayTracingKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RayTracingKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.Float16ImageAMD)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Float16ImageAMD",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ImageGatherBiasLodAMD)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageGatherBiasLodAMD",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.FragmentMaskAMD)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentMaskAMD",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.StencilExportEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StencilExportEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ImageReadWriteLodAMD)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageReadWriteLodAMD",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.Int64ImageEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability Int64ImageEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ShaderClockKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderClockKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SampleMaskOverrideCoverageNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampleMaskOverrideCoverageNV",
         .dependencies = featureSet(&[_]Feature{
             .SampleRateShading,
         }),
     };
     result[@intFromEnum(Feature.GeometryShaderPassthroughNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GeometryShaderPassthroughNV",
         .dependencies = featureSet(&[_]Feature{
             .Geometry,
         }),
     };
     result[@intFromEnum(Feature.ShaderViewportIndexLayerEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderViewportIndexLayerEXT",
         .dependencies = featureSet(&[_]Feature{
             .MultiViewport,
         }),
     };
     result[@intFromEnum(Feature.ShaderViewportIndexLayerNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderViewportIndexLayerNV",
         .dependencies = featureSet(&[_]Feature{
             .MultiViewport,
         }),
     };
     result[@intFromEnum(Feature.ShaderViewportMaskNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderViewportMaskNV",
         .dependencies = featureSet(&[_]Feature{
             .ShaderViewportIndexLayerNV,
         }),
     };
     result[@intFromEnum(Feature.ShaderStereoViewNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderStereoViewNV",
         .dependencies = featureSet(&[_]Feature{
             .ShaderViewportMaskNV,
         }),
     };
     result[@intFromEnum(Feature.PerViewAttributesNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability PerViewAttributesNV",
         .dependencies = featureSet(&[_]Feature{
             .MultiView,
         }),
     };
     result[@intFromEnum(Feature.FragmentFullyCoveredEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentFullyCoveredEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.MeshShadingNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability MeshShadingNV",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ImageFootprintNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ImageFootprintNV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FragmentBarycentricNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentBarycentricNV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ComputeDerivativeGroupQuadsNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ComputeDerivativeGroupQuadsNV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FragmentDensityEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentDensityEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ShadingRateNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShadingRateNV",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.GroupNonUniformPartitionedNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability GroupNonUniformPartitionedNV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ShaderNonUniform)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderNonUniform",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .Shader,
@@ -1576,7 +1369,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.ShaderNonUniformEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderNonUniformEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .Shader,
@@ -1584,7 +1376,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.RuntimeDescriptorArray)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RuntimeDescriptorArray",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .Shader,
@@ -1592,7 +1383,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.RuntimeDescriptorArrayEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RuntimeDescriptorArrayEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .Shader,
@@ -1600,7 +1390,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.InputAttachmentArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability InputAttachmentArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .InputAttachment,
@@ -1608,7 +1397,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.InputAttachmentArrayDynamicIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability InputAttachmentArrayDynamicIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .InputAttachment,
@@ -1616,7 +1404,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.UniformTexelBufferArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformTexelBufferArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .SampledBuffer,
@@ -1624,7 +1411,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.UniformTexelBufferArrayDynamicIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformTexelBufferArrayDynamicIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .SampledBuffer,
@@ -1632,7 +1418,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageTexelBufferArrayDynamicIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageTexelBufferArrayDynamicIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ImageBuffer,
@@ -1640,7 +1425,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageTexelBufferArrayDynamicIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageTexelBufferArrayDynamicIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ImageBuffer,
@@ -1648,7 +1432,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.UniformBufferArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformBufferArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1656,7 +1439,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.UniformBufferArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformBufferArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1664,7 +1446,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.SampledImageArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampledImageArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1672,7 +1453,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.SampledImageArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SampledImageArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1680,7 +1460,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageBufferArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageBufferArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1688,7 +1467,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageBufferArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageBufferArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1696,7 +1474,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageImageArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1704,7 +1481,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageImageArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageImageArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ShaderNonUniform,
@@ -1712,7 +1488,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.InputAttachmentArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability InputAttachmentArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .InputAttachment,
@@ -1721,7 +1496,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.InputAttachmentArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability InputAttachmentArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .InputAttachment,
@@ -1730,7 +1504,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.UniformTexelBufferArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformTexelBufferArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .SampledBuffer,
@@ -1739,7 +1512,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.UniformTexelBufferArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UniformTexelBufferArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .SampledBuffer,
@@ -1748,7 +1520,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageTexelBufferArrayNonUniformIndexing)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageTexelBufferArrayNonUniformIndexing",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ImageBuffer,
@@ -1757,7 +1528,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.StorageTexelBufferArrayNonUniformIndexingEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability StorageTexelBufferArrayNonUniformIndexingEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .ImageBuffer,
@@ -1766,42 +1536,36 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.RayTracingNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RayTracingNV",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.VulkanMemoryModel)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VulkanMemoryModel",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.VulkanMemoryModelKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VulkanMemoryModelKHR",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.VulkanMemoryModelDeviceScope)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VulkanMemoryModelDeviceScope",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.VulkanMemoryModelDeviceScopeKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VulkanMemoryModelDeviceScopeKHR",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
         }),
     };
     result[@intFromEnum(Feature.PhysicalStorageBufferAddresses)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability PhysicalStorageBufferAddresses",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .Shader,
@@ -1809,7 +1573,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.PhysicalStorageBufferAddressesEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability PhysicalStorageBufferAddressesEXT",
         .dependencies = featureSet(&[_]Feature{
             .v1_5,
             .Shader,
@@ -1817,261 +1580,214 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.ComputeDerivativeGroupLinearNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ComputeDerivativeGroupLinearNV",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.RayTracingProvisionalKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RayTracingProvisionalKHR",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.CooperativeMatrixNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability CooperativeMatrixNV",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.FragmentShaderSampleInterlockEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentShaderSampleInterlockEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.FragmentShaderShadingRateInterlockEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentShaderShadingRateInterlockEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.ShaderSMBuiltinsNV)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ShaderSMBuiltinsNV",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.FragmentShaderPixelInterlockEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FragmentShaderPixelInterlockEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.DemoteToHelperInvocationEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability DemoteToHelperInvocationEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.SubgroupShuffleINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupShuffleINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SubgroupBufferBlockIOINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupBufferBlockIOINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SubgroupImageBlockIOINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupImageBlockIOINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SubgroupImageMediaBlockIOINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupImageMediaBlockIOINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.RoundToInfinityINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability RoundToInfinityINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FloatingPointModeINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FloatingPointModeINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.IntegerFunctions2INTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability IntegerFunctions2INTEL",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.FunctionPointersINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FunctionPointersINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.IndirectReferencesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability IndirectReferencesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.AsmINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AsmINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.AtomicFloat32MinMaxEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicFloat32MinMaxEXT",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.AtomicFloat64MinMaxEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicFloat64MinMaxEXT",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.AtomicFloat16MinMaxEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicFloat16MinMaxEXT",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.VectorComputeINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VectorComputeINTEL",
         .dependencies = featureSet(&[_]Feature{
             .VectorAnyINTEL,
         }),
     };
     result[@intFromEnum(Feature.VectorAnyINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VectorAnyINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ExpectAssumeKHR)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ExpectAssumeKHR",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SubgroupAvcMotionEstimationINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupAvcMotionEstimationINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SubgroupAvcMotionEstimationIntraINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupAvcMotionEstimationIntraINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.SubgroupAvcMotionEstimationChromaINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability SubgroupAvcMotionEstimationChromaINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.VariableLengthArrayINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability VariableLengthArrayINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FunctionFloatControlINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FunctionFloatControlINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGAMemoryAttributesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGAMemoryAttributesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPFastMathModeINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPFastMathModeINTEL",
         .dependencies = featureSet(&[_]Feature{
             .Kernel,
         }),
     };
     result[@intFromEnum(Feature.ArbitraryPrecisionIntegersINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability ArbitraryPrecisionIntegersINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.UnstructuredLoopControlsINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability UnstructuredLoopControlsINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGALoopControlsINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGALoopControlsINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.KernelAttributesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability KernelAttributesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGAKernelAttributesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGAKernelAttributesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGAMemoryAccessesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGAMemoryAccessesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGAClusterAttributesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGAClusterAttributesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.LoopFuseINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability LoopFuseINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGABufferLocationINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGABufferLocationINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.USMStorageClassesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability USMStorageClassesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.IOPipesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability IOPipesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.BlockingPipesINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability BlockingPipesINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.FPGARegINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability FPGARegINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.AtomicFloat32AddEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicFloat32AddEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.AtomicFloat64AddEXT)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability AtomicFloat64AddEXT",
         .dependencies = featureSet(&[_]Feature{
             .Shader,
         }),
     };
     result[@intFromEnum(Feature.LongConstantCompositeINTEL)] = .{
         .llvm_name = null,
-        .description = "Enable SPIR-V capability LongConstantCompositeINTEL",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -2079,6 +1795,296 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.v1_1)] = "SPIR-V version 1.1";
+    result[@intFromEnum(Feature.v1_2)] = "SPIR-V version 1.2";
+    result[@intFromEnum(Feature.v1_3)] = "SPIR-V version 1.3";
+    result[@intFromEnum(Feature.v1_4)] = "SPIR-V version 1.4";
+    result[@intFromEnum(Feature.v1_5)] = "SPIR-V version 1.5";
+    result[@intFromEnum(Feature.SPV_AMD_gcn_shader)] = "SPIR-V extension SPV_AMD_gcn_shader";
+    result[@intFromEnum(Feature.SPV_AMD_gpu_shader_half_float)] = "SPIR-V extension SPV_AMD_gpu_shader_half_float";
+    result[@intFromEnum(Feature.SPV_AMD_gpu_shader_half_float_fetch)] = "SPIR-V extension SPV_AMD_gpu_shader_half_float_fetch";
+    result[@intFromEnum(Feature.SPV_AMD_gpu_shader_int16)] = "SPIR-V extension SPV_AMD_gpu_shader_int16";
+    result[@intFromEnum(Feature.SPV_AMD_shader_ballot)] = "SPIR-V extension SPV_AMD_shader_ballot";
+    result[@intFromEnum(Feature.SPV_AMD_shader_explicit_vertex_parameter)] = "SPIR-V extension SPV_AMD_shader_explicit_vertex_parameter";
+    result[@intFromEnum(Feature.SPV_AMD_shader_fragment_mask)] = "SPIR-V extension SPV_AMD_shader_fragment_mask";
+    result[@intFromEnum(Feature.SPV_AMD_shader_image_load_store_lod)] = "SPIR-V extension SPV_AMD_shader_image_load_store_lod";
+    result[@intFromEnum(Feature.SPV_AMD_shader_trinary_minmax)] = "SPIR-V extension SPV_AMD_shader_trinary_minmax";
+    result[@intFromEnum(Feature.SPV_AMD_texture_gather_bias_lod)] = "SPIR-V extension SPV_AMD_texture_gather_bias_lod";
+    result[@intFromEnum(Feature.SPV_EXT_demote_to_helper_invocation)] = "SPIR-V extension SPV_EXT_demote_to_helper_invocation";
+    result[@intFromEnum(Feature.SPV_EXT_descriptor_indexing)] = "SPIR-V extension SPV_EXT_descriptor_indexing";
+    result[@intFromEnum(Feature.SPV_EXT_fragment_fully_covered)] = "SPIR-V extension SPV_EXT_fragment_fully_covered";
+    result[@intFromEnum(Feature.SPV_EXT_fragment_invocation_density)] = "SPIR-V extension SPV_EXT_fragment_invocation_density";
+    result[@intFromEnum(Feature.SPV_EXT_fragment_shader_interlock)] = "SPIR-V extension SPV_EXT_fragment_shader_interlock";
+    result[@intFromEnum(Feature.SPV_EXT_physical_storage_buffer)] = "SPIR-V extension SPV_EXT_physical_storage_buffer";
+    result[@intFromEnum(Feature.SPV_EXT_shader_atomic_float_add)] = "SPIR-V extension SPV_EXT_shader_atomic_float_add";
+    result[@intFromEnum(Feature.SPV_EXT_shader_atomic_float_min_max)] = "SPIR-V extension SPV_EXT_shader_atomic_float_min_max";
+    result[@intFromEnum(Feature.SPV_EXT_shader_image_int64)] = "SPIR-V extension SPV_EXT_shader_image_int64";
+    result[@intFromEnum(Feature.SPV_EXT_shader_stencil_export)] = "SPIR-V extension SPV_EXT_shader_stencil_export";
+    result[@intFromEnum(Feature.SPV_EXT_shader_viewport_index_layer)] = "SPIR-V extension SPV_EXT_shader_viewport_index_layer";
+    result[@intFromEnum(Feature.SPV_GOOGLE_decorate_string)] = "SPIR-V extension SPV_GOOGLE_decorate_string";
+    result[@intFromEnum(Feature.SPV_GOOGLE_hlsl_functionality1)] = "SPIR-V extension SPV_GOOGLE_hlsl_functionality1";
+    result[@intFromEnum(Feature.SPV_GOOGLE_user_type)] = "SPIR-V extension SPV_GOOGLE_user_type";
+    result[@intFromEnum(Feature.SPV_INTEL_arbitrary_precision_integers)] = "SPIR-V extension SPV_INTEL_arbitrary_precision_integers";
+    result[@intFromEnum(Feature.SPV_INTEL_blocking_pipes)] = "SPIR-V extension SPV_INTEL_blocking_pipes";
+    result[@intFromEnum(Feature.SPV_INTEL_device_side_avc_motion_estimation)] = "SPIR-V extension SPV_INTEL_device_side_avc_motion_estimation";
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_cluster_attributes)] = "SPIR-V extension SPV_INTEL_fpga_cluster_attributes";
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_dsp_control)] = "SPIR-V extension SPV_INTEL_fpga_dsp_control";
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_loop_controls)] = "SPIR-V extension SPV_INTEL_fpga_loop_controls";
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_memory_accesses)] = "SPIR-V extension SPV_INTEL_fpga_memory_accesses";
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_memory_attributes)] = "SPIR-V extension SPV_INTEL_fpga_memory_attributes";
+    result[@intFromEnum(Feature.SPV_INTEL_fpga_reg)] = "SPIR-V extension SPV_INTEL_fpga_reg";
+    result[@intFromEnum(Feature.SPV_INTEL_fp_fast_math_mode)] = "SPIR-V extension SPV_INTEL_fp_fast_math_mode";
+    result[@intFromEnum(Feature.SPV_INTEL_io_pipes)] = "SPIR-V extension SPV_INTEL_io_pipes";
+    result[@intFromEnum(Feature.SPV_INTEL_kernel_attributes)] = "SPIR-V extension SPV_INTEL_kernel_attributes";
+    result[@intFromEnum(Feature.SPV_INTEL_loop_fuse)] = "SPIR-V extension SPV_INTEL_loop_fuse";
+    result[@intFromEnum(Feature.SPV_INTEL_media_block_io)] = "SPIR-V extension SPV_INTEL_media_block_io";
+    result[@intFromEnum(Feature.SPV_INTEL_shader_integer_functions2)] = "SPIR-V extension SPV_INTEL_shader_integer_functions2";
+    result[@intFromEnum(Feature.SPV_INTEL_subgroups)] = "SPIR-V extension SPV_INTEL_subgroups";
+    result[@intFromEnum(Feature.SPV_INTEL_unstructured_loop_controls)] = "SPIR-V extension SPV_INTEL_unstructured_loop_controls";
+    result[@intFromEnum(Feature.SPV_KHR_16bit_storage)] = "SPIR-V extension SPV_KHR_16bit_storage";
+    result[@intFromEnum(Feature.SPV_KHR_8bit_storage)] = "SPIR-V extension SPV_KHR_8bit_storage";
+    result[@intFromEnum(Feature.SPV_KHR_device_group)] = "SPIR-V extension SPV_KHR_device_group";
+    result[@intFromEnum(Feature.SPV_KHR_expect_assume)] = "SPIR-V extension SPV_KHR_expect_assume";
+    result[@intFromEnum(Feature.SPV_KHR_float_controls)] = "SPIR-V extension SPV_KHR_float_controls";
+    result[@intFromEnum(Feature.SPV_KHR_fragment_shading_rate)] = "SPIR-V extension SPV_KHR_fragment_shading_rate";
+    result[@intFromEnum(Feature.SPV_KHR_linkonce_odr)] = "SPIR-V extension SPV_KHR_linkonce_odr";
+    result[@intFromEnum(Feature.SPV_KHR_multiview)] = "SPIR-V extension SPV_KHR_multiview";
+    result[@intFromEnum(Feature.SPV_KHR_non_semantic_info)] = "SPIR-V extension SPV_KHR_non_semantic_info";
+    result[@intFromEnum(Feature.SPV_KHR_no_integer_wrap_decoration)] = "SPIR-V extension SPV_KHR_no_integer_wrap_decoration";
+    result[@intFromEnum(Feature.SPV_KHR_physical_storage_buffer)] = "SPIR-V extension SPV_KHR_physical_storage_buffer";
+    result[@intFromEnum(Feature.SPV_KHR_post_depth_coverage)] = "SPIR-V extension SPV_KHR_post_depth_coverage";
+    result[@intFromEnum(Feature.SPV_KHR_ray_query)] = "SPIR-V extension SPV_KHR_ray_query";
+    result[@intFromEnum(Feature.SPV_KHR_ray_tracing)] = "SPIR-V extension SPV_KHR_ray_tracing";
+    result[@intFromEnum(Feature.SPV_KHR_shader_atomic_counter_ops)] = "SPIR-V extension SPV_KHR_shader_atomic_counter_ops";
+    result[@intFromEnum(Feature.SPV_KHR_shader_ballot)] = "SPIR-V extension SPV_KHR_shader_ballot";
+    result[@intFromEnum(Feature.SPV_KHR_shader_clock)] = "SPIR-V extension SPV_KHR_shader_clock";
+    result[@intFromEnum(Feature.SPV_KHR_shader_draw_parameters)] = "SPIR-V extension SPV_KHR_shader_draw_parameters";
+    result[@intFromEnum(Feature.SPV_KHR_storage_buffer_storage_class)] = "SPIR-V extension SPV_KHR_storage_buffer_storage_class";
+    result[@intFromEnum(Feature.SPV_KHR_subgroup_vote)] = "SPIR-V extension SPV_KHR_subgroup_vote";
+    result[@intFromEnum(Feature.SPV_KHR_terminate_invocation)] = "SPIR-V extension SPV_KHR_terminate_invocation";
+    result[@intFromEnum(Feature.SPV_KHR_variable_pointers)] = "SPIR-V extension SPV_KHR_variable_pointers";
+    result[@intFromEnum(Feature.SPV_KHR_vulkan_memory_model)] = "SPIR-V extension SPV_KHR_vulkan_memory_model";
+    result[@intFromEnum(Feature.SPV_KHR_workgroup_memory_explicit_layout)] = "SPIR-V extension SPV_KHR_workgroup_memory_explicit_layout";
+    result[@intFromEnum(Feature.SPV_NVX_multiview_per_view_attributes)] = "SPIR-V extension SPV_NVX_multiview_per_view_attributes";
+    result[@intFromEnum(Feature.SPV_NV_compute_shader_derivatives)] = "SPIR-V extension SPV_NV_compute_shader_derivatives";
+    result[@intFromEnum(Feature.SPV_NV_cooperative_matrix)] = "SPIR-V extension SPV_NV_cooperative_matrix";
+    result[@intFromEnum(Feature.SPV_NV_fragment_shader_barycentric)] = "SPIR-V extension SPV_NV_fragment_shader_barycentric";
+    result[@intFromEnum(Feature.SPV_NV_geometry_shader_passthrough)] = "SPIR-V extension SPV_NV_geometry_shader_passthrough";
+    result[@intFromEnum(Feature.SPV_NV_mesh_shader)] = "SPIR-V extension SPV_NV_mesh_shader";
+    result[@intFromEnum(Feature.SPV_NV_ray_tracing)] = "SPIR-V extension SPV_NV_ray_tracing";
+    result[@intFromEnum(Feature.SPV_NV_sample_mask_override_coverage)] = "SPIR-V extension SPV_NV_sample_mask_override_coverage";
+    result[@intFromEnum(Feature.SPV_NV_shader_image_footprint)] = "SPIR-V extension SPV_NV_shader_image_footprint";
+    result[@intFromEnum(Feature.SPV_NV_shader_sm_builtins)] = "SPIR-V extension SPV_NV_shader_sm_builtins";
+    result[@intFromEnum(Feature.SPV_NV_shader_subgroup_partitioned)] = "SPIR-V extension SPV_NV_shader_subgroup_partitioned";
+    result[@intFromEnum(Feature.SPV_NV_shading_rate)] = "SPIR-V extension SPV_NV_shading_rate";
+    result[@intFromEnum(Feature.SPV_NV_stereo_view_rendering)] = "SPIR-V extension SPV_NV_stereo_view_rendering";
+    result[@intFromEnum(Feature.SPV_NV_viewport_array2)] = "SPIR-V extension SPV_NV_viewport_array2";
+    result[@intFromEnum(Feature.Matrix)] = "Enable SPIR-V capability Matrix";
+    result[@intFromEnum(Feature.Shader)] = "Enable SPIR-V capability Shader";
+    result[@intFromEnum(Feature.Geometry)] = "Enable SPIR-V capability Geometry";
+    result[@intFromEnum(Feature.Tessellation)] = "Enable SPIR-V capability Tessellation";
+    result[@intFromEnum(Feature.Addresses)] = "Enable SPIR-V capability Addresses";
+    result[@intFromEnum(Feature.Linkage)] = "Enable SPIR-V capability Linkage";
+    result[@intFromEnum(Feature.Kernel)] = "Enable SPIR-V capability Kernel";
+    result[@intFromEnum(Feature.Vector16)] = "Enable SPIR-V capability Vector16";
+    result[@intFromEnum(Feature.Float16Buffer)] = "Enable SPIR-V capability Float16Buffer";
+    result[@intFromEnum(Feature.Float16)] = "Enable SPIR-V capability Float16";
+    result[@intFromEnum(Feature.Float64)] = "Enable SPIR-V capability Float64";
+    result[@intFromEnum(Feature.Int64)] = "Enable SPIR-V capability Int64";
+    result[@intFromEnum(Feature.Int64Atomics)] = "Enable SPIR-V capability Int64Atomics";
+    result[@intFromEnum(Feature.ImageBasic)] = "Enable SPIR-V capability ImageBasic";
+    result[@intFromEnum(Feature.ImageReadWrite)] = "Enable SPIR-V capability ImageReadWrite";
+    result[@intFromEnum(Feature.ImageMipmap)] = "Enable SPIR-V capability ImageMipmap";
+    result[@intFromEnum(Feature.Pipes)] = "Enable SPIR-V capability Pipes";
+    result[@intFromEnum(Feature.Groups)] = "Enable SPIR-V capability Groups";
+    result[@intFromEnum(Feature.DeviceEnqueue)] = "Enable SPIR-V capability DeviceEnqueue";
+    result[@intFromEnum(Feature.LiteralSampler)] = "Enable SPIR-V capability LiteralSampler";
+    result[@intFromEnum(Feature.AtomicStorage)] = "Enable SPIR-V capability AtomicStorage";
+    result[@intFromEnum(Feature.Int16)] = "Enable SPIR-V capability Int16";
+    result[@intFromEnum(Feature.TessellationPointSize)] = "Enable SPIR-V capability TessellationPointSize";
+    result[@intFromEnum(Feature.GeometryPointSize)] = "Enable SPIR-V capability GeometryPointSize";
+    result[@intFromEnum(Feature.ImageGatherExtended)] = "Enable SPIR-V capability ImageGatherExtended";
+    result[@intFromEnum(Feature.StorageImageMultisample)] = "Enable SPIR-V capability StorageImageMultisample";
+    result[@intFromEnum(Feature.UniformBufferArrayDynamicIndexing)] = "Enable SPIR-V capability UniformBufferArrayDynamicIndexing";
+    result[@intFromEnum(Feature.SampledImageArrayDynamicIndexing)] = "Enable SPIR-V capability SampledImageArrayDynamicIndexing";
+    result[@intFromEnum(Feature.StorageBufferArrayDynamicIndexing)] = "Enable SPIR-V capability StorageBufferArrayDynamicIndexing";
+    result[@intFromEnum(Feature.StorageImageArrayDynamicIndexing)] = "Enable SPIR-V capability StorageImageArrayDynamicIndexing";
+    result[@intFromEnum(Feature.ClipDistance)] = "Enable SPIR-V capability ClipDistance";
+    result[@intFromEnum(Feature.CullDistance)] = "Enable SPIR-V capability CullDistance";
+    result[@intFromEnum(Feature.ImageCubeArray)] = "Enable SPIR-V capability ImageCubeArray";
+    result[@intFromEnum(Feature.SampleRateShading)] = "Enable SPIR-V capability SampleRateShading";
+    result[@intFromEnum(Feature.ImageRect)] = "Enable SPIR-V capability ImageRect";
+    result[@intFromEnum(Feature.SampledRect)] = "Enable SPIR-V capability SampledRect";
+    result[@intFromEnum(Feature.GenericPointer)] = "Enable SPIR-V capability GenericPointer";
+    result[@intFromEnum(Feature.Int8)] = "Enable SPIR-V capability Int8";
+    result[@intFromEnum(Feature.InputAttachment)] = "Enable SPIR-V capability InputAttachment";
+    result[@intFromEnum(Feature.SparseResidency)] = "Enable SPIR-V capability SparseResidency";
+    result[@intFromEnum(Feature.MinLod)] = "Enable SPIR-V capability MinLod";
+    result[@intFromEnum(Feature.Sampled1D)] = "Enable SPIR-V capability Sampled1D";
+    result[@intFromEnum(Feature.Image1D)] = "Enable SPIR-V capability Image1D";
+    result[@intFromEnum(Feature.SampledCubeArray)] = "Enable SPIR-V capability SampledCubeArray";
+    result[@intFromEnum(Feature.SampledBuffer)] = "Enable SPIR-V capability SampledBuffer";
+    result[@intFromEnum(Feature.ImageBuffer)] = "Enable SPIR-V capability ImageBuffer";
+    result[@intFromEnum(Feature.ImageMSArray)] = "Enable SPIR-V capability ImageMSArray";
+    result[@intFromEnum(Feature.StorageImageExtendedFormats)] = "Enable SPIR-V capability StorageImageExtendedFormats";
+    result[@intFromEnum(Feature.ImageQuery)] = "Enable SPIR-V capability ImageQuery";
+    result[@intFromEnum(Feature.DerivativeControl)] = "Enable SPIR-V capability DerivativeControl";
+    result[@intFromEnum(Feature.InterpolationFunction)] = "Enable SPIR-V capability InterpolationFunction";
+    result[@intFromEnum(Feature.TransformFeedback)] = "Enable SPIR-V capability TransformFeedback";
+    result[@intFromEnum(Feature.GeometryStreams)] = "Enable SPIR-V capability GeometryStreams";
+    result[@intFromEnum(Feature.StorageImageReadWithoutFormat)] = "Enable SPIR-V capability StorageImageReadWithoutFormat";
+    result[@intFromEnum(Feature.StorageImageWriteWithoutFormat)] = "Enable SPIR-V capability StorageImageWriteWithoutFormat";
+    result[@intFromEnum(Feature.MultiViewport)] = "Enable SPIR-V capability MultiViewport";
+    result[@intFromEnum(Feature.SubgroupDispatch)] = "Enable SPIR-V capability SubgroupDispatch";
+    result[@intFromEnum(Feature.NamedBarrier)] = "Enable SPIR-V capability NamedBarrier";
+    result[@intFromEnum(Feature.PipeStorage)] = "Enable SPIR-V capability PipeStorage";
+    result[@intFromEnum(Feature.GroupNonUniform)] = "Enable SPIR-V capability GroupNonUniform";
+    result[@intFromEnum(Feature.GroupNonUniformVote)] = "Enable SPIR-V capability GroupNonUniformVote";
+    result[@intFromEnum(Feature.GroupNonUniformArithmetic)] = "Enable SPIR-V capability GroupNonUniformArithmetic";
+    result[@intFromEnum(Feature.GroupNonUniformBallot)] = "Enable SPIR-V capability GroupNonUniformBallot";
+    result[@intFromEnum(Feature.GroupNonUniformShuffle)] = "Enable SPIR-V capability GroupNonUniformShuffle";
+    result[@intFromEnum(Feature.GroupNonUniformShuffleRelative)] = "Enable SPIR-V capability GroupNonUniformShuffleRelative";
+    result[@intFromEnum(Feature.GroupNonUniformClustered)] = "Enable SPIR-V capability GroupNonUniformClustered";
+    result[@intFromEnum(Feature.GroupNonUniformQuad)] = "Enable SPIR-V capability GroupNonUniformQuad";
+    result[@intFromEnum(Feature.ShaderLayer)] = "Enable SPIR-V capability ShaderLayer";
+    result[@intFromEnum(Feature.ShaderViewportIndex)] = "Enable SPIR-V capability ShaderViewportIndex";
+    result[@intFromEnum(Feature.FragmentShadingRateKHR)] = "Enable SPIR-V capability FragmentShadingRateKHR";
+    result[@intFromEnum(Feature.SubgroupBallotKHR)] = "Enable SPIR-V capability SubgroupBallotKHR";
+    result[@intFromEnum(Feature.DrawParameters)] = "Enable SPIR-V capability DrawParameters";
+    result[@intFromEnum(Feature.WorkgroupMemoryExplicitLayoutKHR)] = "Enable SPIR-V capability WorkgroupMemoryExplicitLayoutKHR";
+    result[@intFromEnum(Feature.WorkgroupMemoryExplicitLayout8BitAccessKHR)] = "Enable SPIR-V capability WorkgroupMemoryExplicitLayout8BitAccessKHR";
+    result[@intFromEnum(Feature.WorkgroupMemoryExplicitLayout16BitAccessKHR)] = "Enable SPIR-V capability WorkgroupMemoryExplicitLayout16BitAccessKHR";
+    result[@intFromEnum(Feature.SubgroupVoteKHR)] = "Enable SPIR-V capability SubgroupVoteKHR";
+    result[@intFromEnum(Feature.StorageBuffer16BitAccess)] = "Enable SPIR-V capability StorageBuffer16BitAccess";
+    result[@intFromEnum(Feature.StorageUniformBufferBlock16)] = "Enable SPIR-V capability StorageUniformBufferBlock16";
+    result[@intFromEnum(Feature.UniformAndStorageBuffer16BitAccess)] = "Enable SPIR-V capability UniformAndStorageBuffer16BitAccess";
+    result[@intFromEnum(Feature.StorageUniform16)] = "Enable SPIR-V capability StorageUniform16";
+    result[@intFromEnum(Feature.StoragePushConstant16)] = "Enable SPIR-V capability StoragePushConstant16";
+    result[@intFromEnum(Feature.StorageInputOutput16)] = "Enable SPIR-V capability StorageInputOutput16";
+    result[@intFromEnum(Feature.DeviceGroup)] = "Enable SPIR-V capability DeviceGroup";
+    result[@intFromEnum(Feature.MultiView)] = "Enable SPIR-V capability MultiView";
+    result[@intFromEnum(Feature.VariablePointersStorageBuffer)] = "Enable SPIR-V capability VariablePointersStorageBuffer";
+    result[@intFromEnum(Feature.VariablePointers)] = "Enable SPIR-V capability VariablePointers";
+    result[@intFromEnum(Feature.AtomicStorageOps)] = "Enable SPIR-V capability AtomicStorageOps";
+    result[@intFromEnum(Feature.SampleMaskPostDepthCoverage)] = "Enable SPIR-V capability SampleMaskPostDepthCoverage";
+    result[@intFromEnum(Feature.StorageBuffer8BitAccess)] = "Enable SPIR-V capability StorageBuffer8BitAccess";
+    result[@intFromEnum(Feature.UniformAndStorageBuffer8BitAccess)] = "Enable SPIR-V capability UniformAndStorageBuffer8BitAccess";
+    result[@intFromEnum(Feature.StoragePushConstant8)] = "Enable SPIR-V capability StoragePushConstant8";
+    result[@intFromEnum(Feature.DenormPreserve)] = "Enable SPIR-V capability DenormPreserve";
+    result[@intFromEnum(Feature.DenormFlushToZero)] = "Enable SPIR-V capability DenormFlushToZero";
+    result[@intFromEnum(Feature.SignedZeroInfNanPreserve)] = "Enable SPIR-V capability SignedZeroInfNanPreserve";
+    result[@intFromEnum(Feature.RoundingModeRTE)] = "Enable SPIR-V capability RoundingModeRTE";
+    result[@intFromEnum(Feature.RoundingModeRTZ)] = "Enable SPIR-V capability RoundingModeRTZ";
+    result[@intFromEnum(Feature.RayQueryProvisionalKHR)] = "Enable SPIR-V capability RayQueryProvisionalKHR";
+    result[@intFromEnum(Feature.RayQueryKHR)] = "Enable SPIR-V capability RayQueryKHR";
+    result[@intFromEnum(Feature.RayTraversalPrimitiveCullingKHR)] = "Enable SPIR-V capability RayTraversalPrimitiveCullingKHR";
+    result[@intFromEnum(Feature.RayTracingKHR)] = "Enable SPIR-V capability RayTracingKHR";
+    result[@intFromEnum(Feature.Float16ImageAMD)] = "Enable SPIR-V capability Float16ImageAMD";
+    result[@intFromEnum(Feature.ImageGatherBiasLodAMD)] = "Enable SPIR-V capability ImageGatherBiasLodAMD";
+    result[@intFromEnum(Feature.FragmentMaskAMD)] = "Enable SPIR-V capability FragmentMaskAMD";
+    result[@intFromEnum(Feature.StencilExportEXT)] = "Enable SPIR-V capability StencilExportEXT";
+    result[@intFromEnum(Feature.ImageReadWriteLodAMD)] = "Enable SPIR-V capability ImageReadWriteLodAMD";
+    result[@intFromEnum(Feature.Int64ImageEXT)] = "Enable SPIR-V capability Int64ImageEXT";
+    result[@intFromEnum(Feature.ShaderClockKHR)] = "Enable SPIR-V capability ShaderClockKHR";
+    result[@intFromEnum(Feature.SampleMaskOverrideCoverageNV)] = "Enable SPIR-V capability SampleMaskOverrideCoverageNV";
+    result[@intFromEnum(Feature.GeometryShaderPassthroughNV)] = "Enable SPIR-V capability GeometryShaderPassthroughNV";
+    result[@intFromEnum(Feature.ShaderViewportIndexLayerEXT)] = "Enable SPIR-V capability ShaderViewportIndexLayerEXT";
+    result[@intFromEnum(Feature.ShaderViewportIndexLayerNV)] = "Enable SPIR-V capability ShaderViewportIndexLayerNV";
+    result[@intFromEnum(Feature.ShaderViewportMaskNV)] = "Enable SPIR-V capability ShaderViewportMaskNV";
+    result[@intFromEnum(Feature.ShaderStereoViewNV)] = "Enable SPIR-V capability ShaderStereoViewNV";
+    result[@intFromEnum(Feature.PerViewAttributesNV)] = "Enable SPIR-V capability PerViewAttributesNV";
+    result[@intFromEnum(Feature.FragmentFullyCoveredEXT)] = "Enable SPIR-V capability FragmentFullyCoveredEXT";
+    result[@intFromEnum(Feature.MeshShadingNV)] = "Enable SPIR-V capability MeshShadingNV";
+    result[@intFromEnum(Feature.ImageFootprintNV)] = "Enable SPIR-V capability ImageFootprintNV";
+    result[@intFromEnum(Feature.FragmentBarycentricNV)] = "Enable SPIR-V capability FragmentBarycentricNV";
+    result[@intFromEnum(Feature.ComputeDerivativeGroupQuadsNV)] = "Enable SPIR-V capability ComputeDerivativeGroupQuadsNV";
+    result[@intFromEnum(Feature.FragmentDensityEXT)] = "Enable SPIR-V capability FragmentDensityEXT";
+    result[@intFromEnum(Feature.ShadingRateNV)] = "Enable SPIR-V capability ShadingRateNV";
+    result[@intFromEnum(Feature.GroupNonUniformPartitionedNV)] = "Enable SPIR-V capability GroupNonUniformPartitionedNV";
+    result[@intFromEnum(Feature.ShaderNonUniform)] = "Enable SPIR-V capability ShaderNonUniform";
+    result[@intFromEnum(Feature.ShaderNonUniformEXT)] = "Enable SPIR-V capability ShaderNonUniformEXT";
+    result[@intFromEnum(Feature.RuntimeDescriptorArray)] = "Enable SPIR-V capability RuntimeDescriptorArray";
+    result[@intFromEnum(Feature.RuntimeDescriptorArrayEXT)] = "Enable SPIR-V capability RuntimeDescriptorArrayEXT";
+    result[@intFromEnum(Feature.InputAttachmentArrayDynamicIndexing)] = "Enable SPIR-V capability InputAttachmentArrayDynamicIndexing";
+    result[@intFromEnum(Feature.InputAttachmentArrayDynamicIndexingEXT)] = "Enable SPIR-V capability InputAttachmentArrayDynamicIndexingEXT";
+    result[@intFromEnum(Feature.UniformTexelBufferArrayDynamicIndexing)] = "Enable SPIR-V capability UniformTexelBufferArrayDynamicIndexing";
+    result[@intFromEnum(Feature.UniformTexelBufferArrayDynamicIndexingEXT)] = "Enable SPIR-V capability UniformTexelBufferArrayDynamicIndexingEXT";
+    result[@intFromEnum(Feature.StorageTexelBufferArrayDynamicIndexing)] = "Enable SPIR-V capability StorageTexelBufferArrayDynamicIndexing";
+    result[@intFromEnum(Feature.StorageTexelBufferArrayDynamicIndexingEXT)] = "Enable SPIR-V capability StorageTexelBufferArrayDynamicIndexingEXT";
+    result[@intFromEnum(Feature.UniformBufferArrayNonUniformIndexing)] = "Enable SPIR-V capability UniformBufferArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.UniformBufferArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability UniformBufferArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.SampledImageArrayNonUniformIndexing)] = "Enable SPIR-V capability SampledImageArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.SampledImageArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability SampledImageArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.StorageBufferArrayNonUniformIndexing)] = "Enable SPIR-V capability StorageBufferArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.StorageBufferArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability StorageBufferArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.StorageImageArrayNonUniformIndexing)] = "Enable SPIR-V capability StorageImageArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.StorageImageArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability StorageImageArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.InputAttachmentArrayNonUniformIndexing)] = "Enable SPIR-V capability InputAttachmentArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.InputAttachmentArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability InputAttachmentArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.UniformTexelBufferArrayNonUniformIndexing)] = "Enable SPIR-V capability UniformTexelBufferArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.UniformTexelBufferArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability UniformTexelBufferArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.StorageTexelBufferArrayNonUniformIndexing)] = "Enable SPIR-V capability StorageTexelBufferArrayNonUniformIndexing";
+    result[@intFromEnum(Feature.StorageTexelBufferArrayNonUniformIndexingEXT)] = "Enable SPIR-V capability StorageTexelBufferArrayNonUniformIndexingEXT";
+    result[@intFromEnum(Feature.RayTracingNV)] = "Enable SPIR-V capability RayTracingNV";
+    result[@intFromEnum(Feature.VulkanMemoryModel)] = "Enable SPIR-V capability VulkanMemoryModel";
+    result[@intFromEnum(Feature.VulkanMemoryModelKHR)] = "Enable SPIR-V capability VulkanMemoryModelKHR";
+    result[@intFromEnum(Feature.VulkanMemoryModelDeviceScope)] = "Enable SPIR-V capability VulkanMemoryModelDeviceScope";
+    result[@intFromEnum(Feature.VulkanMemoryModelDeviceScopeKHR)] = "Enable SPIR-V capability VulkanMemoryModelDeviceScopeKHR";
+    result[@intFromEnum(Feature.PhysicalStorageBufferAddresses)] = "Enable SPIR-V capability PhysicalStorageBufferAddresses";
+    result[@intFromEnum(Feature.PhysicalStorageBufferAddressesEXT)] = "Enable SPIR-V capability PhysicalStorageBufferAddressesEXT";
+    result[@intFromEnum(Feature.ComputeDerivativeGroupLinearNV)] = "Enable SPIR-V capability ComputeDerivativeGroupLinearNV";
+    result[@intFromEnum(Feature.RayTracingProvisionalKHR)] = "Enable SPIR-V capability RayTracingProvisionalKHR";
+    result[@intFromEnum(Feature.CooperativeMatrixNV)] = "Enable SPIR-V capability CooperativeMatrixNV";
+    result[@intFromEnum(Feature.FragmentShaderSampleInterlockEXT)] = "Enable SPIR-V capability FragmentShaderSampleInterlockEXT";
+    result[@intFromEnum(Feature.FragmentShaderShadingRateInterlockEXT)] = "Enable SPIR-V capability FragmentShaderShadingRateInterlockEXT";
+    result[@intFromEnum(Feature.ShaderSMBuiltinsNV)] = "Enable SPIR-V capability ShaderSMBuiltinsNV";
+    result[@intFromEnum(Feature.FragmentShaderPixelInterlockEXT)] = "Enable SPIR-V capability FragmentShaderPixelInterlockEXT";
+    result[@intFromEnum(Feature.DemoteToHelperInvocationEXT)] = "Enable SPIR-V capability DemoteToHelperInvocationEXT";
+    result[@intFromEnum(Feature.SubgroupShuffleINTEL)] = "Enable SPIR-V capability SubgroupShuffleINTEL";
+    result[@intFromEnum(Feature.SubgroupBufferBlockIOINTEL)] = "Enable SPIR-V capability SubgroupBufferBlockIOINTEL";
+    result[@intFromEnum(Feature.SubgroupImageBlockIOINTEL)] = "Enable SPIR-V capability SubgroupImageBlockIOINTEL";
+    result[@intFromEnum(Feature.SubgroupImageMediaBlockIOINTEL)] = "Enable SPIR-V capability SubgroupImageMediaBlockIOINTEL";
+    result[@intFromEnum(Feature.RoundToInfinityINTEL)] = "Enable SPIR-V capability RoundToInfinityINTEL";
+    result[@intFromEnum(Feature.FloatingPointModeINTEL)] = "Enable SPIR-V capability FloatingPointModeINTEL";
+    result[@intFromEnum(Feature.IntegerFunctions2INTEL)] = "Enable SPIR-V capability IntegerFunctions2INTEL";
+    result[@intFromEnum(Feature.FunctionPointersINTEL)] = "Enable SPIR-V capability FunctionPointersINTEL";
+    result[@intFromEnum(Feature.IndirectReferencesINTEL)] = "Enable SPIR-V capability IndirectReferencesINTEL";
+    result[@intFromEnum(Feature.AsmINTEL)] = "Enable SPIR-V capability AsmINTEL";
+    result[@intFromEnum(Feature.AtomicFloat32MinMaxEXT)] = "Enable SPIR-V capability AtomicFloat32MinMaxEXT";
+    result[@intFromEnum(Feature.AtomicFloat64MinMaxEXT)] = "Enable SPIR-V capability AtomicFloat64MinMaxEXT";
+    result[@intFromEnum(Feature.AtomicFloat16MinMaxEXT)] = "Enable SPIR-V capability AtomicFloat16MinMaxEXT";
+    result[@intFromEnum(Feature.VectorComputeINTEL)] = "Enable SPIR-V capability VectorComputeINTEL";
+    result[@intFromEnum(Feature.VectorAnyINTEL)] = "Enable SPIR-V capability VectorAnyINTEL";
+    result[@intFromEnum(Feature.ExpectAssumeKHR)] = "Enable SPIR-V capability ExpectAssumeKHR";
+    result[@intFromEnum(Feature.SubgroupAvcMotionEstimationINTEL)] = "Enable SPIR-V capability SubgroupAvcMotionEstimationINTEL";
+    result[@intFromEnum(Feature.SubgroupAvcMotionEstimationIntraINTEL)] = "Enable SPIR-V capability SubgroupAvcMotionEstimationIntraINTEL";
+    result[@intFromEnum(Feature.SubgroupAvcMotionEstimationChromaINTEL)] = "Enable SPIR-V capability SubgroupAvcMotionEstimationChromaINTEL";
+    result[@intFromEnum(Feature.VariableLengthArrayINTEL)] = "Enable SPIR-V capability VariableLengthArrayINTEL";
+    result[@intFromEnum(Feature.FunctionFloatControlINTEL)] = "Enable SPIR-V capability FunctionFloatControlINTEL";
+    result[@intFromEnum(Feature.FPGAMemoryAttributesINTEL)] = "Enable SPIR-V capability FPGAMemoryAttributesINTEL";
+    result[@intFromEnum(Feature.FPFastMathModeINTEL)] = "Enable SPIR-V capability FPFastMathModeINTEL";
+    result[@intFromEnum(Feature.ArbitraryPrecisionIntegersINTEL)] = "Enable SPIR-V capability ArbitraryPrecisionIntegersINTEL";
+    result[@intFromEnum(Feature.UnstructuredLoopControlsINTEL)] = "Enable SPIR-V capability UnstructuredLoopControlsINTEL";
+    result[@intFromEnum(Feature.FPGALoopControlsINTEL)] = "Enable SPIR-V capability FPGALoopControlsINTEL";
+    result[@intFromEnum(Feature.KernelAttributesINTEL)] = "Enable SPIR-V capability KernelAttributesINTEL";
+    result[@intFromEnum(Feature.FPGAKernelAttributesINTEL)] = "Enable SPIR-V capability FPGAKernelAttributesINTEL";
+    result[@intFromEnum(Feature.FPGAMemoryAccessesINTEL)] = "Enable SPIR-V capability FPGAMemoryAccessesINTEL";
+    result[@intFromEnum(Feature.FPGAClusterAttributesINTEL)] = "Enable SPIR-V capability FPGAClusterAttributesINTEL";
+    result[@intFromEnum(Feature.LoopFuseINTEL)] = "Enable SPIR-V capability LoopFuseINTEL";
+    result[@intFromEnum(Feature.FPGABufferLocationINTEL)] = "Enable SPIR-V capability FPGABufferLocationINTEL";
+    result[@intFromEnum(Feature.USMStorageClassesINTEL)] = "Enable SPIR-V capability USMStorageClassesINTEL";
+    result[@intFromEnum(Feature.IOPipesINTEL)] = "Enable SPIR-V capability IOPipesINTEL";
+    result[@intFromEnum(Feature.BlockingPipesINTEL)] = "Enable SPIR-V capability BlockingPipesINTEL";
+    result[@intFromEnum(Feature.FPGARegINTEL)] = "Enable SPIR-V capability FPGARegINTEL";
+    result[@intFromEnum(Feature.AtomicFloat32AddEXT)] = "Enable SPIR-V capability AtomicFloat32AddEXT";
+    result[@intFromEnum(Feature.AtomicFloat64AddEXT)] = "Enable SPIR-V capability AtomicFloat64AddEXT";
+    result[@intFromEnum(Feature.LongConstantCompositeINTEL)] = "Enable SPIR-V capability LongConstantCompositeINTEL";
     break :blk result;
 };
 

--- a/lib/std/Target/ve.zig
+++ b/lib/std/Target/ve.zig
@@ -19,7 +19,6 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.vpu)] = .{
         .llvm_name = "vpu",
-        .description = "Enable the VPU",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -27,6 +26,13 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.vpu)] = "Enable the VPU";
     break :blk result;
 };
 

--- a/lib/std/Target/wasm.zig
+++ b/lib/std/Target/wasm.zig
@@ -31,67 +31,54 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.atomics)] = .{
         .llvm_name = "atomics",
-        .description = "Enable Atomics",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.bulk_memory)] = .{
         .llvm_name = "bulk-memory",
-        .description = "Enable bulk memory operations",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.exception_handling)] = .{
         .llvm_name = "exception-handling",
-        .description = "Enable Wasm exception handling",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.extended_const)] = .{
         .llvm_name = "extended-const",
-        .description = "Enable extended const expressions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.multimemory)] = .{
         .llvm_name = "multimemory",
-        .description = "Enable multiple memories",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.multivalue)] = .{
         .llvm_name = "multivalue",
-        .description = "Enable multivalue blocks, instructions, and functions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mutable_globals)] = .{
         .llvm_name = "mutable-globals",
-        .description = "Enable mutable globals",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nontrapping_fptoint)] = .{
         .llvm_name = "nontrapping-fptoint",
-        .description = "Enable non-trapping float-to-int conversion operators",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.reference_types)] = .{
         .llvm_name = "reference-types",
-        .description = "Enable reference types",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.relaxed_simd)] = .{
         .llvm_name = "relaxed-simd",
-        .description = "Enable relaxed-simd instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sign_ext)] = .{
         .llvm_name = "sign-ext",
-        .description = "Enable sign extension operators",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.simd128)] = .{
         .llvm_name = "simd128",
-        .description = "Enable 128-bit SIMD",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tail_call)] = .{
         .llvm_name = "tail-call",
-        .description = "Enable tail call instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -99,6 +86,25 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.atomics)] = "Enable Atomics";
+    result[@intFromEnum(Feature.bulk_memory)] = "Enable bulk memory operations";
+    result[@intFromEnum(Feature.exception_handling)] = "Enable Wasm exception handling";
+    result[@intFromEnum(Feature.extended_const)] = "Enable extended const expressions";
+    result[@intFromEnum(Feature.multimemory)] = "Enable multiple memories";
+    result[@intFromEnum(Feature.multivalue)] = "Enable multivalue blocks, instructions, and functions";
+    result[@intFromEnum(Feature.mutable_globals)] = "Enable mutable globals";
+    result[@intFromEnum(Feature.nontrapping_fptoint)] = "Enable non-trapping float-to-int conversion operators";
+    result[@intFromEnum(Feature.reference_types)] = "Enable reference types";
+    result[@intFromEnum(Feature.relaxed_simd)] = "Enable relaxed-simd instructions";
+    result[@intFromEnum(Feature.sign_ext)] = "Enable sign extension operators";
+    result[@intFromEnum(Feature.simd128)] = "Enable 128-bit SIMD";
+    result[@intFromEnum(Feature.tail_call)] = "Enable tail call instructions";
     break :blk result;
 };
 

--- a/lib/std/Target/x86.zig
+++ b/lib/std/Target/x86.zig
@@ -204,93 +204,78 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.@"16bit_mode")] = .{
         .llvm_name = "16bit-mode",
-        .description = "16-bit mode (i8086)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"32bit_mode")] = .{
         .llvm_name = "32bit-mode",
-        .description = "32-bit mode (80386)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.@"3dnow")] = .{
         .llvm_name = "3dnow",
-        .description = "Enable 3DNow! instructions",
         .dependencies = featureSet(&[_]Feature{
             .mmx,
         }),
     };
     result[@intFromEnum(Feature.@"3dnowa")] = .{
         .llvm_name = "3dnowa",
-        .description = "Enable 3DNow! Athlon instructions",
         .dependencies = featureSet(&[_]Feature{
             .@"3dnow",
         }),
     };
     result[@intFromEnum(Feature.@"64bit")] = .{
         .llvm_name = "64bit",
-        .description = "Support 64-bit instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.adx)] = .{
         .llvm_name = "adx",
-        .description = "Support ADX instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.aes)] = .{
         .llvm_name = "aes",
-        .description = "Enable AES instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse2,
         }),
     };
     result[@intFromEnum(Feature.allow_light_256_bit)] = .{
         .llvm_name = "allow-light-256-bit",
-        .description = "Enable generation of 256-bit load/stores even if we prefer 128-bit",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.amx_bf16)] = .{
         .llvm_name = "amx-bf16",
-        .description = "Support AMX-BF16 instructions",
         .dependencies = featureSet(&[_]Feature{
             .amx_tile,
         }),
     };
     result[@intFromEnum(Feature.amx_complex)] = .{
         .llvm_name = "amx-complex",
-        .description = "Support AMX-COMPLEX instructions",
         .dependencies = featureSet(&[_]Feature{
             .amx_tile,
         }),
     };
     result[@intFromEnum(Feature.amx_fp16)] = .{
         .llvm_name = "amx-fp16",
-        .description = "Support AMX amx-fp16 instructions",
         .dependencies = featureSet(&[_]Feature{
             .amx_tile,
         }),
     };
     result[@intFromEnum(Feature.amx_int8)] = .{
         .llvm_name = "amx-int8",
-        .description = "Support AMX-INT8 instructions",
         .dependencies = featureSet(&[_]Feature{
             .amx_tile,
         }),
     };
     result[@intFromEnum(Feature.amx_tile)] = .{
         .llvm_name = "amx-tile",
-        .description = "Support AMX-TILE instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.avx)] = .{
         .llvm_name = "avx",
-        .description = "Enable AVX instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse4_2,
         }),
     };
     result[@intFromEnum(Feature.avx10_1_256)] = .{
         .llvm_name = "avx10.1-256",
-        .description = "Support AVX10.1 up to 256-bit instruction",
         .dependencies = featureSet(&[_]Feature{
             .avx512bf16,
             .avx512bitalg,
@@ -307,7 +292,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avx10_1_512)] = .{
         .llvm_name = "avx10.1-512",
-        .description = "Support AVX10.1 up to 512-bit instruction",
         .dependencies = featureSet(&[_]Feature{
             .avx10_1_256,
             .evex512,
@@ -315,56 +299,48 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avx2)] = .{
         .llvm_name = "avx2",
-        .description = "Enable AVX2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx,
         }),
     };
     result[@intFromEnum(Feature.avx512bf16)] = .{
         .llvm_name = "avx512bf16",
-        .description = "Support bfloat16 floating point",
         .dependencies = featureSet(&[_]Feature{
             .avx512bw,
         }),
     };
     result[@intFromEnum(Feature.avx512bitalg)] = .{
         .llvm_name = "avx512bitalg",
-        .description = "Enable AVX-512 Bit Algorithms",
         .dependencies = featureSet(&[_]Feature{
             .avx512bw,
         }),
     };
     result[@intFromEnum(Feature.avx512bw)] = .{
         .llvm_name = "avx512bw",
-        .description = "Enable AVX-512 Byte and Word Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512cd)] = .{
         .llvm_name = "avx512cd",
-        .description = "Enable AVX-512 Conflict Detection Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512dq)] = .{
         .llvm_name = "avx512dq",
-        .description = "Enable AVX-512 Doubleword and Quadword Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512er)] = .{
         .llvm_name = "avx512er",
-        .description = "Enable AVX-512 Exponential and Reciprocal Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512f)] = .{
         .llvm_name = "avx512f",
-        .description = "Enable AVX-512 instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
             .f16c,
@@ -373,7 +349,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avx512fp16)] = .{
         .llvm_name = "avx512fp16",
-        .description = "Support 16-bit floating point",
         .dependencies = featureSet(&[_]Feature{
             .avx512bw,
             .avx512dq,
@@ -382,319 +357,262 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.avx512ifma)] = .{
         .llvm_name = "avx512ifma",
-        .description = "Enable AVX-512 Integer Fused Multiple-Add",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512pf)] = .{
         .llvm_name = "avx512pf",
-        .description = "Enable AVX-512 PreFetch Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512vbmi)] = .{
         .llvm_name = "avx512vbmi",
-        .description = "Enable AVX-512 Vector Byte Manipulation Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512bw,
         }),
     };
     result[@intFromEnum(Feature.avx512vbmi2)] = .{
         .llvm_name = "avx512vbmi2",
-        .description = "Enable AVX-512 further Vector Byte Manipulation Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512bw,
         }),
     };
     result[@intFromEnum(Feature.avx512vl)] = .{
         .llvm_name = "avx512vl",
-        .description = "Enable AVX-512 Vector Length eXtensions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512vnni)] = .{
         .llvm_name = "avx512vnni",
-        .description = "Enable AVX-512 Vector Neural Network Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512vp2intersect)] = .{
         .llvm_name = "avx512vp2intersect",
-        .description = "Enable AVX-512 vp2intersect",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avx512vpopcntdq)] = .{
         .llvm_name = "avx512vpopcntdq",
-        .description = "Enable AVX-512 Population Count Instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx512f,
         }),
     };
     result[@intFromEnum(Feature.avxifma)] = .{
         .llvm_name = "avxifma",
-        .description = "Enable AVX-IFMA",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.avxneconvert)] = .{
         .llvm_name = "avxneconvert",
-        .description = "Support AVX-NE-CONVERT instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.avxvnni)] = .{
         .llvm_name = "avxvnni",
-        .description = "Support AVX_VNNI encoding",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.avxvnniint16)] = .{
         .llvm_name = "avxvnniint16",
-        .description = "Enable AVX-VNNI-INT16",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.avxvnniint8)] = .{
         .llvm_name = "avxvnniint8",
-        .description = "Enable AVX-VNNI-INT8",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.bmi)] = .{
         .llvm_name = "bmi",
-        .description = "Support BMI instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.bmi2)] = .{
         .llvm_name = "bmi2",
-        .description = "Support BMI2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.branchfusion)] = .{
         .llvm_name = "branchfusion",
-        .description = "CMP/TEST can be fused with conditional branches",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ccmp)] = .{
         .llvm_name = "ccmp",
-        .description = "Support conditional cmp & test instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cf)] = .{
         .llvm_name = "cf",
-        .description = "Support conditional faulting",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cldemote)] = .{
         .llvm_name = "cldemote",
-        .description = "Enable Cache Line Demote",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.clflushopt)] = .{
         .llvm_name = "clflushopt",
-        .description = "Flush A Cache Line Optimized",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.clwb)] = .{
         .llvm_name = "clwb",
-        .description = "Cache Line Write Back",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.clzero)] = .{
         .llvm_name = "clzero",
-        .description = "Enable Cache Line Zero",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cmov)] = .{
         .llvm_name = "cmov",
-        .description = "Enable conditional move instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cmpccxadd)] = .{
         .llvm_name = "cmpccxadd",
-        .description = "Support CMPCCXADD instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.crc32)] = .{
         .llvm_name = "crc32",
-        .description = "Enable SSE 4.2 CRC32 instruction (used when SSE4.2 is supported but function is GPR only)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.cx16)] = .{
         .llvm_name = "cx16",
-        .description = "64-bit with cmpxchg16b (this is true for most x86-64 chips, but not the first AMD chips)",
         .dependencies = featureSet(&[_]Feature{
             .cx8,
         }),
     };
     result[@intFromEnum(Feature.cx8)] = .{
         .llvm_name = "cx8",
-        .description = "Support CMPXCHG8B instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.egpr)] = .{
         .llvm_name = "egpr",
-        .description = "Support extended general purpose register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.enqcmd)] = .{
         .llvm_name = "enqcmd",
-        .description = "Has ENQCMD instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ermsb)] = .{
         .llvm_name = "ermsb",
-        .description = "REP MOVS/STOS are fast",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.evex512)] = .{
         .llvm_name = "evex512",
-        .description = "Support ZMM and 64-bit mask instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.f16c)] = .{
         .llvm_name = "f16c",
-        .description = "Support 16-bit floating point conversion instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx,
         }),
     };
     result[@intFromEnum(Feature.false_deps_getmant)] = .{
         .llvm_name = "false-deps-getmant",
-        .description = "VGETMANTSS/SD/SH and VGETMANDPS/PD(memory version) has a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.false_deps_lzcnt_tzcnt)] = .{
         .llvm_name = "false-deps-lzcnt-tzcnt",
-        .description = "LZCNT/TZCNT have a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.false_deps_mulc)] = .{
         .llvm_name = "false-deps-mulc",
-        .description = "VF[C]MULCPH/SH has a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.false_deps_mullq)] = .{
         .llvm_name = "false-deps-mullq",
-        .description = "VPMULLQ has a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.false_deps_perm)] = .{
         .llvm_name = "false-deps-perm",
-        .description = "VPERMD/Q/PS/PD has a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.false_deps_popcnt)] = .{
         .llvm_name = "false-deps-popcnt",
-        .description = "POPCNT has a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.false_deps_range)] = .{
         .llvm_name = "false-deps-range",
-        .description = "VRANGEPD/PS/SD/SS has a false dependency on dest register",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_11bytenop)] = .{
         .llvm_name = "fast-11bytenop",
-        .description = "Target can quickly decode up to 11 byte NOPs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_15bytenop)] = .{
         .llvm_name = "fast-15bytenop",
-        .description = "Target can quickly decode up to 15 byte NOPs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_7bytenop)] = .{
         .llvm_name = "fast-7bytenop",
-        .description = "Target can quickly decode up to 7 byte NOPs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_bextr)] = .{
         .llvm_name = "fast-bextr",
-        .description = "Indicates that the BEXTR instruction is implemented as a single uop with good throughput",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_gather)] = .{
         .llvm_name = "fast-gather",
-        .description = "Indicates if gather is reasonably fast (this is true for Skylake client and all AVX-512 CPUs)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_hops)] = .{
         .llvm_name = "fast-hops",
-        .description = "Prefer horizontal vector math instructions (haddp, phsub, etc.) over normal vector instructions with shuffles",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_lzcnt)] = .{
         .llvm_name = "fast-lzcnt",
-        .description = "LZCNT instructions are as fast as most simple integer ops",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_movbe)] = .{
         .llvm_name = "fast-movbe",
-        .description = "Prefer a movbe over a single-use load + bswap / single-use bswap + store",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_scalar_fsqrt)] = .{
         .llvm_name = "fast-scalar-fsqrt",
-        .description = "Scalar SQRT is fast (disable Newton-Raphson)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_scalar_shift_masks)] = .{
         .llvm_name = "fast-scalar-shift-masks",
-        .description = "Prefer a left/right scalar logical shift pair over a shift+and pair",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_shld_rotate)] = .{
         .llvm_name = "fast-shld-rotate",
-        .description = "SHLD can be used as a faster rotate",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_variable_crosslane_shuffle)] = .{
         .llvm_name = "fast-variable-crosslane-shuffle",
-        .description = "Cross-lane shuffles with variable masks are fast",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_variable_perlane_shuffle)] = .{
         .llvm_name = "fast-variable-perlane-shuffle",
-        .description = "Per-lane shuffles with variable masks are fast",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_vector_fsqrt)] = .{
         .llvm_name = "fast-vector-fsqrt",
-        .description = "Vector SQRT is fast (disable Newton-Raphson)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fast_vector_shift_masks)] = .{
         .llvm_name = "fast-vector-shift-masks",
-        .description = "Prefer a left/right vector logical shift pair over a shift+and pair",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.faster_shift_than_shuffle)] = .{
         .llvm_name = "faster-shift-than-shuffle",
-        .description = "Shifts are faster (or as fast) as shuffle",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fma)] = .{
         .llvm_name = "fma",
-        .description = "Enable three-operand fused multiple-add",
         .dependencies = featureSet(&[_]Feature{
             .avx,
         }),
     };
     result[@intFromEnum(Feature.fma4)] = .{
         .llvm_name = "fma4",
-        .description = "Enable four-operand fused multiple-add",
         .dependencies = featureSet(&[_]Feature{
             .avx,
             .sse4a,
@@ -702,268 +620,216 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.fsgsbase)] = .{
         .llvm_name = "fsgsbase",
-        .description = "Support FS/GS Base instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fsrm)] = .{
         .llvm_name = "fsrm",
-        .description = "REP MOVSB of short lengths is faster",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.fxsr)] = .{
         .llvm_name = "fxsr",
-        .description = "Support fxsave/fxrestore instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.gfni)] = .{
         .llvm_name = "gfni",
-        .description = "Enable Galois Field Arithmetic Instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse2,
         }),
     };
     result[@intFromEnum(Feature.harden_sls_ijmp)] = .{
         .llvm_name = "harden-sls-ijmp",
-        .description = "Harden against straight line speculation across indirect JMP instructions.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.harden_sls_ret)] = .{
         .llvm_name = "harden-sls-ret",
-        .description = "Harden against straight line speculation across RET instructions.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.hreset)] = .{
         .llvm_name = "hreset",
-        .description = "Has hreset instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.idivl_to_divb)] = .{
         .llvm_name = "idivl-to-divb",
-        .description = "Use 8-bit divide for positive values less than 256",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.idivq_to_divl)] = .{
         .llvm_name = "idivq-to-divl",
-        .description = "Use 32-bit divide for positive values less than 2^32",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.invpcid)] = .{
         .llvm_name = "invpcid",
-        .description = "Invalidate Process-Context Identifier",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.kl)] = .{
         .llvm_name = "kl",
-        .description = "Support Key Locker kl Instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse2,
         }),
     };
     result[@intFromEnum(Feature.lea_sp)] = .{
         .llvm_name = "lea-sp",
-        .description = "Use LEA for adjusting the stack pointer (this is an optimization for Intel Atom processors)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lea_uses_ag)] = .{
         .llvm_name = "lea-uses-ag",
-        .description = "LEA instruction needs inputs at AG stage",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lvi_cfi)] = .{
         .llvm_name = "lvi-cfi",
-        .description = "Prevent indirect calls/branches from using a memory operand, and precede all indirect calls/branches from a register with an LFENCE instruction to serialize control flow. Also decompose RET instructions into a POP+LFENCE+JMP sequence.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lvi_load_hardening)] = .{
         .llvm_name = "lvi-load-hardening",
-        .description = "Insert LFENCE instructions to prevent data speculatively injected into loads from being used maliciously.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lwp)] = .{
         .llvm_name = "lwp",
-        .description = "Enable LWP instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.lzcnt)] = .{
         .llvm_name = "lzcnt",
-        .description = "Support LZCNT instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.macrofusion)] = .{
         .llvm_name = "macrofusion",
-        .description = "Various instructions can be fused with conditional branches",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mmx)] = .{
         .llvm_name = "mmx",
-        .description = "Enable MMX instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.movbe)] = .{
         .llvm_name = "movbe",
-        .description = "Support MOVBE instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.movdir64b)] = .{
         .llvm_name = "movdir64b",
-        .description = "Support movdir64b instruction (direct store 64 bytes)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.movdiri)] = .{
         .llvm_name = "movdiri",
-        .description = "Support movdiri instruction (direct store integer)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.mwaitx)] = .{
         .llvm_name = "mwaitx",
-        .description = "Enable MONITORX/MWAITX timer functionality",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ndd)] = .{
         .llvm_name = "ndd",
-        .description = "Support non-destructive destination",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_bypass_delay)] = .{
         .llvm_name = "no-bypass-delay",
-        .description = "Has no bypass delay when using the 'wrong' domain",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_bypass_delay_blend)] = .{
         .llvm_name = "no-bypass-delay-blend",
-        .description = "Has no bypass delay when using the 'wrong' blend type",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_bypass_delay_mov)] = .{
         .llvm_name = "no-bypass-delay-mov",
-        .description = "Has no bypass delay when using the 'wrong' mov type",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.no_bypass_delay_shuffle)] = .{
         .llvm_name = "no-bypass-delay-shuffle",
-        .description = "Has no bypass delay when using the 'wrong' shuffle type",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.nopl)] = .{
         .llvm_name = "nopl",
-        .description = "Enable NOPL instruction (generally pentium pro+)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pad_short_functions)] = .{
         .llvm_name = "pad-short-functions",
-        .description = "Pad short functions (to prevent a stall when returning too early)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pclmul)] = .{
         .llvm_name = "pclmul",
-        .description = "Enable packed carry-less multiplication instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse2,
         }),
     };
     result[@intFromEnum(Feature.pconfig)] = .{
         .llvm_name = "pconfig",
-        .description = "platform configuration instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.pku)] = .{
         .llvm_name = "pku",
-        .description = "Enable protection keys",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.popcnt)] = .{
         .llvm_name = "popcnt",
-        .description = "Support POPCNT instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ppx)] = .{
         .llvm_name = "ppx",
-        .description = "Support Push-Pop Acceleration",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_128_bit)] = .{
         .llvm_name = "prefer-128-bit",
-        .description = "Prefer 128-bit AVX instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_256_bit)] = .{
         .llvm_name = "prefer-256-bit",
-        .description = "Prefer 256-bit AVX instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_mask_registers)] = .{
         .llvm_name = "prefer-mask-registers",
-        .description = "Prefer AVX512 mask registers over PTEST/MOVMSK",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_movmsk_over_vtest)] = .{
         .llvm_name = "prefer-movmsk-over-vtest",
-        .description = "Prefer movmsk over vtest instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_no_gather)] = .{
         .llvm_name = "prefer-no-gather",
-        .description = "Prefer no gather instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefer_no_scatter)] = .{
         .llvm_name = "prefer-no-scatter",
-        .description = "Prefer no scatter instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefetchi)] = .{
         .llvm_name = "prefetchi",
-        .description = "Prefetch instruction with T0 or T1 Hint",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prefetchwt1)] = .{
         .llvm_name = "prefetchwt1",
-        .description = "Prefetch with Intent to Write and T1 Hint",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.prfchw)] = .{
         .llvm_name = "prfchw",
-        .description = "Support PRFCHW instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ptwrite)] = .{
         .llvm_name = "ptwrite",
-        .description = "Support ptwrite instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.push2pop2)] = .{
         .llvm_name = "push2pop2",
-        .description = "Support PUSH2/POP2 instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.raoint)] = .{
         .llvm_name = "raoint",
-        .description = "Support RAO-INT instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rdpid)] = .{
         .llvm_name = "rdpid",
-        .description = "Support RDPID instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rdpru)] = .{
         .llvm_name = "rdpru",
-        .description = "Support RDPRU instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rdrnd)] = .{
         .llvm_name = "rdrnd",
-        .description = "Support RDRAND instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rdseed)] = .{
         .llvm_name = "rdseed",
-        .description = "Support RDSEED instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.retpoline)] = .{
         .llvm_name = "retpoline",
-        .description = "Remove speculation of indirect branches from the generated code, either by avoiding them entirely or lowering them with a speculation blocking construct",
         .dependencies = featureSet(&[_]Feature{
             .retpoline_indirect_branches,
             .retpoline_indirect_calls,
@@ -971,231 +837,190 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.retpoline_external_thunk)] = .{
         .llvm_name = "retpoline-external-thunk",
-        .description = "When lowering an indirect call or branch using a `retpoline`, rely on the specified user provided thunk rather than emitting one ourselves. Only has effect when combined with some other retpoline feature",
         .dependencies = featureSet(&[_]Feature{
             .retpoline_indirect_calls,
         }),
     };
     result[@intFromEnum(Feature.retpoline_indirect_branches)] = .{
         .llvm_name = "retpoline-indirect-branches",
-        .description = "Remove speculation of indirect branches from the generated code",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.retpoline_indirect_calls)] = .{
         .llvm_name = "retpoline-indirect-calls",
-        .description = "Remove speculation of indirect calls from the generated code",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.rtm)] = .{
         .llvm_name = "rtm",
-        .description = "Support RTM instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sahf)] = .{
         .llvm_name = "sahf",
-        .description = "Support LAHF and SAHF instructions in 64-bit mode",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sbb_dep_breaking)] = .{
         .llvm_name = "sbb-dep-breaking",
-        .description = "SBB with same register has no source dependency",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.serialize)] = .{
         .llvm_name = "serialize",
-        .description = "Has serialize instruction",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.seses)] = .{
         .llvm_name = "seses",
-        .description = "Prevent speculative execution side channel timing attacks by inserting a speculation barrier before memory reads, memory writes, and conditional branches. Implies LVI Control Flow integrity.",
         .dependencies = featureSet(&[_]Feature{
             .lvi_cfi,
         }),
     };
     result[@intFromEnum(Feature.sgx)] = .{
         .llvm_name = "sgx",
-        .description = "Enable Software Guard Extensions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sha)] = .{
         .llvm_name = "sha",
-        .description = "Enable SHA instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse2,
         }),
     };
     result[@intFromEnum(Feature.sha512)] = .{
         .llvm_name = "sha512",
-        .description = "Support SHA512 instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.shstk)] = .{
         .llvm_name = "shstk",
-        .description = "Support CET Shadow-Stack instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_3ops_lea)] = .{
         .llvm_name = "slow-3ops-lea",
-        .description = "LEA instruction with 3 ops or certain registers is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_incdec)] = .{
         .llvm_name = "slow-incdec",
-        .description = "INC and DEC instructions are slower than ADD and SUB",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_lea)] = .{
         .llvm_name = "slow-lea",
-        .description = "LEA instruction with certain arguments is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_pmaddwd)] = .{
         .llvm_name = "slow-pmaddwd",
-        .description = "PMADDWD is slower than PMULLD",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_pmulld)] = .{
         .llvm_name = "slow-pmulld",
-        .description = "PMULLD instruction is slow (compared to PMULLW/PMULHW and PMULUDQ)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_shld)] = .{
         .llvm_name = "slow-shld",
-        .description = "SHLD instruction is slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_two_mem_ops)] = .{
         .llvm_name = "slow-two-mem-ops",
-        .description = "Two memory operand instructions are slow",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_unaligned_mem_16)] = .{
         .llvm_name = "slow-unaligned-mem-16",
-        .description = "Slow unaligned 16-byte memory access",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.slow_unaligned_mem_32)] = .{
         .llvm_name = "slow-unaligned-mem-32",
-        .description = "Slow unaligned 32-byte memory access",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sm3)] = .{
         .llvm_name = "sm3",
-        .description = "Support SM3 instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx,
         }),
     };
     result[@intFromEnum(Feature.sm4)] = .{
         .llvm_name = "sm4",
-        .description = "Support SM4 instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx2,
         }),
     };
     result[@intFromEnum(Feature.soft_float)] = .{
         .llvm_name = "soft-float",
-        .description = "Use software floating point features",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sse)] = .{
         .llvm_name = "sse",
-        .description = "Enable SSE instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.sse2)] = .{
         .llvm_name = "sse2",
-        .description = "Enable SSE2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse,
         }),
     };
     result[@intFromEnum(Feature.sse3)] = .{
         .llvm_name = "sse3",
-        .description = "Enable SSE3 instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse2,
         }),
     };
     result[@intFromEnum(Feature.sse4_1)] = .{
         .llvm_name = "sse4.1",
-        .description = "Enable SSE 4.1 instructions",
         .dependencies = featureSet(&[_]Feature{
             .ssse3,
         }),
     };
     result[@intFromEnum(Feature.sse4_2)] = .{
         .llvm_name = "sse4.2",
-        .description = "Enable SSE 4.2 instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse4_1,
         }),
     };
     result[@intFromEnum(Feature.sse4a)] = .{
         .llvm_name = "sse4a",
-        .description = "Support SSE 4a instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse3,
         }),
     };
     result[@intFromEnum(Feature.sse_unaligned_mem)] = .{
         .llvm_name = "sse-unaligned-mem",
-        .description = "Allow unaligned memory operands with SSE instructions (this may require setting a configuration bit in the processor)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.ssse3)] = .{
         .llvm_name = "ssse3",
-        .description = "Enable SSSE3 instructions",
         .dependencies = featureSet(&[_]Feature{
             .sse3,
         }),
     };
     result[@intFromEnum(Feature.tagged_globals)] = .{
         .llvm_name = "tagged-globals",
-        .description = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits.",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tbm)] = .{
         .llvm_name = "tbm",
-        .description = "Enable TBM instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tsxldtrk)] = .{
         .llvm_name = "tsxldtrk",
-        .description = "Support TSXLDTRK instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.tuning_fast_imm_vector_shift)] = .{
         .llvm_name = "tuning-fast-imm-vector-shift",
-        .description = "Vector shifts are fast (2/cycle) as opposed to slow (1/cycle)",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.uintr)] = .{
         .llvm_name = "uintr",
-        .description = "Has UINTR Instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_glm_div_sqrt_costs)] = .{
         .llvm_name = "use-glm-div-sqrt-costs",
-        .description = "Use Goldmont specific floating point div/sqrt costs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_slm_arith_costs)] = .{
         .llvm_name = "use-slm-arith-costs",
-        .description = "Use Silvermont specific arithmetic costs",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.usermsr)] = .{
         .llvm_name = "usermsr",
-        .description = "Support USERMSR instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.vaes)] = .{
         .llvm_name = "vaes",
-        .description = "Promote selected AES instructions to AVX512/AVX registers",
         .dependencies = featureSet(&[_]Feature{
             .aes,
             .avx2,
@@ -1203,7 +1028,6 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vpclmulqdq)] = .{
         .llvm_name = "vpclmulqdq",
-        .description = "Enable vpclmulqdq instructions",
         .dependencies = featureSet(&[_]Feature{
             .avx,
             .pclmul,
@@ -1211,60 +1035,50 @@ pub const all_features = blk: {
     };
     result[@intFromEnum(Feature.vzeroupper)] = .{
         .llvm_name = "vzeroupper",
-        .description = "Should insert vzeroupper instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.waitpkg)] = .{
         .llvm_name = "waitpkg",
-        .description = "Wait and pause enhancements",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.wbnoinvd)] = .{
         .llvm_name = "wbnoinvd",
-        .description = "Write Back No Invalidate",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.widekl)] = .{
         .llvm_name = "widekl",
-        .description = "Support Key Locker wide Instructions",
         .dependencies = featureSet(&[_]Feature{
             .kl,
         }),
     };
     result[@intFromEnum(Feature.x87)] = .{
         .llvm_name = "x87",
-        .description = "Enable X87 float instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xop)] = .{
         .llvm_name = "xop",
-        .description = "Enable XOP instructions",
         .dependencies = featureSet(&[_]Feature{
             .fma4,
         }),
     };
     result[@intFromEnum(Feature.xsave)] = .{
         .llvm_name = "xsave",
-        .description = "Support xsave instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.xsavec)] = .{
         .llvm_name = "xsavec",
-        .description = "Support xsavec instructions",
         .dependencies = featureSet(&[_]Feature{
             .xsave,
         }),
     };
     result[@intFromEnum(Feature.xsaveopt)] = .{
         .llvm_name = "xsaveopt",
-        .description = "Support xsaveopt instructions",
         .dependencies = featureSet(&[_]Feature{
             .xsave,
         }),
     };
     result[@intFromEnum(Feature.xsaves)] = .{
         .llvm_name = "xsaves",
-        .description = "Support xsaves instructions",
         .dependencies = featureSet(&[_]Feature{
             .xsave,
         }),
@@ -1274,6 +1088,198 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.@"16bit_mode")] = "16-bit mode (i8086)";
+    result[@intFromEnum(Feature.@"32bit_mode")] = "32-bit mode (80386)";
+    result[@intFromEnum(Feature.@"3dnow")] = "Enable 3DNow! instructions";
+    result[@intFromEnum(Feature.@"3dnowa")] = "Enable 3DNow! Athlon instructions";
+    result[@intFromEnum(Feature.@"64bit")] = "Support 64-bit instructions";
+    result[@intFromEnum(Feature.adx)] = "Support ADX instructions";
+    result[@intFromEnum(Feature.aes)] = "Enable AES instructions";
+    result[@intFromEnum(Feature.allow_light_256_bit)] = "Enable generation of 256-bit load/stores even if we prefer 128-bit";
+    result[@intFromEnum(Feature.amx_bf16)] = "Support AMX-BF16 instructions";
+    result[@intFromEnum(Feature.amx_complex)] = "Support AMX-COMPLEX instructions";
+    result[@intFromEnum(Feature.amx_fp16)] = "Support AMX amx-fp16 instructions";
+    result[@intFromEnum(Feature.amx_int8)] = "Support AMX-INT8 instructions";
+    result[@intFromEnum(Feature.amx_tile)] = "Support AMX-TILE instructions";
+    result[@intFromEnum(Feature.avx)] = "Enable AVX instructions";
+    result[@intFromEnum(Feature.avx10_1_256)] = "Support AVX10.1 up to 256-bit instruction";
+    result[@intFromEnum(Feature.avx10_1_512)] = "Support AVX10.1 up to 512-bit instruction";
+    result[@intFromEnum(Feature.avx2)] = "Enable AVX2 instructions";
+    result[@intFromEnum(Feature.avx512bf16)] = "Support bfloat16 floating point";
+    result[@intFromEnum(Feature.avx512bitalg)] = "Enable AVX-512 Bit Algorithms";
+    result[@intFromEnum(Feature.avx512bw)] = "Enable AVX-512 Byte and Word Instructions";
+    result[@intFromEnum(Feature.avx512cd)] = "Enable AVX-512 Conflict Detection Instructions";
+    result[@intFromEnum(Feature.avx512dq)] = "Enable AVX-512 Doubleword and Quadword Instructions";
+    result[@intFromEnum(Feature.avx512er)] = "Enable AVX-512 Exponential and Reciprocal Instructions";
+    result[@intFromEnum(Feature.avx512f)] = "Enable AVX-512 instructions";
+    result[@intFromEnum(Feature.avx512fp16)] = "Support 16-bit floating point";
+    result[@intFromEnum(Feature.avx512ifma)] = "Enable AVX-512 Integer Fused Multiple-Add";
+    result[@intFromEnum(Feature.avx512pf)] = "Enable AVX-512 PreFetch Instructions";
+    result[@intFromEnum(Feature.avx512vbmi)] = "Enable AVX-512 Vector Byte Manipulation Instructions";
+    result[@intFromEnum(Feature.avx512vbmi2)] = "Enable AVX-512 further Vector Byte Manipulation Instructions";
+    result[@intFromEnum(Feature.avx512vl)] = "Enable AVX-512 Vector Length eXtensions";
+    result[@intFromEnum(Feature.avx512vnni)] = "Enable AVX-512 Vector Neural Network Instructions";
+    result[@intFromEnum(Feature.avx512vp2intersect)] = "Enable AVX-512 vp2intersect";
+    result[@intFromEnum(Feature.avx512vpopcntdq)] = "Enable AVX-512 Population Count Instructions";
+    result[@intFromEnum(Feature.avxifma)] = "Enable AVX-IFMA";
+    result[@intFromEnum(Feature.avxneconvert)] = "Support AVX-NE-CONVERT instructions";
+    result[@intFromEnum(Feature.avxvnni)] = "Support AVX_VNNI encoding";
+    result[@intFromEnum(Feature.avxvnniint16)] = "Enable AVX-VNNI-INT16";
+    result[@intFromEnum(Feature.avxvnniint8)] = "Enable AVX-VNNI-INT8";
+    result[@intFromEnum(Feature.bmi)] = "Support BMI instructions";
+    result[@intFromEnum(Feature.bmi2)] = "Support BMI2 instructions";
+    result[@intFromEnum(Feature.branchfusion)] = "CMP/TEST can be fused with conditional branches";
+    result[@intFromEnum(Feature.ccmp)] = "Support conditional cmp & test instructions";
+    result[@intFromEnum(Feature.cf)] = "Support conditional faulting";
+    result[@intFromEnum(Feature.cldemote)] = "Enable Cache Line Demote";
+    result[@intFromEnum(Feature.clflushopt)] = "Flush A Cache Line Optimized";
+    result[@intFromEnum(Feature.clwb)] = "Cache Line Write Back";
+    result[@intFromEnum(Feature.clzero)] = "Enable Cache Line Zero";
+    result[@intFromEnum(Feature.cmov)] = "Enable conditional move instructions";
+    result[@intFromEnum(Feature.cmpccxadd)] = "Support CMPCCXADD instructions";
+    result[@intFromEnum(Feature.crc32)] = "Enable SSE 4.2 CRC32 instruction (used when SSE4.2 is supported but function is GPR only)";
+    result[@intFromEnum(Feature.cx16)] = "64-bit with cmpxchg16b (this is true for most x86-64 chips, but not the first AMD chips)";
+    result[@intFromEnum(Feature.cx8)] = "Support CMPXCHG8B instructions";
+    result[@intFromEnum(Feature.egpr)] = "Support extended general purpose register";
+    result[@intFromEnum(Feature.enqcmd)] = "Has ENQCMD instructions";
+    result[@intFromEnum(Feature.ermsb)] = "REP MOVS/STOS are fast";
+    result[@intFromEnum(Feature.evex512)] = "Support ZMM and 64-bit mask instructions";
+    result[@intFromEnum(Feature.f16c)] = "Support 16-bit floating point conversion instructions";
+    result[@intFromEnum(Feature.false_deps_getmant)] = "VGETMANTSS/SD/SH and VGETMANDPS/PD(memory version) has a false dependency on dest register";
+    result[@intFromEnum(Feature.false_deps_lzcnt_tzcnt)] = "LZCNT/TZCNT have a false dependency on dest register";
+    result[@intFromEnum(Feature.false_deps_mulc)] = "VF[C]MULCPH/SH has a false dependency on dest register";
+    result[@intFromEnum(Feature.false_deps_mullq)] = "VPMULLQ has a false dependency on dest register";
+    result[@intFromEnum(Feature.false_deps_perm)] = "VPERMD/Q/PS/PD has a false dependency on dest register";
+    result[@intFromEnum(Feature.false_deps_popcnt)] = "POPCNT has a false dependency on dest register";
+    result[@intFromEnum(Feature.false_deps_range)] = "VRANGEPD/PS/SD/SS has a false dependency on dest register";
+    result[@intFromEnum(Feature.fast_11bytenop)] = "Target can quickly decode up to 11 byte NOPs";
+    result[@intFromEnum(Feature.fast_15bytenop)] = "Target can quickly decode up to 15 byte NOPs";
+    result[@intFromEnum(Feature.fast_7bytenop)] = "Target can quickly decode up to 7 byte NOPs";
+    result[@intFromEnum(Feature.fast_bextr)] = "Indicates that the BEXTR instruction is implemented as a single uop with good throughput";
+    result[@intFromEnum(Feature.fast_gather)] = "Indicates if gather is reasonably fast (this is true for Skylake client and all AVX-512 CPUs)";
+    result[@intFromEnum(Feature.fast_hops)] = "Prefer horizontal vector math instructions (haddp, phsub, etc.) over normal vector instructions with shuffles";
+    result[@intFromEnum(Feature.fast_lzcnt)] = "LZCNT instructions are as fast as most simple integer ops";
+    result[@intFromEnum(Feature.fast_movbe)] = "Prefer a movbe over a single-use load + bswap / single-use bswap + store";
+    result[@intFromEnum(Feature.fast_scalar_fsqrt)] = "Scalar SQRT is fast (disable Newton-Raphson)";
+    result[@intFromEnum(Feature.fast_scalar_shift_masks)] = "Prefer a left/right scalar logical shift pair over a shift+and pair";
+    result[@intFromEnum(Feature.fast_shld_rotate)] = "SHLD can be used as a faster rotate";
+    result[@intFromEnum(Feature.fast_variable_crosslane_shuffle)] = "Cross-lane shuffles with variable masks are fast";
+    result[@intFromEnum(Feature.fast_variable_perlane_shuffle)] = "Per-lane shuffles with variable masks are fast";
+    result[@intFromEnum(Feature.fast_vector_fsqrt)] = "Vector SQRT is fast (disable Newton-Raphson)";
+    result[@intFromEnum(Feature.fast_vector_shift_masks)] = "Prefer a left/right vector logical shift pair over a shift+and pair";
+    result[@intFromEnum(Feature.faster_shift_than_shuffle)] = "Shifts are faster (or as fast) as shuffle";
+    result[@intFromEnum(Feature.fma)] = "Enable three-operand fused multiple-add";
+    result[@intFromEnum(Feature.fma4)] = "Enable four-operand fused multiple-add";
+    result[@intFromEnum(Feature.fsgsbase)] = "Support FS/GS Base instructions";
+    result[@intFromEnum(Feature.fsrm)] = "REP MOVSB of short lengths is faster";
+    result[@intFromEnum(Feature.fxsr)] = "Support fxsave/fxrestore instructions";
+    result[@intFromEnum(Feature.gfni)] = "Enable Galois Field Arithmetic Instructions";
+    result[@intFromEnum(Feature.harden_sls_ijmp)] = "Harden against straight line speculation across indirect JMP instructions.";
+    result[@intFromEnum(Feature.harden_sls_ret)] = "Harden against straight line speculation across RET instructions.";
+    result[@intFromEnum(Feature.hreset)] = "Has hreset instruction";
+    result[@intFromEnum(Feature.idivl_to_divb)] = "Use 8-bit divide for positive values less than 256";
+    result[@intFromEnum(Feature.idivq_to_divl)] = "Use 32-bit divide for positive values less than 2^32";
+    result[@intFromEnum(Feature.invpcid)] = "Invalidate Process-Context Identifier";
+    result[@intFromEnum(Feature.kl)] = "Support Key Locker kl Instructions";
+    result[@intFromEnum(Feature.lea_sp)] = "Use LEA for adjusting the stack pointer (this is an optimization for Intel Atom processors)";
+    result[@intFromEnum(Feature.lea_uses_ag)] = "LEA instruction needs inputs at AG stage";
+    result[@intFromEnum(Feature.lvi_cfi)] = "Prevent indirect calls/branches from using a memory operand, and precede all indirect calls/branches from a register with an LFENCE instruction to serialize control flow. Also decompose RET instructions into a POP+LFENCE+JMP sequence.";
+    result[@intFromEnum(Feature.lvi_load_hardening)] = "Insert LFENCE instructions to prevent data speculatively injected into loads from being used maliciously.";
+    result[@intFromEnum(Feature.lwp)] = "Enable LWP instructions";
+    result[@intFromEnum(Feature.lzcnt)] = "Support LZCNT instruction";
+    result[@intFromEnum(Feature.macrofusion)] = "Various instructions can be fused with conditional branches";
+    result[@intFromEnum(Feature.mmx)] = "Enable MMX instructions";
+    result[@intFromEnum(Feature.movbe)] = "Support MOVBE instruction";
+    result[@intFromEnum(Feature.movdir64b)] = "Support movdir64b instruction (direct store 64 bytes)";
+    result[@intFromEnum(Feature.movdiri)] = "Support movdiri instruction (direct store integer)";
+    result[@intFromEnum(Feature.mwaitx)] = "Enable MONITORX/MWAITX timer functionality";
+    result[@intFromEnum(Feature.ndd)] = "Support non-destructive destination";
+    result[@intFromEnum(Feature.no_bypass_delay)] = "Has no bypass delay when using the 'wrong' domain";
+    result[@intFromEnum(Feature.no_bypass_delay_blend)] = "Has no bypass delay when using the 'wrong' blend type";
+    result[@intFromEnum(Feature.no_bypass_delay_mov)] = "Has no bypass delay when using the 'wrong' mov type";
+    result[@intFromEnum(Feature.no_bypass_delay_shuffle)] = "Has no bypass delay when using the 'wrong' shuffle type";
+    result[@intFromEnum(Feature.nopl)] = "Enable NOPL instruction (generally pentium pro+)";
+    result[@intFromEnum(Feature.pad_short_functions)] = "Pad short functions (to prevent a stall when returning too early)";
+    result[@intFromEnum(Feature.pclmul)] = "Enable packed carry-less multiplication instructions";
+    result[@intFromEnum(Feature.pconfig)] = "platform configuration instruction";
+    result[@intFromEnum(Feature.pku)] = "Enable protection keys";
+    result[@intFromEnum(Feature.popcnt)] = "Support POPCNT instruction";
+    result[@intFromEnum(Feature.ppx)] = "Support Push-Pop Acceleration";
+    result[@intFromEnum(Feature.prefer_128_bit)] = "Prefer 128-bit AVX instructions";
+    result[@intFromEnum(Feature.prefer_256_bit)] = "Prefer 256-bit AVX instructions";
+    result[@intFromEnum(Feature.prefer_mask_registers)] = "Prefer AVX512 mask registers over PTEST/MOVMSK";
+    result[@intFromEnum(Feature.prefer_movmsk_over_vtest)] = "Prefer movmsk over vtest instruction";
+    result[@intFromEnum(Feature.prefer_no_gather)] = "Prefer no gather instructions";
+    result[@intFromEnum(Feature.prefer_no_scatter)] = "Prefer no scatter instructions";
+    result[@intFromEnum(Feature.prefetchi)] = "Prefetch instruction with T0 or T1 Hint";
+    result[@intFromEnum(Feature.prefetchwt1)] = "Prefetch with Intent to Write and T1 Hint";
+    result[@intFromEnum(Feature.prfchw)] = "Support PRFCHW instructions";
+    result[@intFromEnum(Feature.ptwrite)] = "Support ptwrite instruction";
+    result[@intFromEnum(Feature.push2pop2)] = "Support PUSH2/POP2 instructions";
+    result[@intFromEnum(Feature.raoint)] = "Support RAO-INT instructions";
+    result[@intFromEnum(Feature.rdpid)] = "Support RDPID instructions";
+    result[@intFromEnum(Feature.rdpru)] = "Support RDPRU instructions";
+    result[@intFromEnum(Feature.rdrnd)] = "Support RDRAND instruction";
+    result[@intFromEnum(Feature.rdseed)] = "Support RDSEED instruction";
+    result[@intFromEnum(Feature.retpoline)] = "Remove speculation of indirect branches from the generated code, either by avoiding them entirely or lowering them with a speculation blocking construct";
+    result[@intFromEnum(Feature.retpoline_external_thunk)] = "When lowering an indirect call or branch using a `retpoline`, rely on the specified user provided thunk rather than emitting one ourselves. Only has effect when combined with some other retpoline feature";
+    result[@intFromEnum(Feature.retpoline_indirect_branches)] = "Remove speculation of indirect branches from the generated code";
+    result[@intFromEnum(Feature.retpoline_indirect_calls)] = "Remove speculation of indirect calls from the generated code";
+    result[@intFromEnum(Feature.rtm)] = "Support RTM instructions";
+    result[@intFromEnum(Feature.sahf)] = "Support LAHF and SAHF instructions in 64-bit mode";
+    result[@intFromEnum(Feature.sbb_dep_breaking)] = "SBB with same register has no source dependency";
+    result[@intFromEnum(Feature.serialize)] = "Has serialize instruction";
+    result[@intFromEnum(Feature.seses)] = "Prevent speculative execution side channel timing attacks by inserting a speculation barrier before memory reads, memory writes, and conditional branches. Implies LVI Control Flow integrity.";
+    result[@intFromEnum(Feature.sgx)] = "Enable Software Guard Extensions";
+    result[@intFromEnum(Feature.sha)] = "Enable SHA instructions";
+    result[@intFromEnum(Feature.sha512)] = "Support SHA512 instructions";
+    result[@intFromEnum(Feature.shstk)] = "Support CET Shadow-Stack instructions";
+    result[@intFromEnum(Feature.slow_3ops_lea)] = "LEA instruction with 3 ops or certain registers is slow";
+    result[@intFromEnum(Feature.slow_incdec)] = "INC and DEC instructions are slower than ADD and SUB";
+    result[@intFromEnum(Feature.slow_lea)] = "LEA instruction with certain arguments is slow";
+    result[@intFromEnum(Feature.slow_pmaddwd)] = "PMADDWD is slower than PMULLD";
+    result[@intFromEnum(Feature.slow_pmulld)] = "PMULLD instruction is slow (compared to PMULLW/PMULHW and PMULUDQ)";
+    result[@intFromEnum(Feature.slow_shld)] = "SHLD instruction is slow";
+    result[@intFromEnum(Feature.slow_two_mem_ops)] = "Two memory operand instructions are slow";
+    result[@intFromEnum(Feature.slow_unaligned_mem_16)] = "Slow unaligned 16-byte memory access";
+    result[@intFromEnum(Feature.slow_unaligned_mem_32)] = "Slow unaligned 32-byte memory access";
+    result[@intFromEnum(Feature.sm3)] = "Support SM3 instructions";
+    result[@intFromEnum(Feature.sm4)] = "Support SM4 instructions";
+    result[@intFromEnum(Feature.soft_float)] = "Use software floating point features";
+    result[@intFromEnum(Feature.sse)] = "Enable SSE instructions";
+    result[@intFromEnum(Feature.sse2)] = "Enable SSE2 instructions";
+    result[@intFromEnum(Feature.sse3)] = "Enable SSE3 instructions";
+    result[@intFromEnum(Feature.sse4_1)] = "Enable SSE 4.1 instructions";
+    result[@intFromEnum(Feature.sse4_2)] = "Enable SSE 4.2 instructions";
+    result[@intFromEnum(Feature.sse4a)] = "Support SSE 4a instructions";
+    result[@intFromEnum(Feature.sse_unaligned_mem)] = "Allow unaligned memory operands with SSE instructions (this may require setting a configuration bit in the processor)";
+    result[@intFromEnum(Feature.ssse3)] = "Enable SSSE3 instructions";
+    result[@intFromEnum(Feature.tagged_globals)] = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits.";
+    result[@intFromEnum(Feature.tbm)] = "Enable TBM instructions";
+    result[@intFromEnum(Feature.tsxldtrk)] = "Support TSXLDTRK instructions";
+    result[@intFromEnum(Feature.tuning_fast_imm_vector_shift)] = "Vector shifts are fast (2/cycle) as opposed to slow (1/cycle)";
+    result[@intFromEnum(Feature.uintr)] = "Has UINTR Instructions";
+    result[@intFromEnum(Feature.use_glm_div_sqrt_costs)] = "Use Goldmont specific floating point div/sqrt costs";
+    result[@intFromEnum(Feature.use_slm_arith_costs)] = "Use Silvermont specific arithmetic costs";
+    result[@intFromEnum(Feature.usermsr)] = "Support USERMSR instructions";
+    result[@intFromEnum(Feature.vaes)] = "Promote selected AES instructions to AVX512/AVX registers";
+    result[@intFromEnum(Feature.vpclmulqdq)] = "Enable vpclmulqdq instructions";
+    result[@intFromEnum(Feature.vzeroupper)] = "Should insert vzeroupper instructions";
+    result[@intFromEnum(Feature.waitpkg)] = "Wait and pause enhancements";
+    result[@intFromEnum(Feature.wbnoinvd)] = "Write Back No Invalidate";
+    result[@intFromEnum(Feature.widekl)] = "Support Key Locker wide Instructions";
+    result[@intFromEnum(Feature.x87)] = "Enable X87 float instructions";
+    result[@intFromEnum(Feature.xop)] = "Enable XOP instructions";
+    result[@intFromEnum(Feature.xsave)] = "Support xsave instructions";
+    result[@intFromEnum(Feature.xsavec)] = "Support xsavec instructions";
+    result[@intFromEnum(Feature.xsaveopt)] = "Support xsaveopt instructions";
+    result[@intFromEnum(Feature.xsaves)] = "Support xsaves instructions";
     break :blk result;
 };
 

--- a/lib/std/Target/xtensa.zig
+++ b/lib/std/Target/xtensa.zig
@@ -19,7 +19,6 @@ pub const all_features = blk: {
     var result: [len]CpuFeature = undefined;
     result[@intFromEnum(Feature.density)] = .{
         .llvm_name = "density",
-        .description = "Enable Density instructions",
         .dependencies = featureSet(&[_]Feature{}),
     };
     const ti = @typeInfo(Feature);
@@ -27,6 +26,13 @@ pub const all_features = blk: {
         elem.index = i;
         elem.name = ti.Enum.fields[i].name;
     }
+    break :blk result;
+};
+
+pub const feature_descs = blk: {
+    const len = @typeInfo(Feature).Enum.fields.len;
+    var result: [len][]const u8 = undefined;
+    result[@intFromEnum(Feature.density)] = "Enable Density instructions";
     break :blk result;
 };
 

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -641,8 +641,8 @@ pub fn parseTargetQueryOrReportFatalError(
             help: {
                 var help_text = std.ArrayList(u8).init(allocator);
                 defer help_text.deinit();
-                for (diags.arch.?.allFeaturesList()) |feature| {
-                    help_text.writer().print(" {s}: {s}\n", .{ feature.name, feature.description }) catch break :help;
+                for (diags.arch.?.allFeaturesList(), diags.arch.?.allFeaturesDescList()) |feature, desc| {
+                    help_text.writer().print(" {s}: {s}\n", .{ feature.name, desc }) catch break :help;
                 }
                 std.log.info("available CPU features for architecture '{s}':\n{s}", .{
                     @tagName(diags.arch.?), help_text.items,

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -1359,25 +1359,21 @@ fn processOneTarget(job: Job) anyerror!void {
             try w.print(
                 \\    result[@intFromEnum(Feature.{p_})] = .{{
                 \\        .llvm_name = "{}",
-                \\        .description = "{}",
                 \\        .dependencies = featureSet(&[_]Feature{{
             ,
                 .{
                     std.zig.fmtId(feature.zig_name),
                     std.zig.fmtEscapes(llvm_name),
-                    std.zig.fmtEscapes(feature.desc),
                 },
             );
         } else {
             try w.print(
                 \\    result[@intFromEnum(Feature.{p_})] = .{{
                 \\        .llvm_name = null,
-                \\        .description = "{}",
                 \\        .dependencies = featureSet(&[_]Feature{{
             ,
                 .{
                     std.zig.fmtId(feature.zig_name),
-                    std.zig.fmtEscapes(feature.desc),
                 },
             );
         }
@@ -1419,6 +1415,32 @@ fn processOneTarget(job: Job) anyerror!void {
         \\        elem.index = i;
         \\        elem.name = ti.Enum.fields[i].name;
         \\    }
+        \\    break :blk result;
+        \\};
+        \\
+        \\pub const feature_descs = blk: {
+        \\    const len = @typeInfo(Feature).Enum.fields.len;
+        \\    var result: [len][]const u8 = undefined;
+        \\
+    );
+    // Note: Description strings were moved out of `Cpu.Feature` to avoid
+    //       them being included in binaries that use `Target` but do not
+    //       use/reference the descriptions.
+    //
+    // TODO: Move the descriptions back into `Cpu.Feature`.
+    //       See https://github.com/ziglang/zig/issues/21010
+    for (all_features.items) |feature| {
+        try w.print(
+            \\    result[@intFromEnum(Feature.{p_})] = "{}";
+            \\
+        ,
+            .{
+                std.zig.fmtId(feature.zig_name),
+                std.zig.fmtEscapes(feature.desc),
+            },
+        );
+    }
+    try w.writeAll(
         \\    break :blk result;
         \\};
         \\


### PR DESCRIPTION
I happened to notice that there were a bunch of these description strings in the data section of compiled [resinator](https://github.com/squeek502/resinator) binaries. It turns out they were coming from [Aro](https://github.com/Vexu/arocc) because Aro uses `std.Target`. Aro does not actually use the description strings, though, so in both Aro and resinator, those strings are wasted space in the binary.

So, this PR allows users of std.Target to not include all the description strings in their program if they don't actually use them.

Counting all the bytes of the description strings after they were separated out using this code:

```zig
comptime {
    @setEvalBranchQuota(10000000);
    var total_byte_count: usize = 0;
    for (std.enums.values(Arch)) |arch| {
        const descs = allFeaturesDescList(arch);
        for (descs) |desc| {
            total_byte_count += desc.len;
        }
    }
    @compileLog(total_byte_count);
}
```

gives a total size of 146898 bytes or ~143 KiB. However, I have not seen quite that much saved in compiled binaries in practice. A test program like this:

```zig
const std = @import("std");

pub fn main() !void {
    const target = try std.zig.system.resolveTargetQuery(.{});
    std.debug.print("{any}\n", .{target});
}
```

compiled in ReleaseSmall with `-fstrip` on Windows gives these results:

- `Before: 321024 bytes (313.5 KiB)`
- `After:  219648 bytes (214.5 KiB)`
- `Delta:  101376 bytes ( 99.0 KiB)`

> Side note: the use of `std.Target` still increases the size of the binary a *lot*; for comparison, a simple hello world compiled in ReleaseSmall is 5 KiB

Note: The spirv features were not intended to be changed, but I'm not sure what exact versions of the Headers/Registry were used to generate the current `Target/spirv.zig`. I used commits around the time of the last `Target/spirv.zig` update in May 2021 (98dc8eb7d97bd05ced6908c4da3c5e0a55e2c41b); in particular, I used commits 60af2c93c46294a2bc9758889a90d935b6f9325f for SPIRV-Registry and ba29b3f59633836c6bb160b951007c8fc3842dee for SPIRV-Headers. Newer Registry/Headers versions were not used because (1) there are a *lot* more features, more than the current `Feature.Set.needed_bit_count` and (2) the current update_spirv_features.zig cannot handle some of the new files, e.g. https://raw.githubusercontent.com/KhronosGroup/SPIRV-Registry/main/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space.asciidoc

cc @Snektron 