### PR TITLE
std: Fix `test-std` for x86_64 Zen 3.

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -233,7 +233,7 @@ fn _start() callconv(.Naked) noreturn {
     }
 
     // Move this to the riscv prong below when this is resolved: https://github.com/ziglang/zig/issues/20918
-    if (builtin.cpu.arch.isRISCV() and builtin.zig_backend != .stage2_riscv64) asm volatile (
+    if (comptime builtin.cpu.arch.isRISCV() and builtin.zig_backend != .stage2_riscv64) asm volatile (
         \\ .weak __global_pointer$
         \\ .hidden __global_pointer$
         \\ .option push


### PR DESCRIPTION
The specific reason why these tests started failing is not entirely understood, but a `git bisect` shows commit ziglang/zig@b917d778c6 introduced the regression. The tests failed with the following output:

```
test-std
└─ run test std-x86_64-linux.6.6.45...6.6.45-musl-znver3-Debug-single failure
error: the following command terminated with signal 11 (expected exited with code 0):
/.../.zig-cache/o/9ac060d740082c5b24fc08a330b62a76/test --seed=0xa94a8403 --cache-dir=/home/gcoakes/src/zig/.zig-cache --listen=-
test-std
└─ run test std-x86_64-linux.6.6.45...6.6.45-musl-znver3-Debug failure
error: the following command terminated with signal 11 (expected exited with code 0):
/.../.zig-cache/o/d49b45cb46614e2b4c5c1c7ecce408fc/test --seed=0xa94a8403 --cache-dir=/home/gcoakes/src/zig/.zig-cache --listen=-
```

Presumably, this is only seen in AMD Zen 3 systems judging by the `znver3` of the test names.

From a wild guess after looking at the regressing patch, it was discovered the issue is fixed by merely forcing the conditional which guards the RISC-V assembly at the beginning of `_start` to be comptime.