### PR TITLE
`generate_c_size_and_align_checks`: Remove extraneous newline

### DIFF
--- a/tools/generate_c_size_and_align_checks.zig
+++ b/tools/generate_c_size_and_align_checks.zig
@@ -49,7 +49,7 @@ pub fn main() !void {
             c_name(c_type),
             target.c_type_byte_size(c_type),
         });
-        try stdout.print("_Static_assert(_Alignof({0s}) == {1d}, \"_Alignof({0s}) == {1d}\");\n\n", .{
+        try stdout.print("_Static_assert(_Alignof({0s}) == {1d}, \"_Alignof({0s}) == {1d}\");\n", .{
             c_name(c_type),
             target.c_type_alignment(c_type),
         });


### PR DESCRIPTION
Groups the assertions together properly.