### PR TITLE
cmake: CLANG_LIBRARIES: find libclang-cpp.so.18.1

### DIFF
--- a/cmake/Findclang.cmake
+++ b/cmake/Findclang.cmake
@@ -18,6 +18,7 @@ if(${LLVM_LINK_MODE} STREQUAL "shared")
   find_library(CLANG_LIBRARIES
     NAMES
       libclang-cpp.so.18
+      libclang-cpp.so.18.1
       clang-cpp-18.0
       clang-cpp180
       clang-cpp


### PR DESCRIPTION
This fixes the failure to find CLANG_LIBRARIES on debian, which packages the relevant .so file at these paths:

libclang-cpp18: /usr/lib/llvm-18/lib/libclang-cpp.so.18.1
libclang-cpp18: /usr/lib/x86_64-linux-gnu/libclang-cpp.so.18.1
libclang-cpp18: /usr/lib/x86_64-linux-gnu/libclang-cpp.so.18

(The latter two paths are symlinks to the first.)

Without the patch, cmake fails with this error:

    -- Could NOT find clang (missing: CLANG_LIBRARIES) (Required is at least version "18")