### PR TITLE
loongarch: add missing getcontext

### DIFF
--- a/lib/std/os/linux/loongarch64.zig
+++ b/lib/std/os/linux/loongarch64.zig
@@ -201,3 +201,6 @@ pub const ucontext_t = extern struct {
 };
 
 pub const Elf_Symndx = u32;
+
+/// TODO
+pub const getcontext = {};


### PR DESCRIPTION
to make it work for `zig-bootstrap` for `loongarch64-linux-musl`