### PR TITLE
fuzzing: Move to an iterator pattern for input.

### DIFF
--- a/lib/init/src/main.zig
+++ b/lib/init/src/main.zig
@@ -28,6 +28,8 @@ test "simple test" {
 
 test "fuzz example" {
     // Try passing `--fuzz` to `zig build` and see if it manages to fail this test case!
-    const input_bytes = std.testing.fuzzInput(.{});
-    try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input_bytes));
+    var fuzzer = std.testing.fuzzer(.{});
+    while (fuzzer.next()) |run| {
+        try std.testing.expect(!std.mem.eql(u8, "canyoufindme", run.input));
+    }
 }

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -1137,10 +1137,23 @@ pub fn refAllDeclsRecursive(comptime T: type) void {
     }
 }
 
-pub const FuzzInputOptions = struct {
+pub const FuzzerOptions = struct {
     corpus: []const []const u8 = &.{},
 };
 
-pub inline fn fuzzInput(options: FuzzInputOptions) []const u8 {
-    return @import("root").fuzzInput(options);
+pub inline fn fuzzer(options: FuzzerOptions) Fuzzer {
+    @import("root").fuzzerInit(options);
+    return .{};
 }
+
+pub const Fuzzer = struct {
+    pub const Run = struct {
+        allocator: std.mem.Allocator,
+        input: []const u8,
+    };
+
+    pub fn next(self: *Fuzzer) ?Run {
+        _ = self;
+        return @import("root").fuzzerNext();
+    }
+};


### PR DESCRIPTION
Previously, the `std.testing.fuzzInput` interface was called once for a given test function. This had the downside that the test functions were unable to initialize state independent of the fuzz loop.

Now, `std.testing.fuzzInput` has been replaced with `std.testing.fuzzer` which returns a `std.testing.Fuzzer`. To receive fuzz input, the function must loop on the `std.testing.Fuzzer.next` function, retrieving one `std.testing.Run` at a time. That run object contains a reference to a per-loop allocator and the fuzz input for that loop.

Additionally, with the ability to accept multiple fuzz inputs within the test function, the corpus provided to `std.testing.fuzzer` is now used to dry-run the test will all the provided inputs. In a future commit, this may also be used to seed the fuzzer.

Some notes on testing:

1. The newly added web interface is unable to load for me with many error messages emitted in the console. This issue exists on the master branch independent of my changes.
2. Many aarch64 related tests are failing on my machine. I suspect this is a local issue not related to my changes. This issue also exists on the master branch.