### PR TITLE
std.Target.Query: Fix `parse` test on ABIs like `gnueabi`, `gnuabi64`, etc.

### DIFF
--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -588,14 +588,7 @@ test parse {
         const text = try query.zigTriple(std.testing.allocator);
         defer std.testing.allocator.free(text);
 
-        var buf: [256]u8 = undefined;
-        const triple = std.fmt.bufPrint(
-            buf[0..],
-            "native-native-{s}.2.1.1",
-            .{@tagName(builtin.target.abi)},
-        ) catch unreachable;
-
-        try std.testing.expectEqualSlices(u8, triple, text);
+        try std.testing.expectEqualSlices(u8, "native-native-gnu.2.1.1", text);
     }
     {
         const query = try Query.parse(.{


### PR DESCRIPTION
The `zigTriple()` implementation simply returns `gnu` when a glibc version is provided but a more specific ABI isn't.

https://github.com/ziglang/zig/blob/bb70501060a8bfff25818cf1d80491d724f8a634/lib/std/Target/Query.zig#L433-L445

I do realize I sound like a broken record at this point, but this is another problem we have because [we conflate libc and ABI](https://github.com/ziglang/zig/issues/20690).

Note: I think this test has been broken for a long time, but it was not failing in CI because you need to be testing for a target like `arm-linux-gnueabi`, `mips64-linux-gnuabi64`, etc, and AFAIK the CI machines do not have non-native glibcs installed (which is a bit of a shame IMO, but I digress).