### PR TITLE
`llvm`: Disable lowering to f16 on s390x.

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -11756,6 +11756,7 @@ fn backendSupportsF16(target: std.Target) bool {
         .mipsel,
         .mips64,
         .mips64el,
+        .s390x,
         => false,
         .aarch64 => std.Target.aarch64.featureSetHas(target.cpu.features, .fp_armv8),
         else => true,


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/50374

Not seeing any indication that this will be fixed anytime soon, so let's just not lower to `f16` for now.