### PR TITLE
`std.os.linux`: Add clone() implementation for mips64.

### DIFF
--- a/lib/std/os/linux/mips64.zig
+++ b/lib/std/os/linux/mips64.zig
@@ -118,9 +118,6 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
     );
 }
 
-// NOTE: The o32 calling convention requires the callee to reserve 16 bytes for
-// the first four arguments even though they're passed in $a0-$a3.
-
 pub fn syscall6(
     number: SYS,
     arg1: usize,


### PR DESCRIPTION
See https://github.com/ziglang/zig/pull/20904#discussion_r1700906991 for some context. This is just a translation of the musl code here: https://git.musl-libc.org/cgit/musl/tree/src/thread/mips64/clone.s

This is only for N64 for now; N32 support will come later as it requires wider changes.