### PR TITLE
std.c.passwd: support macOS and NetBSD

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -177,7 +177,7 @@ pub const passwd = switch (native_os) {
         dir: ?[*:0]const u8, // home directory
         shell: ?[*:0]const u8, // shell program
     },
-    .openbsd => extern struct {
+    .netbsd, .openbsd, .macos => extern struct {
         name: ?[*:0]const u8, // user name
         passwd: ?[*:0]const u8, // encrypted password
         uid: uid_t, // user uid


### PR DESCRIPTION
OpenBSD definition:
https://github.com/openbsd/src/blob/95d5c33/include/pwd.h#L80-L91

From `MacOSX.sdk/usr/include/pwd.h`:

```c
struct passwd {
	char	*pw_name;		/* user name */
	char	*pw_passwd;		/* encrypted password */
	uid_t	pw_uid;			/* user uid */
	gid_t	pw_gid;			/* user gid */
	__darwin_time_t pw_change;		/* password change time */
	char	*pw_class;		/* user access class */
	char	*pw_gecos;		/* Honeywell login info */
	char	*pw_dir;		/* home directory */
	char	*pw_shell;		/* default shell */
	__darwin_time_t pw_expire;		/* account expiration */
};
```

NetBSD definition:
https://github.com/NetBSD/src/blob/51abf16/include/pwd.h#L107-L118

On FreeBSD, `passwd` also has an internal `pw_fields` field:
https://github.com/freebsd/freebsd-src/blob/6e75812/include/pwd.h#L111-L123

Ditto for DragonFly:
https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/include/pwd.h#L112-L124