### PR TITLE
IoUring: Split on `-` to ignore unnecessary `pre`-suffix info in kernel version string

### DIFF
--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -3885,7 +3885,8 @@ inline fn skipKernelLessThan(required: std.SemanticVersion) !void {
         else => |errno| return posix.unexpectedErrno(errno),
     }
 
-    const release = mem.sliceTo(&uts.release, 0);
+    var it = mem.splitScalar(u8, mem.sliceTo(&uts.release, 0), '-');
+    const release = it.first();
     var current = try std.SemanticVersion.parse(release);
     current.pre = null; // don't check pre field
     if (required.order(current) == .gt) return error.SkipZigTest;


### PR DESCRIPTION
This allows IoUring tests to successfully parse kernel version even in Linux distributions that include invalid SemVer characters as a suffix to the kernel version string, e.g. Fedora that includes distribution version and architecture.

`pre` part of kernel SemVer is already ignored _after_ SemVer parsing; this simply allows for avoiding parsing failures.

Closes #21166 