### PR TITLE
Revert "ci: Enable -Dtest-slow-targets."

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -62,8 +62,7 @@ stage3-debug/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy \
-  -Dtest-slow-targets
+  -Denable-tidy
 
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-debug/bin/zig build update-zig1

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -62,8 +62,7 @@ stage3-release/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy \
-  -Dtest-slow-targets
+  -Denable-tidy
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \

--- a/ci/aarch64-macos-debug.sh
+++ b/ci/aarch64-macos-debug.sh
@@ -55,5 +55,4 @@ stage3-debug/bin/zig build test docs \
   -Denable-macos-sdk \
   -Dstatic-llvm \
   -Dskip-non-native \
-  --search-prefix "$PREFIX" \
-  -Dtest-slow-targets
+  --search-prefix "$PREFIX"

--- a/ci/aarch64-macos-release.sh
+++ b/ci/aarch64-macos-release.sh
@@ -55,8 +55,7 @@ stage3-release/bin/zig build test docs \
   -Denable-macos-sdk \
   -Dstatic-llvm \
   -Dskip-non-native \
-  --search-prefix "$PREFIX" \
-  -Dtest-slow-targets
+  --search-prefix "$PREFIX"
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \

--- a/ci/aarch64-windows.ps1
+++ b/ci/aarch64-windows.ps1
@@ -67,8 +67,7 @@ Write-Output "Main test suite..."
   --search-prefix "$PREFIX_PATH" `
   -Dstatic-llvm `
   -Dskip-non-native `
-  -Denable-symlinks-windows `
-  -Dtest-slow-targets
+  -Denable-symlinks-windows
 CheckLastExitCode
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -71,8 +71,7 @@ stage3-debug/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy \
-  -Dtest-slow-targets
+  -Denable-tidy
 
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-debug/bin/zig build update-zig1

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -71,8 +71,7 @@ stage3-release/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy \
-  -Dtest-slow-targets
+  -Denable-tidy
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \

--- a/ci/x86_64-macos-release.sh
+++ b/ci/x86_64-macos-release.sh
@@ -59,8 +59,7 @@ stage3/bin/zig build test docs \
   -Denable-macos-sdk \
   -Dstatic-llvm \
   -Dskip-non-native \
-  --search-prefix "$PREFIX" \
-  -Dtest-slow-targets
+  --search-prefix "$PREFIX"
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3/bin/zig build \

--- a/ci/x86_64-windows-debug.ps1
+++ b/ci/x86_64-windows-debug.ps1
@@ -68,8 +68,7 @@ Write-Output "Main test suite..."
   -Dstatic-llvm `
   -Dskip-non-native `
   -Dskip-release `
-  -Denable-symlinks-windows `
-  -Dtest-slow-targets
+  -Denable-symlinks-windows
 CheckLastExitCode
 
 Write-Output "Build x86_64-windows-msvc behavior tests using the C backend..."

--- a/ci/x86_64-windows-release.ps1
+++ b/ci/x86_64-windows-release.ps1
@@ -67,8 +67,7 @@ Write-Output "Main test suite..."
   --search-prefix "$PREFIX_PATH" `
   -Dstatic-llvm `
   -Dskip-non-native `
-  -Denable-symlinks-windows `
-  -Dtest-slow-targets
+  -Denable-symlinks-windows
 CheckLastExitCode
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.


### PR DESCRIPTION
This reverts commit 55cc9dda66a24ed2a86a358533ecf5840d47b3d7.

Checking if this resolves the `x86_64-linux-*` timeouts.