### PR TITLE
`llvm`: Disable lowering to f128 on sparc32.

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -11767,7 +11767,9 @@ fn backendSupportsF16(target: std.Target) bool {
 /// or if it produces miscompilations.
 fn backendSupportsF128(target: std.Target) bool {
     return switch (target.cpu.arch) {
-        .amdgcn => false,
+        .amdgcn,
+        .sparc,
+        => false,
         .aarch64 => std.Target.aarch64.featureSetHas(target.cpu.features, .fp_armv8),
         else => true,
     };


### PR DESCRIPTION
https://github.com/llvm/llvm-project/blob/efc6b50d2d93fa571572ee3ef1d4565c09ad1610/llvm/lib/Target/Sparc/SparcISelLowering.cpp#L561-L562