### PR TITLE
Update c.zig, openbsd don't have getcontext

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -9499,8 +9499,8 @@ pub const LC = enum(c_int) {
 
 pub extern "c" fn setlocale(category: LC, locale: ?[*:0]const u8) ?[*:0]const u8;
 
-pub const getcontext = if (builtin.target.isAndroid())
-{} // android bionic libc does not implement getcontext
+pub const getcontext = if (builtin.target.isAndroid() or builtin.target.os.tag == .openbsd)
+{} // android bionic and openbsd libc does not implement getcontext
 else if (native_os == .linux and builtin.target.isMusl())
     linux.getcontext
 else


### PR DESCRIPTION
Hello zig developers !

After, building zig at the latest branch (0.14.0-dev.1248+997c4bd52), i find it out that 
getcontext is undefined on openbsd too.

Here a short patch, for fix the issue !