### PR TITLE
std.Target: Run update_cpu_features against the LLVM version used by CI

### DIFF
--- a/lib/std/Target/riscv.zig
+++ b/lib/std/Target/riscv.zig
@@ -78,7 +78,6 @@ pub const Feature = enum {
     svnapot,
     svpbmt,
     tagged_globals,
-    unaligned_scalar_mem,
     use_postra_scheduler,
     v,
     ventana_veyron,
@@ -583,11 +582,6 @@ pub const all_features = blk: {
     result[@intFromEnum(Feature.tagged_globals)] = .{
         .llvm_name = "tagged-globals",
         .description = "Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits",
-        .dependencies = featureSet(&[_]Feature{}),
-    };
-    result[@intFromEnum(Feature.unaligned_scalar_mem)] = .{
-        .llvm_name = "unaligned-scalar-mem",
-        .description = "Has reasonably performant unaligned scalar loads and stores",
         .dependencies = featureSet(&[_]Feature{}),
     };
     result[@intFromEnum(Feature.use_postra_scheduler)] = .{


### PR DESCRIPTION
In #20975, update_cpu_features was run against LLVM 18.1.8, but the CI uses 18.1.5, and unaligned-scalar-mem was added in LLVM 18.1.6, so the CI was outputting:

```
+- test-link
   +- link_test_cases
      +- test-elf
         +- test-elf-linking-c-riscv64-linux.4.19...6.10.3-musl-Debug-llvm-no-lld
            +- CheckObject
               +- zig build-exe test Debug riscv64-linux-musl failure
error: '-unaligned-scalar-mem' is not a recognized feature for this target (ignoring feature)
'-unaligned-scalar-mem' is not a recognized feature for this target (ignoring feature)
'-unaligned-scalar-mem' is not a recognized feature for this target (ignoring feature)
```