### PR TITLE
`glibc`: Pass `-Qunused-arguments` when building `libc_nonshared.a`.

### DIFF
--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -369,6 +369,7 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progre
                     "-fmath-errno",
                     "-ftls-model=initial-exec",
                     "-Wno-ignored-attributes",
+                    "-Qunused-arguments",
                 });
                 try add_include_dirs(comp, arena, &args);
 


### PR DESCRIPTION
For some platforms, the math-related flags are ignored and produce warnings. There's nothing we can do about that, so just silence them.

This started showing up after #20909. For example, for `mips64-linux-gnuabi64.2.32`:

```
warning: overriding currently unsupported rounding mode on this target [-Wunsupported-floating-point-opt]
```

The warning is confusingly worded; it's just informing us that [it's disabling rounding math despite us passing `-frounding-math`](https://github.com/llvm/llvm-project/blob/69f76c782b554a004078af6909c19a11e3846415/clang/lib/Frontend/CompilerInstance.cpp#L130-L134). So it's the same as if we hadn't passed `-frounding-math` in the first place.