### PR TITLE
Incremental compilation progress

### DIFF
--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -72,6 +72,11 @@ pub fn BoundedArrayAligned(
             self.len = @intCast(len);
         }
 
+        /// Remove all elements from the slice.
+        pub fn clear(self: *Self) void {
+            self.len = 0;
+        }
+
         /// Copy the content of an existing slice.
         pub fn fromSlice(m: []const T) error{Overflow}!Self {
             var list = try init(m.len);

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -603,7 +603,7 @@ pub const Inst = struct {
         /// Uses the `un_node` field.
         typeof,
         /// Implements `@TypeOf` for one operand.
-        /// Uses the `pl_node` field.
+        /// Uses the `pl_node` field. Payload is `Block`.
         typeof_builtin,
         /// Given a value, look at the type of it, which must be an integer type.
         /// Returns the integer type for the RHS of a shift operation.
@@ -2727,6 +2727,9 @@ pub const Inst = struct {
         field_name_start: NullTerminatedString,
     };
 
+    /// There is a body of instructions at `extra[body_index..][0..body_len]`.
+    /// Trailing:
+    /// 0. operand: Ref // for each `operands_len`
     pub const TypeOfPeer = struct {
         src_node: i32,
         body_len: u32,
@@ -2844,6 +2847,40 @@ pub const Inst = struct {
         src_line: u32,
     };
 
+    /// Trailing:
+    /// 0. multi_cases_len: u32 // if `has_multi_cases`
+    /// 1. err_capture_inst: u32 // if `any_uses_err_capture`
+    /// 2. non_err_body {
+    ///        info: ProngInfo,
+    ///        inst: Index // for every `info.body_len`
+    ///     }
+    /// 3. else_body { // if `has_else`
+    ///        info: ProngInfo,
+    ///        inst: Index // for every `info.body_len`
+    ///     }
+    /// 4. scalar_cases: { // for every `scalar_cases_len`
+    ///        item: Ref,
+    ///        info: ProngInfo,
+    ///        inst: Index // for every `info.body_len`
+    ///     }
+    /// 5. multi_cases: { // for every `multi_cases_len`
+    ///        items_len: u32,
+    ///        ranges_len: u32,
+    ///        info: ProngInfo,
+    ///        item: Ref // for every `items_len`
+    ///        ranges: { // for every `ranges_len`
+    ///            item_first: Ref,
+    ///            item_last: Ref,
+    ///        }
+    ///        inst: Index // for every `info.body_len`
+    ///    }
+    ///
+    /// When analyzing a case body, the switch instruction itself refers to the
+    /// captured error, or to the success value in `non_err_body`. Whether this
+    /// is captured by reference or by value depends on whether the `byref` bit
+    /// is set for the corresponding body. `err_capture_inst` refers to the error
+    /// capture outside of the `switch`, i.e. `err` in
+    /// `x catch |err| switch (err) { ... }`.
     pub const SwitchBlockErrUnion = struct {
         operand: Ref,
         bits: Bits,
@@ -3153,7 +3190,7 @@ pub const Inst = struct {
     /// 1. captures_len: u32 // if has_captures_len
     /// 2. body_len: u32, // if has_body_len
     /// 3. fields_len: u32, // if has_fields_len
-    /// 4. decls_len: u37, // if has_decls_len
+    /// 4. decls_len: u32, // if has_decls_len
     /// 5. capture: Capture // for every captures_len
     /// 6. decl: Index, // for every decls_len; points to a `declaration` instruction
     /// 7. inst: Index // for every body_len
@@ -3624,33 +3661,492 @@ pub fn declIterator(zir: Zir, decl_inst: Zir.Inst.Index) DeclIterator {
     }
 }
 
-/// The iterator would have to allocate memory anyway to iterate. So here we populate
-/// an ArrayList as the result.
-pub fn findDecls(zir: Zir, list: *std.ArrayList(Inst.Index), decl_inst: Zir.Inst.Index) !void {
+/// Find all type declarations, recursively, within a `declaration` instruction. Does not recurse through
+/// said type declarations' declarations; to find all declarations, call this function on the declarations
+/// of the discovered types recursively.
+/// The iterator would have to allocate memory anyway to iterate, so an `ArrayList` is populated as the result.
+pub fn findDecls(zir: Zir, gpa: Allocator, list: *std.ArrayListUnmanaged(Inst.Index), decl_inst: Zir.Inst.Index) !void {
     list.clearRetainingCapacity();
     const declaration, const extra_end = zir.getDeclaration(decl_inst);
     const bodies = declaration.getBodies(extra_end, zir);
 
-    try zir.findDeclsBody(list, bodies.value_body);
-    if (bodies.align_body) |b| try zir.findDeclsBody(list, b);
-    if (bodies.linksection_body) |b| try zir.findDeclsBody(list, b);
-    if (bodies.addrspace_body) |b| try zir.findDeclsBody(list, b);
+    // `defer` instructions duplicate the same body arbitrarily many times, but we only want to traverse
+    // their contents once per defer. So, we store the extra index of the body here to deduplicate.
+    var found_defers: std.AutoHashMapUnmanaged(u32, void) = .{};
+    defer found_defers.deinit(gpa);
+
+    try zir.findDeclsBody(gpa, list, &found_defers, bodies.value_body);
+    if (bodies.align_body) |b| try zir.findDeclsBody(gpa, list, &found_defers, b);
+    if (bodies.linksection_body) |b| try zir.findDeclsBody(gpa, list, &found_defers, b);
+    if (bodies.addrspace_body) |b| try zir.findDeclsBody(gpa, list, &found_defers, b);
 }
 
 fn findDeclsInner(
     zir: Zir,
-    list: *std.ArrayList(Inst.Index),
+    gpa: Allocator,
+    list: *std.ArrayListUnmanaged(Inst.Index),
+    defers: *std.AutoHashMapUnmanaged(u32, void),
     inst: Inst.Index,
 ) Allocator.Error!void {
     const tags = zir.instructions.items(.tag);
     const datas = zir.instructions.items(.data);
 
     switch (tags[@intFromEnum(inst)]) {
+        .declaration => unreachable,
+
+        // Boring instruction tags first. These have no body and are not declarations or type declarations.
+        .add,
+        .addwrap,
+        .add_sat,
+        .add_unsafe,
+        .sub,
+        .subwrap,
+        .sub_sat,
+        .mul,
+        .mulwrap,
+        .mul_sat,
+        .div_exact,
+        .div_floor,
+        .div_trunc,
+        .mod,
+        .rem,
+        .mod_rem,
+        .shl,
+        .shl_exact,
+        .shl_sat,
+        .shr,
+        .shr_exact,
+        .param_anytype,
+        .param_anytype_comptime,
+        .array_cat,
+        .array_mul,
+        .array_type,
+        .array_type_sentinel,
+        .vector_type,
+        .elem_type,
+        .indexable_ptr_elem_type,
+        .vector_elem_type,
+        .indexable_ptr_len,
+        .anyframe_type,
+        .as_node,
+        .as_shift_operand,
+        .bit_and,
+        .bitcast,
+        .bit_not,
+        .bit_or,
+        .bool_not,
+        .bool_br_and,
+        .bool_br_or,
+        .@"break",
+        .break_inline,
+        .check_comptime_control_flow,
+        .builtin_call,
+        .cmp_lt,
+        .cmp_lte,
+        .cmp_eq,
+        .cmp_gte,
+        .cmp_gt,
+        .cmp_neq,
+        .error_set_decl,
+        .dbg_stmt,
+        .dbg_var_ptr,
+        .dbg_var_val,
+        .decl_ref,
+        .decl_val,
+        .load,
+        .div,
+        .elem_ptr_node,
+        .elem_ptr,
+        .elem_val_node,
+        .elem_val,
+        .elem_val_imm,
+        .ensure_result_used,
+        .ensure_result_non_error,
+        .ensure_err_union_payload_void,
+        .error_union_type,
+        .error_value,
+        .@"export",
+        .export_value,
+        .field_ptr,
+        .field_val,
+        .field_ptr_named,
+        .field_val_named,
+        .import,
+        .int,
+        .int_big,
+        .float,
+        .float128,
+        .int_type,
+        .is_non_null,
+        .is_non_null_ptr,
+        .is_non_err,
+        .is_non_err_ptr,
+        .ret_is_non_err,
+        .repeat,
+        .repeat_inline,
+        .for_len,
+        .merge_error_sets,
+        .ref,
+        .ret_node,
+        .ret_load,
+        .ret_implicit,
+        .ret_err_value,
+        .ret_err_value_code,
+        .ret_ptr,
+        .ret_type,
+        .ptr_type,
+        .slice_start,
+        .slice_end,
+        .slice_sentinel,
+        .slice_length,
+        .store_node,
+        .store_to_inferred_ptr,
+        .str,
+        .negate,
+        .negate_wrap,
+        .typeof,
+        .typeof_log2_int_type,
+        .@"unreachable",
+        .xor,
+        .optional_type,
+        .optional_payload_safe,
+        .optional_payload_unsafe,
+        .optional_payload_safe_ptr,
+        .optional_payload_unsafe_ptr,
+        .err_union_payload_unsafe,
+        .err_union_payload_unsafe_ptr,
+        .err_union_code,
+        .err_union_code_ptr,
+        .enum_literal,
+        .validate_deref,
+        .validate_destructure,
+        .field_type_ref,
+        .opt_eu_base_ptr_init,
+        .coerce_ptr_elem_ty,
+        .validate_ref_ty,
+        .struct_init_empty,
+        .struct_init_empty_result,
+        .struct_init_empty_ref_result,
+        .struct_init_anon,
+        .struct_init,
+        .struct_init_ref,
+        .validate_struct_init_ty,
+        .validate_struct_init_result_ty,
+        .validate_ptr_struct_init,
+        .struct_init_field_type,
+        .struct_init_field_ptr,
+        .array_init_anon,
+        .array_init,
+        .array_init_ref,
+        .validate_array_init_ty,
+        .validate_array_init_result_ty,
+        .validate_array_init_ref_ty,
+        .validate_ptr_array_init,
+        .array_init_elem_type,
+        .array_init_elem_ptr,
+        .union_init,
+        .type_info,
+        .size_of,
+        .bit_size_of,
+        .int_from_ptr,
+        .compile_error,
+        .set_eval_branch_quota,
+        .int_from_enum,
+        .align_of,
+        .int_from_bool,
+        .embed_file,
+        .error_name,
+        .panic,
+        .trap,
+        .set_runtime_safety,
+        .sqrt,
+        .sin,
+        .cos,
+        .tan,
+        .exp,
+        .exp2,
+        .log,
+        .log2,
+        .log10,
+        .abs,
+        .floor,
+        .ceil,
+        .trunc,
+        .round,
+        .tag_name,
+        .type_name,
+        .frame_type,
+        .frame_size,
+        .int_from_float,
+        .float_from_int,
+        .ptr_from_int,
+        .enum_from_int,
+        .float_cast,
+        .int_cast,
+        .ptr_cast,
+        .truncate,
+        .has_decl,
+        .has_field,
+        .clz,
+        .ctz,
+        .pop_count,
+        .byte_swap,
+        .bit_reverse,
+        .bit_offset_of,
+        .offset_of,
+        .splat,
+        .reduce,
+        .shuffle,
+        .atomic_load,
+        .atomic_rmw,
+        .atomic_store,
+        .mul_add,
+        .memcpy,
+        .memset,
+        .min,
+        .max,
+        .alloc,
+        .alloc_mut,
+        .alloc_comptime_mut,
+        .alloc_inferred,
+        .alloc_inferred_mut,
+        .alloc_inferred_comptime,
+        .alloc_inferred_comptime_mut,
+        .resolve_inferred_alloc,
+        .make_ptr_const,
+        .@"resume",
+        .@"await",
+        .save_err_ret_index,
+        .restore_err_ret_index_unconditional,
+        .restore_err_ret_index_fn_entry,
+        => return,
+
+        .extended => {
+            const extended = datas[@intFromEnum(inst)].extended;
+            switch (extended.opcode) {
+                .value_placeholder => unreachable,
+
+                // Once again, we start with the boring tags.
+                .variable,
+                .this,
+                .ret_addr,
+                .builtin_src,
+                .error_return_trace,
+                .frame,
+                .frame_address,
+                .alloc,
+                .builtin_extern,
+                .@"asm",
+                .asm_expr,
+                .compile_log,
+                .min_multi,
+                .max_multi,
+                .add_with_overflow,
+                .sub_with_overflow,
+                .mul_with_overflow,
+                .shl_with_overflow,
+                .c_undef,
+                .c_include,
+                .c_define,
+                .wasm_memory_size,
+                .wasm_memory_grow,
+                .prefetch,
+                .fence,
+                .set_float_mode,
+                .set_align_stack,
+                .set_cold,
+                .error_cast,
+                .await_nosuspend,
+                .breakpoint,
+                .disable_instrumentation,
+                .select,
+                .int_from_error,
+                .error_from_int,
+                .builtin_async_call,
+                .cmpxchg,
+                .c_va_arg,
+                .c_va_copy,
+                .c_va_end,
+                .c_va_start,
+                .ptr_cast_full,
+                .ptr_cast_no_dest,
+                .work_item_id,
+                .work_group_size,
+                .work_group_id,
+                .in_comptime,
+                .restore_err_ret_index,
+                .closure_get,
+                .field_parent_ptr,
+                => return,
+
+                // `@TypeOf` has a body.
+                .typeof_peer => {
+                    const extra = zir.extraData(Zir.Inst.TypeOfPeer, extended.operand);
+                    const body = zir.bodySlice(extra.data.body_index, extra.data.body_len);
+                    try zir.findDeclsBody(gpa, list, defers, body);
+                },
+
+                // Reifications and opaque declarations need tracking, but have no body.
+                .reify, .opaque_decl => return list.append(gpa, inst),
+
+                // Struct declarations need tracking and have bodies.
+                .struct_decl => {
+                    try list.append(gpa, inst);
+
+                    const small: Zir.Inst.StructDecl.Small = @bitCast(extended.small);
+                    const extra = zir.extraData(Zir.Inst.StructDecl, extended.operand);
+                    var extra_index = extra.end;
+                    const captures_len = if (small.has_captures_len) blk: {
+                        const captures_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk captures_len;
+                    } else 0;
+                    const fields_len = if (small.has_fields_len) blk: {
+                        const fields_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk fields_len;
+                    } else 0;
+                    const decls_len = if (small.has_decls_len) blk: {
+                        const decls_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk decls_len;
+                    } else 0;
+                    extra_index += captures_len;
+                    if (small.has_backing_int) {
+                        const backing_int_body_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        if (backing_int_body_len == 0) {
+                            extra_index += 1; // backing_int_ref
+                        } else {
+                            const body = zir.bodySlice(extra_index, backing_int_body_len);
+                            extra_index += backing_int_body_len;
+                            try zir.findDeclsBody(gpa, list, defers, body);
+                        }
+                    }
+                    extra_index += decls_len;
+
+                    // This ZIR is structured in a slightly awkward way, so we have to split up the iteration.
+                    // `extra_index` iterates `flags` (bags of bits).
+                    // `fields_extra_index` iterates `fields`.
+                    // We accumulate the total length of bodies into `total_bodies_len`. This is sufficient because
+                    // the bodies are packed together in `extra` and we only need to traverse their instructions (we
+                    // don't really care about the structure).
+
+                    const bits_per_field = 4;
+                    const fields_per_u32 = 32 / bits_per_field;
+                    const bit_bags_count = std.math.divCeil(usize, fields_len, fields_per_u32) catch unreachable;
+                    var cur_bit_bag: u32 = undefined;
+
+                    var fields_extra_index = extra_index + bit_bags_count;
+                    var total_bodies_len: u32 = 0;
+
+                    for (0..fields_len) |field_i| {
+                        if (field_i % fields_per_u32 == 0) {
+                            cur_bit_bag = zir.extra[extra_index];
+                            extra_index += 1;
+                        }
+
+                        const has_align = @as(u1, @truncate(cur_bit_bag)) != 0;
+                        cur_bit_bag >>= 1;
+                        const has_init = @as(u1, @truncate(cur_bit_bag)) != 0;
+                        cur_bit_bag >>= 2; // also skip `is_comptime`; we don't care
+                        const has_type_body = @as(u1, @truncate(cur_bit_bag)) != 0;
+                        cur_bit_bag >>= 1;
+
+                        fields_extra_index += @intFromBool(!small.is_tuple); // field_name
+                        fields_extra_index += 1; // doc_comment
+
+                        if (has_type_body) {
+                            const field_type_body_len = zir.extra[fields_extra_index];
+                            total_bodies_len += field_type_body_len;
+                        }
+                        fields_extra_index += 1; // field_type or field_type_body_len
+
+                        if (has_align) {
+                            const align_body_len = zir.extra[fields_extra_index];
+                            fields_extra_index += 1;
+                            total_bodies_len += align_body_len;
+                        }
+
+                        if (has_init) {
+                            const init_body_len = zir.extra[fields_extra_index];
+                            fields_extra_index += 1;
+                            total_bodies_len += init_body_len;
+                        }
+                    }
+
+                    // Now, `fields_extra_index` points to `bodies`. Let's treat this as one big body.
+                    const merged_bodies = zir.bodySlice(fields_extra_index, total_bodies_len);
+                    try zir.findDeclsBody(gpa, list, defers, merged_bodies);
+                },
+
+                // Union declarations need tracking and have a body.
+                .union_decl => {
+                    try list.append(gpa, inst);
+
+                    const small: Zir.Inst.UnionDecl.Small = @bitCast(extended.small);
+                    const extra = zir.extraData(Zir.Inst.UnionDecl, extended.operand);
+                    var extra_index = extra.end;
+                    extra_index += @intFromBool(small.has_tag_type);
+                    const captures_len = if (small.has_captures_len) blk: {
+                        const captures_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk captures_len;
+                    } else 0;
+                    const body_len = if (small.has_body_len) blk: {
+                        const body_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk body_len;
+                    } else 0;
+                    extra_index += @intFromBool(small.has_fields_len);
+                    const decls_len = if (small.has_decls_len) blk: {
+                        const decls_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk decls_len;
+                    } else 0;
+                    extra_index += captures_len;
+                    extra_index += decls_len;
+                    const body = zir.bodySlice(extra_index, body_len);
+                    try zir.findDeclsBody(gpa, list, defers, body);
+                },
+
+                // Enum declarations need tracking and have a body.
+                .enum_decl => {
+                    try list.append(gpa, inst);
+
+                    const small: Zir.Inst.EnumDecl.Small = @bitCast(extended.small);
+                    const extra = zir.extraData(Zir.Inst.EnumDecl, extended.operand);
+                    var extra_index = extra.end;
+                    extra_index += @intFromBool(small.has_tag_type);
+                    const captures_len = if (small.has_captures_len) blk: {
+                        const captures_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk captures_len;
+                    } else 0;
+                    const body_len = if (small.has_body_len) blk: {
+                        const body_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk body_len;
+                    } else 0;
+                    extra_index += @intFromBool(small.has_fields_len);
+                    const decls_len = if (small.has_decls_len) blk: {
+                        const decls_len = zir.extra[extra_index];
+                        extra_index += 1;
+                        break :blk decls_len;
+                    } else 0;
+                    extra_index += captures_len;
+                    extra_index += decls_len;
+                    const body = zir.bodySlice(extra_index, body_len);
+                    try zir.findDeclsBody(gpa, list, defers, body);
+                },
+            }
+        },
+
         // Functions instructions are interesting and have a body.
         .func,
         .func_inferred,
         => {
-            try list.append(inst);
+            try list.append(gpa, inst);
 
             const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.Func, inst_data.payload_index);
@@ -3661,14 +4157,14 @@ fn findDeclsInner(
                 else => {
                     const body = zir.bodySlice(extra_index, extra.data.ret_body_len);
                     extra_index += body.len;
-                    try zir.findDeclsBody(list, body);
+                    try zir.findDeclsBody(gpa, list, defers, body);
                 },
             }
             const body = zir.bodySlice(extra_index, extra.data.body_len);
-            return zir.findDeclsBody(list, body);
+            return zir.findDeclsBody(gpa, list, defers, body);
         },
         .func_fancy => {
-            try list.append(inst);
+            try list.append(gpa, inst);
 
             const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.FuncFancy, inst_data.payload_index);
@@ -3679,7 +4175,7 @@ fn findDeclsInner(
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
                 const body = zir.bodySlice(extra_index, body_len);
-                try zir.findDeclsBody(list, body);
+                try zir.findDeclsBody(gpa, list, defers, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_align_ref) {
                 extra_index += 1;
@@ -3689,7 +4185,7 @@ fn findDeclsInner(
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
                 const body = zir.bodySlice(extra_index, body_len);
-                try zir.findDeclsBody(list, body);
+                try zir.findDeclsBody(gpa, list, defers, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_addrspace_ref) {
                 extra_index += 1;
@@ -3699,7 +4195,7 @@ fn findDeclsInner(
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
                 const body = zir.bodySlice(extra_index, body_len);
-                try zir.findDeclsBody(list, body);
+                try zir.findDeclsBody(gpa, list, defers, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_section_ref) {
                 extra_index += 1;
@@ -3709,7 +4205,7 @@ fn findDeclsInner(
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
                 const body = zir.bodySlice(extra_index, body_len);
-                try zir.findDeclsBody(list, body);
+                try zir.findDeclsBody(gpa, list, defers, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_cc_ref) {
                 extra_index += 1;
@@ -3719,7 +4215,7 @@ fn findDeclsInner(
                 const body_len = zir.extra[extra_index];
                 extra_index += 1;
                 const body = zir.bodySlice(extra_index, body_len);
-                try zir.findDeclsBody(list, body);
+                try zir.findDeclsBody(gpa, list, defers, body);
                 extra_index += body.len;
             } else if (extra.data.bits.has_ret_ty_ref) {
                 extra_index += 1;
@@ -3728,62 +4224,99 @@ fn findDeclsInner(
             extra_index += @intFromBool(extra.data.bits.has_any_noalias);
 
             const body = zir.bodySlice(extra_index, extra.data.body_len);
-            return zir.findDeclsBody(list, body);
-        },
-        .extended => {
-            const extended = datas[@intFromEnum(inst)].extended;
-            switch (extended.opcode) {
-
-                // Decl instructions are interesting but have no body.
-                // TODO yes they do have a body actually. recurse over them just like block instructions.
-                .struct_decl,
-                .union_decl,
-                .enum_decl,
-                .opaque_decl,
-                .reify,
-                => return list.append(inst),
-
-                else => return,
-            }
+            return zir.findDeclsBody(gpa, list, defers, body);
         },
 
         // Block instructions, recurse over the bodies.
 
-        .block, .block_comptime, .block_inline => {
+        .block,
+        .block_comptime,
+        .block_inline,
+        .c_import,
+        .typeof_builtin,
+        .loop,
+        => {
             const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.Block, inst_data.payload_index);
             const body = zir.bodySlice(extra.end, extra.data.body_len);
-            return zir.findDeclsBody(list, body);
+            return zir.findDeclsBody(gpa, list, defers, body);
         },
         .condbr, .condbr_inline => {
             const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.CondBr, inst_data.payload_index);
             const then_body = zir.bodySlice(extra.end, extra.data.then_body_len);
             const else_body = zir.bodySlice(extra.end + then_body.len, extra.data.else_body_len);
-            try zir.findDeclsBody(list, then_body);
-            try zir.findDeclsBody(list, else_body);
+            try zir.findDeclsBody(gpa, list, defers, then_body);
+            try zir.findDeclsBody(gpa, list, defers, else_body);
         },
         .@"try", .try_ptr => {
             const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.Try, inst_data.payload_index);
             const body = zir.bodySlice(extra.end, extra.data.body_len);
-            try zir.findDeclsBody(list, body);
+            try zir.findDeclsBody(gpa, list, defers, body);
         },
-        .switch_block => return findDeclsSwitch(zir, list, inst),
+        .switch_block, .switch_block_ref => return zir.findDeclsSwitch(gpa, list, defers, inst, .normal),
+        .switch_block_err_union => return zir.findDeclsSwitch(gpa, list, defers, inst, .err_union),
 
         .suspend_block => @panic("TODO iterate suspend block"),
 
-        else => return, // Regular instruction, not interesting.
+        .param, .param_comptime => {
+            const inst_data = datas[@intFromEnum(inst)].pl_tok;
+            const extra = zir.extraData(Inst.Param, inst_data.payload_index);
+            const body = zir.bodySlice(extra.end, extra.data.body_len);
+            try zir.findDeclsBody(gpa, list, defers, body);
+        },
+
+        inline .call, .field_call => |tag| {
+            const inst_data = datas[@intFromEnum(inst)].pl_node;
+            const extra = zir.extraData(switch (tag) {
+                .call => Inst.Call,
+                .field_call => Inst.FieldCall,
+                else => unreachable,
+            }, inst_data.payload_index);
+            // It's easiest to just combine all the arg bodies into one body, like we do above for `struct_decl`.
+            const args_len = extra.data.flags.args_len;
+            if (args_len > 0) {
+                const first_arg_start_off = args_len;
+                const final_arg_end_off = zir.extra[extra.end + args_len - 1];
+                const args_body = zir.bodySlice(extra.end + first_arg_start_off, final_arg_end_off - first_arg_start_off);
+                try zir.findDeclsBody(gpa, list, defers, args_body);
+            }
+        },
+        .@"defer" => {
+            const inst_data = datas[@intFromEnum(inst)].@"defer";
+            const gop = try defers.getOrPut(gpa, inst_data.index);
+            if (!gop.found_existing) {
+                const body = zir.bodySlice(inst_data.index, inst_data.len);
+                try zir.findDeclsBody(gpa, list, defers, body);
+            }
+        },
+        .defer_err_code => {
+            const inst_data = datas[@intFromEnum(inst)].defer_err_code;
+            const extra = zir.extraData(Inst.DeferErrCode, inst_data.payload_index).data;
+            const gop = try defers.getOrPut(gpa, extra.index);
+            if (!gop.found_existing) {
+                const body = zir.bodySlice(extra.index, extra.len);
+                try zir.findDeclsBody(gpa, list, defers, body);
+            }
+        },
     }
 }
 
 fn findDeclsSwitch(
     zir: Zir,
-    list: *std.ArrayList(Inst.Index),
+    gpa: Allocator,
+    list: *std.ArrayListUnmanaged(Inst.Index),
+    defers: *std.AutoHashMapUnmanaged(u32, void),
     inst: Inst.Index,
+    /// Distinguishes between `switch_block[_ref]` and `switch_block_err_union`.
+    comptime kind: enum { normal, err_union },
 ) Allocator.Error!void {
     const inst_data = zir.instructions.items(.data)[@intFromEnum(inst)].pl_node;
-    const extra = zir.extraData(Inst.SwitchBlock, inst_data.payload_index);
+    const extra = zir.extraData(switch (kind) {
+        .normal => Inst.SwitchBlock,
+        .err_union => Inst.SwitchBlockErrUnion,
+    }, inst_data.payload_index);
 
     var extra_index: usize = extra.end;
 
@@ -3793,18 +4326,35 @@ fn findDeclsSwitch(
         break :blk multi_cases_len;
     } else 0;
 
-    if (extra.data.bits.any_has_tag_capture) {
+    if (switch (kind) {
+        .normal => extra.data.bits.any_has_tag_capture,
+        .err_union => extra.data.bits.any_uses_err_capture,
+    }) {
         extra_index += 1;
     }
 
-    const special_prong = extra.data.bits.specialProng();
-    if (special_prong != .none) {
+    const has_special = switch (kind) {
+        .normal => extra.data.bits.specialProng() != .none,
+        .err_union => has_special: {
+            // Handle `non_err_body` first.
+            const prong_info: Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
+            extra_index += 1;
+            const body = zir.bodySlice(extra_index, prong_info.body_len);
+            extra_index += body.len;
+
+            try zir.findDeclsBody(gpa, list, defers, body);
+
+            break :has_special extra.data.bits.has_else;
+        },
+    };
+
+    if (has_special) {
         const prong_info: Inst.SwitchBlock.ProngInfo = @bitCast(zir.extra[extra_index]);
         extra_index += 1;
         const body = zir.bodySlice(extra_index, prong_info.body_len);
         extra_index += body.len;
 
-        try zir.findDeclsBody(list, body);
+        try zir.findDeclsBody(gpa, list, defers, body);
     }
 
     {
@@ -3816,7 +4366,7 @@ fn findDeclsSwitch(
             const body = zir.bodySlice(extra_index, prong_info.body_len);
             extra_index += body.len;
 
-            try zir.findDeclsBody(list, body);
+            try zir.findDeclsBody(gpa, list, defers, body);
         }
     }
     {
@@ -3833,18 +4383,20 @@ fn findDeclsSwitch(
             const body = zir.bodySlice(extra_index, prong_info.body_len);
             extra_index += body.len;
 
-            try zir.findDeclsBody(list, body);
+            try zir.findDeclsBody(gpa, list, defers, body);
         }
     }
 }
 
 fn findDeclsBody(
     zir: Zir,
-    list: *std.ArrayList(Inst.Index),
+    gpa: Allocator,
+    list: *std.ArrayListUnmanaged(Inst.Index),
+    defers: *std.AutoHashMapUnmanaged(u32, void),
     body: []const Inst.Index,
 ) Allocator.Error!void {
     for (body) |member| {
-        try zir.findDeclsInner(list, member);
+        try zir.findDeclsInner(gpa, list, defers, member);
     }
 }
 
@@ -4042,7 +4594,7 @@ pub fn getAssociatedSrcHash(zir: Zir, inst: Zir.Inst.Index) ?std.zig.SrcHash {
                 return null;
             }
             const extra_index = extra.end +
-                1 +
+                extra.data.ret_body_len +
                 extra.data.body_len +
                 @typeInfo(Inst.Func.SrcLocs).Struct.fields.len;
             return @bitCast([4]u32{

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3685,7 +3685,10 @@ fn performAllTheWorkInner(
         zcu.codegen_prog_node = main_progress_node.start("Code Generation", 0);
     }
 
-    if (!InternPool.single_threaded) comp.thread_pool.spawnWgId(&work_queue_wait_group, codegenThread, .{comp});
+    if (!InternPool.single_threaded) {
+        comp.codegen_work.done = false; // may be `true` from a prior update
+        comp.thread_pool.spawnWgId(&work_queue_wait_group, codegenThread, .{comp});
+    }
     defer if (!InternPool.single_threaded) {
         {
             comp.codegen_work.mutex.lock();

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2269,7 +2269,7 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
         try comp.queueJob(.{ .analyze_mod = std_mod });
         zcu.analysis_roots.appendAssumeCapacity(std_mod);
 
-        if (comp.config.is_test) {
+        if (comp.config.is_test and zcu.main_mod != std_mod) {
             try comp.queueJob(.{ .analyze_mod = zcu.main_mod });
             zcu.analysis_roots.appendAssumeCapacity(zcu.main_mod);
         }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2264,7 +2264,7 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
             }
         }
 
-        zcu.analysis_roots.resize(0) catch unreachable;
+        zcu.analysis_roots.clear();
 
         try comp.queueJob(.{ .analyze_mod = std_mod });
         zcu.analysis_roots.appendAssumeCapacity(std_mod);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3569,6 +3569,8 @@ pub fn performAllTheWork(
         mod.sema_prog_node = std.Progress.Node.none;
         mod.codegen_prog_node.end();
         mod.codegen_prog_node = std.Progress.Node.none;
+
+        mod.generation += 1;
     };
     try comp.performAllTheWorkInner(main_progress_node);
     if (!InternPool.single_threaded) if (comp.codegen_work.job_error) |job_error| return job_error;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22062,7 +22062,8 @@ fn reifyEnum(
             return Air.internedToRef(ty);
         },
     };
-    errdefer wip_ty.cancel(ip, pt.tid);
+    var done = false;
+    errdefer if (!done) wip_ty.cancel(ip, pt.tid);
 
     if (tag_ty.zigTypeTag(mod) != .Int) {
         return sema.fail(block, src, "Type.Enum.tag_type must be an integer type", .{});
@@ -22088,6 +22089,7 @@ fn reifyEnum(
     try sema.addTypeReferenceEntry(src, wip_ty.index);
     wip_ty.prepare(ip, new_cau_index, new_namespace_index);
     wip_ty.setTagTy(ip, tag_ty.toIntern());
+    done = true;
 
     for (0..fields_len) |field_idx| {
         const field_info = try fields_val.elemValue(pt, field_idx);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36641,11 +36641,11 @@ fn semaUnionFields(pt: Zcu.PerThread, arena: Allocator, union_ty: InternPool.Ind
             }
         } else {
             // The provided type is the enum tag type.
-            union_type.setTagType(ip, provided_ty.toIntern());
             const enum_type = switch (ip.indexToKey(provided_ty.toIntern())) {
                 .enum_type => ip.loadEnumType(provided_ty.toIntern()),
                 else => return sema.fail(&block_scope, tag_ty_src, "expected enum tag type, found '{}'", .{provided_ty.fmt(pt)}),
             };
+            union_type.setTagType(ip, provided_ty.toIntern());
             // The fields of the union must match the enum exactly.
             // A flag per field is used to check for missing and extraneous fields.
             explicit_tags_seen = try sema.arena.alloc(bool, enum_type.names.len);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2504,12 +2504,12 @@ pub fn failWithOwnedErrorMsg(sema: *Sema, block: ?*Block, err_msg: *Module.Error
     const mod = sema.pt.zcu;
 
     if (build_options.enable_debug_extensions and mod.comp.debug_compile_errors) {
-        var all_references = mod.resolveReferences() catch @panic("out of memory");
+        var all_references: ?std.AutoHashMapUnmanaged(AnalUnit, ?Zcu.ResolvedReference) = null;
         var wip_errors: std.zig.ErrorBundle.Wip = undefined;
         wip_errors.init(gpa) catch @panic("out of memory");
-        Compilation.addModuleErrorMsg(mod, &wip_errors, err_msg.*, &all_references) catch unreachable;
+        Compilation.addModuleErrorMsg(mod, &wip_errors, err_msg.*, &all_references) catch @panic("out of memory");
         std.debug.print("compile error during Sema:\n", .{});
-        var error_bundle = wip_errors.toOwnedBundle("") catch unreachable;
+        var error_bundle = wip_errors.toOwnedBundle("") catch @panic("out of memory");
         error_bundle.renderToStdErr(.{ .ttyconf = .no_color });
         crash_report.compilerPanic("unexpected compile error occurred", null, null);
     }

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17729,7 +17729,7 @@ fn zirClosureGet(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstDat
         const msg = msg: {
             const name = name: {
                 // TODO: we should probably store this name in the ZIR to avoid this complexity.
-                const file, const src_base_node = Module.LazySrcLoc.resolveBaseNode(block.src_base_inst, mod);
+                const file, const src_base_node = Module.LazySrcLoc.resolveBaseNode(block.src_base_inst, mod).?;
                 const tree = file.getTree(sema.gpa) catch |err| {
                     // In this case we emit a warning + a less precise source location.
                     log.warn("unable to load {s}: {s}", .{
@@ -17757,7 +17757,7 @@ fn zirClosureGet(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstDat
     if (!block.is_typeof and !block.is_comptime and sema.func_index != .none) {
         const msg = msg: {
             const name = name: {
-                const file, const src_base_node = Module.LazySrcLoc.resolveBaseNode(block.src_base_inst, mod);
+                const file, const src_base_node = Module.LazySrcLoc.resolveBaseNode(block.src_base_inst, mod).?;
                 const tree = file.getTree(sema.gpa) catch |err| {
                     // In this case we emit a warning + a less precise source location.
                     log.warn("unable to load {s}: {s}", .{

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -3437,7 +3437,7 @@ pub fn typeDeclSrcLine(ty: Type, zcu: *Zcu) ?u32 {
         },
         else => return null,
     };
-    const info = tracked.resolveFull(&zcu.intern_pool);
+    const info = tracked.resolveFull(&zcu.intern_pool) orelse return null;
     const file = zcu.fileByIndex(info.file);
     assert(file.zir_loaded);
     const zir = file.zir;

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2557,10 +2557,10 @@ pub fn mapOldZirToNew(
     });
 
     // Used as temporary buffers for namespace declaration instructions
-    var old_decls = std.ArrayList(Zir.Inst.Index).init(gpa);
-    defer old_decls.deinit();
-    var new_decls = std.ArrayList(Zir.Inst.Index).init(gpa);
-    defer new_decls.deinit();
+    var old_decls: std.ArrayListUnmanaged(Zir.Inst.Index) = .{};
+    defer old_decls.deinit(gpa);
+    var new_decls: std.ArrayListUnmanaged(Zir.Inst.Index) = .{};
+    defer new_decls.deinit(gpa);
 
     while (match_stack.popOrNull()) |match_item| {
         // Match the namespace declaration itself
@@ -2647,11 +2647,11 @@ pub fn mapOldZirToNew(
             // Match the `declaration` instruction
             try inst_map.put(gpa, old_decl_inst, new_decl_inst);
 
-            // Find namespace declarations within this declaration
-            try old_zir.findDecls(&old_decls, old_decl_inst);
-            try new_zir.findDecls(&new_decls, new_decl_inst);
+            // Find container type declarations within this declaration
+            try old_zir.findDecls(gpa, &old_decls, old_decl_inst);
+            try new_zir.findDecls(gpa, &new_decls, new_decl_inst);
 
-            // We don't have any smart way of matching up these namespace declarations, so we always
+            // We don't have any smart way of matching up these type declarations, so we always
             // correlate them based on source order.
             const n = @min(old_decls.items.len, new_decls.items.len);
             try match_stack.ensureUnusedCapacity(gpa, n);

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2429,7 +2429,11 @@ fn markTransitiveDependersPotentiallyOutdated(zcu: *Zcu, maybe_outdated: AnalUni
 pub fn findOutdatedToAnalyze(zcu: *Zcu) Allocator.Error!?AnalUnit {
     if (!zcu.comp.incremental) return null;
 
-    if (zcu.outdated.count() == 0 and zcu.potentially_outdated.count() == 0) {
+    if (zcu.outdated.count() == 0) {
+        // Any units in `potentially_outdated` must just be stuck in loops with one another: none of those
+        // units have had any outdated dependencies so far, and all of their remaining PO deps are triggered
+        // by other units in `potentially_outdated`. So, we can safety assume those units up-to-date.
+        zcu.potentially_outdated.clear();
         log.debug("findOutdatedToAnalyze: no outdated depender", .{});
         return null;
     }

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2433,7 +2433,7 @@ pub fn findOutdatedToAnalyze(zcu: *Zcu) Allocator.Error!?AnalUnit {
         // Any units in `potentially_outdated` must just be stuck in loops with one another: none of those
         // units have had any outdated dependencies so far, and all of their remaining PO deps are triggered
         // by other units in `potentially_outdated`. So, we can safety assume those units up-to-date.
-        zcu.potentially_outdated.clear();
+        zcu.potentially_outdated.clearRetainingCapacity();
         log.debug("findOutdatedToAnalyze: no outdated depender", .{});
         return null;
     }

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -432,7 +432,7 @@ pub fn updateZirRefs(pt: Zcu.PerThread) Allocator.Error!void {
                         new_zir.nullTerminatedString(name_zir),
                         .no_embedded_nulls,
                     );
-                    if (!old_names.swapRemove(name_ip)) continue;
+                    if (old_names.swapRemove(name_ip)) continue;
                     // Name added
                     any_change = true;
                     try zcu.markDependeeOutdated(.not_marked_po, .{ .namespace_name = .{

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2040,6 +2040,9 @@ const ScanDeclIter = struct {
                 const want_analysis = switch (kind) {
                     .@"comptime" => unreachable,
                     .@"usingnamespace" => a: {
+                        if (comp.incremental) {
+                            @panic("'usingnamespace' is not supported by incremental compilation");
+                        }
                         if (declaration.flags.is_pub) {
                             try namespace.pub_usingnamespace.append(gpa, nav);
                         } else {

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -1,3 +1,6 @@
+//! This type provides a wrapper around a `*Zcu` for uses which require a thread `Id`.
+//! Any operation which mutates `InternPool` state lives here rather than on `Zcu`.
+
 zcu: *Zcu,
 
 /// Dense, per-thread unique index.

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -98,7 +98,7 @@ pub fn generateLazyFunction(
     debug_output: DebugInfoOutput,
 ) CodeGenError!Result {
     const zcu = pt.zcu;
-    const file = Type.fromInterned(lazy_sym.ty).typeDeclInstAllowGeneratedTag(zcu).?.resolveFull(&zcu.intern_pool).file;
+    const file = Type.fromInterned(lazy_sym.ty).typeDeclInstAllowGeneratedTag(zcu).?.resolveFile(&zcu.intern_pool);
     const target = zcu.fileByIndex(file).mod.resolved_target.result;
     switch (target_util.zigBackend(target, false)) {
         else => unreachable,

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -2585,7 +2585,7 @@ pub fn genTypeDecl(
                 const ty = Type.fromInterned(index);
                 _ = try renderTypePrefix(.flush, global_ctype_pool, zcu, writer, global_ctype, .suffix, .{});
                 try writer.writeByte(';');
-                const file_scope = ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFull(ip).file;
+                const file_scope = ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFile(ip);
                 if (!zcu.fileByIndex(file_scope).mod.strip) try writer.print(" /* {} */", .{
                     ty.containerTypeName(ip).fmt(ip),
                 });

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1959,7 +1959,7 @@ pub const Object = struct {
                     );
                 }
 
-                const file = try o.getDebugFile(ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFull(ip).file);
+                const file = try o.getDebugFile(ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFile(ip));
                 const scope = if (ty.getParentNamespace(zcu).unwrap()) |parent_namespace|
                     try o.namespaceToDebugScope(parent_namespace)
                 else
@@ -2137,7 +2137,7 @@ pub const Object = struct {
                 const name = try o.allocTypeName(ty);
                 defer gpa.free(name);
 
-                const file = try o.getDebugFile(ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFull(ip).file);
+                const file = try o.getDebugFile(ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFile(ip));
                 const scope = if (ty.getParentNamespace(zcu).unwrap()) |parent_namespace|
                     try o.namespaceToDebugScope(parent_namespace)
                 else
@@ -2772,7 +2772,7 @@ pub const Object = struct {
     fn makeEmptyNamespaceDebugType(o: *Object, ty: Type) !Builder.Metadata {
         const zcu = o.pt.zcu;
         const ip = &zcu.intern_pool;
-        const file = try o.getDebugFile(ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFull(ip).file);
+        const file = try o.getDebugFile(ty.typeDeclInstAllowGeneratedTag(zcu).?.resolveFile(ip));
         const scope = if (ty.getParentNamespace(zcu).unwrap()) |parent_namespace|
             try o.namespaceToDebugScope(parent_namespace)
         else

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -786,7 +786,7 @@ const Entry = struct {
             const ip = &zcu.intern_pool;
             for (dwarf.types.keys(), dwarf.types.values()) |ty, other_entry| {
                 const ty_unit: Unit.Index = if (Type.fromInterned(ty).typeDeclInst(zcu)) |inst_index|
-                    dwarf.getUnit(zcu.fileByIndex(inst_index.resolveFull(ip).file).mod) catch unreachable
+                    dwarf.getUnit(zcu.fileByIndex(inst_index.resolveFile(ip)).mod) catch unreachable
                 else
                     .main;
                 if (sec.getUnit(ty_unit) == unit and unit.getEntry(other_entry) == entry)
@@ -796,7 +796,7 @@ const Entry = struct {
                     });
             }
             for (dwarf.navs.keys(), dwarf.navs.values()) |nav, other_entry| {
-                const nav_unit = dwarf.getUnit(zcu.fileByIndex(ip.getNav(nav).srcInst(ip).resolveFull(ip).file).mod) catch unreachable;
+                const nav_unit = dwarf.getUnit(zcu.fileByIndex(ip.getNav(nav).srcInst(ip).resolveFile(ip)).mod) catch unreachable;
                 if (sec.getUnit(nav_unit) == unit and unit.getEntry(other_entry) == entry)
                     log.err("missing Nav({}({d}))", .{ ip.getNav(nav).fqn.fmt(ip), @intFromEnum(nav) });
             }
@@ -1201,7 +1201,7 @@ pub const WipNav = struct {
         const ip = &zcu.intern_pool;
         const maybe_inst_index = ty.typeDeclInst(zcu);
         const unit = if (maybe_inst_index) |inst_index|
-            try wip_nav.dwarf.getUnit(zcu.fileByIndex(inst_index.resolveFull(ip).file).mod)
+            try wip_nav.dwarf.getUnit(zcu.fileByIndex(inst_index.resolveFile(ip)).mod)
         else
             .main;
         const gop = try wip_nav.dwarf.types.getOrPut(wip_nav.dwarf.gpa, ty.toIntern());
@@ -1539,7 +1539,7 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
     const nav = ip.getNav(nav_index);
     log.debug("initWipNav({})", .{nav.fqn.fmt(ip)});
 
-    const inst_info = nav.srcInst(ip).resolveFull(ip);
+    const inst_info = nav.srcInst(ip).resolveFull(ip).?;
     const file = zcu.fileByIndex(inst_info.file);
 
     const unit = try dwarf.getUnit(file.mod);
@@ -1874,7 +1874,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
     const nav = ip.getNav(nav_index);
     log.debug("updateComptimeNav({})", .{nav.fqn.fmt(ip)});
 
-    const inst_info = nav.srcInst(ip).resolveFull(ip);
+    const inst_info = nav.srcInst(ip).resolveFull(ip).?;
     const file = zcu.fileByIndex(inst_info.file);
     assert(file.zir_loaded);
     const decl_inst = file.zir.instructions.get(@intFromEnum(inst_info.inst));
@@ -1937,7 +1937,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
                     };
                     break :value_inst value_inst;
                 };
-                const type_inst_info = loaded_struct.zir_index.unwrap().?.resolveFull(ip);
+                const type_inst_info = loaded_struct.zir_index.unwrap().?.resolveFull(ip).?;
                 if (type_inst_info.inst != value_inst) break :decl_struct;
 
                 const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
@@ -2053,7 +2053,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
                     };
                     break :value_inst value_inst;
                 };
-                const type_inst_info = loaded_enum.zir_index.unwrap().?.resolveFull(ip);
+                const type_inst_info = loaded_enum.zir_index.unwrap().?.resolveFull(ip).?;
                 if (type_inst_info.inst != value_inst) break :decl_enum;
 
                 const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
@@ -2127,7 +2127,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
                     };
                     break :value_inst value_inst;
                 };
-                const type_inst_info = loaded_union.zir_index.resolveFull(ip);
+                const type_inst_info = loaded_union.zir_index.resolveFull(ip).?;
                 if (type_inst_info.inst != value_inst) break :decl_union;
 
                 const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
@@ -2240,7 +2240,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
                     };
                     break :value_inst value_inst;
                 };
-                const type_inst_info = loaded_opaque.zir_index.resolveFull(ip);
+                const type_inst_info = loaded_opaque.zir_index.resolveFull(ip).?;
                 if (type_inst_info.inst != value_inst) break :decl_opaque;
 
                 const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
@@ -2704,7 +2704,7 @@ pub fn updateContainerType(dwarf: *Dwarf, pt: Zcu.PerThread, type_index: InternP
     const ty = Type.fromInterned(type_index);
     log.debug("updateContainerType({}({d}))", .{ ty.fmt(pt), @intFromEnum(type_index) });
 
-    const inst_info = ty.typeDeclInst(zcu).?.resolveFull(ip);
+    const inst_info = ty.typeDeclInst(zcu).?.resolveFull(ip).?;
     const file = zcu.fileByIndex(inst_info.file);
     if (inst_info.inst == .main_struct_inst) {
         const unit = try dwarf.getUnit(file.mod);
@@ -2922,7 +2922,7 @@ pub fn updateNavLineNumber(dwarf: *Dwarf, zcu: *Zcu, nav_index: InternPool.Nav.I
     const ip = &zcu.intern_pool;
 
     const zir_index = ip.getCau(ip.getNav(nav_index).analysis_owner.unwrap() orelse return).zir_index;
-    const inst_info = zir_index.resolveFull(ip);
+    const inst_info = zir_index.resolveFull(ip).?;
     assert(inst_info.inst != .main_struct_inst);
     const file = zcu.fileByIndex(inst_info.file);
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3257,9 +3257,12 @@ fn buildOutputType(
         else => false,
     };
 
+    const incremental = opt_incremental orelse false;
+
     const disable_lld_caching = !output_to_cache;
 
     const cache_mode: Compilation.CacheMode = b: {
+        if (incremental) break :b .incremental;
         if (disable_lld_caching) break :b .incremental;
         if (!create_module.resolved_options.have_zcu) break :b .whole;
 
@@ -3271,8 +3274,6 @@ fn buildOutputType(
 
         break :b .incremental;
     };
-
-    const incremental = opt_incremental orelse false;
 
     process.raiseFileDescriptorLimit();
 

--- a/test/incremental/add_decl
+++ b/test/incremental/add_decl
@@ -1,0 +1,59 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(foo);
+}
+const foo = "good morning\n";
+#expect_stdout="good morning\n"
+
+#update=add new declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(foo);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+#expect_stdout="good morning\n"
+
+#update=reference new declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(bar);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+#expect_stdout="good evening\n"
+
+#update=reference missing declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(qux);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+#expect_error=ignored
+
+#update=add missing declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(qux);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+const qux = "good night\n";
+#expect_stdout="good night\n"
+
+#update=remove unused declarations
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(qux);
+}
+const qux = "good night\n";
+#expect_stdout="good night\n"

--- a/test/incremental/add_decl_namespaced
+++ b/test/incremental/add_decl_namespaced
@@ -1,0 +1,59 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(@This().foo);
+}
+const foo = "good morning\n";
+#expect_stdout="good morning\n"
+
+#update=add new declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(@This().foo);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+#expect_stdout="good morning\n"
+
+#update=reference new declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(@This().bar);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+#expect_stdout="good evening\n"
+
+#update=reference missing declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(@This().qux);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+#expect_error=ignored
+
+#update=add missing declaration
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(@This().qux);
+}
+const foo = "good morning\n";
+const bar = "good evening\n";
+const qux = "good night\n";
+#expect_stdout="good night\n"
+
+#update=remove unused declarations
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(@This().qux);
+}
+const qux = "good night\n";
+#expect_stdout="good night\n"

--- a/test/incremental/delete_comptime_decls
+++ b/test/incremental/delete_comptime_decls
@@ -1,0 +1,38 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+pub fn main() void {}
+comptime {
+    var array = [_:0]u8{ 1, 2, 3, 4 };
+    const src_slice: [:0]u8 = &array;
+    const slice = src_slice[2..6];
+    _ = slice;
+}
+comptime {
+    var array = [_:0]u8{ 1, 2, 3, 4 };
+    const slice = array[2..6];
+    _ = slice;
+}
+comptime {
+    var array = [_]u8{ 1, 2, 3, 4 };
+    const slice = array[2..5];
+    _ = slice;
+}
+comptime {
+    var array = [_:0]u8{ 1, 2, 3, 4 };
+    const slice = array[3..2];
+    _ = slice;
+}
+#expect_error=ignored
+
+#update=delete and modify comptime decls
+#file=main.zig
+pub fn main() void {}
+comptime {
+    const x: [*c]u8 = null;
+    var runtime_len: usize = undefined;
+		runtime_len = 0;
+    const y = x[0..runtime_len];
+    _ = y;
+}
+#expect_error=ignored

--- a/test/incremental/unreferenced_error
+++ b/test/incremental/unreferenced_error
@@ -1,0 +1,38 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(a);
+}
+const a = "Hello, World!\n";
+#expect_stdout="Hello, World!\n"
+
+#update=introduce compile error
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(a);
+}
+const a = @compileError("bad a");
+#expect_error=ignored
+
+#update=remove error reference
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(b);
+}
+const a = @compileError("bad a");
+const b = "Hi there!\n";
+#expect_stdout="Hi there!\n"
+
+#update=introduce and remove reference to error
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writeAll(a);
+}
+const a = "Back to a\n";
+const b = @compileError("bad b");
+#expect_stdout="Back to a\n"

--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -2,7 +2,13 @@ const std = @import("std");
 const fatal = std.process.fatal;
 const Allocator = std.mem.Allocator;
 
-const usage = "usage: incr-check <zig binary path> <input file> [-fno-emit-bin] [--zig-lib-dir lib] [--debug-zcu]";
+const usage = "usage: incr-check <zig binary path> <input file> [--zig-lib-dir lib] [--debug-zcu] [--emit none|bin|c] [--zig-cc-binary /path/to/zig]";
+
+const EmitMode = enum {
+    none,
+    bin,
+    c,
+};
 
 pub fn main() !void {
     var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -12,19 +18,24 @@ pub fn main() !void {
     var opt_zig_exe: ?[]const u8 = null;
     var opt_input_file_name: ?[]const u8 = null;
     var opt_lib_dir: ?[]const u8 = null;
-    var no_bin = false;
+    var opt_cc_zig: ?[]const u8 = null;
+    var emit: EmitMode = .bin;
     var debug_zcu = false;
 
     var arg_it = try std.process.argsWithAllocator(arena);
     _ = arg_it.skip();
     while (arg_it.next()) |arg| {
         if (arg.len > 0 and arg[0] == '-') {
-            if (std.mem.eql(u8, arg, "-fno-emit-bin")) {
-                no_bin = true;
-            } else if (std.mem.eql(u8, arg, "--debug-zcu")) {
-                debug_zcu = true;
+            if (std.mem.eql(u8, arg, "--emit")) {
+                const emit_str = arg_it.next() orelse fatal("expected arg after '--emit'\n{s}", .{usage});
+                emit = std.meta.stringToEnum(EmitMode, emit_str) orelse
+                    fatal("invalid emit mode '{s}'\n{s}", .{ emit_str, usage });
             } else if (std.mem.eql(u8, arg, "--zig-lib-dir")) {
                 opt_lib_dir = arg_it.next() orelse fatal("expected arg after '--zig-lib-dir'\n{s}", .{usage});
+            } else if (std.mem.eql(u8, arg, "--debug-zcu")) {
+                debug_zcu = true;
+            } else if (std.mem.eql(u8, arg, "--zig-cc-binary")) {
+                opt_cc_zig = arg_it.next() orelse fatal("expect arg after '--zig-cc-binary'\n{s}", .{usage});
             } else {
                 fatal("unknown option '{s}'\n{s}", .{ arg, usage });
             }
@@ -51,20 +62,19 @@ pub fn main() !void {
     const tmp_dir_path = "tmp_" ++ std.fmt.hex(rand_int);
     const tmp_dir = try std.fs.cwd().makeOpenPath(tmp_dir_path, .{});
 
-    if (opt_lib_dir) |lib_dir| {
-        if (!std.fs.path.isAbsolute(lib_dir)) {
-            // The cwd of the subprocess is within the tmp dir, so prepend `..` to the path.
-            opt_lib_dir = try std.fs.path.join(arena, &.{ "..", lib_dir });
-        }
-    }
-
     const child_prog_node = prog_node.start("zig build-exe", 0);
     defer child_prog_node.end();
 
+    // Convert paths to be relative to the cwd of the subprocess.
+    const resolved_zig_exe = try std.fs.path.relative(arena, tmp_dir_path, zig_exe);
+    const opt_resolved_lib_dir = if (opt_lib_dir) |lib_dir|
+        try std.fs.path.relative(arena, tmp_dir_path, lib_dir)
+    else
+        null;
+
     var child_args: std.ArrayListUnmanaged([]const u8) = .{};
     try child_args.appendSlice(arena, &.{
-        // Convert incr-check-relative path to subprocess-relative path.
-        try std.fs.path.relative(arena, tmp_dir_path, zig_exe),
+        resolved_zig_exe,
         "build-exe",
         case.root_source_file,
         "-fincremental",
@@ -76,13 +86,13 @@ pub fn main() !void {
         ".global_cache",
         "--listen=-",
     });
-    if (opt_lib_dir) |lib_dir| {
-        try child_args.appendSlice(arena, &.{ "--zig-lib-dir", lib_dir });
+    if (opt_resolved_lib_dir) |resolved_lib_dir| {
+        try child_args.appendSlice(arena, &.{ "--zig-lib-dir", resolved_lib_dir });
     }
-    if (no_bin) {
-        try child_args.append(arena, "-fno-emit-bin");
-    } else {
-        try child_args.appendSlice(arena, &.{ "-fno-llvm", "-fno-lld" });
+    switch (emit) {
+        .bin => try child_args.appendSlice(arena, &.{ "-fno-llvm", "-fno-lld" }),
+        .none => try child_args.append(arena, "-fno-emit-bin"),
+        .c => try child_args.appendSlice(arena, &.{ "-ofmt=c", "-lc" }),
     }
     if (debug_zcu) {
         try child_args.appendSlice(arena, &.{ "--debug-log", "zcu" });
@@ -96,6 +106,24 @@ pub fn main() !void {
     child.cwd_dir = tmp_dir;
     child.cwd = tmp_dir_path;
 
+    var cc_child_args: std.ArrayListUnmanaged([]const u8) = .{};
+    if (emit == .c) {
+        const resolved_cc_zig_exe = if (opt_cc_zig) |cc_zig_exe|
+            try std.fs.path.relative(arena, tmp_dir_path, cc_zig_exe)
+        else
+            resolved_zig_exe;
+
+        try cc_child_args.appendSlice(arena, &.{
+            resolved_cc_zig_exe,
+            "cc",
+            "-target",
+            case.target_query,
+            "-I",
+            opt_resolved_lib_dir orelse fatal("'--zig-lib-dir' required when using '--emit c'", .{}),
+            "-o",
+        });
+    }
+
     var eval: Eval = .{
         .arena = arena,
         .case = case,
@@ -103,6 +131,8 @@ pub fn main() !void {
         .tmp_dir_path = tmp_dir_path,
         .child = &child,
         .allow_stderr = debug_zcu,
+        .emit = emit,
+        .cc_child_args = &cc_child_args,
     };
 
     try child.spawn();
@@ -123,7 +153,7 @@ pub fn main() !void {
 
         eval.write(update);
         try eval.requestUpdate();
-        try eval.check(&poller, update);
+        try eval.check(&poller, update, update_node);
     }
 
     try eval.end(&poller);
@@ -138,6 +168,10 @@ const Eval = struct {
     tmp_dir_path: []const u8,
     child: *std.process.Child,
     allow_stderr: bool,
+    emit: EmitMode,
+    /// When `emit == .c`, this contains the first few arguments to `zig cc` to build the generated binary.
+    /// The arguments `out.c in.c` must be appended before spawning the subprocess.
+    cc_child_args: *std.ArrayListUnmanaged([]const u8),
 
     const StreamEnum = enum { stdout, stderr };
     const Poller = std.io.Poller(StreamEnum);
@@ -159,7 +193,7 @@ const Eval = struct {
         }
     }
 
-    fn check(eval: *Eval, poller: *Poller, update: Case.Update) !void {
+    fn check(eval: *Eval, poller: *Poller, update: Case.Update, prog_node: std.Progress.Node) !void {
         const arena = eval.arena;
         const Header = std.zig.Server.Message.Header;
         const stdout = poller.fifo(.stdout);
@@ -201,12 +235,7 @@ const Eval = struct {
                     }
                     if (result_error_bundle.errorMessageCount() == 0) {
                         // Empty bundle indicates successful update in a `-fno-emit-bin` build.
-                        // We can't do a full success check since we don't have a binary, but let's
-                        // at least check that no errors were expected.
-                        switch (update.outcome) {
-                            .unknown, .stdout, .exit_code => {},
-                            .compile_errors => fatal("expected compile errors but compilation incorrectly succeeded", .{}),
-                        }
+                        try eval.checkSuccessOutcome(update, null, prog_node);
                     } else {
                         try eval.checkErrorOutcome(update, result_error_bundle);
                     }
@@ -227,7 +256,7 @@ const Eval = struct {
                             fatal("emit_bin_path included unexpected stderr:\n{s}", .{stderr_data});
                         }
                     }
-                    try eval.checkSuccessOutcome(update, result_binary);
+                    try eval.checkSuccessOutcome(update, result_binary, prog_node);
                     // This message indicates the end of the update.
                     stdout.discard(body.len);
                     return;
@@ -270,12 +299,28 @@ const Eval = struct {
         }
     }
 
-    fn checkSuccessOutcome(eval: *Eval, update: Case.Update, binary_path: []const u8) !void {
+    fn checkSuccessOutcome(eval: *Eval, update: Case.Update, opt_emitted_path: ?[]const u8, prog_node: std.Progress.Node) !void {
         switch (update.outcome) {
             .unknown => return,
             .compile_errors => fatal("expected compile errors but compilation incorrectly succeeded", .{}),
             .stdout, .exit_code => {},
         }
+        const emitted_path = opt_emitted_path orelse {
+            std.debug.assert(eval.emit == .none);
+            return;
+        };
+
+        const binary_path = switch (eval.emit) {
+            .none => unreachable,
+            .bin => emitted_path,
+            .c => bin: {
+                const rand_int = std.crypto.random.int(u64);
+                const out_bin_name = "./out_" ++ std.fmt.hex(rand_int);
+                try eval.buildCOutput(update, emitted_path, out_bin_name, prog_node);
+                break :bin out_bin_name;
+            },
+        };
+
         const result = std.process.Child.run(.{
             .allocator = eval.arena,
             .argv = &.{binary_path},
@@ -343,6 +388,50 @@ const Eval = struct {
         if (stderr.readableLength() > 0) {
             const stderr_data = try stderr.toOwnedSlice();
             fatal("unexpected stderr:\n{s}", .{stderr_data});
+        }
+    }
+
+    fn buildCOutput(eval: *Eval, update: Case.Update, c_path: []const u8, out_path: []const u8, prog_node: std.Progress.Node) !void {
+        std.debug.assert(eval.cc_child_args.items.len > 0);
+
+        const child_prog_node = prog_node.start("build cbe output", 0);
+        defer child_prog_node.end();
+
+        try eval.cc_child_args.appendSlice(eval.arena, &.{ out_path, c_path });
+        defer eval.cc_child_args.items.len -= 2;
+
+        const result = std.process.Child.run(.{
+            .allocator = eval.arena,
+            .argv = eval.cc_child_args.items,
+            .cwd_dir = eval.tmp_dir,
+            .cwd = eval.tmp_dir_path,
+            .progress_node = child_prog_node,
+        }) catch |err| {
+            fatal("update '{s}': failed to spawn zig cc for '{s}': {s}", .{
+                update.name, c_path, @errorName(err),
+            });
+        };
+        switch (result.term) {
+            .Exited => |code| if (code != 0) {
+                if (result.stderr.len != 0) {
+                    std.log.err("update '{s}': zig cc stderr:\n{s}", .{
+                        update.name, result.stderr,
+                    });
+                }
+                fatal("update '{s}': zig cc for '{s}' failed with code {d}", .{
+                    update.name, c_path, code,
+                });
+            },
+            .Signal, .Stopped, .Unknown => {
+                if (result.stderr.len != 0) {
+                    std.log.err("update '{s}': zig cc stderr:\n{s}", .{
+                        update.name, result.stderr,
+                    });
+                }
+                fatal("update '{s}': zig cc for '{s}' terminated unexpectedly", .{
+                    update.name, c_path,
+                });
+            },
         }
     }
 };


### PR DESCRIPTION
> Say you build quick? Baby I know,
> That's that incremental

-Sabrina Carpenter 2024

---

We're getting close now, folks!

This PR makes progress towards incremental compilation. Various bugs and regressions have been fixed. The `incr-check` tool is expanded with some more options, such as passing through `-fno-emit-bin` to the compiler. With this option, the existing incremental compilation test, and the 3 added by this commit, all succeed. I don't know whether the right things are going to codegen, but some hacky CBE testing indicates... maybe?

The biggest blocker right now is linker work from @kubkon -- it's currently hard for me to know for sure whether the full pipeline is actually working correctly. Once one of the self-hosted linkers (presumably ELF) can perform basic incremental updates, we can ramp up the testing.

Trying to run the `hello` test without `-fno-emit-bin` currently results in the following linker crash:
```
error: update 'change the string' failed:
thread 16224 panic: reached unreachable code
/home/mlugg/zig/the-great-decl-split-mk2/lib/std/debug.zig:399:14: 0x18c9b9d in assert (zig)
    if (!ok) unreachable; // assertion failure
             ^
/home/mlugg/zig/the-great-decl-split-mk2/lib/std/hash_map.zig:1089:19: 0x1ce013e in putAssumeCapacityNoClobberContext (zig)
            assert(!self.containsContext(key, ctx));
                  ^
/home/mlugg/zig/the-great-decl-split-mk2/lib/std/hash_map.zig:1065:51: 0x1aeeb02 in putNoClobberContext (zig)
            self.putAssumeCapacityNoClobberContext(key, value, ctx);
                                                  ^
/home/mlugg/zig/the-great-decl-split-mk2/lib/std/hash_map.zig:1057:44: 0x193b813 in putNoClobber (zig)
            return self.putNoClobberContext(allocator, key, value, undefined);
                                           ^
/home/mlugg/zig/the-great-decl-split-mk2/src/link/Elf.zig:4175:53: 0x210e222 in allocateAllocSections (zig)
            try self.phdr_to_shdr_table.putNoClobber(gpa, shndx, phndx);
                                                    ^
/home/mlugg/zig/the-great-decl-split-mk2/src/link/Elf.zig:1309:35: 0x1e1b785 in flushModule (zig)
    try self.allocateAllocSections();
                                  ^
/home/mlugg/zig/the-great-decl-split-mk2/src/link/Elf.zig:1008:25: 0x1ba8d8d in flush (zig)
    try self.flushModule(arena, tid, prog_node);
                        ^
/home/mlugg/zig/the-great-decl-split-mk2/src/link.zig:610:77: 0x19c4382 in flush (zig)
                return @as(*tag.Type(), @fieldParentPtr("base", base)).flush(arena, tid, prog_node);
                                                                            ^
/home/mlugg/zig/the-great-decl-split-mk2/src/Compilation.zig:2444:17: 0x19c3bea in flush (zig)
        lf.flush(arena, tid, prog_node) catch |err| switch (err) {
                ^
/home/mlugg/zig/the-great-decl-split-mk2/src/Compilation.zig:2411:22: 0x19c7d96 in update (zig)
            try flush(comp, arena, .main, main_progress_node);
                     ^
```