### PR TITLE
fix several debug info bugs

### DIFF
--- a/lib/std/Build/Fuzz/WebServer.zig
+++ b/lib/std/Build/Fuzz/WebServer.zig
@@ -634,10 +634,28 @@ fn prepareTables(
     const pcs = header.pcAddrs();
     const source_locations = try gpa.alloc(Coverage.SourceLocation, pcs.len);
     errdefer gpa.free(source_locations);
-    debug_info.resolveAddresses(gpa, pcs, source_locations) catch |err| {
+
+    // Unfortunately the PCs array that LLVM gives us from the 8-bit PC
+    // counters feature is not sorted.
+    var sorted_pcs: std.MultiArrayList(struct { pc: u64, index: u32, sl: Coverage.SourceLocation }) = .{};
+    defer sorted_pcs.deinit(gpa);
+    try sorted_pcs.resize(gpa, pcs.len);
+    @memcpy(sorted_pcs.items(.pc), pcs);
+    for (sorted_pcs.items(.index), 0..) |*v, i| v.* = @intCast(i);
+    sorted_pcs.sortUnstable(struct {
+        addrs: []const u64,
+
+        pub fn lessThan(ctx: @This(), a_index: usize, b_index: usize) bool {
+            return ctx.addrs[a_index] < ctx.addrs[b_index];
+        }
+    }{ .addrs = sorted_pcs.items(.pc) });
+
+    debug_info.resolveAddresses(gpa, sorted_pcs.items(.pc), sorted_pcs.items(.sl)) catch |err| {
         log.err("failed to resolve addresses to source locations: {s}", .{@errorName(err)});
         return error.AlreadyReported;
     };
+
+    for (sorted_pcs.items(.index), sorted_pcs.items(.sl)) |i, sl| source_locations[i] = sl;
     gop.value_ptr.source_locations = source_locations;
 
     ws.coverage_condition.broadcast();

--- a/lib/std/Build/Fuzz/WebServer.zig
+++ b/lib/std/Build/Fuzz/WebServer.zig
@@ -664,8 +664,8 @@ fn addEntryPoint(ws: *WebServer, coverage_id: u64, addr: u64) error{ AlreadyRepo
     if (false) {
         const sl = coverage_map.source_locations[index];
         const file_name = coverage_map.coverage.stringAt(coverage_map.coverage.fileAt(sl.file).basename);
-        log.debug("server found entry point {s}:{d}:{d}", .{
-            file_name, sl.line, sl.column,
+        log.debug("server found entry point for 0x{x} at {s}:{d}:{d}", .{
+            addr, file_name, sl.line, sl.column,
         });
     }
     const gpa = ws.gpa;

--- a/lib/std/debug/Info.zig
+++ b/lib/std/debug/Info.zig
@@ -27,7 +27,7 @@ pub const LoadError = Dwarf.ElfModule.LoadError;
 pub fn load(gpa: Allocator, path: Path, coverage: *Coverage) LoadError!Info {
     var sections: Dwarf.SectionArray = Dwarf.null_section_array;
     var elf_module = try Dwarf.ElfModule.loadPath(gpa, path, null, null, &sections, null);
-    try elf_module.dwarf.sortCompileUnits();
+    try elf_module.dwarf.populateRanges(gpa);
     var info: Info = .{
         .address_map = .{},
         .coverage = coverage,

--- a/lib/std/debug/Info.zig
+++ b/lib/std/debug/Info.zig
@@ -51,6 +51,7 @@ pub const ResolveAddressesError = Coverage.ResolveAddressesDwarfError;
 pub fn resolveAddresses(
     info: *Info,
     gpa: Allocator,
+    /// Asserts the addresses are in ascending order.
     sorted_pc_addrs: []const u64,
     /// Asserts its length equals length of `sorted_pc_addrs`.
     output: []SourceLocation,

--- a/lib/std/debug/SelfInfo.zig
+++ b/lib/std/debug/SelfInfo.zig
@@ -606,7 +606,6 @@ pub const Module = switch (native_os) {
                 .endian = .little,
                 .sections = sections,
                 .is_macho = true,
-                .compile_units_sorted = false,
             };
 
             try Dwarf.open(&di, allocator);
@@ -996,7 +995,6 @@ fn readCoffDebugInfo(allocator: Allocator, coff_obj: *coff.Coff) !Module {
                 .endian = native_endian,
                 .sections = sections,
                 .is_macho = false,
-                .compile_units_sorted = false,
             };
 
             try Dwarf.open(&dwarf, allocator);
@@ -1810,7 +1808,6 @@ fn unwindFrameMachODwarf(
     var di: Dwarf = .{
         .endian = native_endian,
         .is_macho = true,
-        .compile_units_sorted = false,
     };
     defer di.deinit(context.allocator);
 

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -311,7 +311,10 @@ ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machi
         }
     });
 
-    pass_builder.registerOptimizerEarlyEPCallback([&](ModulePassManager &module_pm, OptimizationLevel OL) {
+    //pass_builder.registerOptimizerEarlyEPCallback([&](ModulePassManager &module_pm, OptimizationLevel OL) {
+    //});
+
+    pass_builder.registerOptimizerLastEPCallback([&](ModulePassManager &module_pm, OptimizationLevel level) {
         // Code coverage instrumentation.
         if (options.sancov) {
             module_pm.addPass(SanitizerCoveragePass(getSanCovOptions(options.coverage)));
@@ -322,9 +325,7 @@ ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machi
             module_pm.addPass(ModuleThreadSanitizerPass());
             module_pm.addPass(createModuleToFunctionPassAdaptor(ThreadSanitizerPass()));
         }
-    });
 
-    pass_builder.registerOptimizerLastEPCallback([&](ModulePassManager &module_pm, OptimizationLevel level) {
         // Verify the output
         if (assertions_on) {
             module_pm.addPass(VerifierPass());

--- a/tools/dump-cov.zig
+++ b/tools/dump-cov.zig
@@ -54,21 +54,30 @@ pub fn main() !void {
     const header: *SeenPcsHeader = @ptrCast(cov_bytes);
     try stdout.print("{any}\n", .{header.*});
     const pcs = header.pcAddrs();
-    for (0.., pcs[0 .. pcs.len - 1], pcs[1..]) |i, a, b| {
-        if (a > b) std.log.err("{d}: 0x{x} > 0x{x}", .{ i, a, b });
-    }
-    assert(std.sort.isSorted(usize, pcs, {}, std.sort.asc(usize)));
+
+    var indexed_pcs: std.AutoArrayHashMapUnmanaged(usize, void) = .{};
+    try indexed_pcs.entries.resize(arena, pcs.len);
+    @memcpy(indexed_pcs.entries.items(.key), pcs);
+    try indexed_pcs.reIndex(arena);
+
+    const sorted_pcs = try arena.dupe(usize, pcs);
+    std.mem.sortUnstable(usize, sorted_pcs, {}, std.sort.asc(usize));
+
+    const source_locations = try arena.alloc(std.debug.Coverage.SourceLocation, sorted_pcs.len);
+    try debug_info.resolveAddresses(gpa, sorted_pcs, source_locations);
 
     const seen_pcs = header.seenBits();
 
-    const source_locations = try arena.alloc(std.debug.Coverage.SourceLocation, pcs.len);
-    try debug_info.resolveAddresses(gpa, pcs, source_locations);
-
-    for (pcs, source_locations, 0..) |pc, sl, i| {
+    for (sorted_pcs, source_locations) |pc, sl| {
+        if (sl.file == .invalid) {
+            try stdout.print(" {x}: invalid\n", .{pc});
+            continue;
+        }
         const file = debug_info.coverage.fileAt(sl.file);
         const dir_name = debug_info.coverage.directories.keys()[file.directory_index];
         const dir_name_slice = debug_info.coverage.stringAt(dir_name);
-        const hit: u1 = @truncate(seen_pcs[i / @bitSizeOf(usize)] >> @intCast(i % @bitSizeOf(usize)));
+        const seen_i = indexed_pcs.getIndex(pc).?;
+        const hit: u1 = @truncate(seen_pcs[seen_i / @bitSizeOf(usize)] >> @intCast(seen_i % @bitSizeOf(usize)));
         try stdout.print("{c}{x}: {s}/{s}:{d}:{d}\n", .{
             "-+"[hit], pc, dir_name_slice, debug_info.coverage.stringAt(file.basename), sl.line, sl.column,
         });


### PR DESCRIPTION
See individual commit messages.

Closes #20990

The motivating example looks a lot better in ReleaseSafe mode:

![image](https://github.com/user-attachments/assets/8e263aeb-551d-4fbd-a6d8-ccab79b4a7cb)

But it looks worse in debug mode for some reason:

![image](https://github.com/user-attachments/assets/f1ad32fe-c628-4624-ab84-74e3c1f0dc73)

However, I verified that our LLVM IR looks good, and our debug info logic matches GDB exactly. So, I think it's two steps forward, one step back. Remaining issues are tracked by:
* #20992
* #20989