### PR TITLE
incremental: more progress

### DIFF
--- a/lib/compiler/aro/aro/Builtins/Builtin.zig
+++ b/lib/compiler/aro/aro/Builtins/Builtin.zig
@@ -5165,7 +5165,7 @@ const dafsa = [_]Node{
     .{ .char = 'e', .end_of_word = false, .end_of_list = true, .number = 1, .child_index = 4913 },
 };
 pub const data = blk: {
-    @setEvalBranchQuota(3986);
+    @setEvalBranchQuota(30_000);
     break :blk [_]@This(){
         // _Block_object_assign
         .{ .tag = @enumFromInt(0), .properties = .{ .param_str = "vv*vC*iC", .header = .blocks, .attributes = .{ .lib_function_without_prefix = true } } },

--- a/lib/compiler/aro/aro/Parser.zig
+++ b/lib/compiler/aro/aro/Parser.zig
@@ -4802,6 +4802,7 @@ const CallExpr = union(enum) {
     }
 
     fn shouldPromoteVarArg(self: CallExpr, arg_idx: u32) bool {
+        @setEvalBranchQuota(2000);
         return switch (self) {
             .standard => true,
             .builtin => |builtin| switch (builtin.tag) {
@@ -4902,6 +4903,7 @@ const CallExpr = union(enum) {
     }
 
     fn returnType(self: CallExpr, p: *Parser, callable_ty: Type) Type {
+        @setEvalBranchQuota(6000);
         return switch (self) {
             .standard => callable_ty.returnType(),
             .builtin => |builtin| switch (builtin.tag) {

--- a/lib/std/crypto/aes/soft.zig
+++ b/lib/std/crypto/aes/soft.zig
@@ -629,6 +629,8 @@ fn generateSbox(invert: bool) [256]u8 {
 
 // Generate lookup tables.
 fn generateTable(invert: bool) [4][256]u32 {
+    @setEvalBranchQuota(50000);
+
     var table: [4][256]u32 = undefined;
 
     for (generateSbox(invert), 0..) |value, index| {

--- a/lib/std/crypto/blake2.zig
+++ b/lib/std/crypto/blake2.zig
@@ -786,7 +786,7 @@ test "blake2b384 streaming" {
 
 test "comptime blake2b384" {
     comptime {
-        @setEvalBranchQuota(10000);
+        @setEvalBranchQuota(20000);
         var block = [_]u8{0} ** Blake2b384.block_length;
         var out: [Blake2b384.digest_length]u8 = undefined;
 
@@ -878,7 +878,7 @@ test "blake2b512 keyed" {
 
 test "comptime blake2b512" {
     comptime {
-        @setEvalBranchQuota(10000);
+        @setEvalBranchQuota(12000);
         var block = [_]u8{0} ** Blake2b512.block_length;
         var out: [Blake2b512.digest_length]u8 = undefined;
 

--- a/lib/std/crypto/pcurves/p384.zig
+++ b/lib/std/crypto/pcurves/p384.zig
@@ -393,7 +393,7 @@ pub const P384 = struct {
     }
 
     const basePointPc = pc: {
-        @setEvalBranchQuota(50000);
+        @setEvalBranchQuota(70000);
         break :pc precompute(P384.basePoint, 15);
     };
 

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -6,7 +6,7 @@ const testing = std.testing;
 const EnumField = std.builtin.Type.EnumField;
 
 /// Increment this value when adding APIs that add single backwards branches.
-const eval_branch_quota_cushion = 5;
+const eval_branch_quota_cushion = 10;
 
 /// Returns a struct with a field matching each unique named enum element.
 /// If the enum is extern and has multiple names for the same value, only

--- a/lib/std/hash/xxhash.zig
+++ b/lib/std/hash/xxhash.zig
@@ -890,7 +890,7 @@ test "xxhash32 smhasher" {
         }
     };
     try Test.do();
-    @setEvalBranchQuota(75000);
+    @setEvalBranchQuota(85000);
     comptime try Test.do();
 }
 

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -749,31 +749,23 @@ test rotl {
     try testing.expect(rotl(@Vector(1, u32), @Vector(1, u32){1 << 31}, @as(isize, -1))[0] == @as(u32, 1) << 30);
 }
 
-/// Returns an unsigned int type that can hold the number of bits in T
-/// - 1. Suitable for 0-based bit indices of T.
+/// Returns an unsigned int type that can hold the number of bits in T - 1.
+/// Suitable for 0-based bit indices of T.
 pub fn Log2Int(comptime T: type) type {
     // comptime ceil log2
     if (T == comptime_int) return comptime_int;
-    comptime var count = 0;
-    comptime var s = @typeInfo(T).Int.bits - 1;
-    inline while (s != 0) : (s >>= 1) {
-        count += 1;
-    }
-
-    return std.meta.Int(.unsigned, count);
+    const bits: u16 = @typeInfo(T).Int.bits;
+    const log2_bits = 16 - @clz(bits - 1);
+    return std.meta.Int(.unsigned, log2_bits);
 }
 
 /// Returns an unsigned int type that can hold the number of bits in T.
 pub fn Log2IntCeil(comptime T: type) type {
     // comptime ceil log2
     if (T == comptime_int) return comptime_int;
-    comptime var count = 0;
-    comptime var s = @typeInfo(T).Int.bits;
-    inline while (s != 0) : (s >>= 1) {
-        count += 1;
-    }
-
-    return std.meta.Int(.unsigned, count);
+    const bits: u16 = @typeInfo(T).Int.bits;
+    const log2_bits = 16 - @clz(bits);
+    return std.meta.Int(.unsigned, log2_bits);
 }
 
 /// Returns the smallest integer type that can hold both from and to.

--- a/lib/std/math/hypot.zig
+++ b/lib/std/math/hypot.zig
@@ -114,6 +114,7 @@ test "hypot.precise" {
 }
 
 test "hypot.special" {
+    @setEvalBranchQuota(2000);
     inline for (.{ f16, f32, f64, f128 }) |T| {
         try expect(math.isNan(hypot(nan(T), 0.0)));
         try expect(math.isNan(hypot(0.0, nan(T))));

--- a/lib/std/math/nextafter.zig
+++ b/lib/std/math/nextafter.zig
@@ -144,7 +144,7 @@ test "int" {
 }
 
 test "float" {
-    @setEvalBranchQuota(3000);
+    @setEvalBranchQuota(4000);
 
     // normal -> normal
     try expect(nextAfter(f16, 0x1.234p0, 2.0) == 0x1.238p0);

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -535,6 +535,7 @@ fn testUtf16CountCodepoints() !void {
 }
 
 test "utf16 count codepoints" {
+    @setEvalBranchQuota(2000);
     try testUtf16CountCodepoints();
     try comptime testUtf16CountCodepoints();
 }

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2391,6 +2391,7 @@ pub const Key = union(enum) {
         func: Index,
         arg_values: []const Index,
         result: Index,
+        branch_count: u32,
     };
 
     pub fn hash32(key: Key, ip: *const InternPool) u32 {
@@ -6157,6 +6158,7 @@ pub const MemoizedCall = struct {
     func: Index,
     args_len: u32,
     result: Index,
+    branch_count: u32,
 };
 
 pub fn init(ip: *InternPool, gpa: Allocator, available_threads: usize) !void {
@@ -6785,6 +6787,7 @@ pub fn indexToKey(ip: *const InternPool, index: Index) Key {
                 .func = extra.data.func,
                 .arg_values = @ptrCast(extra_list.view().items(.@"0")[extra.end..][0..extra.data.args_len]),
                 .result = extra.data.result,
+                .branch_count = extra.data.branch_count,
             } };
         },
     };
@@ -7955,6 +7958,7 @@ pub fn get(ip: *InternPool, gpa: Allocator, tid: Zcu.PerThread.Id, key: Key) All
                     .func = memoized_call.func,
                     .args_len = @intCast(memoized_call.arg_values.len),
                     .result = memoized_call.result,
+                    .branch_count = memoized_call.branch_count,
                 }),
             });
             extra.appendSliceAssumeCapacity(.{@ptrCast(memoized_call.arg_values)});

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7598,6 +7598,9 @@ fn analyzeCall(
 
         const module_fn = zcu.funcInfo(module_fn_index);
 
+        // The call site definitely depends on the function's signature.
+        try sema.declareDependency(.{ .src_hash = module_fn.zir_body_inst });
+
         // This is not a function instance, so the function's `Nav` has a
         // `Cau` -- we don't need to check `generic_owner`.
         const fn_nav = ip.getNav(module_fn.owner_nav);
@@ -7754,6 +7757,10 @@ fn analyzeCall(
             sema.branch_count += memoized_call.branch_count;
             break :res Air.internedToRef(memoized_call.result);
         }
+
+        // Since we're doing an inline call, we depend on the source code of the whole
+        // function declaration.
+        try sema.declareDependency(.{ .src_hash = fn_cau.zir_index });
 
         new_fn_info.return_type = sema.fn_ret_ty.toIntern();
         if (!is_comptime_call and !block.is_typeof) {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7734,123 +7734,117 @@ fn analyzeCall(
             } }));
         }
 
-        // This `res2` is here instead of directly breaking from `res` due to a stage1
-        // bug generating invalid LLVM IR.
-        const res2: Air.Inst.Ref = res2: {
-            memoize: {
-                if (!should_memoize) break :memoize;
-                if (!is_comptime_call) break :memoize;
-                const memoized_call_index = ip.getIfExists(.{
-                    .memoized_call = .{
-                        .func = module_fn_index,
-                        .arg_values = memoized_arg_values,
-                        .result = undefined, // ignored by hash+eql
-                        .branch_count = undefined, // ignored by hash+eql
-                    },
-                }) orelse break :memoize;
-                const memoized_call = ip.indexToKey(memoized_call_index).memoized_call;
-                if (sema.branch_count + memoized_call.branch_count > sema.branch_quota) {
-                    // Let the call play out se we get the correct source location for the
-                    // "evaluation exceeded X backwards branches" error.
-                    break :memoize;
-                }
-                sema.branch_count += memoized_call.branch_count;
-                break :res2 Air.internedToRef(memoized_call.result);
+        memoize: {
+            if (!should_memoize) break :memoize;
+            if (!is_comptime_call) break :memoize;
+            const memoized_call_index = ip.getIfExists(.{
+                .memoized_call = .{
+                    .func = module_fn_index,
+                    .arg_values = memoized_arg_values,
+                    .result = undefined, // ignored by hash+eql
+                    .branch_count = undefined, // ignored by hash+eql
+                },
+            }) orelse break :memoize;
+            const memoized_call = ip.indexToKey(memoized_call_index).memoized_call;
+            if (sema.branch_count + memoized_call.branch_count > sema.branch_quota) {
+                // Let the call play out se we get the correct source location for the
+                // "evaluation exceeded X backwards branches" error.
+                break :memoize;
             }
+            sema.branch_count += memoized_call.branch_count;
+            break :res Air.internedToRef(memoized_call.result);
+        }
 
-            new_fn_info.return_type = sema.fn_ret_ty.toIntern();
-            if (!is_comptime_call and !block.is_typeof) {
-                const zir_tags = sema.code.instructions.items(.tag);
-                for (fn_info.param_body) |param| switch (zir_tags[@intFromEnum(param)]) {
-                    .param, .param_comptime => {
-                        const inst_data = sema.code.instructions.items(.data)[@intFromEnum(param)].pl_tok;
-                        const extra = sema.code.extraData(Zir.Inst.Param, inst_data.payload_index);
-                        const param_name = sema.code.nullTerminatedString(extra.data.name);
-                        const inst = sema.inst_map.get(param).?;
+        new_fn_info.return_type = sema.fn_ret_ty.toIntern();
+        if (!is_comptime_call and !block.is_typeof) {
+            const zir_tags = sema.code.instructions.items(.tag);
+            for (fn_info.param_body) |param| switch (zir_tags[@intFromEnum(param)]) {
+                .param, .param_comptime => {
+                    const inst_data = sema.code.instructions.items(.data)[@intFromEnum(param)].pl_tok;
+                    const extra = sema.code.extraData(Zir.Inst.Param, inst_data.payload_index);
+                    const param_name = sema.code.nullTerminatedString(extra.data.name);
+                    const inst = sema.inst_map.get(param).?;
 
-                        try sema.addDbgVar(&child_block, inst, .dbg_arg_inline, param_name);
-                    },
-                    .param_anytype, .param_anytype_comptime => {
-                        const inst_data = sema.code.instructions.items(.data)[@intFromEnum(param)].str_tok;
-                        const param_name = inst_data.get(sema.code);
-                        const inst = sema.inst_map.get(param).?;
+                    try sema.addDbgVar(&child_block, inst, .dbg_arg_inline, param_name);
+                },
+                .param_anytype, .param_anytype_comptime => {
+                    const inst_data = sema.code.instructions.items(.data)[@intFromEnum(param)].str_tok;
+                    const param_name = inst_data.get(sema.code);
+                    const inst = sema.inst_map.get(param).?;
 
-                        try sema.addDbgVar(&child_block, inst, .dbg_arg_inline, param_name);
-                    },
-                    else => continue,
-                };
-            }
-
-            if (is_comptime_call and ensure_result_used) {
-                try sema.ensureResultUsed(block, sema.fn_ret_ty, call_src);
-            }
-
-            if (is_comptime_call or block.is_typeof) {
-                // Save the error trace as our first action in the function
-                // to match the behavior of runtime function calls.
-                const error_return_trace_index = try sema.analyzeSaveErrRetIndex(&child_block);
-                sema.error_return_trace_index_on_fn_entry = error_return_trace_index;
-                child_block.error_return_trace_index = error_return_trace_index;
-            }
-
-            // We temporarily set `allow_memoize` to `true` to track this comptime call.
-            // It is restored after this call finishes analysis, so that a caller may
-            // know whether an in-progress call (containing this call) may be memoized.
-            const old_allow_memoize = sema.allow_memoize;
-            defer sema.allow_memoize = old_allow_memoize and sema.allow_memoize;
-            sema.allow_memoize = true;
-
-            // Store the current eval branch count so we can find out how many eval branches
-            // the comptime call caused.
-            const old_branch_count = sema.branch_count;
-
-            const result = result: {
-                sema.analyzeFnBody(&child_block, fn_info.body) catch |err| switch (err) {
-                    error.ComptimeReturn => break :result inlining.comptime_result,
-                    else => |e| return e,
-                };
-                break :result try sema.resolveAnalyzedBlock(block, call_src, &child_block, merges, need_debug_scope);
+                    try sema.addDbgVar(&child_block, inst, .dbg_arg_inline, param_name);
+                },
+                else => continue,
             };
+        }
 
-            if (is_comptime_call) {
-                const result_val = try sema.resolveConstValue(block, LazySrcLoc.unneeded, result, undefined);
-                const result_interned = result_val.toIntern();
+        if (is_comptime_call and ensure_result_used) {
+            try sema.ensureResultUsed(block, sema.fn_ret_ty, call_src);
+        }
 
-                // Transform ad-hoc inferred error set types into concrete error sets.
-                const result_transformed = try sema.resolveAdHocInferredErrorSet(block, call_src, result_interned);
+        if (is_comptime_call or block.is_typeof) {
+            // Save the error trace as our first action in the function
+            // to match the behavior of runtime function calls.
+            const error_return_trace_index = try sema.analyzeSaveErrRetIndex(&child_block);
+            sema.error_return_trace_index_on_fn_entry = error_return_trace_index;
+            child_block.error_return_trace_index = error_return_trace_index;
+        }
 
-                // If the result can mutate comptime vars, we must not memoize it, as it contains
-                // a reference to `comptime_allocs` so is not stable across instances of `Sema`.
-                // TODO: check whether any external comptime memory was mutated by the
-                // comptime function call. If so, then do not memoize the call here.
-                if (should_memoize and sema.allow_memoize and !Value.fromInterned(result_interned).canMutateComptimeVarState(zcu)) {
-                    _ = try pt.intern(.{ .memoized_call = .{
-                        .func = module_fn_index,
-                        .arg_values = memoized_arg_values,
-                        .result = result_transformed,
-                        .branch_count = sema.branch_count - old_branch_count,
-                    } });
-                }
+        // We temporarily set `allow_memoize` to `true` to track this comptime call.
+        // It is restored after this call finishes analysis, so that a caller may
+        // know whether an in-progress call (containing this call) may be memoized.
+        const old_allow_memoize = sema.allow_memoize;
+        defer sema.allow_memoize = old_allow_memoize and sema.allow_memoize;
+        sema.allow_memoize = true;
 
-                break :res2 Air.internedToRef(result_transformed);
-            }
+        // Store the current eval branch count so we can find out how many eval branches
+        // the comptime call caused.
+        const old_branch_count = sema.branch_count;
 
-            if (try sema.resolveValue(result)) |result_val| {
-                const result_transformed = try sema.resolveAdHocInferredErrorSet(block, call_src, result_val.toIntern());
-                break :res2 Air.internedToRef(result_transformed);
-            }
-
-            const new_ty = try sema.resolveAdHocInferredErrorSetTy(block, call_src, sema.typeOf(result).toIntern());
-            if (new_ty != .none) {
-                // TODO: mutate in place the previous instruction if possible
-                // rather than adding a bitcast instruction.
-                break :res2 try block.addBitCast(Type.fromInterned(new_ty), result);
-            }
-
-            break :res2 result;
+        const result = result: {
+            sema.analyzeFnBody(&child_block, fn_info.body) catch |err| switch (err) {
+                error.ComptimeReturn => break :result inlining.comptime_result,
+                else => |e| return e,
+            };
+            break :result try sema.resolveAnalyzedBlock(block, call_src, &child_block, merges, need_debug_scope);
         };
 
-        break :res res2;
+        if (is_comptime_call) {
+            const result_val = try sema.resolveConstValue(block, LazySrcLoc.unneeded, result, undefined);
+            const result_interned = result_val.toIntern();
+
+            // Transform ad-hoc inferred error set types into concrete error sets.
+            const result_transformed = try sema.resolveAdHocInferredErrorSet(block, call_src, result_interned);
+
+            // If the result can mutate comptime vars, we must not memoize it, as it contains
+            // a reference to `comptime_allocs` so is not stable across instances of `Sema`.
+            // TODO: check whether any external comptime memory was mutated by the
+            // comptime function call. If so, then do not memoize the call here.
+            if (should_memoize and sema.allow_memoize and !Value.fromInterned(result_interned).canMutateComptimeVarState(zcu)) {
+                _ = try pt.intern(.{ .memoized_call = .{
+                    .func = module_fn_index,
+                    .arg_values = memoized_arg_values,
+                    .result = result_transformed,
+                    .branch_count = sema.branch_count - old_branch_count,
+                } });
+            }
+
+            break :res Air.internedToRef(result_transformed);
+        }
+
+        if (try sema.resolveValue(result)) |result_val| {
+            const result_transformed = try sema.resolveAdHocInferredErrorSet(block, call_src, result_val.toIntern());
+            break :res Air.internedToRef(result_transformed);
+        }
+
+        const new_ty = try sema.resolveAdHocInferredErrorSetTy(block, call_src, sema.typeOf(result).toIntern());
+        if (new_ty != .none) {
+            // TODO: mutate in place the previous instruction if possible
+            // rather than adding a bitcast instruction.
+            break :res try block.addBitCast(Type.fromInterned(new_ty), result);
+        }
+
+        break :res result;
     } else res: {
         assert(!func_ty_info.is_generic);
 

--- a/src/register_manager.zig
+++ b/src/register_manager.zig
@@ -93,6 +93,8 @@ pub fn RegisterManager(
             comptime set: []const Register,
             reg: Register,
         ) ?std.math.IntFittingRange(0, set.len - 1) {
+            @setEvalBranchQuota(3000);
+
             const Id = @TypeOf(reg.id());
             comptime var min_id: Id = std.math.maxInt(Id);
             comptime var max_id: Id = std.math.minInt(Id);

--- a/test/incremental/delete_comptime_decls
+++ b/test/incremental/delete_comptime_decls
@@ -31,7 +31,7 @@ pub fn main() void {}
 comptime {
     const x: [*c]u8 = null;
     var runtime_len: usize = undefined;
-		runtime_len = 0;
+    runtime_len = 0;
     const y = x[0..runtime_len];
     _ = y;
 }

--- a/test/incremental/modify_inline_fn
+++ b/test/incremental/modify_inline_fn
@@ -1,0 +1,23 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    const str = getStr();
+    try std.io.getStdOut().writeAll(str);
+}
+inline fn getStr() []const u8 {
+    return "foo\n";
+}
+#expect_stdout="foo\n"
+#update=change the string
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    const str = getStr();
+    try std.io.getStdOut().writeAll(str);
+}
+inline fn getStr() []const u8 {
+    return "bar\n";
+}
+#expect_stdout="bar\n"

--- a/test/incremental/move_src
+++ b/test/incremental/move_src
@@ -1,0 +1,29 @@
+#target=x86_64-linux
+#update=initial version
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writer().print("{d} {d}\n", .{ foo(), bar() });
+}
+fn foo() u32 {
+    return @src().line;
+}
+fn bar() u32 {
+    return 123;
+}
+#expect_stdout="6 123\n"
+
+#update=add newline
+#file=main.zig
+const std = @import("std");
+pub fn main() !void {
+    try std.io.getStdOut().writer().print("{d} {d}\n", .{ foo(), bar() });
+}
+
+fn foo() u32 {
+    return @src().line;
+}
+fn bar() u32 {
+    return 123;
+}
+#expect_stdout="7 123\n"


### PR DESCRIPTION
Two main things:
* Handle eval branch quota properly when memoizing calls. This is actually a bugfix to **non-** incremental, which brings it in line with incremental. **This bugfix is a breaking change.**
* Incorporate extra information into AstGen source hashes; most notably, the line and column of `@src()` calls. This solidifies the language change implemented by #17688; see commit message for details.

I added a new incremental compilation test for the `@src()` stuff; it passes with the C backend.

@Vexu, this PR (first commit) required correcting some eval branch quotas in Aro. One of the changes I made was to `aro/Builtins/Builtin.zig`, which is a generated file, but the file used to generate it isn't included downstream. Upstream Aro should make whatever the actual required change is.