### PR TITLE
loongarch: fix asm to set thread pointer

### DIFF
--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -269,7 +269,7 @@ pub fn setThreadPointer(addr: usize) void {
         },
         .loongarch32, .loongarch64 => {
             asm volatile (
-                \\ or $tp, $zero, %[addr]
+                \\ move $tp, %[addr]
                 :
                 : [addr] "r" (addr),
             );

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -269,7 +269,7 @@ pub fn setThreadPointer(addr: usize) void {
         },
         .loongarch32, .loongarch64 => {
             asm volatile (
-                \\ mv tp, %[addr]
+                \\ or $tp, $zero, %[addr]
                 :
                 : [addr] "r" (addr),
             );


### PR DESCRIPTION
Got this error when trying to build a simple zig program for loongarch target

```
$ ~/opt/zig/bin/zig build-exe hello.zig -target loongarch64-linux-gnu
error: <inline asm>:1:3: unrecognized instruction mnemonic, did you mean: move?
         mv tp, $a0
         ^
```

For loongarch there is no `mv` instruction mnemonic, change it to something else.