### PR TITLE
fuzzing: more optimized and correct management of 8-bit PC counters

### DIFF
--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -214,6 +214,9 @@ const Fuzzer = struct {
         });
         defer coverage_file.close();
         const n_bitset_elems = (flagged_pcs.len + 7) / 8;
+        comptime assert(SeenPcsHeader.trailing[0] == .pc_addr);
+        comptime assert(SeenPcsHeader.trailing[1][0] == .pc_bits);
+        comptime assert(SeenPcsHeader.trailing[1][1] == u8);
         const bytes_len = @sizeOf(SeenPcsHeader) + flagged_pcs.len * @sizeOf(usize) + n_bitset_elems;
         const existing_len = coverage_file.getEndPos() catch |err| {
             fatal("unable to check len of coverage file: {s}", .{@errorName(err)});
@@ -301,6 +304,10 @@ const Fuzzer = struct {
 
                 // Track code coverage from all runs.
                 {
+                    comptime assert(SeenPcsHeader.trailing[0] == .pc_addr);
+                    comptime assert(SeenPcsHeader.trailing[1][0] == .pc_bits);
+                    comptime assert(SeenPcsHeader.trailing[1][1] == u8);
+
                     const seen_pcs = f.seen_pcs.items[@sizeOf(SeenPcsHeader) + f.flagged_pcs.len * @sizeOf(usize) ..];
                     for (seen_pcs, 0..) |*elem, i| {
                         const byte_i = i * 8;

--- a/lib/std/Build/Fuzz/abi.zig
+++ b/lib/std/Build/Fuzz/abi.zig
@@ -8,12 +8,19 @@
 ///
 /// Trailing:
 /// * pc_addr: usize for each pcs_len
-/// * 1 bit per pc_addr, usize elements
+/// * 1 bit per pc_addr, u8 elements
 pub const SeenPcsHeader = extern struct {
     n_runs: usize,
     unique_runs: usize,
     pcs_len: usize,
     lowest_stack: usize,
+
+    /// Used for comptime assertions. Provides a mechanism for strategically
+    /// causing compile errors.
+    pub const trailing = .{
+        .pc_addr,
+        .{ .pc_bits, u8 },
+    };
 };
 
 pub const ToClientTag = enum(u8) {


### PR DESCRIPTION
* Upgrade from u8 to usize element types.
  - WebAssembly assumes u64. It should probably try to be target-aware
    instead.
* Move the covered PC bits to after the header so it goes on the same
  page with the other rapidly changing memory (the header stats).

depends on the semantics of accepted proposal #19755

closes #20994
