### PR TITLE
libfuzzer: Track the rate of fuzzing in cycles/s.

### DIFF
--- a/lib/fuzzer/index.html
+++ b/lib/fuzzer/index.html
@@ -145,6 +145,7 @@
     <div id="sectStats" class="hidden">
       <ul>
         <li>Total Runs: <span id="statTotalRuns"></span></li>
+        <li>Rate: <span id="statRate"></span></li>
         <li>Unique Runs: <span id="statUniqueRuns"></span></li>
         <li>Coverage: <span id="statCoverage"></span></li>
         <li>Lowest Stack: <span id="statLowestStack"></span></li>

--- a/lib/fuzzer/main.js
+++ b/lib/fuzzer/main.js
@@ -4,6 +4,7 @@
   const domSectStats = document.getElementById("sectStats");
   const domSourceText = document.getElementById("sourceText");
   const domStatTotalRuns = document.getElementById("statTotalRuns");
+  const domStatRate = document.getElementById("statRate");
   const domStatUniqueRuns = document.getElementById("statUniqueRuns");
   const domStatCoverage = document.getElementById("statCoverage");
   const domStatLowestStack = document.getElementById("statLowestStack");
@@ -34,6 +35,7 @@
       },
       emitSourceIndexChange: onSourceIndexChange,
       emitCoverageUpdate: onCoverageUpdate,
+      emitPeriodicUpdate: onPeriodicUpdate,
       emitEntryPointsUpdate: renderStats,
     },
   }).then(function(obj) {
@@ -146,16 +148,22 @@
     renderCoverage();
   }
 
+  function onPeriodicUpdate() {
+    renderStats();
+  }
+
   function render() {
     domStatus.classList.add("hidden");
   }
 
   function renderStats() {
     const totalRuns = wasm_exports.totalRuns();
+    const cyclesPerSecond = wasm_exports.cyclesPerSecond();
     const uniqueRuns = wasm_exports.uniqueRuns();
     const totalSourceLocations = wasm_exports.totalSourceLocations();
     const coveredSourceLocations = wasm_exports.coveredSourceLocations();
     domStatTotalRuns.innerText = totalRuns;
+    domStatRate.innerText = cyclesPerSecond + " cycles / second";
     domStatUniqueRuns.innerText = uniqueRuns + " (" + percent(uniqueRuns, totalRuns) + "%)";
     domStatCoverage.innerText = coveredSourceLocations + " / " + totalSourceLocations + " (" + percent(coveredSourceLocations, totalSourceLocations) + "%)";
     domStatLowestStack.innerText = unwrapString(wasm_exports.lowestStack());

--- a/lib/std/Build/Fuzz.zig
+++ b/lib/std/Build/Fuzz.zig
@@ -13,6 +13,8 @@ const build_runner = @import("root");
 pub const WebServer = @import("Fuzz/WebServer.zig");
 pub const abi = @import("Fuzz/abi.zig");
 
+pub const StartError = Allocator.Error || std.time.Timer.Error;
+
 pub fn start(
     gpa: Allocator,
     arena: Allocator,
@@ -24,7 +26,7 @@ pub fn start(
     ttyconf: std.io.tty.Config,
     listen_address: std.net.Address,
     prog_node: std.Progress.Node,
-) Allocator.Error!void {
+) StartError!void {
     const fuzz_run_steps = block: {
         const rebuild_node = prog_node.start("Rebuilding Unit Tests", 0);
         defer rebuild_node.end();

--- a/lib/std/Build/Fuzz/WebServer.zig
+++ b/lib/std/Build/Fuzz/WebServer.zig
@@ -247,6 +247,8 @@ fn buildWasmBinary(
         try std.fmt.allocPrint(arena, "-MWalk={}", .{walk_src_path}), //
         "--dep", "Walk", //
         try std.fmt.allocPrint(arena, "-Mhtml_render={}", .{html_render_src_path}), //
+        "--zig-lib-dir",
+        ws.zig_lib_directory.path orelse ".",
         "--listen=-",
     });
 

--- a/lib/std/Build/Fuzz/abi.zig
+++ b/lib/std/Build/Fuzz/abi.zig
@@ -47,6 +47,7 @@ pub const ToClientTag = enum(u8) {
     source_index,
     coverage_update,
     entry_points,
+    periodic,
     _,
 };
 
@@ -101,5 +102,16 @@ pub const EntryPointHeader = extern struct {
     pub const Flags = packed struct(u32) {
         tag: ToClientTag = .entry_points,
         locs_len: u24,
+    };
+};
+
+/// Sent to the fuzzer web client on a periodic basis.
+pub const PeriodicUpdateHeader = extern struct {
+    flags: Flags = .{},
+    cycles_per_second: u64,
+
+    pub const Flags = packed struct(u64) {
+        tag: ToClientTag = .periodic,
+        _: u56 = 0,
     };
 };


### PR DESCRIPTION
As libfuzzer develops or as users design their own fuzz tests which use libfuzzer, it will be essential to understand the performance impact of changes. This change tracks the rate of execution in terms of cycles per second and updates the UI at most every second.