### PR TITLE
Clearer separation of WASI POSIX support with (or without) wasi-libc

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1089,7 +1089,7 @@ fn runCommand(
                         // the `--` before the module name. This appears to work for both old and
                         // new Wasmtime versions.
                         try interp_argv.append(bin_name);
-                        try interp_argv.append("--dir=.");
+                        try interp_argv.append("--dir=."); // Preopen '.' at file descriptor 3 for cwd
                         try interp_argv.append("--");
                         try interp_argv.append(argv[0]);
                         try interp_argv.appendSlice(argv[1..]);

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1712,6 +1712,34 @@ pub const S = switch (native_os) {
         pub const IFREG = 0x8000;
         pub const IFSOCK = 0xc000;
         pub const IFMT = IFBLK | IFCHR | IFDIR | IFIFO | IFLNK | IFREG | IFSOCK;
+
+        pub fn ISBLK(m: u32) bool {
+            return m & IFMT == IFBLK;
+        }
+
+        pub fn ISCHR(m: u32) bool {
+            return m & IFMT == IFCHR;
+        }
+
+        pub fn ISDIR(m: u32) bool {
+            return m & IFMT == IFDIR;
+        }
+
+        pub fn ISFIFO(m: u32) bool {
+            return m & IFMT == IFIFO;
+        }
+
+        pub fn ISLNK(m: u32) bool {
+            return m & IFMT == IFLNK;
+        }
+
+        pub fn ISREG(m: u32) bool {
+            return m & IFMT == IFREG;
+        }
+
+        pub fn ISSOCK(m: u32) bool {
+            return m & IFMT == IFSOCK;
+        }
     },
     .macos, .ios, .tvos, .watchos, .visionos => struct {
         pub const IFMT = 0o170000;
@@ -6489,7 +6517,7 @@ pub const Stat = switch (native_os) {
         dev: dev_t,
         ino: ino_t,
         nlink: nlink_t,
-        mode: mode_t,
+        mode: c_uint, // only the file-type bits (S.IFMT), no permission bits
         uid: uid_t,
         gid: gid_t,
         __pad0: c_uint = 0,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -135,9 +135,8 @@ pub const mode_t = switch (native_os) {
     .emscripten => emscripten.mode_t,
     .openbsd, .haiku, .netbsd, .solaris, .illumos => u32,
     .freebsd, .macos, .ios, .tvos, .watchos, .visionos => u16,
-    .wasi => void,
-    .windows => u0,
-    else => u0, // TODO: should be void?
+    .wasi, .windows => void,
+    else => void,
 };
 
 pub const nlink_t = switch (native_os) {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1017,12 +1017,12 @@ test printLineFromFileAnyOs {
 
     var test_dir = std.testing.tmpDir(.{});
     defer test_dir.cleanup();
-    // Relies on testing.tmpDir internals which is not ideal, but SourceLocation requires paths.
+    // Relies on testing.tmpDir internals which is not ideal, but SourceLocation requires paths relative to cwd.
     const test_dir_path = try join(allocator, &.{ ".zig-cache", "tmp", test_dir.sub_path[0..] });
     defer allocator.free(test_dir_path);
 
-    // Cases
     {
+        // no newlines in file
         const path = try join(allocator, &.{ test_dir_path, "one_line.zig" });
         defer allocator.free(path);
         try test_dir.dir.writeFile(.{ .sub_path = "one_line.zig", .data = "no new lines in this file, but one is printed anyway" });
@@ -1034,6 +1034,7 @@ test printLineFromFileAnyOs {
         output.clearRetainingCapacity();
     }
     {
+        // print 1 & 3 of 3-line file
         const path = try join(allocator, &.{ test_dir_path, "three_lines.zig" });
         defer allocator.free(path);
         try test_dir.dir.writeFile(.{
@@ -1054,6 +1055,7 @@ test printLineFromFileAnyOs {
         output.clearRetainingCapacity();
     }
     {
+        // mem.page_size boundary crossing line
         const file = try test_dir.dir.createFile("line_overlaps_page_boundary.zig", .{});
         defer file.close();
         const path = try join(allocator, &.{ test_dir_path, "line_overlaps_page_boundary.zig" });
@@ -1070,6 +1072,7 @@ test printLineFromFileAnyOs {
         output.clearRetainingCapacity();
     }
     {
+        // ends on mem.page_size boundary
         const file = try test_dir.dir.createFile("file_ends_on_page_boundary.zig", .{});
         defer file.close();
         const path = try join(allocator, &.{ test_dir_path, "file_ends_on_page_boundary.zig" });
@@ -1083,6 +1086,7 @@ test printLineFromFileAnyOs {
         output.clearRetainingCapacity();
     }
     {
+        // multi-mem.page_size "line"
         const file = try test_dir.dir.createFile("very_long_first_line_spanning_multiple_pages.zig", .{});
         defer file.close();
         const path = try join(allocator, &.{ test_dir_path, "very_long_first_line_spanning_multiple_pages.zig" });
@@ -1108,6 +1112,7 @@ test printLineFromFileAnyOs {
         output.clearRetainingCapacity();
     }
     {
+        // mem.page_size pages of newlines
         const file = try test_dir.dir.createFile("file_of_newlines.zig", .{});
         defer file.close();
         const path = try join(allocator, &.{ test_dir_path, "file_of_newlines.zig" });

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1034,7 +1034,7 @@ test printLineFromFileAnyOs {
         output.clearRetainingCapacity();
     }
     {
-        const path = try fs.path.join(allocator, &.{ test_dir_path, "three_lines.zig" });
+        const path = try join(allocator, &.{ test_dir_path, "three_lines.zig" });
         defer allocator.free(path);
         try test_dir.dir.writeFile(.{
             .sub_path = "three_lines.zig",
@@ -1056,7 +1056,7 @@ test printLineFromFileAnyOs {
     {
         const file = try test_dir.dir.createFile("line_overlaps_page_boundary.zig", .{});
         defer file.close();
-        const path = try fs.path.join(allocator, &.{ test_dir_path, "line_overlaps_page_boundary.zig" });
+        const path = try join(allocator, &.{ test_dir_path, "line_overlaps_page_boundary.zig" });
         defer allocator.free(path);
 
         const overlap = 10;
@@ -1072,7 +1072,7 @@ test printLineFromFileAnyOs {
     {
         const file = try test_dir.dir.createFile("file_ends_on_page_boundary.zig", .{});
         defer file.close();
-        const path = try fs.path.join(allocator, &.{ test_dir_path, "file_ends_on_page_boundary.zig" });
+        const path = try join(allocator, &.{ test_dir_path, "file_ends_on_page_boundary.zig" });
         defer allocator.free(path);
 
         var writer = file.writer();
@@ -1085,7 +1085,7 @@ test printLineFromFileAnyOs {
     {
         const file = try test_dir.dir.createFile("very_long_first_line_spanning_multiple_pages.zig", .{});
         defer file.close();
-        const path = try fs.path.join(allocator, &.{ test_dir_path, "very_long_first_line_spanning_multiple_pages.zig" });
+        const path = try join(allocator, &.{ test_dir_path, "very_long_first_line_spanning_multiple_pages.zig" });
         defer allocator.free(path);
 
         var writer = file.writer();
@@ -1110,7 +1110,7 @@ test printLineFromFileAnyOs {
     {
         const file = try test_dir.dir.createFile("file_of_newlines.zig", .{});
         defer file.close();
-        const path = try fs.path.join(allocator, &.{ test_dir_path, "file_of_newlines.zig" });
+        const path = try join(allocator, &.{ test_dir_path, "file_of_newlines.zig" });
         defer allocator.free(path);
 
         var writer = file.writer();

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -4,8 +4,7 @@ pub const Handle = posix.fd_t;
 
 /// Default mode bits for a new directory.
 pub const default_mode = switch (posix.mode_t) {
-    void => {}, // wasi-without-libc has no mode suppport
-    u0 => 0, // Zig's Posix layer doesn't support modes on Windows
+    void => {},
     else => 0o755,
 };
 

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -28,8 +28,7 @@ pub const Kind = enum {
 /// libc implementations use `0o666` inside `fopen` and then rely on the
 /// process-scoped "umask" setting to adjust this number for file creation.
 pub const default_mode = switch (posix.mode_t) {
-    void => {}, // WASI-without-libc has no mode support
-    u0 => 0, // Zig's Posix layer doesn't support modes for Windows
+    void => {},
     else => 0o666,
 };
 
@@ -495,7 +494,7 @@ pub fn stat(self: File) StatError!Stat {
         return .{
             .inode = info.InternalInformation.IndexNumber,
             .size = @as(u64, @bitCast(info.StandardInformation.EndOfFile)),
-            .mode = 0,
+            .mode = {},
             .kind = if (info.BasicInformation.FileAttributes & windows.FILE_ATTRIBUTE_REPARSE_POINT != 0) reparse_point: {
                 var tag_info: windows.FILE_ATTRIBUTE_TAG_INFO = undefined;
                 const tag_rc = windows.ntdll.NtQueryInformationFile(self.handle, &io_status_block, &tag_info, @sizeOf(windows.FILE_ATTRIBUTE_TAG_INFO), .FileAttributeTagInformation);

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -329,14 +329,8 @@ test "accessAbsolute" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
+    const base_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(base_path);
 
     try fs.accessAbsolute(base_path, .{});
 }
@@ -347,32 +341,62 @@ test "openDirAbsolute" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makeDir("subdir");
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+    const tmp_ino = (try tmp.dir.stat()).inode;
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..], "subdir" });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
+    try tmp.dir.makeDir("subdir");
+    const sub_path = try tmp.dir.realpathAlloc(testing.allocator, "subdir");
+    defer testing.allocator.free(sub_path);
+
+    // Can open subdir
+    var tmp_sub = try fs.openDirAbsolute(sub_path, .{});
+    defer tmp_sub.close();
+
+    const sub_ino = (try tmp_sub.stat()).inode;
 
     {
-        var dir = try fs.openDirAbsolute(base_path, .{});
-        defer dir.close();
-    }
+        // Can open parent
+        const dir_path = try fs.path.join(testing.allocator, &.{ sub_path, ".." });
+        defer testing.allocator.free(dir_path);
 
-    for ([_][]const u8{ ".", ".." }) |sub_path| {
-        const dir_path = try fs.path.join(allocator, &.{ base_path, sub_path });
         var dir = try fs.openDirAbsolute(dir_path, .{});
         defer dir.close();
+
+        const ino = (try dir.stat()).inode;
+        try testing.expectEqual(tmp_ino, ino);
+    }
+
+    {
+        // Can open subdir + "."
+        const dir_path = try fs.path.join(testing.allocator, &.{ sub_path, "." });
+        defer testing.allocator.free(dir_path);
+
+        var dir = try fs.openDirAbsolute(dir_path, .{});
+        defer dir.close();
+
+        const ino = (try dir.stat()).inode;
+        try testing.expectEqual(sub_ino, ino);
+    }
+
+    {
+        // Can open subdir + "..", with extra "."
+        const dir_path = try fs.path.join(testing.allocator, &.{ sub_path, ".", "..", "." });
+        defer testing.allocator.free(dir_path);
+
+        var dir = try fs.openDirAbsolute(dir_path, .{});
+        defer dir.close();
+
+        const ino = (try dir.stat()).inode;
+        try testing.expectEqual(tmp_ino, ino);
     }
 }
 
 test "openDir cwd parent '..'" {
-    if (native_os == .wasi) return error.SkipZigTest;
-
-    var dir = try fs.cwd().openDir("..", .{});
+    var dir = fs.cwd().openDir("..", .{}) catch |err| {
+        if (native_os == .wasi and err == error.AccessDenied) {
+            return; // This is okay. WASI disallows escaping from the fs sandbox
+        }
+        return err;
+    };
     defer dir.close();
 }
 
@@ -388,7 +412,15 @@ test "openDir non-cwd parent '..'" {
     var subdir = try tmp.dir.makeOpenPath("subdir", .{});
     defer subdir.close();
 
-    var dir = try subdir.openDir("..", .{});
+    var dir = subdir.openDir("..", .{}) catch |err| {
+        if (native_os == .wasi and err == error.AccessDenied) {
+            // This is odd (we're asking for the parent of a subdirectory,
+            // which should be safely inside the sandbox), but this is the
+            // current wasmtime behavior (with and without libc).
+            return error.SkipZigTest;
+        }
+        return err;
+    };
     defer dir.close();
 
     if (supports_absolute_paths) {
@@ -421,10 +453,7 @@ test "readLinkAbsolute" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
+    const base_path = try tmp.dir.realpathAlloc(allocator, ".");
 
     {
         const target_path = try fs.path.join(allocator, &.{ base_path, "file.txt" });
@@ -760,7 +789,6 @@ test "directory operations on files" {
 test "file operations on directories" {
     // TODO: fix this test on FreeBSD. https://github.com/ziglang/zig/issues/1759
     if (native_os == .freebsd) return error.SkipZigTest;
-    if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/20747
 
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {
@@ -771,18 +799,29 @@ test "file operations on directories" {
             try testing.expectError(error.IsDir, ctx.dir.createFile(test_dir_name, .{}));
             try testing.expectError(error.IsDir, ctx.dir.deleteFile(test_dir_name));
             switch (native_os) {
-                // no error when reading a directory.
-                .dragonfly, .netbsd => {},
-                // Currently, WASI will return error.Unexpected (via ENOTCAPABLE) when attempting fd_read on a directory handle.
-                // TODO: Re-enable on WASI once https://github.com/bytecodealliance/wasmtime/issues/1935 is resolved.
-                .wasi => {},
+                .dragonfly, .netbsd => {
+                    // no error when reading a directory. See https://github.com/ziglang/zig/issues/5732
+                    const buf = try ctx.dir.readFileAlloc(testing.allocator, test_dir_name, std.math.maxInt(usize));
+                    testing.allocator.free(buf);
+                },
+                .wasi => {
+                    // WASI return EBADF, which gets mapped to NotOpenForReading.
+                    // See https://github.com/bytecodealliance/wasmtime/issues/1935
+                    try testing.expectError(error.NotOpenForReading, ctx.dir.readFileAlloc(testing.allocator, test_dir_name, std.math.maxInt(usize)));
+                },
                 else => {
                     try testing.expectError(error.IsDir, ctx.dir.readFileAlloc(testing.allocator, test_dir_name, std.math.maxInt(usize)));
                 },
             }
-            // Note: The `.mode = .read_write` is necessary to ensure the error occurs on all platforms.
-            // TODO: Add a read-only test as well, see https://github.com/ziglang/zig/issues/5732
-            try testing.expectError(error.IsDir, ctx.dir.openFile(test_dir_name, .{ .mode = .read_write }));
+
+            if (native_os == .wasi and builtin.link_libc) {
+                // Older wasmtime errors here, newer ones do not, see https://github.com/ziglang/zig/issues/20747
+                _ = ctx.dir.openFile(test_dir_name, .{ .mode = .read_write }) catch {};
+            } else {
+                // Note: The `.mode = .read_write` is necessary to ensure the error occurs on all platforms.
+                // TODO: Add a read-only test as well, see https://github.com/ziglang/zig/issues/5732
+                try testing.expectError(error.IsDir, ctx.dir.openFile(test_dir_name, .{ .mode = .read_write }));
+            }
 
             if (ctx.path_type == .absolute and supports_absolute_paths) {
                 try testing.expectError(error.IsDir, fs.createFileAbsolute(test_dir_name, .{}));
@@ -1005,10 +1044,7 @@ test "renameAbsolute" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp_dir.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
+    const base_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
 
     try testing.expectError(error.FileNotFound, fs.renameAbsolute(
         try fs.path.join(allocator, &.{ base_path, "missing_file_name" }),
@@ -1398,7 +1434,6 @@ test "sendfile" {
     defer tmp.cleanup();
 
     try tmp.dir.makePath("os_test_tmp");
-    defer tmp.dir.deleteTree("os_test_tmp") catch {};
 
     var dir = try tmp.dir.openDir("os_test_tmp", .{});
     defer dir.close();
@@ -1463,7 +1498,6 @@ test "copyRangeAll" {
     defer tmp.cleanup();
 
     try tmp.dir.makePath("os_test_tmp");
-    defer tmp.dir.deleteTree("os_test_tmp") catch {};
 
     var dir = try tmp.dir.openDir("os_test_tmp", .{});
     defer dir.close();
@@ -1782,10 +1816,7 @@ test "'.' and '..' in absolute functions" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
+    const base_path = try tmp.dir.realpathAlloc(allocator, ".");
 
     const subdir_path = try fs.path.join(allocator, &.{ base_path, "./subdir" });
     try fs.makeDirAbsolute(subdir_path);

--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -108,10 +108,7 @@ test "File seek ops" {
 
     const tmp_file_name = "temp_test_file.txt";
     var file = try tmp.dir.createFile(tmp_file_name, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(tmp_file_name) catch {};
-    }
+    defer file.close();
 
     try file.writeAll(&([_]u8{0x55} ** 8192));
 
@@ -135,10 +132,7 @@ test "setEndPos" {
 
     const tmp_file_name = "temp_test_file.txt";
     var file = try tmp.dir.createFile(tmp_file_name, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(tmp_file_name) catch {};
-    }
+    defer file.close();
 
     // Verify that the file size changes and the file offset is not moved
     try std.testing.expect((try file.getEndPos()) == 0);
@@ -161,10 +155,8 @@ test "updateTimes" {
 
     const tmp_file_name = "just_a_temporary_file.txt";
     var file = try tmp.dir.createFile(tmp_file_name, .{ .read = true });
-    defer {
-        file.close();
-        tmp.dir.deleteFile(tmp_file_name) catch {};
-    }
+    defer file.close();
+
     const stat_old = try file.stat();
     // Set atime and mtime to 5s before
     try file.updateTimes(

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -802,7 +802,7 @@ pub fn readlinkat(dirfd: i32, noalias path: [*:0]const u8, noalias buf_ptr: [*]u
     return syscall4(.readlinkat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), @intFromPtr(buf_ptr), buf_len);
 }
 
-pub fn mkdir(path: [*:0]const u8, mode: u32) usize {
+pub fn mkdir(path: [*:0]const u8, mode: mode_t) usize {
     if (@hasField(SYS, "mkdir")) {
         return syscall2(.mkdir, @intFromPtr(path), mode);
     } else {
@@ -810,11 +810,11 @@ pub fn mkdir(path: [*:0]const u8, mode: u32) usize {
     }
 }
 
-pub fn mkdirat(dirfd: i32, path: [*:0]const u8, mode: u32) usize {
+pub fn mkdirat(dirfd: i32, path: [*:0]const u8, mode: mode_t) usize {
     return syscall3(.mkdirat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode);
 }
 
-pub fn mknod(path: [*:0]const u8, mode: u32, dev: u32) usize {
+pub fn mknod(path: [*:0]const u8, mode: mode_t, dev: u32) usize {
     if (@hasField(SYS, "mknod")) {
         return syscall3(.mknod, @intFromPtr(path), mode, dev);
     } else {
@@ -822,7 +822,7 @@ pub fn mknod(path: [*:0]const u8, mode: u32, dev: u32) usize {
     }
 }
 
-pub fn mknodat(dirfd: i32, path: [*:0]const u8, mode: u32, dev: u32) usize {
+pub fn mknodat(dirfd: i32, path: [*:0]const u8, mode: mode_t, dev: u32) usize {
     return syscall4(.mknodat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode, dev);
 }
 
@@ -1041,7 +1041,7 @@ pub fn pread(fd: i32, buf: [*]u8, count: usize, offset: i64) usize {
     }
 }
 
-pub fn access(path: [*:0]const u8, mode: u32) usize {
+pub fn access(path: [*:0]const u8, mode: mode_t) usize {
     if (@hasField(SYS, "access")) {
         return syscall2(.access, @intFromPtr(path), mode);
     } else {
@@ -1049,7 +1049,7 @@ pub fn access(path: [*:0]const u8, mode: u32) usize {
     }
 }
 
-pub fn faccessat(dirfd: i32, path: [*:0]const u8, mode: u32, flags: u32) usize {
+pub fn faccessat(dirfd: i32, path: [*:0]const u8, mode: mode_t, flags: u32) usize {
     return syscall4(.faccessat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode, flags);
 }
 

--- a/lib/std/os/wasi.zig
+++ b/lib/std/os/wasi.zig
@@ -1,7 +1,7 @@
 //! wasi_snapshot_preview1 spec available (in witx format) here:
 //! * typenames -- https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/typenames.witx
 //! * module -- https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/witx/wasi_snapshot_preview1.witx
-//! Note that libc API does *not* go in this file. wasi libc API goes into std/c/wasi.zig instead.
+//! Note that libc API does *not* go in this file. wasi libc API goes into std/c.zig instead.
 const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -119,7 +119,6 @@ test "chdir smoke test" {
 
 const default_mode = switch (posix.mode_t) {
     void => {},
-    u0 => 0,
     else => 0o666,
 };
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -985,7 +985,7 @@ pub const File = struct {
         // with 0o755 permissions, but it works appropriately if the system is configured
         // more leniently. As another data point, C's fopen seems to open files with the
         // 666 mode.
-        const executable_mode = if (builtin.target.os.tag == .windows) 0 else 0o777;
+        const executable_mode = if (fs.File.Mode == void) {} else 0o777;
         switch (effectiveOutputMode(use_lld, output_mode)) {
             .Lib => return switch (link_mode) {
                 .dynamic => executable_mode,

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -439,8 +439,7 @@ pub fn createEmpty(
                 fs.File.default_mode | 0b001_000_000
             else
                 fs.File.default_mode
-        else
-            0,
+        else {},
     });
     wasm.name = sub_path;
 


### PR DESCRIPTION
Make a clearer separation between the Posix defines for WASI without a libc (the `system` defined in posix.zig) and the Posix defines for WASI with a libc (which should mirror the Musl-based wasi-libc implementation, and are defined in c.zig).

This PR is mostly focused on cleanly separating the `std.posix` and `std.c` WASI implementations, disentangling types and structures where that makes sense.

For context, here are the existing ways to access system services from Zig when compiling against a wasi target (e.g., `-target wasm32-wasi` or `-target wasm32-wasi -lc`):
* The WASI APIs (in `std.os.wasi`).  These are non-POSIX APIs that provide access to APIs outside the WASM sandbox.  Zig provides the "preview 1" version of the WASI API.  
* The Zig `std.posix` API implemented directly on top of the WASI APIs.  This is Zig's implementation of a subset of the POSIX API.   
* The Zig `std.c` API as implemented by wasi-libc (a fork of the Musl C Library for WASI), when built with `-lc`, this provides a richer implementation of the POSIX API implemented by wasi-libc (customized from musl libc) on the WASI API.  
* The Zig standard library (`File.zig`, `Dir.zig`, etc).  These Zig-specific APIs are often built on `std.os.wasi`, but sometimes go through `std.posix`.

### Summary of Changes

Make WASI `posix.O` look more POSIX-y when compiling without libc.  These structures and constants do not need to mirror with with-libc Wasi API.  For example, use of `.ACCMODE`.  This removes a lot of Wasi-specific code in Dir.zig and posix.zig by making the structure use names consistent with other platforms.   Define `.S`, `.timespec`, and `.AT` structs for wasi-without-libc in posix.zig.  These are based on the wasi-with-libc structures, but cleaned up to remove cruft like padding or wholly unsupported fields.

Fix `.S` and `.AT` constants on wasi-with-libc (defined in c.zig) to match wasi-libc headers.

Define `mode_t` type as `void` for wasi targets (and Windows targets) because file permissions are not supported via the Posix APIS on these platforms.  Use `mode_t` as the parameter type on Zig's mkdir\* and openat\* signatures (instead of `u32`).

Note `mode_t` is used both as a parameter for open/chmod/chown type functions (encoding user permissions) and also used as a property of `struct stat` results, which additionally encode file type (link, directory, regular, etc).  These should probably be separate types?

`std.c.makeOFlags()` is an attempt to make initializing `std.posix.O` flags with or without the .ACCMODE simpler.  The wasi-with-libc O flags cannot support ACCMODE due to the layout of the flags in wasi-libc.  

The with-libc WASI `AT` struct needs to mirror the wasi-libc `#defines`.  Fixes #20890

Enable a lot of tests that have accumulated stale not-on-wasi guards, and simplify some tests (e.g., dropping unnecessary absolute paths) so they can run on both of the wasi targets.  Also, factors out `supports_chmod` and `supports_absolute_paths`, etc flags in tests to make the skip-this-test logic more readable.  

Zig's Posix-on-Wasi wrapper defines the current working directory to be `.` (from the `--dir=.` argument to wasmtime).  However, wasi-libc defines the current working directory to be `/`, which makes a bit more sense, as the wasi code is effectively chroot-ed into the given directory.  Perhaps Zig should follow wasi-libc's lead here?  (I'm not sure it makes any difference anywhere, yet.)

Clean up of test cases:
* use `realpathAlloc()`to get the full path of tmpDir() instances  
* use `testing.allocator` where that simplifies things (vs. manual ArenaAllocator for 1 or 2 allocations)  
* Trust TmpDir.cleanup() to clean up sub-trees  
* Add `unique_fname` in posix.zig for creating unique-name files when testing in the default cwd (prefer tmpDir()).  Fixes #14968
* Remove some unnecessary absolute paths (to enable WASI tests)  
* Drop some no-longer necessary `[_][]const u8` explicit types  
* Put cleanups into `defer`



































