### PR TITLE
Update ML-KEM to the final specification

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -74,8 +74,9 @@ pub const dh = struct {
 
 /// Key Encapsulation Mechanisms.
 pub const kem = struct {
-    pub const kyber_d00 = @import("crypto/ml_kem.zig").kyber_d00;
-    pub const ml_kem_01 = @import("crypto/ml_kem.zig").ml_kem_01;
+    pub const kyber_d00 = @import("crypto/ml_kem.zig").d00;
+    pub const ml_kem = @import("crypto/ml_kem.zig").nist;
+    pub const ml_kem_01 = @compileError("deprecated: final version of the specification has been published, use ml_kem instead");
 };
 
 /// Elliptic-curve arithmetic.

--- a/lib/std/crypto/ml_kem.zig
+++ b/lib/std/crypto/ml_kem.zig
@@ -1,13 +1,8 @@
 //! Implementation of the IND-CCA2 post-quantum secure key encapsulation mechanism (KEM)
 //! ML-KEM (NIST FIPS-203 publication) and CRYSTALS-Kyber (v3.02/"draft00" CFRG draft).
 //!
-//! The Kyber namespace suffix (currently `_d00`) refers to the version currently
-//! implemented, in accordance with the CFRG draft.
-//!
-//! The ML-KEM namespace refers to the FIPS-203 publication.
-//!
-//! Suffixes may not be updated if new versions of the documents only include editorial changes.
-//! The suffixes will be removed once the schemes are finalized.
+//! The namespace `d00` refers to the version currently implemented, in accordance with the CFRG draft.
+//! The `nist` namespace refers to the FIPS-203 publication.
 //!
 //! Quoting from the CFRG I-D:
 //!
@@ -146,7 +141,7 @@ const Params = struct {
     dv: u8,
 };
 
-pub const kyber_d00 = struct {
+pub const d00 = struct {
     pub const Kyber512 = Kyber(.{
         .name = "Kyber512",
         .k = 2,
@@ -172,9 +167,7 @@ pub const kyber_d00 = struct {
     });
 };
 
-pub const ml_kem_01 = @compileError("deprecated: final version of the specification has been published, use ml_kem instead");
-
-pub const ml_kem = struct {
+pub const nist = struct {
     pub const MLKem512 = Kyber(.{
         .name = "ML-KEM-512",
         .ml_kem = true,
@@ -204,12 +197,12 @@ pub const ml_kem = struct {
 };
 
 const modes = [_]type{
-    kyber_d00.Kyber512,
-    kyber_d00.Kyber768,
-    kyber_d00.Kyber1024,
-    ml_kem.MLKem512,
-    ml_kem.MLKem768,
-    ml_kem.MLKem1024,
+    d00.Kyber512,
+    d00.Kyber768,
+    d00.Kyber1024,
+    nist.MLKem512,
+    nist.MLKem768,
+    nist.MLKem1024,
 };
 const h_length: usize = 32;
 const inner_seed_length: usize = 32;
@@ -1725,9 +1718,9 @@ const sha2 = crypto.hash.sha2;
 
 test "NIST KAT test" {
     inline for (.{
-        .{ kyber_d00.Kyber512, "e9c2bd37133fcb40772f81559f14b1f58dccd1c816701be9ba6214d43baf4547" },
-        .{ kyber_d00.Kyber1024, "89248f2f33f7f4f7051729111f3049c409a933ec904aedadf035f30fa5646cd5" },
-        .{ kyber_d00.Kyber768, "a1e122cad3c24bc51622e4c242d8b8acbcd3f618fee4220400605ca8f9ea02c2" },
+        .{ d00.Kyber512, "e9c2bd37133fcb40772f81559f14b1f58dccd1c816701be9ba6214d43baf4547" },
+        .{ d00.Kyber1024, "89248f2f33f7f4f7051729111f3049c409a933ec904aedadf035f30fa5646cd5" },
+        .{ d00.Kyber768, "a1e122cad3c24bc51622e4c242d8b8acbcd3f618fee4220400605ca8f9ea02c2" },
     }) |modeHash| {
         const mode = modeHash[0];
         var seed: [48]u8 = undefined;


### PR DESCRIPTION
NIST has published the final specification of ML-KEM, which adds domain separation to the seed used to create the inner secret key.

Deprecate `ml_kem_01` in favor of `ml_kem` .