### PR TITLE
Fix crash when passing missing file to zig test

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2236,21 +2236,13 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
             });
             defer gpa.free(test_source_dir_path);
             
-            var test_source_dir = std.fs.cwd().openDir(test_source_dir_path, .{}) catch |err| switch (err) {
-                error.FileNotFound => {
-                    std.debug.print("unable to access directory '{s}'\n", .{test_source_dir_path});
-                    return error.FileNotFound;
-                },
-                else => |e| return e
+            var test_source_dir = std.fs.cwd().openDir(test_source_dir_path, .{}) catch |err| {
+                fatal("unable to access directory '{s}': {s}", .{ test_source_dir_path, @errorName(err) });
             };
             defer test_source_dir.close();
             
-            _ = test_source_dir.access(zcu.main_mod.root_src_path, .{}) catch |err| switch (err) {
-                error.FileNotFound => {
-                    std.debug.print("unable to load file '{s}/{s}'\n", .{test_source_dir_path, zcu.main_mod.root_src_path});
-                    return error.FileNotFound;
-                },
-                else => |e| return e
+            _ = test_source_dir.access(zcu.main_mod.root_src_path, .{}) catch |err| {
+                fatal("unable to load file '{s}/{s}': {s}", .{ test_source_dir_path, zcu.main_mod.root_src_path, @errorName(err) });
             };
 
             _ = try pt.importPkg(zcu.main_mod);


### PR DESCRIPTION
Resolves #20954 

Error message looks like this:
```
$ zig test tt.zig                                   
error: unable to load file './tt.zig': FileNotFound

$ zig test ./tt.zig
error: unable to load file './tt.zig': FileNotFound

$ zig test /test-folder/tt.zig 
error: unable to access directory '/test-folder': FileNotFound

$ zig test ./test-folder/tt.zig
error: unable to access directory 'test-folder': FileNotFound
```