### PR TITLE
std.os.linux: Fix definition of tc_lflag_t on MIPS

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -6573,7 +6573,7 @@ pub const tc_lflag_t = if (is_mips) packed struct(tcflag_t) {
     PENDIN: bool = false,
     TOSTOP: bool = false,
     EXTPROC: bool = false,
-    _17: u16 = 0,
+    _17: u15 = 0,
 } else if (is_ppc) packed struct(tcflag_t) {
     ECHOKE: bool = false,
     ECHOE: bool = false,


### PR DESCRIPTION
```
[...]/std/os/linux.zig:6558:51: error: backing integer type 'c_uint' has bit size 32 but the struct fields have a total bit size of 33
pub const tc_lflag_t = if (is_mips) packed struct(tcflag_t) {
                                                  ^~~~~~~~
```

cc @alexrp