### PR TITLE
Fix handling of empty XDG environment variables

### DIFF
--- a/lib/std/debug/Dwarf.zig
+++ b/lib/std/debug/Dwarf.zig
@@ -2275,9 +2275,11 @@ pub const ElfModule = struct {
                             break :dir std.fs.openDirAbsolute(path, .{}) catch break :blk;
                         }
                         if (std.posix.getenv("XDG_CACHE_HOME")) |cache_path| {
-                            const path = std.fs.path.join(gpa, &[_][]const u8{ cache_path, "debuginfod_client" }) catch break :blk;
-                            defer gpa.free(path);
-                            break :dir std.fs.openDirAbsolute(path, .{}) catch break :blk;
+                            if (cache_path.len > 0) {
+                                const path = std.fs.path.join(gpa, &[_][]const u8{ cache_path, "debuginfod_client" }) catch break :blk;
+                                defer gpa.free(path);
+                                break :dir std.fs.openDirAbsolute(path, .{}) catch break :blk;
+                            }
                         }
                         if (std.posix.getenv("HOME")) |home_path| {
                             const path = std.fs.path.join(gpa, &[_][]const u8{ home_path, ".cache", "debuginfod_client" }) catch break :blk;

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -32,7 +32,9 @@ pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDi
         },
         .linux, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris, .illumos => {
             if (posix.getenv("XDG_DATA_HOME")) |xdg| {
-                return fs.path.join(allocator, &[_][]const u8{ xdg, appname });
+                if (xdg.len > 0) {
+                    return fs.path.join(allocator, &[_][]const u8{ xdg, appname });
+                }
             }
 
             const home_dir = posix.getenv("HOME") orelse {

--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -90,8 +90,11 @@ pub fn resolveGlobalCacheDir(allocator: mem.Allocator) ![]u8 {
 
     if (builtin.os.tag != .windows) {
         if (std.zig.EnvVar.XDG_CACHE_HOME.getPosix()) |cache_root| {
-            return fs.path.join(allocator, &[_][]const u8{ cache_root, appname });
-        } else if (std.zig.EnvVar.HOME.getPosix()) |home| {
+            if (cache_root.len > 0) {
+                return fs.path.join(allocator, &[_][]const u8{ cache_root, appname });
+            }
+        }
+        if (std.zig.EnvVar.HOME.getPosix()) |home| {
             return fs.path.join(allocator, &[_][]const u8{ home, ".cache", appname });
         }
     }


### PR DESCRIPTION
Closes #21132

According to the XDG Base Directory specification
(https://specifications.freedesktop.org/basedir-spec/latest/#variables), empty values for these environment variables should be treated the same as if they are unset. Specifically, for the instances changed in this commit,

> $XDG_DATA_HOME defines the base directory relative to which
> user-specific data files should be stored. If $XDG_DATA_HOME is either
> not set **or empty**, a default equal to $HOME/.local/share should be
> used.

and

> $XDG_CACHE_HOME defines the base directory relative to which
> user-specific non-essential data files should be stored. If
> $XDG_CACHE_HOME is either not set **or empty**, a default equal to
> $HOME/.cache should be used.

(emphasis mine)

In addition to the case mentioned in the linked issue, all other uses of XDG environment variables were corrected.