### PR TITLE
`glibc`: Some bug fixes, plus arc and csky start files

### DIFF
--- a/lib/libc/glibc/sysdeps/arc/bits/endianness.h
+++ b/lib/libc/glibc/sysdeps/arc/bits/endianness.h
@@ -1,0 +1,15 @@
+#ifndef _BITS_ENDIANNESS_H
+#define _BITS_ENDIANNESS_H 1
+
+#ifndef _BITS_ENDIAN_H
+# error "Never use <bits/endian.h> directly; include <endian.h> instead."
+#endif
+
+/* ARC has selectable endianness.  */
+#ifdef __BIG_ENDIAN__
+# define __BYTE_ORDER __BIG_ENDIAN
+#else
+# define __BYTE_ORDER __LITTLE_ENDIAN
+#endif
+
+#endif /* bits/endianness.h */

--- a/lib/libc/glibc/sysdeps/arc/entry.h
+++ b/lib/libc/glibc/sysdeps/arc/entry.h
@@ -1,0 +1,5 @@
+#ifndef __ASSEMBLY__
+extern void __start (void) attribute_hidden;
+#endif
+
+#define ENTRY_POINT __start

--- a/lib/libc/glibc/sysdeps/arc/start-2.33.S
+++ b/lib/libc/glibc/sysdeps/arc/start-2.33.S
@@ -1,0 +1,74 @@
+/* Startup code for ARC.
+   Copyright (C) 2020-2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#define __ASSEMBLY__ 1
+#include <entry.h>
+#include <sysdep.h>
+
+#ifndef ENTRY_POINT
+# error ENTRY_POINT needs to be defined for ARC
+#endif
+
+/* When we enter this piece of code, the program stack looks like this:
+        argc            argument counter (integer)
+        argv[0]         program name (pointer)
+        argv[1...N]     program args (pointers)
+        argv[argc-1]    end of args (integer)
+        NULL
+        env[0...N]      environment variables (pointers)
+        NULL.  */
+
+ENTRY (ENTRY_POINT)
+
+	/* Needed to make gdb backtraces stop here.  */
+	.cfi_label .Ldummy
+	cfi_undefined (blink)
+
+	mov	fp, 0
+	ld_s	r1, [sp]	/* argc.  */
+
+	mov_s	r5, r0		/* rltd_fini.  */
+	add_s	r2, sp, 4	/* argv.  */
+	and	sp, sp, -8
+	mov	r6, sp
+
+	/* __libc_start_main (main, argc, argv, init, fini, rtld_fini, stack_end).  */
+
+#ifdef SHARED
+	ld	r0, [pcl, @main@gotpc]
+	ld	r3, [pcl, @__libc_csu_init@gotpc]
+	ld	r4, [pcl, @__libc_csu_fini@gotpc]
+	bl	__libc_start_main@plt
+#else
+	mov_s	r0, main
+	mov_s	r3, __libc_csu_init
+	mov	r4, __libc_csu_fini
+	bl	__libc_start_main
+#endif
+
+	/* Should never get here.  */
+	flag    1
+END (ENTRY_POINT)
+
+/* Define a symbol for the first piece of initialized data.  */
+	.data
+	.globl __data_start
+__data_start:
+	.long 0
+	.weak data_start
+	data_start = __data_start

--- a/lib/libc/glibc/sysdeps/arc/start.S
+++ b/lib/libc/glibc/sysdeps/arc/start.S
@@ -1,0 +1,90 @@
+/* Startup code for ARC.
+   Copyright (C) 2020-2024 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   In addition to the permissions in the GNU Lesser General Public
+   License, the Free Software Foundation gives you unlimited
+   permission to link the compiled version of this file with other
+   programs, and to distribute those programs without any restriction
+   coming from the use of this file. (The GNU Lesser General Public
+   License restrictions do apply in other respects; for example, they
+   cover modification of the file, and distribution when not linked
+   into another program.)
+
+   Note that people who make modified versions of this file are not
+   obligated to grant this special exception for their modified
+   versions; it is their choice whether to do so. The GNU Lesser
+   General Public License gives permission to release a modified
+   version without this exception; this exception also makes it
+   possible to release a modified version which carries forward this
+   exception.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#define __ASSEMBLY__ 1
+#include <entry.h>
+#include <sysdep.h>
+
+#ifndef ENTRY_POINT
+# error ENTRY_POINT needs to be defined for ARC
+#endif
+
+/* When we enter this piece of code, the program stack looks like this:
+        argc            argument counter (integer)
+        argv[0]         program name (pointer)
+        argv[1...N]     program args (pointers)
+        argv[argc-1]    end of args (integer)
+        NULL
+        env[0...N]      environment variables (pointers)
+        NULL.  */
+
+ENTRY (ENTRY_POINT)
+
+	/* Needed to make gdb backtraces stop here.  */
+	.cfi_label .Ldummy
+	cfi_undefined (blink)
+
+	mov	fp, 0
+	ld_s	r1, [sp]	/* argc.  */
+
+	mov_s	r5, r0		/* rltd_fini.  */
+	add_s	r2, sp, 4	/* argv.  */
+	and	sp, sp, -8
+	mov	r6, sp
+
+	/* __libc_start_main (main, argc, argv, init, fini, rtld_fini, stack_end).  */
+
+	mov_s	r3, 0 		/* Used to be init.  */
+	mov	r4, 0		/* Used to be fini.  */
+
+#ifdef SHARED
+	ld	r0, [pcl, @main@gotpc]
+	bl	__libc_start_main@plt
+#else
+	mov_s	r0, main
+	bl	__libc_start_main
+#endif
+
+	/* Should never get here.  */
+	flag    1
+END (ENTRY_POINT)
+
+/* Define a symbol for the first piece of initialized data.  */
+	.data
+	.globl __data_start
+__data_start:
+	.long 0
+	.weak data_start
+	data_start = __data_start

--- a/lib/libc/glibc/sysdeps/csky/abiv2/start-2.33.S
+++ b/lib/libc/glibc/sysdeps/csky/abiv2/start-2.33.S
@@ -1,0 +1,112 @@
+/* Startup code compliant to the ELF C-SKY ABIV2.
+   Copyright (C) 2018-2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   In addition to the permissions in the GNU Lesser General Public
+   License, the Free Software Foundation gives you unlimited
+   permission to link the compiled version of this file with other
+   programs, and to distribute those programs without any restriction
+   coming from the use of this file. (The GNU Lesser General Public
+   License restrictions do apply in other respects; for example, they
+   cover modification of the file, and distribution when not linked
+   into another program.)
+
+   Note that people who make modified versions of this file are not
+   obligated to grant this special exception for their modified
+   versions; it is their choice whether to do so. The GNU Lesser
+   General Public License gives permission to release a modified
+   version without this exception; this exception also makes it
+   possible to release a modified version which carries forward this
+   exception.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+/* We need to call:
+   __libc_start_main (int (*main) (int, char **, char **), int argc,
+		      char **argv, void (*init) (void), void (*fini) (void),
+		      void (*rtld_fini) (void), void *stack_end)
+ */
+
+#include <sysdep.h>
+
+	.text
+	.globl _start;
+	.type _start,@function;
+	.align 4;
+_start:
+	cfi_startproc
+	.cfi_label .Ldummy
+	cfi_undefined (lr)
+	subi	sp, 8
+	/* Clear the link register since this is the outermost frame.  */
+	movi	lr, 0
+	/* Pop argc off the stack and save a pointer to argv.  */
+	ldw	a1, (sp, 8)	/* Init argc for __libc_start_main.  */
+	addi	a2, sp, 12	/* Init argv for __libc_start_main.  */
+
+	/* Push stack limit.  */
+	stw	a2, (sp, 8)
+	/* Push rtld_fini.  */
+	stw	a0, (sp, 4)
+
+#ifdef SHARED
+	grs	t0, .Lgetpc
+.Lgetpc:
+	lrw	gb, .Lgetpc@GOTPC
+	addu	gb, t0
+	lrw	a3, __libc_csu_fini@GOT
+	ldr.w	a3, (gb, a3 << 0)
+	stw	a3, (sp, 0)
+
+	lrw	a3, __libc_csu_init@GOT
+	addu	a3, gb
+	ldw	a3, (a3, 0)
+
+	lrw	t0, main@GOT
+	addu	t0, gb
+	ldw	a0, (t0, 0)
+	lrw	t1, __libc_start_main@PLT
+	ldr.w	t1, (gb, t1 << 0)
+	jsr	t1
+
+	lrw	t1, abort@PLT
+	ldr.w	t1, (gb, t1 << 0)
+	jsr	t1
+#else
+	/* Fetch address of __libc_csu_fini.  */
+	lrw	a0, __libc_csu_fini
+	/* Push __libc_csu_fini */
+	stw	a0, (sp, 0)
+
+	/* Set up the other arguments in registers.  */
+	lrw	a0, main
+	lrw	a3, __libc_csu_init
+	/* Let the libc call main and exit with its return code.  */
+	jsri	__libc_start_main
+
+	/* Should never get here.  */
+	jsri	abort
+#endif	/* !SHARED */
+	cfi_endproc
+	.size _start,.-_start
+
+
+	/* Define a symbol for the first piece of initialized data.  */
+	.data
+	.globl __data_start
+__data_start:
+	.long 0
+	.weak data_start
+	data_start = __data_start

--- a/lib/libc/glibc/sysdeps/csky/abiv2/start.S
+++ b/lib/libc/glibc/sysdeps/csky/abiv2/start.S
@@ -1,0 +1,103 @@
+/* Startup code compliant to the ELF C-SKY ABIV2.
+   Copyright (C) 2018-2024 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   In addition to the permissions in the GNU Lesser General Public
+   License, the Free Software Foundation gives you unlimited
+   permission to link the compiled version of this file with other
+   programs, and to distribute those programs without any restriction
+   coming from the use of this file. (The GNU Lesser General Public
+   License restrictions do apply in other respects; for example, they
+   cover modification of the file, and distribution when not linked
+   into another program.)
+
+   Note that people who make modified versions of this file are not
+   obligated to grant this special exception for their modified
+   versions; it is their choice whether to do so. The GNU Lesser
+   General Public License gives permission to release a modified
+   version without this exception; this exception also makes it
+   possible to release a modified version which carries forward this
+   exception.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+/* We need to call:
+   __libc_start_main (int (*main) (int, char **, char **), int argc,
+		      char **argv, void (*init) (void), void (*fini) (void),
+		      void (*rtld_fini) (void), void *stack_end)
+ */
+
+#include <sysdep.h>
+
+	.text
+	.globl _start;
+	.type _start,@function;
+	.align 4;
+_start:
+	cfi_startproc
+	.cfi_label .Ldummy
+	cfi_undefined (lr)
+	subi	sp, 8
+	/* Clear the link register since this is the outermost frame.  */
+	movi	lr, 0
+	/* Pop argc off the stack and save a pointer to argv.  */
+	ldw	a1, (sp, 8)	/* Init argc for __libc_start_main.  */
+	addi	a2, sp, 12	/* Init argv for __libc_start_main.  */
+
+	/* Push stack limit.  */
+	stw	a2, (sp, 8)
+	/* Push rtld_fini.  */
+	stw	a0, (sp, 4)
+
+#ifdef SHARED
+	grs	t0, .Lgetpc
+.Lgetpc:
+	lrw	gb, .Lgetpc@GOTPC
+	addu	gb, t0
+
+	movi	a3, 0		/* Used to be init.  */
+	stw 	a3, (sp, 0) 	/* Used to be fini.  */
+
+	lrw	t0, main@GOT
+	addu	t0, gb
+	ldw	a0, (t0, 0)
+	lrw	t1, __libc_start_main@PLT
+	ldr.w	t1, (gb, t1 << 0)
+	jsr	t1
+
+	lrw	t1, abort@PLT
+	ldr.w	t1, (gb, t1 << 0)
+	jsr	t1
+#else
+	movi	a3, 0		/* Used to be init.  */
+	stw 	a3, (sp, 0) 	/* Used to be fini.  */
+	lrw	a0, main
+	/* Let the libc call main and exit with its return code.  */
+	jsri	__libc_start_main
+
+	/* Should never get here.  */
+	jsri	abort
+#endif	/* !SHARED */
+	cfi_endproc
+	.size _start,.-_start
+
+
+	/* Define a symbol for the first piece of initialized data.  */
+	.data
+	.globl __data_start
+__data_start:
+	.long 0
+	.weak data_start
+	data_start = __data_start

--- a/lib/libc/glibc/sysdeps/csky/bits/endianness.h
+++ b/lib/libc/glibc/sysdeps/csky/bits/endianness.h
@@ -1,0 +1,14 @@
+#ifndef _BITS_ENDIANNESS_H
+#define _BITS_ENDIANNESS_H 1
+
+#ifndef _BITS_ENDIAN_H
+# error "Never use <bits/endianness.h> directly; include <endian.h> instead."
+#endif
+
+#ifdef __CSKYBE__
+# error "Big endian not supported for C-SKY."
+#else
+# define __BYTE_ORDER __LITTLE_ENDIAN
+#endif
+
+#endif /* bits/endianness.h */

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -472,6 +472,8 @@ fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![
         try result.appendSlice("s390" ++ s ++ "s390-64");
     } else if (arch.isLoongArch()) {
         try result.appendSlice("loongarch");
+    } else if (arch == .m68k) {
+        try result.appendSlice("m68k");
     }
 
     try result.appendSlice(s);
@@ -677,6 +679,17 @@ fn add_include_dirs_arch(
     } else if (arch.isLoongArch()) {
         try args.append("-I");
         try args.append(try path.join(arena, &[_][]const u8{ dir, "loongarch" }));
+    } else if (arch == .m68k) {
+        if (opt_nptl) |nptl| {
+            try args.append("-I");
+            try args.append(try path.join(arena, &[_][]const u8{ dir, "m68k", nptl }));
+        } else {
+            // coldfire ABI support requires: https://github.com/ziglang/zig/issues/20690
+            try args.append("-I");
+            try args.append(try path.join(arena, &[_][]const u8{ dir, "m68k" ++ s ++ "m680x0" }));
+            try args.append("-I");
+            try args.append(try path.join(arena, &[_][]const u8{ dir, "m68k" }));
+        }
     }
 }
 

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -474,6 +474,8 @@ fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![
         try result.appendSlice("loongarch");
     } else if (arch == .m68k) {
         try result.appendSlice("m68k");
+    } else if (arch == .arc) {
+        try result.appendSlice("arc");
     }
 
     try result.appendSlice(s);
@@ -690,6 +692,9 @@ fn add_include_dirs_arch(
             try args.append("-I");
             try args.append(try path.join(arena, &[_][]const u8{ dir, "m68k" }));
         }
+    } else if (arch == .arc) {
+        try args.append("-I");
+        try args.append(try path.join(arena, &[_][]const u8{ dir, "arc" }));
     }
 }
 

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -572,6 +572,10 @@ fn add_include_dirs_arch(
                 try args.append("-I");
                 try args.append(try path.join(arena, &[_][]const u8{ dir, "x86_64", nptl }));
             } else {
+                if (target.abi == .gnux32) {
+                    try args.append("-I");
+                    try args.append(try path.join(arena, &[_][]const u8{ dir, "x86_64", "x32" }));
+                }
                 try args.append("-I");
                 try args.append(try path.join(arena, &[_][]const u8{ dir, "x86_64" }));
             }

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -369,6 +369,7 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progre
                     "-fgnu89-inline",
                     "-fmerge-all-constants",
                     "-frounding-math",
+                    "-Wno-unsupported-floating-point-opt", // For targets that don't support -frounding-math.
                     "-fno-stack-protector",
                     "-fno-common",
                     "-fmath-errno",

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -468,6 +468,8 @@ fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![
         } else {
             try result.appendSlice("powerpc" ++ s ++ "powerpc32");
         }
+    } else if (arch == .s390x) {
+        try result.appendSlice("s390" ++ s ++ "s390-64");
     } else if (arch.isLoongArch()) {
         try result.appendSlice("loongarch");
     }
@@ -657,6 +659,16 @@ fn add_include_dirs_arch(
         } else {
             try args.append("-I");
             try args.append(try path.join(arena, &[_][]const u8{ dir, "riscv" }));
+        }
+    } else if (arch == .s390x) {
+        if (opt_nptl) |nptl| {
+            try args.append("-I");
+            try args.append(try path.join(arena, &[_][]const u8{ dir, "s390", nptl }));
+        } else {
+            try args.append("-I");
+            try args.append(try path.join(arena, &[_][]const u8{ dir, "s390" ++ s ++ "s390-64" }));
+            try args.append("-I");
+            try args.append(try path.join(arena, &[_][]const u8{ dir, "s390" }));
         }
     } else if (arch.isLoongArch()) {
         try args.append("-I");

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -476,6 +476,8 @@ fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![
         try result.appendSlice("m68k");
     } else if (arch == .arc) {
         try result.appendSlice("arc");
+    } else if (arch == .csky) {
+        try result.appendSlice("csky" ++ s ++ "abiv2");
     }
 
     try result.appendSlice(s);
@@ -695,6 +697,9 @@ fn add_include_dirs_arch(
     } else if (arch == .arc) {
         try args.append("-I");
         try args.append(try path.join(arena, &[_][]const u8{ dir, "arc" }));
+    } else if (arch == .csky) {
+        try args.append("-I");
+        try args.append(try path.join(arena, &[_][]const u8{ dir, "csky" }));
     }
 }
 


### PR DESCRIPTION
* Fix the `-frounding-math` warning for real this time.
* Fix the `lgammal` duplicate symbol issue.
* Add arc and csky start files for glibc 2.40 and <= 2.33.
* Set asm and include paths for all targets supported by `std.zig.target`.

Closes #14118.
Closes #20376.
Closes #21076.