### PR TITLE
`llvm`: Set `warn-stack-size=0` on naked functions.

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2923,6 +2923,14 @@ pub const Object = struct {
             owner_mod.omit_frame_pointer or fn_info.cc == .Naked,
         );
 
+        // Make LLVM emit a helpful warning if a stack allocation occurs in a naked function.
+        if (fn_info.cc == .Naked) {
+            try attributes.addFnAttr(.{ .string = .{
+                .kind = try o.builder.string("warn-stack-size"),
+                .value = try o.builder.string("0"),
+            } }, &o.builder);
+        }
+
         if (fn_info.return_type == .noreturn_type) try attributes.addFnAttr(.noreturn, &o.builder);
 
         // Add parameter attributes. We handle only the case of extern functions (no body)


### PR DESCRIPTION
This makes LLVM produce a warning if *any* stack allocations happen.

As suggested by @zeroZshadow after discussion about #21193:

```console
❯ zig4 build-obj naked.zig -target powerpc-freestanding-eabi
warning: naked.zig:1:0: stack frame size (4) exceeds limit (0) in function 'someFunc'
```

It's not the most ideal way to surface this information, but it's a *lot* better than silently wrong codegen.