### PR TITLE
`glibc`: Add missing xstatver.h for some linux architectures.

### DIFF
--- a/lib/libc/glibc/sysdeps/unix/sysv/linux/alpha/xstatver.h
+++ b/lib/libc/glibc/sysdeps/unix/sysv/linux/alpha/xstatver.h
@@ -1,0 +1,14 @@
+/* Versions of the 'struct stat' data structure used in compatibility xstat
+   functions.  */
+#define _STAT_VER_KERNEL	0
+#define _STAT_VER_GLIBC2	1
+#define _STAT_VER_GLIBC2_1	2
+#define _STAT_VER_KERNEL64	3
+#define _STAT_VER_GLIBC2_3_4	3
+#define _STAT_VER_LINUX		3
+#define _STAT_VER		_STAT_VER_LINUX
+
+/* Versions of the 'xmknod' interface used in compatibility xmknod
+   functions.  */
+#define _MKNOD_VER_LINUX	0
+#define _MKNOD_VER		_MKNOD_VER_LINUX

--- a/lib/libc/glibc/sysdeps/unix/sysv/linux/arm/xstatver.h
+++ b/lib/libc/glibc/sysdeps/unix/sysv/linux/arm/xstatver.h
@@ -1,0 +1,13 @@
+/* Versions of the 'struct stat' data structure used in compatibility xstat
+   functions.  */
+#define _STAT_VER_LINUX_OLD	1
+#define _STAT_VER_KERNEL	1
+#define _STAT_VER_SVR4		2
+#define _STAT_VER_LINUX		3
+#define _STAT_VER		_STAT_VER_LINUX
+
+/* Versions of the 'xmknod' interface used in compatibility xmknod
+   functions.  */
+#define _MKNOD_VER_LINUX	1
+#define _MKNOD_VER_SVR4		2
+#define _MKNOD_VER		_MKNOD_VER_LINUX

--- a/lib/libc/glibc/sysdeps/unix/sysv/linux/hppa/xstatver.h
+++ b/lib/libc/glibc/sysdeps/unix/sysv/linux/hppa/xstatver.h
@@ -1,0 +1,13 @@
+/* Versions of the 'struct stat' data structure used in compatibility xstat
+   functions.  */
+#define _STAT_VER_LINUX_OLD	1
+#define _STAT_VER_KERNEL	1
+#define _STAT_VER_SVR4		2
+#define _STAT_VER_LINUX		3
+#define _STAT_VER		_STAT_VER_LINUX
+
+/* Versions of the 'xmknod' interface used in compatibility xmknod
+   functions.  */
+#define _MKNOD_VER_LINUX	1
+#define _MKNOD_VER_SVR4		2
+#define _MKNOD_VER		_MKNOD_VER_LINUX

--- a/lib/libc/glibc/sysdeps/unix/sysv/linux/microblaze/xstatver.h
+++ b/lib/libc/glibc/sysdeps/unix/sysv/linux/microblaze/xstatver.h
@@ -1,0 +1,13 @@
+/* Versions of the 'struct stat' data structure used in compatibility xstat
+   functions.  */
+#define _STAT_VER_LINUX_OLD    1
+#define _STAT_VER_KERNEL       1
+#define _STAT_VER_SVR4         2
+#define _STAT_VER_LINUX        3
+#define _STAT_VER              _STAT_VER_LINUX  /* The one defined below.  */
+
+/* Versions of the 'xmknod' interface used in compatibility xmknod
+   functions.  */
+#define _MKNOD_VER_LINUX       1
+#define _MKNOD_VER_SVR4        2
+#define _MKNOD_VER             _MKNOD_VER_LINUX

--- a/lib/libc/glibc/sysdeps/unix/sysv/linux/sh/xstatver.h
+++ b/lib/libc/glibc/sysdeps/unix/sysv/linux/sh/xstatver.h
@@ -1,0 +1,13 @@
+/* Versions of the 'struct stat' data structure used in compatibility xstat
+   functions.  */
+#define _STAT_VER_LINUX_OLD	1
+#define _STAT_VER_KERNEL	1
+#define _STAT_VER_SVR4		2
+#define _STAT_VER_LINUX		3
+#define _STAT_VER		_STAT_VER_LINUX
+
+/* Versions of the 'xmknod' interface used in compatibility xmknod
+   functions.  */
+#define _MKNOD_VER_LINUX	1
+#define _MKNOD_VER_SVR4		2
+#define _MKNOD_VER		_MKNOD_VER_LINUX


### PR DESCRIPTION
Specifically for alpha, arm, hppa, microblaze, and sh.

Closes #20054.