### PR TITLE
std.debug: remove allocator from std.debug.writeStackTrace()

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -295,10 +295,9 @@ pub fn dump(step: *Step, file: std.fs.File) void {
         }) catch {};
         return;
     };
-    const ally = debug_info.allocator;
     if (step.getStackTrace()) |stack_trace| {
         w.print("name: '{s}'. creation stack trace:\n", .{step.name}) catch {};
-        std.debug.writeStackTrace(stack_trace, w, ally, debug_info, tty_config) catch |err| {
+        std.debug.writeStackTrace(stack_trace, w, debug_info, tty_config) catch |err| {
             w.print("Unable to dump stack trace: {s}\n", .{@errorName(err)}) catch {};
             return;
         };

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -48,8 +48,6 @@ pub const StackTrace = struct {
         if (builtin.os.tag == .freestanding) return;
 
         _ = options;
-        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-        defer arena.deinit();
         const debug_info = std.debug.getSelfDebugInfo() catch |err| {
             return writer.print("\nUnable to print stack trace: Unable to open debug info: {s}\n", .{@errorName(err)});
         };

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -55,7 +55,7 @@ pub const StackTrace = struct {
         };
         const tty_config = std.io.tty.detectConfig(std.io.getStdErr());
         try writer.writeAll("\n");
-        std.debug.writeStackTrace(self, writer, arena.allocator(), debug_info, tty_config) catch |err| {
+        std.debug.writeStackTrace(self, writer, debug_info, tty_config) catch |err| {
             try writer.print("Unable to print stack trace: {s}\n", .{@errorName(err)});
         };
     }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -377,7 +377,7 @@ pub fn dumpStackTrace(stack_trace: std.builtin.StackTrace) void {
             stderr.print("Unable to dump stack trace: Unable to open debug info: {s}\n", .{@errorName(err)}) catch return;
             return;
         };
-        writeStackTrace(stack_trace, stderr, getDebugInfoAllocator(), debug_info, io.tty.detectConfig(io.getStdErr())) catch |err| {
+        writeStackTrace(stack_trace, stderr, debug_info, io.tty.detectConfig(io.getStdErr())) catch |err| {
             stderr.print("Unable to dump stack trace: {s}\n", .{@errorName(err)}) catch return;
             return;
         };
@@ -520,11 +520,9 @@ fn waitForOtherThreadToFinishPanicking() void {
 pub fn writeStackTrace(
     stack_trace: std.builtin.StackTrace,
     out_stream: anytype,
-    allocator: mem.Allocator,
     debug_info: *SelfInfo,
     tty_config: io.tty.Config,
 ) !void {
-    _ = allocator;
     if (builtin.strip_debug_info) return error.MissingDebugInfo;
     var frame_index: usize = 0;
     var frames_left: usize = @min(stack_trace.index, stack_trace.instruction_addresses.len);
@@ -1452,7 +1450,7 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
                     .index = frames.len,
                     .instruction_addresses = frames,
                 };
-                writeStackTrace(stack_trace, stderr, getDebugInfoAllocator(), debug_info, tty_config) catch continue;
+                writeStackTrace(stack_trace, stderr, debug_info, tty_config) catch continue;
             }
             if (t.index > end) {
                 stderr.print("{d} more traces not shown; consider increasing trace size\n", .{


### PR DESCRIPTION
Noticed someone on Discord mention that ``std.debug.writeStackTrace`` doesn't use an allocator, so I removed it.