### PR TITLE
loongarch: use medium code model for zig loongarch64 binary

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -648,9 +648,20 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         .sanitize_thread = options.sanitize_thread,
         .single_threaded = options.single_threaded,
         .code_model = switch (options.target.result.cpu.arch) {
-            // FIXME:
-            // now it is only possible to set code model to medium
-            // to build zig on loongarch64 that is debuggable.
+            // NB:
+            // For loongarch, LLVM supports only small, medium and large
+            // code model. If we don't explicitly specify the code model,
+            // the default value `small' will be used.
+            //
+            // Since zig binary itself is relatively large, using a `small'
+            // code model will cause
+            //
+            // relocation R_LARCH_B26 out of range
+            //
+            // error when linking a loongarch64 zig binary.
+            //
+            // Here we explicitly set code model to `medium' to avoid this
+            // error.
             .loongarch64 => .medium,
             else => .default,
         },

--- a/build.zig
+++ b/build.zig
@@ -647,6 +647,10 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         .strip = options.strip,
         .sanitize_thread = options.sanitize_thread,
         .single_threaded = options.single_threaded,
+        .code_model = switch (options.target.result.cpu.arch) {
+            .loongarch64 => .medium,
+            else => .default,
+        }
     });
     exe.root_module.valgrind = options.valgrind;
     exe.stack_size = stack_size;

--- a/build.zig
+++ b/build.zig
@@ -648,6 +648,9 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         .sanitize_thread = options.sanitize_thread,
         .single_threaded = options.single_threaded,
         .code_model = switch (options.target.result.cpu.arch) {
+            // FIXME:
+            // now it is only possible to set code model to medium
+            // to build zig on loongarch64 that is debuggable.
             .loongarch64 => .medium,
             else => .default,
         }

--- a/build.zig
+++ b/build.zig
@@ -653,7 +653,7 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
             // to build zig on loongarch64 that is debuggable.
             .loongarch64 => .medium,
             else => .default,
-        }
+        },
     });
     exe.root_module.valgrind = options.valgrind;
     exe.stack_size = stack_size;


### PR DESCRIPTION
See: https://elixir.bootlin.com/llvm/llvmorg-18.1.8/source/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp#L74

LLVM 18 only supports

- small
- medium
- large

code model on loongarch64.

And it seems to remain the same in LLVM 19.
See: https://elixir.bootlin.com/llvm/llvmorg-19.1.0-rc3/source/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp#L83

I have tried different values, but medium seems to be the only one supported for both `loongarch64-linux-gnu` and `loongarch64-linux-musl` to have a debuggable `loongarch64` zig built.

Also see: https://github.com/ziglang/zig-bootstrap/issues/164#issuecomment-2290639730