### PR TITLE
doc: Fix typo in description of @cmpxchg

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4497,7 +4497,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the current value is the given expected value. It's the equivalent of this code,
       except atomic:
       </p>
       {#code|not_atomic_cmpxchgStrong.zig#}
@@ -4519,7 +4519,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the current value is the given expected value. It's the equivalent of this code,
       except atomic:
       </p>
       {#syntax_block|zig|cmpxchgWeakButNotAtomic#}


### PR DESCRIPTION
## Summary
This PR fixes typo in a documentation.
`@cmpxchgStrong()` and `@cmpxchgWeak()` return `null` if the current (old) value is equal to the expected value, unless my understanding is wrong.