### PR TITLE
`glibc`: Define `_IO_stdin_used` in start code and reference it in stub asm.

### DIFF
--- a/lib/libc/glibc/csu/init.c
+++ b/lib/libc/glibc/csu/init.c
@@ -1,0 +1,23 @@
+/* Special startup support.
+   Copyright (C) 1997-2024 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+/* Vestigial libio version number.  Some code in libio checks whether
+   this symbol exists in the executable, but nothing looks at its
+   value anymore; the value it was historically set to has been
+   preserved out of an abundance of caution.  */
+const int _IO_stdin_used = 0x20001;


### PR DESCRIPTION
This is necessary to inform the real, non-stub glibc that a program built with Zig is using a modern `FILE` structure, i.e. glibc 2.1+. This is particularly important on lesser-used architectures where the legacy code is poorly tested; for example, glibc 2.40 introduced a regression for the legacy case in the libio cleanup code, causing all Zig-compiled MIPS binaries to crash on exit.