### PR TITLE
Add support for unpacking tars with hardlinks

### DIFF
--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -435,7 +435,7 @@ pub fn Iterator(comptime ReaderType: type) type {
                 self.padding = blockPadding(size);
 
                 switch (kind) {
-                    // File types to retrun upstream
+                    // File types to return upstream
                     .directory, .normal, .symbolic_link, .hard_link => {
                         file.kind = switch (kind) {
                             .directory => .directory,

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -15,6 +15,8 @@
 //! GNU tar reference: https://www.gnu.org/software/tar/manual/html_node/Standard.html
 //! pax reference: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#tag_20_92_13
 
+const builtin = @import("builtin");
+const native_os = builtin.os.tag;
 const std = @import("std");
 const assert = std.debug.assert;
 const testing = std.testing;
@@ -34,6 +36,11 @@ pub const Diagnostics = struct {
 
     pub const Error = union(enum) {
         unable_to_create_sym_link: struct {
+            code: anyerror,
+            file_name: []const u8,
+            link_name: []const u8,
+        },
+        unable_to_create_hard_link: struct {
             code: anyerror,
             file_name: []const u8,
             link_name: []const u8,
@@ -91,6 +98,10 @@ pub const Diagnostics = struct {
         for (d.errors.items) |item| {
             switch (item) {
                 .unable_to_create_sym_link => |info| {
+                    d.allocator.free(info.file_name);
+                    d.allocator.free(info.link_name);
+                },
+                .unable_to_create_hard_link => |info| {
                     d.allocator.free(info.file_name);
                     d.allocator.free(info.link_name);
                 },
@@ -313,6 +324,7 @@ pub const FileKind = enum {
     directory,
     sym_link,
     file,
+    hard_link,
 };
 
 /// Iterator over entries in the tar file represented by reader.
@@ -423,12 +435,13 @@ pub fn Iterator(comptime ReaderType: type) type {
                 self.padding = blockPadding(size);
 
                 switch (kind) {
-                    // File types to return upstream
-                    .directory, .normal, .symbolic_link => {
+                    // File types to retrun upstream
+                    .directory, .normal, .symbolic_link, .hard_link => {
                         file.kind = switch (kind) {
                             .directory => .directory,
                             .normal => .file,
                             .symbolic_link => .sym_link,
+                            .hard_link => .hard_link,
                             else => unreachable,
                         };
                         file.mode = try header.mode();
@@ -669,6 +682,17 @@ pub fn pipeToFileSystem(dir: std.fs.Dir, reader: anytype, options: PipeOptions) 
                     } });
                 };
             },
+            .hard_link => {
+                const link_name = file.link_name;
+                createDirAndHardlink(dir, link_name, file_name) catch |err| {
+                    const d = options.diagnostics orelse return error.UnableToCreateHardLink;
+                    try d.errors.append(d.allocator, .{ .unable_to_create_hard_link = .{
+                        .code = err,
+                        .file_name = try d.allocator.dupe(u8, file_name),
+                        .link_name = try d.allocator.dupe(u8, link_name),
+                    } });
+                };
+            },
         }
     }
 }
@@ -693,6 +717,22 @@ fn createDirAndSymlink(dir: std.fs.Dir, link_name: []const u8, file_name: []cons
             if (std.fs.path.dirname(file_name)) |dir_name| {
                 try dir.makePath(dir_name);
                 return try dir.symLink(link_name, file_name, .{});
+            }
+        }
+        return err;
+    };
+}
+
+// Creates a hard link at path `file_name` which points to `link_name`.
+fn createDirAndHardlink(dir: std.fs.Dir, link_name: []const u8, file_name: []const u8) !void {
+    if (native_os == .windows) {
+        return error.UnableToCreateHardLink;
+    }
+    std.posix.linkat(dir.fd, link_name, dir.fd, file_name, 0) catch |err| {
+        if (err == error.FileNotFound) {
+            if (std.fs.path.dirname(file_name)) |dir_name| {
+                try dir.makePath(dir_name);
+                return try std.posix.linkat(dir.fd, link_name, dir.fd, file_name, 0);
             }
         }
         return err;
@@ -987,6 +1027,9 @@ test iterator {
             .sym_link => {
                 try testing.expectEqualStrings("example/b/symlink", file.name);
                 try testing.expectEqualStrings("../a/file", file.link_name);
+            },
+            .hard_link => {
+                unreachable;
             },
         }
     }

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1188,6 +1188,7 @@ fn unpackTarball(f: *Fetch, out_dir: fs.Dir, reader: anytype) RunError!UnpackRes
             switch (item) {
                 .unable_to_create_file => |i| res.unableToCreateFile(stripRoot(i.file_name, res.root_dir), i.code),
                 .unable_to_create_sym_link => |i| res.unableToCreateSymLink(stripRoot(i.file_name, res.root_dir), i.link_name, i.code),
+                .unable_to_create_hard_link => |i| res.unableToCreateHardLink(stripRoot(i.file_name, res.root_dir), i.link_name, i.code),
                 .unsupported_file_type => |i| res.unsupportedFileType(stripRoot(i.file_name, res.root_dir), @intFromEnum(i.file_type)),
                 .components_outside_stripped_prefix => unreachable, // unreachable with strip_components = 0
             }
@@ -1836,6 +1837,11 @@ const UnpackResult = struct {
             file_name: []const u8,
             link_name: []const u8,
         },
+        unable_to_create_hard_link: struct {
+            code: anyerror,
+            file_name: []const u8,
+            link_name: []const u8,
+        },
         unable_to_create_file: struct {
             code: anyerror,
             file_name: []const u8,
@@ -1849,6 +1855,7 @@ const UnpackResult = struct {
             const file_name = switch (self) {
                 .unable_to_create_file => |info| info.file_name,
                 .unable_to_create_sym_link => |info| info.file_name,
+                .unable_to_create_hard_link => |info| info.file_name,
                 .unsupported_file_type => |info| info.file_name,
             };
             return !filter.includePath(file_name);
@@ -1874,6 +1881,15 @@ const UnpackResult = struct {
 
     fn unableToCreateSymLink(self: *UnpackResult, file_name: []const u8, link_name: []const u8, err: anyerror) void {
         self.errors[self.errors_count] = .{ .unable_to_create_sym_link = .{
+            .code = err,
+            .file_name = file_name,
+            .link_name = link_name,
+        } };
+        self.errors_count += 1;
+    }
+
+    fn unableToCreateHardLink(self: *UnpackResult, file_name: []const u8, link_name: []const u8, err: anyerror) void {
+        self.errors[self.errors_count] = .{ .unable_to_create_hard_link = .{
             .code = err,
             .file_name = file_name,
             .link_name = link_name,
@@ -1913,6 +1929,13 @@ const UnpackResult = struct {
                 .unable_to_create_sym_link => |info| {
                     eb.extra.items[note_i] = @intFromEnum(try eb.addErrorMessage(.{
                         .msg = try eb.printString("unable to create symlink from '{s}' to '{s}': {s}", .{
+                            info.file_name, info.link_name, @errorName(info.code),
+                        }),
+                    }));
+                },
+                .unable_to_create_hard_link => |info| {
+                    eb.extra.items[note_i] = @intFromEnum(try eb.addErrorMessage(.{
+                        .msg = try eb.printString("unable to create hardlink from '{s}' to '{s}': {s}", .{
                             info.file_name, info.link_name, @errorName(info.code),
                         }),
                     }));


### PR DESCRIPTION
Not sure how cross platform support for non-posix platforms should be implemented. This depends on std.posix.link

Use case: https://github.com/NilsIrl/dockerc/actions/runs/10414275001/job/28842950131