### PR TITLE
doc: clarify build.zig.zon urls should point to immutable data

### DIFF
--- a/doc/build.zig.zon.md
+++ b/doc/build.zig.zon.md
@@ -47,7 +47,8 @@ String.
 
 When updating this field to a new URL, be sure to delete the corresponding
 `hash`, otherwise you are communicating that you expect to find the old hash at
-the new URL.
+the new URL. If the contents of a URL change this will result in a hash mismatch
+which will prevent zig from using it.
 
 #### `hash`
 

--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -27,7 +27,8 @@
         //.example = .{
         //    // When updating this field to a new URL, be sure to delete the corresponding
         //    // `hash`, otherwise you are communicating that you expect to find the old hash at
-        //    // the new URL.
+        //    // the new URL. If the contents of a URL change this will result in a hash mismatch
+        //    // which will prevent zig from using it.
         //    .url = "https://example.com/foo.tar.gz",
         //
         //    // This is computed from the file contents of the directory of files that is


### PR DESCRIPTION
There's been some proliferation of dependency URLs that reference mutable data such as links to git branches that can change.  This has resulted in broken projects, i.e.

* https://github.com/RohanVashisht1234/raylib_rain_train/blob/9eef9de94c511f2eb4fe5db1d6abd574ee245c9b/build.zig.zon
* https://github.com/rcmagic/ZigFightingGame/commit/4b64353e9c69de0fa2eb87fa9c3a3da76a8a3e7b

There's also disagreement about whether it's fine for URL's to point to git branches, i.e.

https://github.com/Not-Nik/raylib-zig/pull/130

This updates the docs to clarify that urls should reference immutable data.