### PR TITLE
`test`: Re-enable `mips(el)-linux(-musl)` tests.

### DIFF
--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1904,6 +1904,7 @@ test "reinterpret packed union" {
 
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.cpu.arch.isPowerPC32()) return error.SkipZigTest; // TODO
+    if (builtin.cpu.arch.isMIPS()) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21050
     if (builtin.cpu.arch.isWasm()) return error.SkipZigTest; // TODO
     try S.doTheTest();
 }

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -133,6 +133,9 @@ test "vector float operators" {
     try S.doTheTest(f16);
     try comptime S.doTheTest(f16);
 
+    // https://github.com/llvm/llvm-project/issues/102870
+    if (builtin.cpu.arch.isMIPS()) return error.SkipZigTest;
+
     try S.doTheTest(f80);
     try comptime S.doTheTest(f80);
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -305,24 +305,22 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        // https://github.com/ziglang/zig/issues/16846
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .mips,
-        //        .os_tag = .linux,
-        //        .abi = .none,
-        //    },
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .mips,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+        },
 
-        // https://github.com/ziglang/zig/issues/16846
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .mips,
-        //        .os_tag = .linux,
-        //        .abi = .musl,
-        //    },
-        //    .link_libc = true,
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .mips,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
 
         // https://github.com/ziglang/zig/issues/4927
         //.{
@@ -334,24 +332,22 @@ const test_targets = blk: {
         //    .link_libc = true,
         //},
 
-        // https://github.com/ziglang/zig/issues/16846
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .mipsel,
-        //        .os_tag = .linux,
-        //        .abi = .none,
-        //    },
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .mipsel,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+        },
 
-        // https://github.com/ziglang/zig/issues/16846
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .mipsel,
-        //        .os_tag = .linux,
-        //        .abi = .musl,
-        //    },
-        //    .link_libc = true,
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .mipsel,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
 
         // https://github.com/ziglang/zig/issues/4927
         //.{


### PR DESCRIPTION
Andrew [mentioned](https://github.com/ziglang/zig/pull/21036#issuecomment-2283304293) that LLVM's MIPS backend has O(N^2) codegen. Just want to take this for a spin and see if that remains the case.