### PR TITLE
make formatSizeImpl's zero case respect options

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -906,8 +906,7 @@ fn formatSizeImpl(comptime base: comptime_int) type {
 
             // The regular algorithm does not work for 0, so this is a special case.
             if (value == 0) {
-                const new_value: f64 = @floatFromInt(value);
-                const s = formatFloat(&buf, new_value, .{ .mode = .decimal, .precision = options.precision }) catch |err| switch (err) {
+                const s = formatFloat(&buf, 0.0, .{ .mode = .decimal, .precision = options.precision }) catch |err| switch (err) {
                     error.BufferTooSmall => @panic("Buffer is too small to format float."),
                 };
                 buf[s.len] = 'B';

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -930,11 +930,8 @@ fn formatSizeImpl(comptime base: comptime_int) type {
                 else => unreachable,
             };
 
-            const s = switch (magnitude) {
-                0 => buf[0..formatIntBuf(&buf, value, 10, .lower, .{})],
-                else => formatFloat(&buf, new_value, .{ .mode = .decimal, .precision = options.precision }) catch |err| switch (err) {
-                    error.BufferTooSmall => unreachable,
-                },
+            const s = formatFloat(&buf, new_value, .{ .mode = .decimal, .precision = options.precision }) catch |err| switch (err) {
+                error.BufferTooSmall => unreachable,
             };
 
             var i: usize = s.len;

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -903,7 +903,7 @@ fn formatSizeImpl(comptime base: comptime_int) type {
             _ = fmt;
             // The worst case for the calculated float value, plus three bytes for the suffix.
             // TODO: Fix: if options.precision is high enough, this buffer will not be sufficient.
-            var buf: [format_float.bufferSize(.decimal, f64) + 3]u8 = undefined;
+            var buf: [format_float.min_buffer_size + 3]u8 = undefined;
 
             // The regular algorithm does not work for 0, so this is a special case.
             if (value == 0) {


### PR DESCRIPTION
Before, this function would always format 0 as "0B" regardless of the float precision option. This commit makes it consistent with everything else, and replaces a reachable `unreachable` with a panic instead. (It is reachable with high precision values).