### PR TITLE
std.fs: Disable `file operations on directories` test on WASI with wasi-libc.

### DIFF
--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -745,6 +745,7 @@ test "directory operations on files" {
 test "file operations on directories" {
     // TODO: fix this test on FreeBSD. https://github.com/ziglang/zig/issues/1759
     if (native_os == .freebsd) return error.SkipZigTest;
+    if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/20747
 
     try testWithAllSupportedPathTypes(struct {
         fn impl(ctx: *TestContext) !void {


### PR DESCRIPTION
https://github.com/ziglang/zig/issues/20747

Wasmtime developers have acknowledged that this is a regression on their end. I propose that we disable this test temporarily so that new contributors using a recent Wasmtime version don't hit this and get confused (e.g. https://github.com/ziglang/zig/pull/20511#issuecomment-2277214500).