### PR TITLE
fix THREAD_STATE_NONE on darwin

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -23,6 +23,7 @@ pub const mach_port_t = c_uint;
 pub const THREAD_STATE_NONE = switch (native_arch) {
     .aarch64 => 5,
     .x86_64 => 13,
+    else => @compileError("unsupported arch"),
 };
 
 pub const EXC = enum(exception_type_t) {


### PR DESCRIPTION
addresses part of #21094

switch was missing else

this test now passes:

```zig
const std = @import("std");

test {
    _ = &std.c.THREAD_STATE_NONE;
}

```