### PR TITLE
std.os.linux: Fix bunch of compilation errors

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1683,7 +1683,7 @@ pub fn sigaddset(set: *sigset_t, sig: u6) void {
 
 pub fn sigismember(set: *const sigset_t, sig: u6) bool {
     const s = sig - 1;
-    return ((set.*)[@as(usize, @intCast(s)) / usize_bits] & (@as(usize, @intCast(1)) << (s & (usize_bits - 1)))) != 0;
+    return ((set.*)[@as(usize, @intCast(s)) / usize_bits] & (@as(usize, @intCast(1)) << @intCast(s & (usize_bits - 1)))) != 0;
 }
 
 pub fn getsockname(fd: i32, noalias addr: *sockaddr, noalias len: *socklen_t) usize {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -635,7 +635,8 @@ pub fn futex2_waitv(
 }
 
 /// Wait on a futex.
-/// Identical to `FUTEX.FUTEX_WAIT_BITSET`, except it is part of the futex2 family of calls.
+/// Identical to the traditional FUTEX_WAIT_BITSET op, except it is part of the
+/// futex2 familiy of calls.
 pub fn futex2_wait(
     /// Address of the futex to wait on.
     uaddr: *const anyopaque,
@@ -661,8 +662,9 @@ pub fn futex2_wait(
     );
 }
 
-/// Wake a number of waiters.
-/// Identical to `FUTEX.FUTEX_WAKE_BITSET`, except it is part of the futex2 family of calls.
+/// Wake a number of futexes.
+/// Identical to the traditional FUTEX_WAKE_BITSET op, except it is part of the
+/// futex2 family of calls.
 pub fn futex2_wake(
     /// Address of the futex(es) to wake.
     uaddr: *const anyopaque,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -635,7 +635,7 @@ pub fn futex2_waitv(
 }
 
 /// Wait on a futex.
-/// Identical to the traditional FUTEX_WAIT_BITSET op, except it is part of the
+/// Identical to the traditional `FUTEX.FUTEX_WAIT_BITSET` op, except it is part of the
 /// futex2 familiy of calls.
 pub fn futex2_wait(
     /// Address of the futex to wait on.
@@ -663,7 +663,7 @@ pub fn futex2_wait(
 }
 
 /// Wake a number of futexes.
-/// Identical to the traditional FUTEX_WAKE_BITSET op, except it is part of the
+/// Identical to the traditional `FUTEX.FUTEX_WAIT_BITSET` op, except it is part of the
 /// futex2 family of calls.
 pub fn futex2_wake(
     /// Address of the futex(es) to wake.

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5095,7 +5095,7 @@ pub const epoll_event = extern struct {
 
 pub const VFS_CAP_REVISION_MASK = 0xFF000000;
 pub const VFS_CAP_REVISION_SHIFT = 24;
-pub const VFS_CAP_FLAGS_MASK = ~VFS_CAP_REVISION_MASK;
+pub const VFS_CAP_FLAGS_MASK = ~@as(u32, VFS_CAP_REVISION_MASK);
 pub const VFS_CAP_FLAGS_EFFECTIVE = 0x000001;
 
 pub const VFS_CAP_REVISION_1 = 0x01000000;
@@ -5113,7 +5113,7 @@ pub const VFS_CAP_REVISION = VFS_CAP_REVISION_2;
 pub const vfs_cap_data = extern struct {
     //all of these are mandated as little endian
     //when on disk.
-    const Data = struct {
+    const Data = extern struct {
         permitted: u32,
         inheritable: u32,
     };

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -630,12 +630,12 @@ pub fn futex2_waitv(
         nr_futexes,
         flags,
         @intFromPtr(timeout),
-        @bitCast(@as(isize, clockid)),
+        @bitCast(@as(isize, @intFromEnum(clockid))),
     );
 }
 
 /// Wait on a futex.
-/// Identical to `FUTEX.WAIT`, except it is part of the futex2 family of calls.
+/// Identical to `FUTEX.FUTEX_WAIT_BITSET`, except it is part of the futex2 family of calls.
 pub fn futex2_wait(
     /// Address of the futex to wait on.
     uaddr: *const anyopaque,
@@ -646,7 +646,7 @@ pub fn futex2_wait(
     /// `FUTEX2` flags.
     flags: u32,
     /// Optional absolute timeout.
-    timeout: *const timespec,
+    timeout: ?*const timespec,
     /// Clock to be used for the timeout, realtime or monotonic.
     clockid: clockid_t,
 ) usize {
@@ -657,15 +657,15 @@ pub fn futex2_wait(
         mask,
         flags,
         @intFromPtr(timeout),
-        @bitCast(@as(isize, clockid)),
+        @bitCast(@as(isize, @intFromEnum(clockid))),
     );
 }
 
-/// Wake a number of futexes.
-/// Identical to `FUTEX.WAKE`, except it is part of the futex2 family of calls.
+/// Wake a number of waiters.
+/// Identical to `FUTEX.FUTEX_WAKE_BITSET`, except it is part of the futex2 family of calls.
 pub fn futex2_wake(
     /// Address of the futex(es) to wake.
-    uaddr: [*]const anyopaque,
+    uaddr: *const anyopaque,
     /// Bitmask
     mask: usize,
     /// Number of the futexes to wake.

--- a/lib/std/os/linux/bpf/btf.zig
+++ b/lib/std/os/linux/bpf/btf.zig
@@ -83,13 +83,14 @@ pub const Kind = enum(u5) {
 /// int kind is followed by this struct
 pub const IntInfo = packed struct(u32) {
     bits: u8,
-    unused: u8,
+    reserved_1: u8,
     offset: u8,
     encoding: enum(u4) {
         signed = 1 << 0,
         char = 1 << 1,
         boolean = 1 << 2,
     },
+    reserved_2: u4,
 };
 
 test "IntInfo is 32 bits" {

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -125,6 +125,23 @@ test "fadvise" {
     try expectEqual(@as(usize, 0), ret);
 }
 
+test "sigset_t" {
+    var sigset = linux.empty_sigset;
+
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), false);
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), false);
+
+    linux.sigaddset(&sigset, linux.SIG.USR1);
+
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), true);
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), false);
+
+    linux.sigaddset(&sigset, linux.SIG.USR2);
+
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), true);
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), true);
+}
+
 test {
     _ = linux.IoUring;
 }


### PR DESCRIPTION
Fixes for the `std.os.linux` compilation errors reported in #21094 