### PR TITLE
Cleanup type resolution and finish `zcu` rename

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3091,7 +3091,7 @@ pub fn getAllErrorsAlloc(comp: *Compilation) !ErrorBundle {
     var all_references: ?std.AutoHashMapUnmanaged(InternPool.AnalUnit, ?Zcu.ResolvedReference) = null;
     defer if (all_references) |*a| a.deinit(gpa);
 
-    if (comp.module) |zcu| {
+    if (comp.zcu) |zcu| {
         const ip = &zcu.intern_pool;
 
         for (zcu.failed_files.keys(), zcu.failed_files.values()) |file, error_msg| {
@@ -3268,7 +3268,7 @@ pub fn getAllErrorsAlloc(comp: *Compilation) !ErrorBundle {
         }
     }
 
-    if (comp.module) |zcu| {
+    if (comp.zcu) |zcu| {
         if (comp.incremental and bundle.root_list.items.len == 0) {
             const should_have_error = for (zcu.transitive_failed_analysis.keys()) |failed_unit| {
                 if (all_references == null) {
@@ -3976,7 +3976,7 @@ fn processOneCodegenJob(tid: usize, comp: *Compilation, codegen_job: CodegenJob)
             const named_frame = tracy.namedFrame("codegen_type");
             defer named_frame.end();
 
-            const pt: Zcu.PerThread = .{ .zcu = comp.module.?, .tid = @enumFromInt(tid) };
+            const pt: Zcu.PerThread = .{ .zcu = comp.zcu.?, .tid = @enumFromInt(tid) };
             try pt.linkerUpdateContainerType(ty);
         },
     }
@@ -4258,7 +4258,7 @@ fn workerAstGenFile(
     const child_prog_node = prog_node.start(file.sub_file_path, 0);
     defer child_prog_node.end();
 
-    const pt: Zcu.PerThread = .{ .zcu = comp.module.?, .tid = @enumFromInt(tid) };
+    const pt: Zcu.PerThread = .{ .zcu = comp.zcu.?, .tid = @enumFromInt(tid) };
     pt.astGenFile(file, path_digest) catch |err| switch (err) {
         error.AnalysisFail => return,
         else => {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4350,8 +4350,8 @@ fn workerCheckEmbedFile(comp: *Compilation, embed_file: *Zcu.EmbedFile) void {
 }
 
 fn detectEmbedFileUpdate(comp: *Compilation, embed_file: *Zcu.EmbedFile) !void {
-    const mod = comp.zcu.?;
-    const ip = &mod.intern_pool;
+    const zcu = comp.zcu.?;
+    const ip = &zcu.intern_pool;
     var file = try embed_file.owner.root.openFile(embed_file.sub_file_path.toSlice(ip), .{});
     defer file.close();
 
@@ -4663,10 +4663,10 @@ fn reportRetryableEmbedFileError(
     embed_file: *Zcu.EmbedFile,
     err: anyerror,
 ) error{OutOfMemory}!void {
-    const mod = comp.zcu.?;
-    const gpa = mod.gpa;
+    const zcu = comp.zcu.?;
+    const gpa = zcu.gpa;
     const src_loc = embed_file.src_loc;
-    const ip = &mod.intern_pool;
+    const ip = &zcu.intern_pool;
     const err_msg = try Zcu.ErrorMsg.create(gpa, src_loc, "unable to load '{}/{s}': {s}", .{
         embed_file.owner.root,
         embed_file.sub_file_path.toSlice(ip),
@@ -4678,7 +4678,7 @@ fn reportRetryableEmbedFileError(
     {
         comp.mutex.lock();
         defer comp.mutex.unlock();
-        try mod.failed_embed_files.putNoClobber(gpa, embed_file, err_msg);
+        try zcu.failed_embed_files.putNoClobber(gpa, embed_file, err_msg);
     }
 }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3542,8 +3542,7 @@ fn performAllTheWorkInner(
         //    in the `astgen_wait_group`.
         if (comp.job_queued_update_builtin_zig) b: {
             comp.job_queued_update_builtin_zig = false;
-            const zcu = comp.zcu orelse break :b;
-            _ = zcu;
+            if (comp.zcu == null) break :b;
             // TODO put all the modules in a flat array to make them easy to iterate.
             var seen: std.AutoArrayHashMapUnmanaged(*Package.Module, void) = .{};
             defer seen.deinit(comp.gpa);

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -457,7 +457,7 @@ pub const Cau = struct {
                     unwrapped.index);
             }
         };
-        fn unwrap(cau_index: Cau.Index, ip: *const InternPool) Unwrapped {
+        pub fn unwrap(cau_index: Cau.Index, ip: *const InternPool) Unwrapped {
             return .{
                 .tid = @enumFromInt(@intFromEnum(cau_index) >> ip.tid_shift_31 & ip.getTidMask()),
                 .index = @intFromEnum(cau_index) & ip.getIndexMask(u31),
@@ -1464,7 +1464,7 @@ pub const NamespaceIndex = enum(u32) {
                 unwrapped.index);
         }
     };
-    fn unwrap(namespace_index: NamespaceIndex, ip: *const InternPool) Unwrapped {
+    pub fn unwrap(namespace_index: NamespaceIndex, ip: *const InternPool) Unwrapped {
         const index = @intFromEnum(namespace_index) & ip.getIndexMask(u32);
         return .{
             .tid = @enumFromInt(@intFromEnum(namespace_index) >> ip.tid_shift_32 & ip.getTidMask()),

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -457,7 +457,7 @@ pub const Cau = struct {
                     unwrapped.index);
             }
         };
-        pub fn unwrap(cau_index: Cau.Index, ip: *const InternPool) Unwrapped {
+        fn unwrap(cau_index: Cau.Index, ip: *const InternPool) Unwrapped {
             return .{
                 .tid = @enumFromInt(@intFromEnum(cau_index) >> ip.tid_shift_31 & ip.getTidMask()),
                 .index = @intFromEnum(cau_index) & ip.getIndexMask(u31),
@@ -1464,7 +1464,7 @@ pub const NamespaceIndex = enum(u32) {
                 unwrapped.index);
         }
     };
-    pub fn unwrap(namespace_index: NamespaceIndex, ip: *const InternPool) Unwrapped {
+    fn unwrap(namespace_index: NamespaceIndex, ip: *const InternPool) Unwrapped {
         const index = @intFromEnum(namespace_index) & ip.getIndexMask(u32);
         return .{
             .tid = @enumFromInt(@intFromEnum(namespace_index) >> ip.tid_shift_32 & ip.getTidMask()),

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -3483,7 +3483,7 @@ pub const LoadedStructType = struct {
         return s.field_aligns.get(ip)[i];
     }
 
-    pub fn fieldInit(s: LoadedStructType, ip: *InternPool, i: usize) Index {
+    pub fn fieldInit(s: LoadedStructType, ip: *const InternPool, i: usize) Index {
         if (s.field_inits.len == 0) return .none;
         assert(s.haveFieldInits(ip));
         return s.field_inits.get(ip)[i];
@@ -11066,7 +11066,7 @@ pub fn destroyNamespace(
     local.mutate.namespaces.free_list = @intFromEnum(namespace_index);
 }
 
-pub fn filePtr(ip: *InternPool, file_index: FileIndex) *Zcu.File {
+pub fn filePtr(ip: *const InternPool, file_index: FileIndex) *Zcu.File {
     const file_index_unwrapped = file_index.unwrap(ip);
     const files = ip.getLocalShared(file_index_unwrapped.tid).files.acquire();
     return files.view().items(.file)[file_index_unwrapped.index];

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -35458,9 +35458,6 @@ fn backingIntType(
     var analysis_arena = std.heap.ArenaAllocator.init(gpa);
     defer analysis_arena.deinit();
 
-    var comptime_err_ret_trace = std.ArrayList(LazySrcLoc).init(gpa);
-    defer comptime_err_ret_trace.deinit();
-
     var block: Block = .{
         .parent = null,
         .sema = sema,
@@ -36114,9 +36111,6 @@ fn structFields(
         },
     };
 
-    var comptime_err_ret_trace = std.ArrayList(LazySrcLoc).init(gpa);
-    defer comptime_err_ret_trace.deinit();
-
     var block_scope: Block = .{
         .parent = null,
         .sema = sema,
@@ -36300,7 +36294,6 @@ fn structFieldInits(
 ) CompileError!void {
     const pt = sema.pt;
     const zcu = pt.zcu;
-    const gpa = zcu.gpa;
     const ip = &zcu.intern_pool;
 
     assert(!struct_type.haveFieldInits(ip));
@@ -36310,9 +36303,6 @@ fn structFieldInits(
     const zir = zcu.namespacePtr(namespace_index).fileScope(zcu).zir;
     const zir_index = struct_type.zir_index.unwrap().?.resolve(ip) orelse return error.AnalysisFail;
     const fields_len, const small, var extra_index = structZirInfo(zir, zir_index);
-
-    var comptime_err_ret_trace = std.ArrayList(LazySrcLoc).init(gpa);
-    defer comptime_err_ret_trace.deinit();
 
     var block_scope: Block = .{
         .parent = null,
@@ -36475,28 +36465,9 @@ fn unionFields(
     const body = zir.bodySlice(extra_index, body_len);
     extra_index += body.len;
 
-    var comptime_err_ret_trace = std.ArrayList(LazySrcLoc).init(gpa);
-    defer comptime_err_ret_trace.deinit();
-
-    const cau_index = union_type.cau;
-
-    var inner_sema: Sema = .{
-        .pt = pt,
-        .gpa = gpa,
-        .arena = sema.arena,
-        .code = zir,
-        .owner = AnalUnit.wrap(.{ .cau = cau_index }),
-        .func_index = .none,
-        .func_is_naked = false,
-        .fn_ret_ty = Type.void,
-        .fn_ret_ty_ies = null,
-        .comptime_err_ret_trace = &comptime_err_ret_trace,
-    };
-    defer inner_sema.deinit();
-
     var block_scope: Block = .{
         .parent = null,
-        .sema = &inner_sema,
+        .sema = sema,
         .namespace = union_type.namespace,
         .instructions = .{},
         .inlining = null,

--- a/src/Sema/bitcast.zig
+++ b/src/Sema/bitcast.zig
@@ -542,7 +542,7 @@ const PackValueBits = struct {
                             while (it.next()) |field_idx| {
                                 const want_bit_off = ty.structFieldOffset(field_idx, zcu) * 8;
                                 try pack.padding(want_bit_off - cur_bit_off);
-                                const field_ty = ty.structFieldType(field_idx, zcu);
+                                const field_ty = ty.fieldType(field_idx, zcu);
                                 elems[field_idx] = (try pack.get(field_ty)).toIntern();
                                 cur_bit_off = want_bit_off + field_ty.bitSize(zcu);
                             }
@@ -552,7 +552,7 @@ const PackValueBits = struct {
                             var cur_bit_off: u64 = ty.bitSize(zcu);
                             var it = zcu.typeToStruct(ty).?.iterateRuntimeOrderReverse(ip);
                             while (it.next()) |field_idx| {
-                                const field_ty = ty.structFieldType(field_idx, zcu);
+                                const field_ty = ty.fieldType(field_idx, zcu);
                                 const want_bit_off = ty.structFieldOffset(field_idx, zcu) * 8 + field_ty.bitSize(zcu);
                                 try pack.padding(cur_bit_off - want_bit_off);
                                 elems[field_idx] = (try pack.get(field_ty)).toIntern();
@@ -578,7 +578,7 @@ const PackValueBits = struct {
                     // This is identical between LE and BE targets.
                     const elems = try arena.alloc(InternPool.Index, ty.structFieldCount(zcu));
                     for (elems, 0..) |*elem, i| {
-                        const field_ty = ty.structFieldType(i, zcu);
+                        const field_ty = ty.fieldType(i, zcu);
                         elem.* = (try pack.get(field_ty)).toIntern();
                     }
                     return Value.fromInterned(try pt.intern(.{ .aggregate = .{

--- a/src/Sema/bitcast.zig
+++ b/src/Sema/bitcast.zig
@@ -85,23 +85,23 @@ fn bitCastInner(
     assert(val_ty.hasWellDefinedLayout(zcu));
 
     const abi_pad_bits, const host_pad_bits = if (host_bits > 0)
-        .{ val_ty.abiSize(pt) * 8 - host_bits, host_bits - val_ty.bitSize(pt) }
+        .{ val_ty.abiSize(zcu) * 8 - host_bits, host_bits - val_ty.bitSize(zcu) }
     else
-        .{ val_ty.abiSize(pt) * 8 - val_ty.bitSize(pt), 0 };
+        .{ val_ty.abiSize(zcu) * 8 - val_ty.bitSize(zcu), 0 };
 
     const skip_bits = switch (endian) {
         .little => bit_offset + byte_offset * 8,
         .big => if (host_bits > 0)
-            val_ty.abiSize(pt) * 8 - byte_offset * 8 - host_bits + bit_offset
+            val_ty.abiSize(zcu) * 8 - byte_offset * 8 - host_bits + bit_offset
         else
-            val_ty.abiSize(pt) * 8 - byte_offset * 8 - dest_ty.bitSize(pt),
+            val_ty.abiSize(zcu) * 8 - byte_offset * 8 - dest_ty.bitSize(zcu),
     };
 
     var unpack: UnpackValueBits = .{
         .pt = sema.pt,
         .arena = sema.arena,
         .skip_bits = skip_bits,
-        .remaining_bits = dest_ty.bitSize(pt),
+        .remaining_bits = dest_ty.bitSize(zcu),
         .unpacked = std.ArrayList(InternPool.Index).init(sema.arena),
     };
     switch (endian) {
@@ -141,22 +141,22 @@ fn bitCastSpliceInner(
     try val_ty.resolveLayout(pt);
     try splice_val_ty.resolveLayout(pt);
 
-    const splice_bits = splice_val_ty.bitSize(pt);
+    const splice_bits = splice_val_ty.bitSize(zcu);
 
     const splice_offset = switch (endian) {
         .little => bit_offset + byte_offset * 8,
         .big => if (host_bits > 0)
-            val_ty.abiSize(pt) * 8 - byte_offset * 8 - host_bits + bit_offset
+            val_ty.abiSize(zcu) * 8 - byte_offset * 8 - host_bits + bit_offset
         else
-            val_ty.abiSize(pt) * 8 - byte_offset * 8 - splice_bits,
+            val_ty.abiSize(zcu) * 8 - byte_offset * 8 - splice_bits,
     };
 
-    assert(splice_offset + splice_bits <= val_ty.abiSize(pt) * 8);
+    assert(splice_offset + splice_bits <= val_ty.abiSize(zcu) * 8);
 
     const abi_pad_bits, const host_pad_bits = if (host_bits > 0)
-        .{ val_ty.abiSize(pt) * 8 - host_bits, host_bits - val_ty.bitSize(pt) }
+        .{ val_ty.abiSize(zcu) * 8 - host_bits, host_bits - val_ty.bitSize(zcu) }
     else
-        .{ val_ty.abiSize(pt) * 8 - val_ty.bitSize(pt), 0 };
+        .{ val_ty.abiSize(zcu) * 8 - val_ty.bitSize(zcu), 0 };
 
     var unpack: UnpackValueBits = .{
         .pt = pt,
@@ -181,7 +181,7 @@ fn bitCastSpliceInner(
     try unpack.add(splice_val);
 
     unpack.skip_bits = splice_offset + splice_bits;
-    unpack.remaining_bits = val_ty.abiSize(pt) * 8 - splice_offset - splice_bits;
+    unpack.remaining_bits = val_ty.abiSize(zcu) * 8 - splice_offset - splice_bits;
     switch (endian) {
         .little => {
             try unpack.add(val);
@@ -229,7 +229,7 @@ const UnpackValueBits = struct {
         }
 
         const ty = val.typeOf(zcu);
-        const bit_size = ty.bitSize(pt);
+        const bit_size = ty.bitSize(zcu);
 
         if (unpack.skip_bits >= bit_size) {
             unpack.skip_bits -= bit_size;
@@ -291,7 +291,7 @@ const UnpackValueBits = struct {
                     // The final element does not have trailing padding.
                     // Elements are reversed in packed memory on BE targets.
                     const elem_ty = ty.childType(zcu);
-                    const pad_bits = elem_ty.abiSize(pt) * 8 - elem_ty.bitSize(pt);
+                    const pad_bits = elem_ty.abiSize(zcu) * 8 - elem_ty.bitSize(zcu);
                     const len = ty.arrayLen(zcu);
                     const maybe_sent = ty.sentinel(zcu);
 
@@ -323,12 +323,12 @@ const UnpackValueBits = struct {
                             var cur_bit_off: u64 = 0;
                             var it = zcu.typeToStruct(ty).?.iterateRuntimeOrder(ip);
                             while (it.next()) |field_idx| {
-                                const want_bit_off = ty.structFieldOffset(field_idx, pt) * 8;
+                                const want_bit_off = ty.structFieldOffset(field_idx, zcu) * 8;
                                 const pad_bits = want_bit_off - cur_bit_off;
                                 const field_val = try val.fieldValue(pt, field_idx);
                                 try unpack.padding(pad_bits);
                                 try unpack.add(field_val);
-                                cur_bit_off = want_bit_off + field_val.typeOf(zcu).bitSize(pt);
+                                cur_bit_off = want_bit_off + field_val.typeOf(zcu).bitSize(zcu);
                             }
                             // Add trailing padding bits.
                             try unpack.padding(bit_size - cur_bit_off);
@@ -339,11 +339,11 @@ const UnpackValueBits = struct {
                             while (it.next()) |field_idx| {
                                 const field_val = try val.fieldValue(pt, field_idx);
                                 const field_ty = field_val.typeOf(zcu);
-                                const want_bit_off = ty.structFieldOffset(field_idx, pt) * 8 + field_ty.bitSize(pt);
+                                const want_bit_off = ty.structFieldOffset(field_idx, zcu) * 8 + field_ty.bitSize(zcu);
                                 const pad_bits = cur_bit_off - want_bit_off;
                                 try unpack.padding(pad_bits);
                                 try unpack.add(field_val);
-                                cur_bit_off = want_bit_off - field_ty.bitSize(pt);
+                                cur_bit_off = want_bit_off - field_ty.bitSize(zcu);
                             }
                             assert(cur_bit_off == 0);
                         },
@@ -366,7 +366,7 @@ const UnpackValueBits = struct {
                 // This correctly handles the case where `tag == .none`, since the payload is then
                 // either an integer or a byte array, both of which we can unpack.
                 const payload_val = Value.fromInterned(un.val);
-                const pad_bits = bit_size - payload_val.typeOf(zcu).bitSize(pt);
+                const pad_bits = bit_size - payload_val.typeOf(zcu).bitSize(zcu);
                 if (endian == .little or ty.containerLayout(zcu) == .@"packed") {
                     try unpack.add(payload_val);
                     try unpack.padding(pad_bits);
@@ -398,13 +398,14 @@ const UnpackValueBits = struct {
 
     fn primitive(unpack: *UnpackValueBits, val: Value) BitCastError!void {
         const pt = unpack.pt;
+        const zcu = pt.zcu;
 
         if (unpack.remaining_bits == 0) {
             return;
         }
 
         const ty = val.typeOf(pt.zcu);
-        const bit_size = ty.bitSize(pt);
+        const bit_size = ty.bitSize(zcu);
 
         // Note that this skips all zero-bit types.
         if (unpack.skip_bits >= bit_size) {
@@ -429,9 +430,10 @@ const UnpackValueBits = struct {
 
     fn splitPrimitive(unpack: *UnpackValueBits, val: Value, bit_offset: u64, bit_count: u64) BitCastError!void {
         const pt = unpack.pt;
+        const zcu = pt.zcu;
         const ty = val.typeOf(pt.zcu);
 
-        const val_bits = ty.bitSize(pt);
+        const val_bits = ty.bitSize(zcu);
         assert(bit_offset + bit_count <= val_bits);
 
         switch (pt.zcu.intern_pool.indexToKey(val.toIntern())) {
@@ -499,12 +501,12 @@ const PackValueBits = struct {
                 const len = ty.arrayLen(zcu);
                 const elem_ty = ty.childType(zcu);
                 const maybe_sent = ty.sentinel(zcu);
-                const pad_bits = elem_ty.abiSize(pt) * 8 - elem_ty.bitSize(pt);
+                const pad_bits = elem_ty.abiSize(zcu) * 8 - elem_ty.bitSize(zcu);
                 const elems = try arena.alloc(InternPool.Index, @intCast(len));
 
                 if (endian == .big and maybe_sent != null) {
                     // TODO: validate sentinel was preserved!
-                    try pack.padding(elem_ty.bitSize(pt));
+                    try pack.padding(elem_ty.bitSize(zcu));
                     if (len != 0) try pack.padding(pad_bits);
                 }
 
@@ -520,7 +522,7 @@ const PackValueBits = struct {
                 if (endian == .little and maybe_sent != null) {
                     // TODO: validate sentinel was preserved!
                     if (len != 0) try pack.padding(pad_bits);
-                    try pack.padding(elem_ty.bitSize(pt));
+                    try pack.padding(elem_ty.bitSize(zcu));
                 }
 
                 return Value.fromInterned(try pt.intern(.{ .aggregate = .{
@@ -538,23 +540,23 @@ const PackValueBits = struct {
                             var cur_bit_off: u64 = 0;
                             var it = zcu.typeToStruct(ty).?.iterateRuntimeOrder(ip);
                             while (it.next()) |field_idx| {
-                                const want_bit_off = ty.structFieldOffset(field_idx, pt) * 8;
+                                const want_bit_off = ty.structFieldOffset(field_idx, zcu) * 8;
                                 try pack.padding(want_bit_off - cur_bit_off);
                                 const field_ty = ty.structFieldType(field_idx, zcu);
                                 elems[field_idx] = (try pack.get(field_ty)).toIntern();
-                                cur_bit_off = want_bit_off + field_ty.bitSize(pt);
+                                cur_bit_off = want_bit_off + field_ty.bitSize(zcu);
                             }
-                            try pack.padding(ty.bitSize(pt) - cur_bit_off);
+                            try pack.padding(ty.bitSize(zcu) - cur_bit_off);
                         },
                         .big => {
-                            var cur_bit_off: u64 = ty.bitSize(pt);
+                            var cur_bit_off: u64 = ty.bitSize(zcu);
                             var it = zcu.typeToStruct(ty).?.iterateRuntimeOrderReverse(ip);
                             while (it.next()) |field_idx| {
                                 const field_ty = ty.structFieldType(field_idx, zcu);
-                                const want_bit_off = ty.structFieldOffset(field_idx, pt) * 8 + field_ty.bitSize(pt);
+                                const want_bit_off = ty.structFieldOffset(field_idx, zcu) * 8 + field_ty.bitSize(zcu);
                                 try pack.padding(cur_bit_off - want_bit_off);
                                 elems[field_idx] = (try pack.get(field_ty)).toIntern();
-                                cur_bit_off = want_bit_off - field_ty.bitSize(pt);
+                                cur_bit_off = want_bit_off - field_ty.bitSize(zcu);
                             }
                             assert(cur_bit_off == 0);
                         },
@@ -622,16 +624,16 @@ const PackValueBits = struct {
                 for (field_order, 0..) |*f, i| f.* = @intCast(i);
                 // Sort `field_order` to put the fields with the largest bit sizes first.
                 const SizeSortCtx = struct {
-                    pt: Zcu.PerThread,
+                    zcu: *Zcu,
                     field_types: []const InternPool.Index,
                     fn lessThan(ctx: @This(), a_idx: u32, b_idx: u32) bool {
                         const a_ty = Type.fromInterned(ctx.field_types[a_idx]);
                         const b_ty = Type.fromInterned(ctx.field_types[b_idx]);
-                        return a_ty.bitSize(ctx.pt) > b_ty.bitSize(ctx.pt);
+                        return a_ty.bitSize(ctx.zcu) > b_ty.bitSize(ctx.zcu);
                     }
                 };
                 std.mem.sortUnstable(u32, field_order, SizeSortCtx{
-                    .pt = pt,
+                    .zcu = zcu,
                     .field_types = zcu.typeToUnion(ty).?.field_types.get(ip),
                 }, SizeSortCtx.lessThan);
 
@@ -639,7 +641,7 @@ const PackValueBits = struct {
 
                 for (field_order) |field_idx| {
                     const field_ty = Type.fromInterned(zcu.typeToUnion(ty).?.field_types.get(ip)[field_idx]);
-                    const pad_bits = ty.bitSize(pt) - field_ty.bitSize(pt);
+                    const pad_bits = ty.bitSize(zcu) - field_ty.bitSize(zcu);
                     if (!padding_after) try pack.padding(pad_bits);
                     const field_val = pack.get(field_ty) catch |err| switch (err) {
                         error.ReinterpretDeclRef => {
@@ -682,10 +684,11 @@ const PackValueBits = struct {
 
     fn primitive(pack: *PackValueBits, want_ty: Type) BitCastError!Value {
         const pt = pack.pt;
-        const vals, const bit_offset = pack.prepareBits(want_ty.bitSize(pt));
+        const zcu = pt.zcu;
+        const vals, const bit_offset = pack.prepareBits(want_ty.bitSize(zcu));
 
         for (vals) |val| {
-            if (!Value.fromInterned(val).isUndef(pt.zcu)) break;
+            if (!Value.fromInterned(val).isUndef(zcu)) break;
         } else {
             // All bits of the value are `undefined`.
             return pt.undefValue(want_ty);
@@ -706,8 +709,8 @@ const PackValueBits = struct {
         ptr_cast: {
             if (vals.len != 1) break :ptr_cast;
             const val = Value.fromInterned(vals[0]);
-            if (!val.typeOf(pt.zcu).isPtrAtRuntime(pt.zcu)) break :ptr_cast;
-            if (!want_ty.isPtrAtRuntime(pt.zcu)) break :ptr_cast;
+            if (!val.typeOf(zcu).isPtrAtRuntime(zcu)) break :ptr_cast;
+            if (!want_ty.isPtrAtRuntime(zcu)) break :ptr_cast;
             return pt.getCoerced(val, want_ty);
         }
 
@@ -717,7 +720,7 @@ const PackValueBits = struct {
         for (vals) |ip_val| {
             const val = Value.fromInterned(ip_val);
             const ty = val.typeOf(pt.zcu);
-            buf_bits += ty.bitSize(pt);
+            buf_bits += ty.bitSize(zcu);
         }
 
         const buf = try pack.arena.alloc(u8, @intCast((buf_bits + 7) / 8));
@@ -726,11 +729,11 @@ const PackValueBits = struct {
         var cur_bit_off: usize = 0;
         for (vals) |ip_val| {
             const val = Value.fromInterned(ip_val);
-            const ty = val.typeOf(pt.zcu);
-            if (!val.isUndef(pt.zcu)) {
+            const ty = val.typeOf(zcu);
+            if (!val.isUndef(zcu)) {
                 try val.writeToPackedMemory(ty, pt, buf, cur_bit_off);
             }
-            cur_bit_off += @intCast(ty.bitSize(pt));
+            cur_bit_off += @intCast(ty.bitSize(zcu));
         }
 
         return Value.readFromPackedMemory(want_ty, pt, buf, @intCast(bit_offset), pack.arena);
@@ -740,11 +743,12 @@ const PackValueBits = struct {
         if (need_bits == 0) return .{ &.{}, 0 };
 
         const pt = pack.pt;
+        const zcu = pt.zcu;
 
         var bits: u64 = 0;
         var len: usize = 0;
         while (bits < pack.bit_offset + need_bits) {
-            bits += Value.fromInterned(pack.unpacked[len]).typeOf(pt.zcu).bitSize(pt);
+            bits += Value.fromInterned(pack.unpacked[len]).typeOf(pt.zcu).bitSize(zcu);
             len += 1;
         }
 
@@ -757,7 +761,7 @@ const PackValueBits = struct {
             pack.bit_offset = 0;
         } else {
             pack.unpacked = pack.unpacked[len - 1 ..];
-            pack.bit_offset = Value.fromInterned(pack.unpacked[0]).typeOf(pt.zcu).bitSize(pt) - extra_bits;
+            pack.bit_offset = Value.fromInterned(pack.unpacked[0]).typeOf(pt.zcu).bitSize(zcu) - extra_bits;
         }
 
         return .{ result_vals, result_offset };

--- a/src/Sema/comptime_ptr_access.zig
+++ b/src/Sema/comptime_ptr_access.zig
@@ -451,7 +451,7 @@ fn loadComptimePtrInner(
                 .@"packed" => break, // let the bitcast logic handle this
                 .@"extern" => for (0..cur_ty.structFieldCount(zcu)) |field_idx| {
                     const start_off = cur_ty.structFieldOffset(field_idx, zcu);
-                    const end_off = start_off + try cur_ty.structFieldType(field_idx, zcu).abiSizeSema(pt);
+                    const end_off = start_off + try cur_ty.fieldType(field_idx, zcu).abiSizeSema(pt);
                     if (cur_offset >= start_off and cur_offset + need_bytes <= end_off) {
                         cur_val = try cur_val.getElem(sema.pt, field_idx);
                         cur_offset -= start_off;
@@ -873,7 +873,7 @@ fn prepareComptimePtrStore(
                 .@"packed" => break, // let the bitcast logic handle this
                 .@"extern" => for (0..cur_ty.structFieldCount(zcu)) |field_idx| {
                     const start_off = cur_ty.structFieldOffset(field_idx, zcu);
-                    const end_off = start_off + try cur_ty.structFieldType(field_idx, zcu).abiSizeSema(pt);
+                    const end_off = start_off + try cur_ty.fieldType(field_idx, zcu).abiSizeSema(pt);
                     if (cur_offset >= start_off and cur_offset + need_bytes <= end_off) {
                         cur_val = try cur_val.elem(pt, sema.arena, field_idx);
                         cur_offset -= start_off;

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -3926,8 +3926,6 @@ fn resolveStructInner(
     };
     defer sema.deinit();
 
-    assert(sema.owner.unwrap().cau == struct_obj.cau.unwrap().?);
-
     (switch (resolution) {
         .fields => sema.resolveStructFieldTypes(ty.toIntern(), struct_obj),
         .inits => sema.resolveStructFieldInits(ty),
@@ -3981,8 +3979,6 @@ fn resolveUnionInner(
         .comptime_err_ret_trace = &comptime_err_ret_trace,
     };
     defer sema.deinit();
-
-    assert(sema.owner.unwrap().cau == union_obj.cau);
 
     (switch (resolution) {
         .fields => sema.resolveUnionFieldTypes(ty, union_obj),

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -10,8 +10,6 @@ const Value = @import("Value.zig");
 const assert = std.debug.assert;
 const Target = std.Target;
 const Zcu = @import("Zcu.zig");
-/// Deprecated.
-const Module = Zcu;
 const log = std.log.scoped(.Type);
 const target_util = @import("target.zig");
 const Sema = @import("Sema.zig");
@@ -23,15 +21,15 @@ const SemaError = Zcu.SemaError;
 
 ip_index: InternPool.Index,
 
-pub fn zigTypeTag(ty: Type, mod: *const Module) std.builtin.TypeId {
-    return ty.zigTypeTagOrPoison(mod) catch unreachable;
+pub fn zigTypeTag(ty: Type, zcu: *const Zcu) std.builtin.TypeId {
+    return ty.zigTypeTagOrPoison(zcu) catch unreachable;
 }
 
-pub fn zigTypeTagOrPoison(ty: Type, mod: *const Module) error{GenericPoison}!std.builtin.TypeId {
-    return mod.intern_pool.zigTypeTagOrPoison(ty.toIntern());
+pub fn zigTypeTagOrPoison(ty: Type, zcu: *const Zcu) error{GenericPoison}!std.builtin.TypeId {
+    return zcu.intern_pool.zigTypeTagOrPoison(ty.toIntern());
 }
 
-pub fn baseZigTypeTag(self: Type, mod: *Module) std.builtin.TypeId {
+pub fn baseZigTypeTag(self: Type, mod: *Zcu) std.builtin.TypeId {
     return switch (self.zigTypeTag(mod)) {
         .ErrorUnion => self.errorUnionPayload(mod).baseZigTypeTag(mod),
         .Optional => {
@@ -41,15 +39,15 @@ pub fn baseZigTypeTag(self: Type, mod: *Module) std.builtin.TypeId {
     };
 }
 
-pub fn isSelfComparable(ty: Type, mod: *const Module, is_equality_cmp: bool) bool {
-    return switch (ty.zigTypeTag(mod)) {
+pub fn isSelfComparable(ty: Type, zcu: *const Zcu, is_equality_cmp: bool) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Int,
         .Float,
         .ComptimeFloat,
         .ComptimeInt,
         => true,
 
-        .Vector => ty.elemType2(mod).isSelfComparable(mod, is_equality_cmp),
+        .Vector => ty.elemType2(zcu).isSelfComparable(zcu, is_equality_cmp),
 
         .Bool,
         .Type,
@@ -72,25 +70,25 @@ pub fn isSelfComparable(ty: Type, mod: *const Module, is_equality_cmp: bool) boo
         .Frame,
         => false,
 
-        .Pointer => !ty.isSlice(mod) and (is_equality_cmp or ty.isCPtr(mod)),
+        .Pointer => !ty.isSlice(zcu) and (is_equality_cmp or ty.isCPtr(zcu)),
         .Optional => {
             if (!is_equality_cmp) return false;
-            return ty.optionalChild(mod).isSelfComparable(mod, is_equality_cmp);
+            return ty.optionalChild(zcu).isSelfComparable(zcu, is_equality_cmp);
         },
     };
 }
 
 /// If it is a function pointer, returns the function type. Otherwise returns null.
-pub fn castPtrToFn(ty: Type, mod: *const Module) ?Type {
-    if (ty.zigTypeTag(mod) != .Pointer) return null;
-    const elem_ty = ty.childType(mod);
-    if (elem_ty.zigTypeTag(mod) != .Fn) return null;
+pub fn castPtrToFn(ty: Type, zcu: *const Zcu) ?Type {
+    if (ty.zigTypeTag(zcu) != .Pointer) return null;
+    const elem_ty = ty.childType(zcu);
+    if (elem_ty.zigTypeTag(zcu) != .Fn) return null;
     return elem_ty;
 }
 
 /// Asserts the type is a pointer.
-pub fn ptrIsMutable(ty: Type, mod: *const Module) bool {
-    return !mod.intern_pool.indexToKey(ty.toIntern()).ptr_type.flags.is_const;
+pub fn ptrIsMutable(ty: Type, zcu: *const Zcu) bool {
+    return !zcu.intern_pool.indexToKey(ty.toIntern()).ptr_type.flags.is_const;
 }
 
 pub const ArrayInfo = struct {
@@ -99,18 +97,18 @@ pub const ArrayInfo = struct {
     len: u64,
 };
 
-pub fn arrayInfo(self: Type, mod: *const Module) ArrayInfo {
+pub fn arrayInfo(self: Type, zcu: *const Zcu) ArrayInfo {
     return .{
-        .len = self.arrayLen(mod),
-        .sentinel = self.sentinel(mod),
-        .elem_type = self.childType(mod),
+        .len = self.arrayLen(zcu),
+        .sentinel = self.sentinel(zcu),
+        .elem_type = self.childType(zcu),
     };
 }
 
-pub fn ptrInfo(ty: Type, mod: *const Module) InternPool.Key.PtrType {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn ptrInfo(ty: Type, zcu: *const Zcu) InternPool.Key.PtrType {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |p| p,
-        .opt_type => |child| switch (mod.intern_pool.indexToKey(child)) {
+        .opt_type => |child| switch (zcu.intern_pool.indexToKey(child)) {
             .ptr_type => |p| p,
             else => unreachable,
         },
@@ -118,8 +116,8 @@ pub fn ptrInfo(ty: Type, mod: *const Module) InternPool.Key.PtrType {
     };
 }
 
-pub fn eql(a: Type, b: Type, mod: *const Module) bool {
-    _ = mod; // TODO: remove this parameter
+pub fn eql(a: Type, b: Type, zcu: *const Zcu) bool {
+    _ = zcu; // TODO: remove this parameter
     // The InternPool data structure hashes based on Key to make interned objects
     // unique. An Index can be treated simply as u32 value for the
     // purpose of Type/Value hashing and equality.
@@ -179,8 +177,8 @@ pub fn dump(
 /// Prints a name suitable for `@typeName`.
 /// TODO: take an `opt_sema` to pass to `fmtValue` when printing sentinels.
 pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error!void {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
         .int_type => |int_type| {
             const sign_char: u8 = switch (int_type.signedness) {
@@ -190,7 +188,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
             return writer.print("{c}{d}", .{ sign_char, int_type.bits });
         },
         .ptr_type => {
-            const info = ty.ptrInfo(mod);
+            const info = ty.ptrInfo(zcu);
 
             if (info.sentinel != .none) switch (info.flags.size) {
                 .One, .C => unreachable,
@@ -210,7 +208,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
                 const alignment = if (info.flags.alignment != .none)
                     info.flags.alignment
                 else
-                    Type.fromInterned(info.child).abiAlignment(pt);
+                    Type.fromInterned(info.child).abiAlignment(pt.zcu);
                 try writer.print("align({d}", .{alignment.toByteUnits() orelse 0});
 
                 if (info.packed_offset.bit_offset != 0 or info.packed_offset.host_size != 0) {
@@ -268,7 +266,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
             return;
         },
         .inferred_error_set_type => |func_index| {
-            const func_nav = ip.getNav(mod.funcInfo(func_index).owner_nav);
+            const func_nav = ip.getNav(zcu.funcInfo(func_index).owner_nav);
             try writer.print("@typeInfo(@typeInfo(@TypeOf({})).Fn.return_type.?).ErrorUnion.error_set", .{
                 func_nav.fqn.fmt(ip),
             });
@@ -338,7 +336,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
                     try writer.writeAll("comptime ");
                 }
                 if (anon_struct.names.len != 0) {
-                    try writer.print("{}: ", .{anon_struct.names.get(ip)[i].fmt(&mod.intern_pool)});
+                    try writer.print("{}: ", .{anon_struct.names.get(ip)[i].fmt(&zcu.intern_pool)});
                 }
 
                 try print(Type.fromInterned(field_ty), writer, pt);
@@ -367,7 +365,7 @@ pub fn print(ty: Type, writer: anytype, pt: Zcu.PerThread) @TypeOf(writer).Error
                 try writer.writeAll("noinline ");
             }
             try writer.writeAll("fn (");
-            const param_types = fn_info.param_types.get(&mod.intern_pool);
+            const param_types = fn_info.param_types.get(&zcu.intern_pool);
             for (param_types, 0..) |param_ty, i| {
                 if (i != 0) try writer.writeAll(", ");
                 if (std.math.cast(u5, i)) |index| {
@@ -448,6 +446,21 @@ pub fn toValue(self: Type) Value {
 
 const RuntimeBitsError = SemaError || error{NeedLazy};
 
+pub fn hasRuntimeBits(ty: Type, zcu: *Zcu) bool {
+    return hasRuntimeBitsInner(ty, false, .eager, zcu, {}) catch unreachable;
+}
+
+pub fn hasRuntimeBitsSema(ty: Type, pt: Zcu.PerThread) SemaError!bool {
+    return hasRuntimeBitsInner(ty, false, .sema, pt.zcu, pt.tid) catch |err| switch (err) {
+        error.NeedLazy => unreachable, // this would require a resolve strat of lazy
+        else => |e| return e,
+    };
+}
+
+pub fn hasRuntimeBitsIgnoreComptime(ty: Type, zcu: *Zcu) bool {
+    return hasRuntimeBitsInner(ty, true, .eager, zcu, {}) catch unreachable;
+}
+
 /// true if and only if the type takes up space in memory at runtime.
 /// There are two reasons a type will return false:
 /// * the type is a comptime-only type. For example, the type `type` itself.
@@ -459,14 +472,14 @@ const RuntimeBitsError = SemaError || error{NeedLazy};
 ///     making it one-possible-value only if the integer tag type has 0 bits.
 /// When `ignore_comptime_only` is true, then types that are comptime-only
 /// may return false positives.
-pub fn hasRuntimeBitsAdvanced(
+pub fn hasRuntimeBitsInner(
     ty: Type,
-    pt: Zcu.PerThread,
     ignore_comptime_only: bool,
     comptime strat: ResolveStratLazy,
+    zcu: *Zcu,
+    tid: strat.Tid(),
 ) RuntimeBitsError!bool {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const ip = &zcu.intern_pool;
     return switch (ty.toIntern()) {
         // False because it is a comptime-only type.
         .empty_struct_type => false,
@@ -477,26 +490,29 @@ pub fn hasRuntimeBitsAdvanced(
                 // to comptime-only types do not, with the exception of function pointers.
                 if (ignore_comptime_only) return true;
                 return switch (strat) {
-                    .sema => !try ty.comptimeOnlyAdvanced(pt, .sema),
-                    .eager => !ty.comptimeOnly(pt),
+                    .sema => {
+                        const pt = strat.pt(zcu, tid);
+                        return !try ty.comptimeOnlySema(pt);
+                    },
+                    .eager => !ty.comptimeOnly(zcu),
                     .lazy => error.NeedLazy,
                 };
             },
             .anyframe_type => true,
             .array_type => |array_type| return array_type.lenIncludingSentinel() > 0 and
-                try Type.fromInterned(array_type.child).hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat),
+                try Type.fromInterned(array_type.child).hasRuntimeBitsInner(ignore_comptime_only, strat, zcu, tid),
             .vector_type => |vector_type| return vector_type.len > 0 and
-                try Type.fromInterned(vector_type.child).hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat),
+                try Type.fromInterned(vector_type.child).hasRuntimeBitsInner(ignore_comptime_only, strat, zcu, tid),
             .opt_type => |child| {
                 const child_ty = Type.fromInterned(child);
-                if (child_ty.isNoReturn(mod)) {
+                if (child_ty.isNoReturn(zcu)) {
                     // Then the optional is comptime-known to be null.
                     return false;
                 }
                 if (ignore_comptime_only) return true;
                 return switch (strat) {
-                    .sema => !try child_ty.comptimeOnlyAdvanced(pt, .sema),
-                    .eager => !child_ty.comptimeOnly(pt),
+                    .sema => !try child_ty.comptimeOnlyInner(.sema, zcu, tid),
+                    .eager => !child_ty.comptimeOnly(zcu),
                     .lazy => error.NeedLazy,
                 };
             },
@@ -556,14 +572,14 @@ pub fn hasRuntimeBitsAdvanced(
                     return true;
                 }
                 switch (strat) {
-                    .sema => try ty.resolveFields(pt),
+                    .sema => try ty.resolveFields(strat.pt(zcu, tid)),
                     .eager => assert(struct_type.haveFieldTypes(ip)),
                     .lazy => if (!struct_type.haveFieldTypes(ip)) return error.NeedLazy,
                 }
                 for (0..struct_type.field_types.len) |i| {
                     if (struct_type.comptime_bits.getBit(ip, i)) continue;
                     const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
-                    if (try field_ty.hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat))
+                    if (try field_ty.hasRuntimeBitsInner(ignore_comptime_only, strat, zcu, tid))
                         return true;
                 } else {
                     return false;
@@ -572,7 +588,12 @@ pub fn hasRuntimeBitsAdvanced(
             .anon_struct_type => |tuple| {
                 for (tuple.types.get(ip), tuple.values.get(ip)) |field_ty, val| {
                     if (val != .none) continue; // comptime field
-                    if (try Type.fromInterned(field_ty).hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat)) return true;
+                    if (try Type.fromInterned(field_ty).hasRuntimeBitsInner(
+                        ignore_comptime_only,
+                        strat,
+                        zcu,
+                        tid,
+                    )) return true;
                 }
                 return false;
             },
@@ -591,21 +612,25 @@ pub fn hasRuntimeBitsAdvanced(
                         // tag_ty will be `none` if this union's tag type is not resolved yet,
                         // in which case we want control flow to continue down below.
                         if (tag_ty != .none and
-                            try Type.fromInterned(tag_ty).hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat))
-                        {
+                            try Type.fromInterned(tag_ty).hasRuntimeBitsInner(
+                            ignore_comptime_only,
+                            strat,
+                            zcu,
+                            tid,
+                        )) {
                             return true;
                         }
                     },
                 }
                 switch (strat) {
-                    .sema => try ty.resolveFields(pt),
+                    .sema => try ty.resolveFields(strat.pt(zcu, tid)),
                     .eager => assert(union_flags.status.haveFieldTypes()),
                     .lazy => if (!union_flags.status.haveFieldTypes())
                         return error.NeedLazy,
                 }
                 for (0..union_type.field_types.len) |field_index| {
                     const field_ty = Type.fromInterned(union_type.field_types.get(ip)[field_index]);
-                    if (try field_ty.hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat))
+                    if (try field_ty.hasRuntimeBitsInner(ignore_comptime_only, strat, zcu, tid))
                         return true;
                 } else {
                     return false;
@@ -613,7 +638,12 @@ pub fn hasRuntimeBitsAdvanced(
             },
 
             .opaque_type => true,
-            .enum_type => Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).hasRuntimeBitsAdvanced(pt, ignore_comptime_only, strat),
+            .enum_type => Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).hasRuntimeBitsInner(
+                ignore_comptime_only,
+                strat,
+                zcu,
+                tid,
+            ),
 
             // values, not types
             .undef,
@@ -643,8 +673,8 @@ pub fn hasRuntimeBitsAdvanced(
 /// true if and only if the type has a well-defined memory layout
 /// readFrom/writeToMemory are supported only for types with a well-
 /// defined memory layout
-pub fn hasWellDefinedLayout(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn hasWellDefinedLayout(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .int_type,
         .vector_type,
@@ -660,8 +690,8 @@ pub fn hasWellDefinedLayout(ty: Type, mod: *Module) bool {
         .func_type,
         => false,
 
-        .array_type => |array_type| Type.fromInterned(array_type.child).hasWellDefinedLayout(mod),
-        .opt_type => ty.isPtrLikeOptional(mod),
+        .array_type => |array_type| Type.fromInterned(array_type.child).hasWellDefinedLayout(zcu),
+        .opt_type => ty.isPtrLikeOptional(zcu),
         .ptr_type => |ptr_type| ptr_type.flags.size != .Slice,
 
         .simple_type => |t| switch (t) {
@@ -740,94 +770,99 @@ pub fn hasWellDefinedLayout(ty: Type, mod: *Module) bool {
     };
 }
 
-pub fn hasRuntimeBits(ty: Type, pt: Zcu.PerThread) bool {
-    return hasRuntimeBitsAdvanced(ty, pt, false, .eager) catch unreachable;
+pub fn fnHasRuntimeBits(ty: Type, zcu: *Zcu) bool {
+    return ty.fnHasRuntimeBitsInner(.normal, zcu, {}) catch unreachable;
 }
 
-pub fn hasRuntimeBitsIgnoreComptime(ty: Type, pt: Zcu.PerThread) bool {
-    return hasRuntimeBitsAdvanced(ty, pt, true, .eager) catch unreachable;
-}
-
-pub fn fnHasRuntimeBits(ty: Type, pt: Zcu.PerThread) bool {
-    return ty.fnHasRuntimeBitsAdvanced(pt, .normal) catch unreachable;
+pub fn fnHasRuntimeBitsSema(ty: Type, pt: Zcu.PerThread) SemaError!bool {
+    return try ty.fnHasRuntimeBitsInner(.sema, pt.zcu, pt.tid);
 }
 
 /// Determines whether a function type has runtime bits, i.e. whether a
 /// function with this type can exist at runtime.
 /// Asserts that `ty` is a function type.
-pub fn fnHasRuntimeBitsAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: ResolveStrat) SemaError!bool {
-    const fn_info = pt.zcu.typeToFunc(ty).?;
+pub fn fnHasRuntimeBitsInner(
+    ty: Type,
+    comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) SemaError!bool {
+    const fn_info = zcu.typeToFunc(ty).?;
     if (fn_info.is_generic) return false;
     if (fn_info.is_var_args) return true;
     if (fn_info.cc == .Inline) return false;
-    return !try Type.fromInterned(fn_info.return_type).comptimeOnlyAdvanced(pt, strat);
+    return !try Type.fromInterned(fn_info.return_type).comptimeOnlyInner(strat, zcu, tid);
 }
 
-pub fn isFnOrHasRuntimeBits(ty: Type, pt: Zcu.PerThread) bool {
-    switch (ty.zigTypeTag(pt.zcu)) {
-        .Fn => return ty.fnHasRuntimeBits(pt),
-        else => return ty.hasRuntimeBits(pt),
+pub fn isFnOrHasRuntimeBits(ty: Type, zcu: *Zcu) bool {
+    switch (ty.zigTypeTag(zcu)) {
+        .Fn => return ty.fnHasRuntimeBits(zcu),
+        else => return ty.hasRuntimeBits(zcu),
     }
 }
 
 /// Same as `isFnOrHasRuntimeBits` but comptime-only types may return a false positive.
-pub fn isFnOrHasRuntimeBitsIgnoreComptime(ty: Type, pt: Zcu.PerThread) bool {
-    return switch (ty.zigTypeTag(pt.zcu)) {
+pub fn isFnOrHasRuntimeBitsIgnoreComptime(ty: Type, zcu: *Zcu) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Fn => true,
-        else => return ty.hasRuntimeBitsIgnoreComptime(pt),
+        else => return ty.hasRuntimeBitsIgnoreComptime(zcu),
     };
 }
 
-pub fn isNoReturn(ty: Type, mod: *Module) bool {
-    return mod.intern_pool.isNoReturn(ty.toIntern());
+pub fn isNoReturn(ty: Type, zcu: *const Zcu) bool {
+    return zcu.intern_pool.isNoReturn(ty.toIntern());
 }
 
 /// Returns `none` if the pointer is naturally aligned and the element type is 0-bit.
-pub fn ptrAlignment(ty: Type, pt: Zcu.PerThread) Alignment {
-    return ptrAlignmentAdvanced(ty, pt, .normal) catch unreachable;
+pub fn ptrAlignment(ty: Type, zcu: *Zcu) Alignment {
+    return ptrAlignmentInner(ty, .normal, zcu, {}) catch unreachable;
 }
 
-pub fn ptrAlignmentAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: ResolveStrat) !Alignment {
-    return switch (pt.zcu.intern_pool.indexToKey(ty.toIntern())) {
+pub fn ptrAlignmentSema(ty: Type, pt: Zcu.PerThread) SemaError!Alignment {
+    return try ty.ptrAlignmentInner(.sema, pt.zcu, pt.tid);
+}
+
+pub fn ptrAlignmentInner(
+    ty: Type,
+    comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) !Alignment {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| {
             if (ptr_type.flags.alignment != .none)
                 return ptr_type.flags.alignment;
 
             if (strat == .sema) {
-                const res = try Type.fromInterned(ptr_type.child).abiAlignmentAdvanced(pt, .sema);
+                const res = try Type.fromInterned(ptr_type.child).abiAlignmentInner(.sema, zcu, tid);
                 return res.scalar;
             }
 
-            return (Type.fromInterned(ptr_type.child).abiAlignmentAdvanced(pt, .eager) catch unreachable).scalar;
+            return Type.fromInterned(ptr_type.child).abiAlignment(zcu);
         },
-        .opt_type => |child| Type.fromInterned(child).ptrAlignmentAdvanced(pt, strat),
+        .opt_type => |child| Type.fromInterned(child).ptrAlignmentInner(strat, zcu, tid),
         else => unreachable,
     };
 }
 
-pub fn ptrAddressSpace(ty: Type, mod: *const Module) std.builtin.AddressSpace {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn ptrAddressSpace(ty: Type, zcu: *const Zcu) std.builtin.AddressSpace {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| ptr_type.flags.address_space,
-        .opt_type => |child| mod.intern_pool.indexToKey(child).ptr_type.flags.address_space,
+        .opt_type => |child| zcu.intern_pool.indexToKey(child).ptr_type.flags.address_space,
         else => unreachable,
     };
-}
-
-/// Never returns `none`. Asserts that all necessary type resolution is already done.
-pub fn abiAlignment(ty: Type, pt: Zcu.PerThread) Alignment {
-    return (ty.abiAlignmentAdvanced(pt, .eager) catch unreachable).scalar;
 }
 
 /// May capture a reference to `ty`.
 /// Returned value has type `comptime_int`.
 pub fn lazyAbiAlignment(ty: Type, pt: Zcu.PerThread) !Value {
-    switch (try ty.abiAlignmentAdvanced(pt, .lazy)) {
+    switch (try ty.abiAlignmentInner(.lazy, pt.zcu, pt.tid)) {
         .val => |val| return val,
         .scalar => |x| return pt.intValue(Type.comptime_int, x.toByteUnits() orelse 0),
     }
 }
 
-pub const AbiAlignmentAdvanced = union(enum) {
+pub const AbiAlignmentInner = union(enum) {
     scalar: Alignment,
     val: Value,
 };
@@ -842,6 +877,23 @@ pub const ResolveStratLazy = enum {
     /// Return a scalar result, performing type resolution as necessary.
     /// This should typically be used from semantic analysis.
     sema,
+
+    pub fn Tid(comptime strat: ResolveStratLazy) type {
+        return switch (strat) {
+            .lazy, .sema => Zcu.PerThread.Id,
+            .eager => void,
+        };
+    }
+
+    pub fn pt(comptime strat: ResolveStratLazy, zcu: *Zcu, tid: strat.Tid()) switch (strat) {
+        .lazy, .sema => Zcu.PerThread,
+        .eager => void,
+    } {
+        return switch (strat) {
+            .lazy, .sema => .{ .tid = tid, .zcu = zcu },
+            else => {},
+        };
+    }
 };
 
 /// The chosen strategy can be easily optimized away in release builds.
@@ -854,6 +906,23 @@ pub const ResolveStrat = enum {
     /// This should typically be used from semantic analysis.
     sema,
 
+    pub fn Tid(comptime strat: ResolveStrat) type {
+        return switch (strat) {
+            .sema => Zcu.PerThread.Id,
+            .normal => void,
+        };
+    }
+
+    pub fn pt(comptime strat: ResolveStrat, zcu: *Zcu, tid: strat.Tid()) switch (strat) {
+        .sema => Zcu.PerThread,
+        .normal => void,
+    } {
+        return switch (strat) {
+            .sema => .{ .tid = tid, .zcu = zcu },
+            .normal => {},
+        };
+    }
+
     pub inline fn toLazy(strat: ResolveStrat) ResolveStratLazy {
         return switch (strat) {
             .normal => .eager,
@@ -862,21 +931,31 @@ pub const ResolveStrat = enum {
     }
 };
 
+/// Never returns `none`. Asserts that all necessary type resolution is already done.
+pub fn abiAlignment(ty: Type, zcu: *Zcu) Alignment {
+    return (ty.abiAlignmentInner(.eager, zcu, {}) catch unreachable).scalar;
+}
+
+pub fn abiAlignmentSema(ty: Type, pt: Zcu.PerThread) SemaError!Alignment {
+    return (try ty.abiAlignmentInner(.sema, pt.zcu, pt.tid)).scalar;
+}
+
 /// If you pass `eager` you will get back `scalar` and assert the type is resolved.
 /// In this case there will be no error, guaranteed.
 /// If you pass `lazy` you may get back `scalar` or `val`.
 /// If `val` is returned, a reference to `ty` has been captured.
 /// If you pass `sema` you will get back `scalar` and resolve the type if
 /// necessary, possibly returning a CompileError.
-pub fn abiAlignmentAdvanced(
+pub fn abiAlignmentInner(
     ty: Type,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStratLazy,
-) SemaError!AbiAlignmentAdvanced {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
-    const use_llvm = mod.comp.config.use_llvm;
-    const ip = &mod.intern_pool;
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) SemaError!AbiAlignmentInner {
+    const pt = strat.pt(zcu, tid);
+    const target = zcu.getTarget();
+    const use_llvm = zcu.comp.config.use_llvm;
+    const ip = &zcu.intern_pool;
 
     switch (ty.toIntern()) {
         .empty_struct_type => return .{ .scalar = .@"1" },
@@ -889,22 +968,22 @@ pub fn abiAlignmentAdvanced(
                 return .{ .scalar = ptrAbiAlignment(target) };
             },
             .array_type => |array_type| {
-                return Type.fromInterned(array_type.child).abiAlignmentAdvanced(pt, strat);
+                return Type.fromInterned(array_type.child).abiAlignmentInner(strat, zcu, tid);
             },
             .vector_type => |vector_type| {
                 if (vector_type.len == 0) return .{ .scalar = .@"1" };
-                switch (mod.comp.getZigBackend()) {
+                switch (zcu.comp.getZigBackend()) {
                     else => {
                         // This is fine because the child type of a vector always has a bit-size known
                         // without needing any type resolution.
-                        const elem_bits: u32 = @intCast(Type.fromInterned(vector_type.child).bitSize(pt));
+                        const elem_bits: u32 = @intCast(Type.fromInterned(vector_type.child).bitSize(zcu));
                         if (elem_bits == 0) return .{ .scalar = .@"1" };
                         const bytes = ((elem_bits * vector_type.len) + 7) / 8;
                         const alignment = std.math.ceilPowerOfTwoAssert(u32, bytes);
                         return .{ .scalar = Alignment.fromByteUnits(alignment) };
                     },
                     .stage2_c => {
-                        return Type.fromInterned(vector_type.child).abiAlignmentAdvanced(pt, strat);
+                        return Type.fromInterned(vector_type.child).abiAlignmentInner(strat, zcu, tid);
                     },
                     .stage2_x86_64 => {
                         if (vector_type.child == .bool_type) {
@@ -915,7 +994,7 @@ pub fn abiAlignmentAdvanced(
                             const alignment = std.math.ceilPowerOfTwoAssert(u32, bytes);
                             return .{ .scalar = Alignment.fromByteUnits(alignment) };
                         }
-                        const elem_bytes: u32 = @intCast((try Type.fromInterned(vector_type.child).abiSizeAdvanced(pt, strat)).scalar);
+                        const elem_bytes: u32 = @intCast((try Type.fromInterned(vector_type.child).abiSizeInner(strat, zcu, tid)).scalar);
                         if (elem_bytes == 0) return .{ .scalar = .@"1" };
                         const bytes = elem_bytes * vector_type.len;
                         if (bytes > 32 and std.Target.x86.featureSetHas(target.cpu.features, .avx512f)) return .{ .scalar = .@"64" };
@@ -925,11 +1004,16 @@ pub fn abiAlignmentAdvanced(
                 }
             },
 
-            .opt_type => return ty.abiAlignmentAdvancedOptional(pt, strat),
-            .error_union_type => |info| return ty.abiAlignmentAdvancedErrorUnion(pt, strat, Type.fromInterned(info.payload_type)),
+            .opt_type => return ty.abiAlignmentInnerOptional(strat, zcu, tid),
+            .error_union_type => |info| return ty.abiAlignmentInnerErrorUnion(
+                strat,
+                zcu,
+                tid,
+                Type.fromInterned(info.payload_type),
+            ),
 
             .error_set_type, .inferred_error_set_type => {
-                const bits = mod.errorSetBits();
+                const bits = zcu.errorSetBits();
                 if (bits == 0) return .{ .scalar = .@"1" };
                 return .{ .scalar = intAbiAlignment(bits, target, use_llvm) };
             },
@@ -965,7 +1049,7 @@ pub fn abiAlignmentAdvanced(
                 },
                 .f80 => switch (target.cTypeBitSize(.longdouble)) {
                     80 => return .{ .scalar = cTypeAlign(target, .longdouble) },
-                    else => return .{ .scalar = Type.u80.abiAlignment(pt) },
+                    else => return .{ .scalar = Type.u80.abiAlignment(zcu) },
                 },
                 .f128 => switch (target.cTypeBitSize(.longdouble)) {
                     128 => return .{ .scalar = cTypeAlign(target, .longdouble) },
@@ -973,7 +1057,7 @@ pub fn abiAlignmentAdvanced(
                 },
 
                 .anyerror, .adhoc_inferred_error_set => {
-                    const bits = mod.errorSetBits();
+                    const bits = zcu.errorSetBits();
                     if (bits == 0) return .{ .scalar = .@"1" };
                     return .{ .scalar = intAbiAlignment(bits, target, use_llvm) };
                 },
@@ -1003,7 +1087,7 @@ pub fn abiAlignmentAdvanced(
                         },
                         .eager => {},
                     }
-                    return .{ .scalar = Type.fromInterned(struct_type.backingIntTypeUnordered(ip)).abiAlignment(pt) };
+                    return .{ .scalar = Type.fromInterned(struct_type.backingIntTypeUnordered(ip)).abiAlignment(zcu) };
                 }
 
                 if (struct_type.flagsUnordered(ip).alignment == .none) switch (strat) {
@@ -1021,11 +1105,11 @@ pub fn abiAlignmentAdvanced(
                 var big_align: Alignment = .@"1";
                 for (tuple.types.get(ip), tuple.values.get(ip)) |field_ty, val| {
                     if (val != .none) continue; // comptime field
-                    switch (try Type.fromInterned(field_ty).abiAlignmentAdvanced(pt, strat)) {
+                    switch (try Type.fromInterned(field_ty).abiAlignmentInner(strat, zcu, tid)) {
                         .scalar => |field_align| big_align = big_align.max(field_align),
                         .val => switch (strat) {
                             .eager => unreachable, // field type alignment not resolved
-                            .sema => unreachable, // passed to abiAlignmentAdvanced above
+                            .sema => unreachable, // passed to abiAlignmentInner above
                             .lazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
                                 .ty = .comptime_int_type,
                                 .storage = .{ .lazy_align = ty.toIntern() },
@@ -1051,7 +1135,7 @@ pub fn abiAlignmentAdvanced(
             },
             .opaque_type => return .{ .scalar = .@"1" },
             .enum_type => return .{
-                .scalar = Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).abiAlignment(pt),
+                .scalar = Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).abiAlignment(zcu),
             },
 
             // values, not types
@@ -1079,32 +1163,37 @@ pub fn abiAlignmentAdvanced(
     }
 }
 
-fn abiAlignmentAdvancedErrorUnion(
+fn abiAlignmentInnerErrorUnion(
     ty: Type,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStratLazy,
+    zcu: *Zcu,
+    tid: strat.Tid(),
     payload_ty: Type,
-) SemaError!AbiAlignmentAdvanced {
+) SemaError!AbiAlignmentInner {
     // This code needs to be kept in sync with the equivalent switch prong
-    // in abiSizeAdvanced.
-    const code_align = Type.anyerror.abiAlignment(pt);
+    // in abiSizeInner.
+    const code_align = Type.anyerror.abiAlignment(zcu);
     switch (strat) {
         .eager, .sema => {
-            if (!(payload_ty.hasRuntimeBitsAdvanced(pt, false, strat) catch |err| switch (err) {
-                error.NeedLazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                    .ty = .comptime_int_type,
-                    .storage = .{ .lazy_align = ty.toIntern() },
-                } })) },
+            if (!(payload_ty.hasRuntimeBitsInner(false, strat, zcu, tid) catch |err| switch (err) {
+                error.NeedLazy => if (strat == .lazy) {
+                    const pt = strat.pt(zcu, tid);
+                    return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                        .ty = .comptime_int_type,
+                        .storage = .{ .lazy_align = ty.toIntern() },
+                    } })) };
+                } else unreachable,
                 else => |e| return e,
             })) {
                 return .{ .scalar = code_align };
             }
             return .{ .scalar = code_align.max(
-                (try payload_ty.abiAlignmentAdvanced(pt, strat)).scalar,
+                (try payload_ty.abiAlignmentInner(strat, zcu, tid)).scalar,
             ) };
         },
         .lazy => {
-            switch (try payload_ty.abiAlignmentAdvanced(pt, strat)) {
+            const pt = strat.pt(zcu, tid);
+            switch (try payload_ty.abiAlignmentInner(strat, zcu, tid)) {
                 .scalar => |payload_align| return .{ .scalar = code_align.max(payload_align) },
                 .val => {},
             }
@@ -1116,36 +1205,39 @@ fn abiAlignmentAdvancedErrorUnion(
     }
 }
 
-fn abiAlignmentAdvancedOptional(
+fn abiAlignmentInnerOptional(
     ty: Type,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStratLazy,
-) SemaError!AbiAlignmentAdvanced {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
-    const child_type = ty.optionalChild(mod);
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) SemaError!AbiAlignmentInner {
+    const pt = strat.pt(zcu, tid);
+    const target = zcu.getTarget();
+    const child_type = ty.optionalChild(zcu);
 
-    switch (child_type.zigTypeTag(mod)) {
+    switch (child_type.zigTypeTag(zcu)) {
         .Pointer => return .{ .scalar = ptrAbiAlignment(target) },
-        .ErrorSet => return Type.anyerror.abiAlignmentAdvanced(pt, strat),
+        .ErrorSet => return Type.anyerror.abiAlignmentInner(strat, zcu, tid),
         .NoReturn => return .{ .scalar = .@"1" },
         else => {},
     }
 
     switch (strat) {
         .eager, .sema => {
-            if (!(child_type.hasRuntimeBitsAdvanced(pt, false, strat) catch |err| switch (err) {
-                error.NeedLazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                    .ty = .comptime_int_type,
-                    .storage = .{ .lazy_align = ty.toIntern() },
-                } })) },
+            if (!(child_type.hasRuntimeBitsInner(false, strat, zcu, tid) catch |err| switch (err) {
+                error.NeedLazy => if (strat == .lazy) {
+                    return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                        .ty = .comptime_int_type,
+                        .storage = .{ .lazy_align = ty.toIntern() },
+                    } })) };
+                } else unreachable,
                 else => |e| return e,
             })) {
                 return .{ .scalar = .@"1" };
             }
-            return child_type.abiAlignmentAdvanced(pt, strat);
+            return child_type.abiAlignmentInner(strat, zcu, tid);
         },
-        .lazy => switch (try child_type.abiAlignmentAdvanced(pt, strat)) {
+        .lazy => switch (try child_type.abiAlignmentInner(strat, zcu, tid)) {
             .scalar => |x| return .{ .scalar = x.max(.@"1") },
             .val => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
                 .ty = .comptime_int_type,
@@ -1155,24 +1247,28 @@ fn abiAlignmentAdvancedOptional(
     }
 }
 
+const AbiSizeInner = union(enum) {
+    scalar: u64,
+    val: Value,
+};
+
+/// Asserts the type has the ABI size already resolved.
+/// Types that return false for hasRuntimeBits() return 0.
+pub fn abiSize(ty: Type, zcu: *Zcu) u64 {
+    return (abiSizeInner(ty, .eager, zcu, {}) catch unreachable).scalar;
+}
+
 /// May capture a reference to `ty`.
 pub fn lazyAbiSize(ty: Type, pt: Zcu.PerThread) !Value {
-    switch (try ty.abiSizeAdvanced(pt, .lazy)) {
+    switch (try ty.abiSizeInner(.lazy, pt.zcu, pt.tid)) {
         .val => |val| return val,
         .scalar => |x| return pt.intValue(Type.comptime_int, x),
     }
 }
 
-/// Asserts the type has the ABI size already resolved.
-/// Types that return false for hasRuntimeBits() return 0.
-pub fn abiSize(ty: Type, pt: Zcu.PerThread) u64 {
-    return (abiSizeAdvanced(ty, pt, .eager) catch unreachable).scalar;
+pub fn abiSizeSema(ty: Type, pt: Zcu.PerThread) SemaError!u64 {
+    return (try abiSizeInner(ty, .sema, pt.zcu, pt.tid)).scalar;
 }
-
-const AbiSizeAdvanced = union(enum) {
-    scalar: u64,
-    val: Value,
-};
 
 /// If you pass `eager` you will get back `scalar` and assert the type is resolved.
 /// In this case there will be no error, guaranteed.
@@ -1180,15 +1276,15 @@ const AbiSizeAdvanced = union(enum) {
 /// If `val` is returned, a reference to `ty` has been captured.
 /// If you pass `sema` you will get back `scalar` and resolve the type if
 /// necessary, possibly returning a CompileError.
-pub fn abiSizeAdvanced(
+pub fn abiSizeInner(
     ty: Type,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStratLazy,
-) SemaError!AbiSizeAdvanced {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
-    const use_llvm = mod.comp.config.use_llvm;
-    const ip = &mod.intern_pool;
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) SemaError!AbiSizeInner {
+    const target = zcu.getTarget();
+    const use_llvm = zcu.comp.config.use_llvm;
+    const ip = &zcu.intern_pool;
 
     switch (ty.toIntern()) {
         .empty_struct_type => return .{ .scalar = 0 },
@@ -1207,14 +1303,17 @@ pub fn abiSizeAdvanced(
             .array_type => |array_type| {
                 const len = array_type.lenIncludingSentinel();
                 if (len == 0) return .{ .scalar = 0 };
-                switch (try Type.fromInterned(array_type.child).abiSizeAdvanced(pt, strat)) {
+                switch (try Type.fromInterned(array_type.child).abiSizeInner(strat, zcu, tid)) {
                     .scalar => |elem_size| return .{ .scalar = len * elem_size },
                     .val => switch (strat) {
                         .sema, .eager => unreachable,
-                        .lazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                            .ty = .comptime_int_type,
-                            .storage = .{ .lazy_size = ty.toIntern() },
-                        } })) },
+                        .lazy => {
+                            const pt = strat.pt(zcu, tid);
+                            return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                                .ty = .comptime_int_type,
+                                .storage = .{ .lazy_size = ty.toIntern() },
+                            } })) };
+                        },
                     },
                 }
             },
@@ -1222,41 +1321,38 @@ pub fn abiSizeAdvanced(
                 const sub_strat: ResolveStrat = switch (strat) {
                     .sema => .sema,
                     .eager => .normal,
-                    .lazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                        .ty = .comptime_int_type,
-                        .storage = .{ .lazy_size = ty.toIntern() },
-                    } })) },
+                    .lazy => {
+                        const pt = strat.pt(zcu, tid);
+                        return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                            .ty = .comptime_int_type,
+                            .storage = .{ .lazy_size = ty.toIntern() },
+                        } })) };
+                    },
                 };
-                const alignment = switch (try ty.abiAlignmentAdvanced(pt, strat)) {
-                    .scalar => |x| x,
-                    .val => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                        .ty = .comptime_int_type,
-                        .storage = .{ .lazy_size = ty.toIntern() },
-                    } })) },
-                };
-                const total_bytes = switch (mod.comp.getZigBackend()) {
+                const alignment = (try ty.abiAlignmentInner(strat, zcu, tid)).scalar;
+                const total_bytes = switch (zcu.comp.getZigBackend()) {
                     else => total_bytes: {
-                        const elem_bits = try Type.fromInterned(vector_type.child).bitSizeAdvanced(pt, sub_strat);
+                        const elem_bits = try Type.fromInterned(vector_type.child).bitSizeInner(sub_strat, zcu, tid);
                         const total_bits = elem_bits * vector_type.len;
                         break :total_bytes (total_bits + 7) / 8;
                     },
                     .stage2_c => total_bytes: {
-                        const elem_bytes: u32 = @intCast((try Type.fromInterned(vector_type.child).abiSizeAdvanced(pt, strat)).scalar);
+                        const elem_bytes: u32 = @intCast((try Type.fromInterned(vector_type.child).abiSizeInner(strat, zcu, tid)).scalar);
                         break :total_bytes elem_bytes * vector_type.len;
                     },
                     .stage2_x86_64 => total_bytes: {
                         if (vector_type.child == .bool_type) break :total_bytes std.math.divCeil(u32, vector_type.len, 8) catch unreachable;
-                        const elem_bytes: u32 = @intCast((try Type.fromInterned(vector_type.child).abiSizeAdvanced(pt, strat)).scalar);
+                        const elem_bytes: u32 = @intCast((try Type.fromInterned(vector_type.child).abiSizeInner(strat, zcu, tid)).scalar);
                         break :total_bytes elem_bytes * vector_type.len;
                     },
                 };
                 return .{ .scalar = alignment.forward(total_bytes) };
             },
 
-            .opt_type => return ty.abiSizeAdvancedOptional(pt, strat),
+            .opt_type => return ty.abiSizeInnerOptional(strat, zcu, tid),
 
             .error_set_type, .inferred_error_set_type => {
-                const bits = mod.errorSetBits();
+                const bits = zcu.errorSetBits();
                 if (bits == 0) return .{ .scalar = 0 };
                 return .{ .scalar = intAbiSize(bits, target, use_llvm) };
             },
@@ -1264,29 +1360,35 @@ pub fn abiSizeAdvanced(
             .error_union_type => |error_union_type| {
                 const payload_ty = Type.fromInterned(error_union_type.payload_type);
                 // This code needs to be kept in sync with the equivalent switch prong
-                // in abiAlignmentAdvanced.
-                const code_size = Type.anyerror.abiSize(pt);
-                if (!(payload_ty.hasRuntimeBitsAdvanced(pt, false, strat) catch |err| switch (err) {
-                    error.NeedLazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                        .ty = .comptime_int_type,
-                        .storage = .{ .lazy_size = ty.toIntern() },
-                    } })) },
+                // in abiAlignmentInner.
+                const code_size = Type.anyerror.abiSize(zcu);
+                if (!(payload_ty.hasRuntimeBitsInner(false, strat, zcu, tid) catch |err| switch (err) {
+                    error.NeedLazy => if (strat == .lazy) {
+                        const pt = strat.pt(zcu, tid);
+                        return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                            .ty = .comptime_int_type,
+                            .storage = .{ .lazy_size = ty.toIntern() },
+                        } })) };
+                    } else unreachable,
                     else => |e| return e,
                 })) {
                     // Same as anyerror.
                     return .{ .scalar = code_size };
                 }
-                const code_align = Type.anyerror.abiAlignment(pt);
-                const payload_align = payload_ty.abiAlignment(pt);
-                const payload_size = switch (try payload_ty.abiSizeAdvanced(pt, strat)) {
+                const code_align = Type.anyerror.abiAlignment(zcu);
+                const payload_align = (try payload_ty.abiAlignmentInner(strat, zcu, tid)).scalar;
+                const payload_size = switch (try payload_ty.abiSizeInner(strat, zcu, tid)) {
                     .scalar => |elem_size| elem_size,
                     .val => switch (strat) {
                         .sema => unreachable,
                         .eager => unreachable,
-                        .lazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                            .ty = .comptime_int_type,
-                            .storage = .{ .lazy_size = ty.toIntern() },
-                        } })) },
+                        .lazy => {
+                            const pt = strat.pt(zcu, tid);
+                            return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                                .ty = .comptime_int_type,
+                                .storage = .{ .lazy_size = ty.toIntern() },
+                            } })) };
+                        },
                     },
                 };
 
@@ -1314,7 +1416,7 @@ pub fn abiSizeAdvanced(
                 .f128 => return .{ .scalar = 16 },
                 .f80 => switch (target.cTypeBitSize(.longdouble)) {
                     80 => return .{ .scalar = target.cTypeByteSize(.longdouble) },
-                    else => return .{ .scalar = Type.u80.abiSize(pt) },
+                    else => return .{ .scalar = Type.u80.abiSize(zcu) },
                 },
 
                 .usize,
@@ -1343,7 +1445,7 @@ pub fn abiSizeAdvanced(
                 => return .{ .scalar = 0 },
 
                 .anyerror, .adhoc_inferred_error_set => {
-                    const bits = mod.errorSetBits();
+                    const bits = zcu.errorSetBits();
                     if (bits == 0) return .{ .scalar = 0 };
                     return .{ .scalar = intAbiSize(bits, target, use_llvm) };
                 },
@@ -1354,30 +1456,33 @@ pub fn abiSizeAdvanced(
             .struct_type => {
                 const struct_type = ip.loadStructType(ty.toIntern());
                 switch (strat) {
-                    .sema => try ty.resolveLayout(pt),
-                    .lazy => switch (struct_type.layout) {
-                        .@"packed" => {
-                            if (struct_type.backingIntTypeUnordered(ip) == .none) return .{
-                                .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                                    .ty = .comptime_int_type,
-                                    .storage = .{ .lazy_size = ty.toIntern() },
-                                } })),
-                            };
-                        },
-                        .auto, .@"extern" => {
-                            if (!struct_type.haveLayout(ip)) return .{
-                                .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                                    .ty = .comptime_int_type,
-                                    .storage = .{ .lazy_size = ty.toIntern() },
-                                } })),
-                            };
-                        },
+                    .sema => try ty.resolveLayout(strat.pt(zcu, tid)),
+                    .lazy => {
+                        const pt = strat.pt(zcu, tid);
+                        switch (struct_type.layout) {
+                            .@"packed" => {
+                                if (struct_type.backingIntTypeUnordered(ip) == .none) return .{
+                                    .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                                        .ty = .comptime_int_type,
+                                        .storage = .{ .lazy_size = ty.toIntern() },
+                                    } })),
+                                };
+                            },
+                            .auto, .@"extern" => {
+                                if (!struct_type.haveLayout(ip)) return .{
+                                    .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                                        .ty = .comptime_int_type,
+                                        .storage = .{ .lazy_size = ty.toIntern() },
+                                    } })),
+                                };
+                            },
+                        }
                     },
                     .eager => {},
                 }
                 switch (struct_type.layout) {
                     .@"packed" => return .{
-                        .scalar = Type.fromInterned(struct_type.backingIntTypeUnordered(ip)).abiSize(pt),
+                        .scalar = Type.fromInterned(struct_type.backingIntTypeUnordered(ip)).abiSize(zcu),
                     },
                     .auto, .@"extern" => {
                         assert(struct_type.haveLayout(ip));
@@ -1387,25 +1492,28 @@ pub fn abiSizeAdvanced(
             },
             .anon_struct_type => |tuple| {
                 switch (strat) {
-                    .sema => try ty.resolveLayout(pt),
+                    .sema => try ty.resolveLayout(strat.pt(zcu, tid)),
                     .lazy, .eager => {},
                 }
                 const field_count = tuple.types.len;
                 if (field_count == 0) {
                     return .{ .scalar = 0 };
                 }
-                return .{ .scalar = ty.structFieldOffset(field_count, pt) };
+                return .{ .scalar = ty.structFieldOffset(field_count, zcu) };
             },
 
             .union_type => {
                 const union_type = ip.loadUnionType(ty.toIntern());
                 switch (strat) {
-                    .sema => try ty.resolveLayout(pt),
-                    .lazy => if (!union_type.flagsUnordered(ip).status.haveLayout()) return .{
-                        .val = Value.fromInterned(try pt.intern(.{ .int = .{
-                            .ty = .comptime_int_type,
-                            .storage = .{ .lazy_size = ty.toIntern() },
-                        } })),
+                    .sema => try ty.resolveLayout(strat.pt(zcu, tid)),
+                    .lazy => {
+                        const pt = strat.pt(zcu, tid);
+                        if (!union_type.flagsUnordered(ip).status.haveLayout()) return .{
+                            .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                                .ty = .comptime_int_type,
+                                .storage = .{ .lazy_size = ty.toIntern() },
+                            } })),
+                        };
                     },
                     .eager => {},
                 }
@@ -1414,7 +1522,7 @@ pub fn abiSizeAdvanced(
                 return .{ .scalar = union_type.sizeUnordered(ip) };
             },
             .opaque_type => unreachable, // no size available
-            .enum_type => return .{ .scalar = Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).abiSize(pt) },
+            .enum_type => return .{ .scalar = Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).abiSize(zcu) },
 
             // values, not types
             .undef,
@@ -1441,36 +1549,39 @@ pub fn abiSizeAdvanced(
     }
 }
 
-fn abiSizeAdvancedOptional(
+fn abiSizeInnerOptional(
     ty: Type,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStratLazy,
-) SemaError!AbiSizeAdvanced {
-    const mod = pt.zcu;
-    const child_ty = ty.optionalChild(mod);
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) SemaError!AbiSizeInner {
+    const child_ty = ty.optionalChild(zcu);
 
-    if (child_ty.isNoReturn(mod)) {
+    if (child_ty.isNoReturn(zcu)) {
         return .{ .scalar = 0 };
     }
 
-    if (!(child_ty.hasRuntimeBitsAdvanced(pt, false, strat) catch |err| switch (err) {
-        error.NeedLazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
-            .ty = .comptime_int_type,
-            .storage = .{ .lazy_size = ty.toIntern() },
-        } })) },
+    if (!(child_ty.hasRuntimeBitsInner(false, strat, zcu, tid) catch |err| switch (err) {
+        error.NeedLazy => if (strat == .lazy) {
+            const pt = strat.pt(zcu, tid);
+            return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+                .ty = .comptime_int_type,
+                .storage = .{ .lazy_size = ty.toIntern() },
+            } })) };
+        } else unreachable,
         else => |e| return e,
     })) return .{ .scalar = 1 };
 
-    if (ty.optionalReprIsPayload(mod)) {
-        return child_ty.abiSizeAdvanced(pt, strat);
+    if (ty.optionalReprIsPayload(zcu)) {
+        return child_ty.abiSizeInner(strat, zcu, tid);
     }
 
-    const payload_size = switch (try child_ty.abiSizeAdvanced(pt, strat)) {
+    const payload_size = switch (try child_ty.abiSizeInner(strat, zcu, tid)) {
         .scalar => |elem_size| elem_size,
         .val => switch (strat) {
             .sema => unreachable,
             .eager => unreachable,
-            .lazy => return .{ .val = Value.fromInterned(try pt.intern(.{ .int = .{
+            .lazy => return .{ .val = Value.fromInterned(try strat.pt(zcu, tid).intern(.{ .int = .{
                 .ty = .comptime_int_type,
                 .storage = .{ .lazy_size = ty.toIntern() },
             } })) },
@@ -1482,7 +1593,7 @@ fn abiSizeAdvancedOptional(
     // guaranteed to be >= that of bool's (1 byte) the added size is exactly equal
     // to the child type's ABI alignment.
     return .{
-        .scalar = (child_ty.abiAlignment(pt).toByteUnits() orelse 0) + payload_size,
+        .scalar = (child_ty.abiAlignment(zcu).toByteUnits() orelse 0) + payload_size,
     };
 }
 
@@ -1600,18 +1711,22 @@ pub fn maxIntAlignment(target: std.Target, use_llvm: bool) u16 {
     };
 }
 
-pub fn bitSize(ty: Type, pt: Zcu.PerThread) u64 {
-    return bitSizeAdvanced(ty, pt, .normal) catch unreachable;
+pub fn bitSize(ty: Type, zcu: *Zcu) u64 {
+    return bitSizeInner(ty, .normal, zcu, {}) catch unreachable;
 }
 
-pub fn bitSizeAdvanced(
+pub fn bitSizeSema(ty: Type, pt: Zcu.PerThread) SemaError!u64 {
+    return bitSizeInner(ty, .sema, pt.zcu, pt.tid);
+}
+
+pub fn bitSizeInner(
     ty: Type,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
 ) SemaError!u64 {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
-    const ip = &mod.intern_pool;
+    const target = zcu.getTarget();
+    const ip = &zcu.intern_pool;
 
     const strat_lazy: ResolveStratLazy = strat.toLazy();
 
@@ -1628,30 +1743,30 @@ pub fn bitSizeAdvanced(
             if (len == 0) return 0;
             const elem_ty = Type.fromInterned(array_type.child);
             const elem_size = @max(
-                (try elem_ty.abiAlignmentAdvanced(pt, strat_lazy)).scalar.toByteUnits() orelse 0,
-                (try elem_ty.abiSizeAdvanced(pt, strat_lazy)).scalar,
+                (try elem_ty.abiAlignmentInner(strat_lazy, zcu, tid)).scalar.toByteUnits() orelse 0,
+                (try elem_ty.abiSizeInner(strat_lazy, zcu, tid)).scalar,
             );
             if (elem_size == 0) return 0;
-            const elem_bit_size = try elem_ty.bitSizeAdvanced(pt, strat);
+            const elem_bit_size = try elem_ty.bitSizeInner(strat, zcu, tid);
             return (len - 1) * 8 * elem_size + elem_bit_size;
         },
         .vector_type => |vector_type| {
             const child_ty = Type.fromInterned(vector_type.child);
-            const elem_bit_size = try child_ty.bitSizeAdvanced(pt, strat);
+            const elem_bit_size = try child_ty.bitSizeInner(strat, zcu, tid);
             return elem_bit_size * vector_type.len;
         },
         .opt_type => {
             // Optionals and error unions are not packed so their bitsize
             // includes padding bits.
-            return (try ty.abiSizeAdvanced(pt, strat_lazy)).scalar * 8;
+            return (try ty.abiSizeInner(strat_lazy, zcu, tid)).scalar * 8;
         },
 
-        .error_set_type, .inferred_error_set_type => return mod.errorSetBits(),
+        .error_set_type, .inferred_error_set_type => return zcu.errorSetBits(),
 
         .error_union_type => {
             // Optionals and error unions are not packed so their bitsize
             // includes padding bits.
-            return (try ty.abiSizeAdvanced(pt, strat_lazy)).scalar * 8;
+            return (try ty.abiSizeInner(strat_lazy, zcu, tid)).scalar * 8;
         },
         .func_type => unreachable, // represents machine code; not a pointer
         .simple_type => |t| switch (t) {
@@ -1681,7 +1796,7 @@ pub fn bitSizeAdvanced(
 
             .anyerror,
             .adhoc_inferred_error_set,
-            => return mod.errorSetBits(),
+            => return zcu.errorSetBits(),
 
             .anyopaque => unreachable,
             .type => unreachable,
@@ -1697,42 +1812,46 @@ pub fn bitSizeAdvanced(
             const struct_type = ip.loadStructType(ty.toIntern());
             const is_packed = struct_type.layout == .@"packed";
             if (strat == .sema) {
+                const pt = strat.pt(zcu, tid);
                 try ty.resolveFields(pt);
                 if (is_packed) try ty.resolveLayout(pt);
             }
             if (is_packed) {
-                return try Type.fromInterned(struct_type.backingIntTypeUnordered(ip)).bitSizeAdvanced(pt, strat);
+                return try Type.fromInterned(struct_type.backingIntTypeUnordered(ip))
+                    .bitSizeInner(strat, zcu, tid);
             }
-            return (try ty.abiSizeAdvanced(pt, strat_lazy)).scalar * 8;
+            return (try ty.abiSizeInner(strat_lazy, zcu, tid)).scalar * 8;
         },
 
         .anon_struct_type => {
-            if (strat == .sema) try ty.resolveFields(pt);
-            return (try ty.abiSizeAdvanced(pt, strat_lazy)).scalar * 8;
+            if (strat == .sema) try ty.resolveFields(strat.pt(zcu, tid));
+            return (try ty.abiSizeInner(strat_lazy, zcu, tid)).scalar * 8;
         },
 
         .union_type => {
             const union_type = ip.loadUnionType(ty.toIntern());
-            const is_packed = ty.containerLayout(mod) == .@"packed";
+            const is_packed = ty.containerLayout(zcu) == .@"packed";
             if (strat == .sema) {
+                const pt = strat.pt(zcu, tid);
                 try ty.resolveFields(pt);
                 if (is_packed) try ty.resolveLayout(pt);
             }
             if (!is_packed) {
-                return (try ty.abiSizeAdvanced(pt, strat_lazy)).scalar * 8;
+                return (try ty.abiSizeInner(strat_lazy, zcu, tid)).scalar * 8;
             }
             assert(union_type.flagsUnordered(ip).status.haveFieldTypes());
 
             var size: u64 = 0;
             for (0..union_type.field_types.len) |field_index| {
                 const field_ty = union_type.field_types.get(ip)[field_index];
-                size = @max(size, try Type.fromInterned(field_ty).bitSizeAdvanced(pt, strat));
+                size = @max(size, try Type.fromInterned(field_ty).bitSizeInner(strat, zcu, tid));
             }
 
             return size;
         },
         .opaque_type => unreachable,
-        .enum_type => return Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).bitSizeAdvanced(pt, strat),
+        .enum_type => return Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty)
+            .bitSizeInner(strat, zcu, tid),
 
         // values, not types
         .undef,
@@ -1760,61 +1879,61 @@ pub fn bitSizeAdvanced(
 
 /// Returns true if the type's layout is already resolved and it is safe
 /// to use `abiSize`, `abiAlignment` and `bitSize` on it.
-pub fn layoutIsResolved(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn layoutIsResolved(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => ip.loadStructType(ty.toIntern()).haveLayout(ip),
         .union_type => ip.loadUnionType(ty.toIntern()).haveLayout(ip),
         .array_type => |array_type| {
             if (array_type.lenIncludingSentinel() == 0) return true;
-            return Type.fromInterned(array_type.child).layoutIsResolved(mod);
+            return Type.fromInterned(array_type.child).layoutIsResolved(zcu);
         },
-        .opt_type => |child| Type.fromInterned(child).layoutIsResolved(mod),
-        .error_union_type => |k| Type.fromInterned(k.payload_type).layoutIsResolved(mod),
+        .opt_type => |child| Type.fromInterned(child).layoutIsResolved(zcu),
+        .error_union_type => |k| Type.fromInterned(k.payload_type).layoutIsResolved(zcu),
         else => true,
     };
 }
 
-pub fn isSinglePointer(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isSinglePointer(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_info| ptr_info.flags.size == .One,
         else => false,
     };
 }
 
 /// Asserts `ty` is a pointer.
-pub fn ptrSize(ty: Type, mod: *const Module) std.builtin.Type.Pointer.Size {
-    return ty.ptrSizeOrNull(mod).?;
+pub fn ptrSize(ty: Type, zcu: *const Zcu) std.builtin.Type.Pointer.Size {
+    return ty.ptrSizeOrNull(zcu).?;
 }
 
 /// Returns `null` if `ty` is not a pointer.
-pub fn ptrSizeOrNull(ty: Type, mod: *const Module) ?std.builtin.Type.Pointer.Size {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn ptrSizeOrNull(ty: Type, zcu: *const Zcu) ?std.builtin.Type.Pointer.Size {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_info| ptr_info.flags.size,
         else => null,
     };
 }
 
-pub fn isSlice(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isSlice(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| ptr_type.flags.size == .Slice,
         else => false,
     };
 }
 
-pub fn slicePtrFieldType(ty: Type, mod: *const Module) Type {
-    return Type.fromInterned(mod.intern_pool.slicePtrType(ty.toIntern()));
+pub fn slicePtrFieldType(ty: Type, zcu: *const Zcu) Type {
+    return Type.fromInterned(zcu.intern_pool.slicePtrType(ty.toIntern()));
 }
 
-pub fn isConstPtr(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isConstPtr(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| ptr_type.flags.is_const,
         else => false,
     };
 }
 
-pub fn isVolatilePtr(ty: Type, mod: *const Module) bool {
-    return isVolatilePtrIp(ty, &mod.intern_pool);
+pub fn isVolatilePtr(ty: Type, zcu: *const Zcu) bool {
+    return isVolatilePtrIp(ty, &zcu.intern_pool);
 }
 
 pub fn isVolatilePtrIp(ty: Type, ip: *const InternPool) bool {
@@ -1824,28 +1943,28 @@ pub fn isVolatilePtrIp(ty: Type, ip: *const InternPool) bool {
     };
 }
 
-pub fn isAllowzeroPtr(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isAllowzeroPtr(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| ptr_type.flags.is_allowzero,
         .opt_type => true,
         else => false,
     };
 }
 
-pub fn isCPtr(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isCPtr(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| ptr_type.flags.size == .C,
         else => false,
     };
 }
 
-pub fn isPtrAtRuntime(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isPtrAtRuntime(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| switch (ptr_type.flags.size) {
             .Slice => false,
             .One, .Many, .C => true,
         },
-        .opt_type => |child| switch (mod.intern_pool.indexToKey(child)) {
+        .opt_type => |child| switch (zcu.intern_pool.indexToKey(child)) {
             .ptr_type => |p| switch (p.flags.size) {
                 .Slice, .C => false,
                 .Many, .One => !p.flags.is_allowzero,
@@ -1858,17 +1977,17 @@ pub fn isPtrAtRuntime(ty: Type, mod: *const Module) bool {
 
 /// For pointer-like optionals, returns true, otherwise returns the allowzero property
 /// of pointers.
-pub fn ptrAllowsZero(ty: Type, mod: *const Module) bool {
-    if (ty.isPtrLikeOptional(mod)) {
+pub fn ptrAllowsZero(ty: Type, zcu: *const Zcu) bool {
+    if (ty.isPtrLikeOptional(zcu)) {
         return true;
     }
-    return ty.ptrInfo(mod).flags.is_allowzero;
+    return ty.ptrInfo(zcu).flags.is_allowzero;
 }
 
 /// See also `isPtrLikeOptional`.
-pub fn optionalReprIsPayload(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
-        .opt_type => |child_type| child_type == .anyerror_type or switch (mod.intern_pool.indexToKey(child_type)) {
+pub fn optionalReprIsPayload(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
+        .opt_type => |child_type| child_type == .anyerror_type or switch (zcu.intern_pool.indexToKey(child_type)) {
             .ptr_type => |ptr_type| ptr_type.flags.size != .C and !ptr_type.flags.is_allowzero,
             .error_set_type, .inferred_error_set_type => true,
             else => false,
@@ -1881,10 +2000,10 @@ pub fn optionalReprIsPayload(ty: Type, mod: *const Module) bool {
 /// Returns true if the type is optional and would be lowered to a single pointer
 /// address value, using 0 for null. Note that this returns true for C pointers.
 /// This function must be kept in sync with `Sema.typePtrOrOptionalPtrTy`.
-pub fn isPtrLikeOptional(ty: Type, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isPtrLikeOptional(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| ptr_type.flags.size == .C,
-        .opt_type => |child| switch (mod.intern_pool.indexToKey(child)) {
+        .opt_type => |child| switch (zcu.intern_pool.indexToKey(child)) {
             .ptr_type => |ptr_type| switch (ptr_type.flags.size) {
                 .Slice, .C => false,
                 .Many, .One => !ptr_type.flags.is_allowzero,
@@ -1898,8 +2017,8 @@ pub fn isPtrLikeOptional(ty: Type, mod: *const Module) bool {
 /// For *[N]T,  returns [N]T.
 /// For *T,     returns T.
 /// For [*]T,   returns T.
-pub fn childType(ty: Type, mod: *const Module) Type {
-    return childTypeIp(ty, &mod.intern_pool);
+pub fn childType(ty: Type, zcu: *const Zcu) Type {
+    return childTypeIp(ty, &zcu.intern_pool);
 }
 
 pub fn childTypeIp(ty: Type, ip: *const InternPool) Type {
@@ -1915,10 +2034,10 @@ pub fn childTypeIp(ty: Type, ip: *const InternPool) Type {
 /// For [N]T,        returns T.
 /// For []T,         returns T.
 /// For anyframe->T, returns T.
-pub fn elemType2(ty: Type, mod: *const Module) Type {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn elemType2(ty: Type, zcu: *const Zcu) Type {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .ptr_type => |ptr_type| switch (ptr_type.flags.size) {
-            .One => Type.fromInterned(ptr_type.child).shallowElemType(mod),
+            .One => Type.fromInterned(ptr_type.child).shallowElemType(zcu),
             .Many, .C, .Slice => Type.fromInterned(ptr_type.child),
         },
         .anyframe_type => |child| {
@@ -1927,30 +2046,30 @@ pub fn elemType2(ty: Type, mod: *const Module) Type {
         },
         .vector_type => |vector_type| Type.fromInterned(vector_type.child),
         .array_type => |array_type| Type.fromInterned(array_type.child),
-        .opt_type => |child| Type.fromInterned(mod.intern_pool.childType(child)),
+        .opt_type => |child| Type.fromInterned(zcu.intern_pool.childType(child)),
         else => unreachable,
     };
 }
 
-fn shallowElemType(child_ty: Type, mod: *const Module) Type {
-    return switch (child_ty.zigTypeTag(mod)) {
-        .Array, .Vector => child_ty.childType(mod),
+fn shallowElemType(child_ty: Type, zcu: *const Zcu) Type {
+    return switch (child_ty.zigTypeTag(zcu)) {
+        .Array, .Vector => child_ty.childType(zcu),
         else => child_ty,
     };
 }
 
 /// For vectors, returns the element type. Otherwise returns self.
-pub fn scalarType(ty: Type, mod: *Module) Type {
-    return switch (ty.zigTypeTag(mod)) {
-        .Vector => ty.childType(mod),
+pub fn scalarType(ty: Type, zcu: *const Zcu) Type {
+    return switch (ty.zigTypeTag(zcu)) {
+        .Vector => ty.childType(zcu),
         else => ty,
     };
 }
 
 /// Asserts that the type is an optional.
 /// Note that for C pointers this returns the type unmodified.
-pub fn optionalChild(ty: Type, mod: *const Module) Type {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn optionalChild(ty: Type, zcu: *const Zcu) Type {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .opt_type => |child| Type.fromInterned(child),
         .ptr_type => |ptr_type| b: {
             assert(ptr_type.flags.size == .C);
@@ -1962,8 +2081,8 @@ pub fn optionalChild(ty: Type, mod: *const Module) Type {
 
 /// Returns the tag type of a union, if the type is a union and it has a tag type.
 /// Otherwise, returns `null`.
-pub fn unionTagType(ty: Type, mod: *Module) ?Type {
-    const ip = &mod.intern_pool;
+pub fn unionTagType(ty: Type, zcu: *const Zcu) ?Type {
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
         .union_type => {},
         else => return null,
@@ -1981,8 +2100,8 @@ pub fn unionTagType(ty: Type, mod: *Module) ?Type {
 
 /// Same as `unionTagType` but includes safety tag.
 /// Codegen should use this version.
-pub fn unionTagTypeSafety(ty: Type, mod: *Module) ?Type {
-    const ip = &mod.intern_pool;
+pub fn unionTagTypeSafety(ty: Type, zcu: *const Zcu) ?Type {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .union_type => {
             const union_type = ip.loadUnionType(ty.toIntern());
@@ -1996,35 +2115,35 @@ pub fn unionTagTypeSafety(ty: Type, mod: *Module) ?Type {
 
 /// Asserts the type is a union; returns the tag type, even if the tag will
 /// not be stored at runtime.
-pub fn unionTagTypeHypothetical(ty: Type, mod: *Module) Type {
-    const union_obj = mod.typeToUnion(ty).?;
+pub fn unionTagTypeHypothetical(ty: Type, zcu: *const Zcu) Type {
+    const union_obj = zcu.typeToUnion(ty).?;
     return Type.fromInterned(union_obj.enum_tag_ty);
 }
 
-pub fn unionFieldType(ty: Type, enum_tag: Value, mod: *Module) ?Type {
-    const ip = &mod.intern_pool;
-    const union_obj = mod.typeToUnion(ty).?;
+pub fn unionFieldType(ty: Type, enum_tag: Value, zcu: *const Zcu) ?Type {
+    const ip = &zcu.intern_pool;
+    const union_obj = zcu.typeToUnion(ty).?;
     const union_fields = union_obj.field_types.get(ip);
-    const index = mod.unionTagFieldIndex(union_obj, enum_tag) orelse return null;
+    const index = zcu.unionTagFieldIndex(union_obj, enum_tag) orelse return null;
     return Type.fromInterned(union_fields[index]);
 }
 
-pub fn unionFieldTypeByIndex(ty: Type, index: usize, mod: *Module) Type {
-    const ip = &mod.intern_pool;
-    const union_obj = mod.typeToUnion(ty).?;
+pub fn unionFieldTypeByIndex(ty: Type, index: usize, zcu: *const Zcu) Type {
+    const ip = &zcu.intern_pool;
+    const union_obj = zcu.typeToUnion(ty).?;
     return Type.fromInterned(union_obj.field_types.get(ip)[index]);
 }
 
-pub fn unionTagFieldIndex(ty: Type, enum_tag: Value, mod: *Module) ?u32 {
-    const union_obj = mod.typeToUnion(ty).?;
-    return mod.unionTagFieldIndex(union_obj, enum_tag);
+pub fn unionTagFieldIndex(ty: Type, enum_tag: Value, zcu: *const Zcu) ?u32 {
+    const union_obj = zcu.typeToUnion(ty).?;
+    return zcu.unionTagFieldIndex(union_obj, enum_tag);
 }
 
-pub fn unionHasAllZeroBitFieldTypes(ty: Type, pt: Zcu.PerThread) bool {
-    const ip = &pt.zcu.intern_pool;
-    const union_obj = pt.zcu.typeToUnion(ty).?;
+pub fn unionHasAllZeroBitFieldTypes(ty: Type, zcu: *Zcu) bool {
+    const ip = &zcu.intern_pool;
+    const union_obj = zcu.typeToUnion(ty).?;
     for (union_obj.field_types.get(ip)) |field_ty| {
-        if (Type.fromInterned(field_ty).hasRuntimeBits(pt)) return false;
+        if (Type.fromInterned(field_ty).hasRuntimeBits(zcu)) return false;
     }
     return true;
 }
@@ -2032,20 +2151,21 @@ pub fn unionHasAllZeroBitFieldTypes(ty: Type, pt: Zcu.PerThread) bool {
 /// Returns the type used for backing storage of this union during comptime operations.
 /// Asserts the type is either an extern or packed union.
 pub fn unionBackingType(ty: Type, pt: Zcu.PerThread) !Type {
-    return switch (ty.containerLayout(pt.zcu)) {
-        .@"extern" => try pt.arrayType(.{ .len = ty.abiSize(pt), .child = .u8_type }),
-        .@"packed" => try pt.intType(.unsigned, @intCast(ty.bitSize(pt))),
+    const zcu = pt.zcu;
+    return switch (ty.containerLayout(zcu)) {
+        .@"extern" => try pt.arrayType(.{ .len = ty.abiSize(zcu), .child = .u8_type }),
+        .@"packed" => try pt.intType(.unsigned, @intCast(ty.bitSize(zcu))),
         .auto => unreachable,
     };
 }
 
-pub fn unionGetLayout(ty: Type, pt: Zcu.PerThread) Module.UnionLayout {
-    const union_obj = pt.zcu.intern_pool.loadUnionType(ty.toIntern());
-    return pt.getUnionLayout(union_obj);
+pub fn unionGetLayout(ty: Type, zcu: *Zcu) Zcu.UnionLayout {
+    const union_obj = zcu.intern_pool.loadUnionType(ty.toIntern());
+    return Type.getUnionLayout(union_obj, zcu);
 }
 
-pub fn containerLayout(ty: Type, mod: *Module) std.builtin.Type.ContainerLayout {
-    const ip = &mod.intern_pool;
+pub fn containerLayout(ty: Type, zcu: *const Zcu) std.builtin.Type.ContainerLayout {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => ip.loadStructType(ty.toIntern()).layout,
         .anon_struct_type => .auto,
@@ -2055,18 +2175,18 @@ pub fn containerLayout(ty: Type, mod: *Module) std.builtin.Type.ContainerLayout 
 }
 
 /// Asserts that the type is an error union.
-pub fn errorUnionPayload(ty: Type, mod: *Module) Type {
-    return Type.fromInterned(mod.intern_pool.indexToKey(ty.toIntern()).error_union_type.payload_type);
+pub fn errorUnionPayload(ty: Type, zcu: *const Zcu) Type {
+    return Type.fromInterned(zcu.intern_pool.indexToKey(ty.toIntern()).error_union_type.payload_type);
 }
 
 /// Asserts that the type is an error union.
-pub fn errorUnionSet(ty: Type, mod: *Module) Type {
-    return Type.fromInterned(mod.intern_pool.errorUnionSet(ty.toIntern()));
+pub fn errorUnionSet(ty: Type, zcu: *const Zcu) Type {
+    return Type.fromInterned(zcu.intern_pool.errorUnionSet(ty.toIntern()));
 }
 
 /// Returns false for unresolved inferred error sets.
-pub fn errorSetIsEmpty(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn errorSetIsEmpty(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ty.toIntern()) {
         .anyerror_type, .adhoc_inferred_error_set_type => false,
         else => switch (ip.indexToKey(ty.toIntern())) {
@@ -2083,20 +2203,20 @@ pub fn errorSetIsEmpty(ty: Type, mod: *Module) bool {
 /// Returns true if it is an error set that includes anyerror, false otherwise.
 /// Note that the result may be a false negative if the type did not get error set
 /// resolution prior to this call.
-pub fn isAnyError(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn isAnyError(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ty.toIntern()) {
         .anyerror_type => true,
         .adhoc_inferred_error_set_type => false,
-        else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
             .inferred_error_set_type => |i| ip.funcIesResolvedUnordered(i) == .anyerror_type,
             else => false,
         },
     };
 }
 
-pub fn isError(ty: Type, mod: *const Module) bool {
-    return switch (ty.zigTypeTag(mod)) {
+pub fn isError(ty: Type, zcu: *const Zcu) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .ErrorUnion, .ErrorSet => true,
         else => false,
     };
@@ -2127,8 +2247,8 @@ pub fn errorSetHasFieldIp(
 /// Returns whether ty, which must be an error set, includes an error `name`.
 /// Might return a false negative if `ty` is an inferred error set and not fully
 /// resolved yet.
-pub fn errorSetHasField(ty: Type, name: []const u8, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn errorSetHasField(ty: Type, name: []const u8, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ty.toIntern()) {
         .anyerror_type => true,
         else => switch (ip.indexToKey(ty.toIntern())) {
@@ -2152,20 +2272,20 @@ pub fn errorSetHasField(ty: Type, name: []const u8, mod: *Module) bool {
 }
 
 /// Asserts the type is an array or vector or struct.
-pub fn arrayLen(ty: Type, mod: *const Module) u64 {
-    return ty.arrayLenIp(&mod.intern_pool);
+pub fn arrayLen(ty: Type, zcu: *const Zcu) u64 {
+    return ty.arrayLenIp(&zcu.intern_pool);
 }
 
 pub fn arrayLenIp(ty: Type, ip: *const InternPool) u64 {
     return ip.aggregateTypeLen(ty.toIntern());
 }
 
-pub fn arrayLenIncludingSentinel(ty: Type, mod: *const Module) u64 {
-    return mod.intern_pool.aggregateTypeLenIncludingSentinel(ty.toIntern());
+pub fn arrayLenIncludingSentinel(ty: Type, zcu: *const Zcu) u64 {
+    return zcu.intern_pool.aggregateTypeLenIncludingSentinel(ty.toIntern());
 }
 
-pub fn vectorLen(ty: Type, mod: *const Module) u32 {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn vectorLen(ty: Type, zcu: *const Zcu) u32 {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .vector_type => |vector_type| vector_type.len,
         .anon_struct_type => |tuple| @intCast(tuple.types.len),
         else => unreachable,
@@ -2173,8 +2293,8 @@ pub fn vectorLen(ty: Type, mod: *const Module) u32 {
 }
 
 /// Asserts the type is an array, pointer or vector.
-pub fn sentinel(ty: Type, mod: *const Module) ?Value {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn sentinel(ty: Type, zcu: *const Zcu) ?Value {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .vector_type,
         .struct_type,
         .anon_struct_type,
@@ -2188,17 +2308,17 @@ pub fn sentinel(ty: Type, mod: *const Module) ?Value {
 }
 
 /// Returns true if and only if the type is a fixed-width integer.
-pub fn isInt(self: Type, mod: *const Module) bool {
+pub fn isInt(self: Type, zcu: *const Zcu) bool {
     return self.toIntern() != .comptime_int_type and
-        mod.intern_pool.isIntegerType(self.toIntern());
+        zcu.intern_pool.isIntegerType(self.toIntern());
 }
 
 /// Returns true if and only if the type is a fixed-width, signed integer.
-pub fn isSignedInt(ty: Type, mod: *const Module) bool {
+pub fn isSignedInt(ty: Type, zcu: *const Zcu) bool {
     return switch (ty.toIntern()) {
-        .c_char_type => mod.getTarget().charSignedness() == .signed,
+        .c_char_type => zcu.getTarget().charSignedness() == .signed,
         .isize_type, .c_short_type, .c_int_type, .c_long_type, .c_longlong_type => true,
-        else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
             .int_type => |int_type| int_type.signedness == .signed,
             else => false,
         },
@@ -2206,11 +2326,11 @@ pub fn isSignedInt(ty: Type, mod: *const Module) bool {
 }
 
 /// Returns true if and only if the type is a fixed-width, unsigned integer.
-pub fn isUnsignedInt(ty: Type, mod: *const Module) bool {
+pub fn isUnsignedInt(ty: Type, zcu: *const Zcu) bool {
     return switch (ty.toIntern()) {
-        .c_char_type => mod.getTarget().charSignedness() == .unsigned,
+        .c_char_type => zcu.getTarget().charSignedness() == .unsigned,
         .usize_type, .c_ushort_type, .c_uint_type, .c_ulong_type, .c_ulonglong_type => true,
-        else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
             .int_type => |int_type| int_type.signedness == .unsigned,
             else => false,
         },
@@ -2219,27 +2339,27 @@ pub fn isUnsignedInt(ty: Type, mod: *const Module) bool {
 
 /// Returns true for integers, enums, error sets, and packed structs.
 /// If this function returns true, then intInfo() can be called on the type.
-pub fn isAbiInt(ty: Type, mod: *Module) bool {
-    return switch (ty.zigTypeTag(mod)) {
+pub fn isAbiInt(ty: Type, zcu: *const Zcu) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Int, .Enum, .ErrorSet => true,
-        .Struct => ty.containerLayout(mod) == .@"packed",
+        .Struct => ty.containerLayout(zcu) == .@"packed",
         else => false,
     };
 }
 
 /// Asserts the type is an integer, enum, error set, or vector of one of them.
-pub fn intInfo(starting_ty: Type, mod: *Module) InternPool.Key.IntType {
-    const ip = &mod.intern_pool;
-    const target = mod.getTarget();
+pub fn intInfo(starting_ty: Type, zcu: *const Zcu) InternPool.Key.IntType {
+    const ip = &zcu.intern_pool;
+    const target = zcu.getTarget();
     var ty = starting_ty;
 
     while (true) switch (ty.toIntern()) {
         .anyerror_type, .adhoc_inferred_error_set_type => {
-            return .{ .signedness = .unsigned, .bits = mod.errorSetBits() };
+            return .{ .signedness = .unsigned, .bits = zcu.errorSetBits() };
         },
         .usize_type => return .{ .signedness = .unsigned, .bits = target.ptrBitWidth() },
         .isize_type => return .{ .signedness = .signed, .bits = target.ptrBitWidth() },
-        .c_char_type => return .{ .signedness = mod.getTarget().charSignedness(), .bits = target.cTypeBitSize(.char) },
+        .c_char_type => return .{ .signedness = zcu.getTarget().charSignedness(), .bits = target.cTypeBitSize(.char) },
         .c_short_type => return .{ .signedness = .signed, .bits = target.cTypeBitSize(.short) },
         .c_ushort_type => return .{ .signedness = .unsigned, .bits = target.cTypeBitSize(.ushort) },
         .c_int_type => return .{ .signedness = .signed, .bits = target.cTypeBitSize(.int) },
@@ -2255,7 +2375,7 @@ pub fn intInfo(starting_ty: Type, mod: *Module) InternPool.Key.IntType {
             .vector_type => |vector_type| ty = Type.fromInterned(vector_type.child),
 
             .error_set_type, .inferred_error_set_type => {
-                return .{ .signedness = .unsigned, .bits = mod.errorSetBits() };
+                return .{ .signedness = .unsigned, .bits = zcu.errorSetBits() };
             },
 
             .anon_struct_type => unreachable,
@@ -2363,35 +2483,35 @@ pub fn floatBits(ty: Type, target: Target) u16 {
 }
 
 /// Asserts the type is a function or a function pointer.
-pub fn fnReturnType(ty: Type, mod: *Module) Type {
-    return Type.fromInterned(mod.intern_pool.funcTypeReturnType(ty.toIntern()));
+pub fn fnReturnType(ty: Type, zcu: *const Zcu) Type {
+    return Type.fromInterned(zcu.intern_pool.funcTypeReturnType(ty.toIntern()));
 }
 
 /// Asserts the type is a function.
-pub fn fnCallingConvention(ty: Type, mod: *Module) std.builtin.CallingConvention {
-    return mod.intern_pool.indexToKey(ty.toIntern()).func_type.cc;
+pub fn fnCallingConvention(ty: Type, zcu: *const Zcu) std.builtin.CallingConvention {
+    return zcu.intern_pool.indexToKey(ty.toIntern()).func_type.cc;
 }
 
-pub fn isValidParamType(self: Type, mod: *const Module) bool {
-    return switch (self.zigTypeTagOrPoison(mod) catch return true) {
+pub fn isValidParamType(self: Type, zcu: *const Zcu) bool {
+    return switch (self.zigTypeTagOrPoison(zcu) catch return true) {
         .Opaque, .NoReturn => false,
         else => true,
     };
 }
 
-pub fn isValidReturnType(self: Type, mod: *const Module) bool {
-    return switch (self.zigTypeTagOrPoison(mod) catch return true) {
+pub fn isValidReturnType(self: Type, zcu: *const Zcu) bool {
+    return switch (self.zigTypeTagOrPoison(zcu) catch return true) {
         .Opaque => false,
         else => true,
     };
 }
 
 /// Asserts the type is a function.
-pub fn fnIsVarArgs(ty: Type, mod: *Module) bool {
-    return mod.intern_pool.indexToKey(ty.toIntern()).func_type.is_var_args;
+pub fn fnIsVarArgs(ty: Type, zcu: *const Zcu) bool {
+    return zcu.intern_pool.indexToKey(ty.toIntern()).func_type.is_var_args;
 }
 
-pub fn isNumeric(ty: Type, mod: *const Module) bool {
+pub fn isNumeric(ty: Type, zcu: *const Zcu) bool {
     return switch (ty.toIntern()) {
         .f16_type,
         .f32_type,
@@ -2414,7 +2534,7 @@ pub fn isNumeric(ty: Type, mod: *const Module) bool {
         .c_ulonglong_type,
         => true,
 
-        else => switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
             .int_type => true,
             else => false,
         },
@@ -2424,9 +2544,9 @@ pub fn isNumeric(ty: Type, mod: *const Module) bool {
 /// During semantic analysis, instead call `Sema.typeHasOnePossibleValue` which
 /// resolves field types rather than asserting they are already resolved.
 pub fn onePossibleValue(starting_type: Type, pt: Zcu.PerThread) !?Value {
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     var ty = starting_type;
-    const ip = &mod.intern_pool;
+    const ip = &zcu.intern_pool;
     while (true) switch (ty.toIntern()) {
         .empty_struct_type => return Value.empty_struct,
 
@@ -2509,8 +2629,8 @@ pub fn onePossibleValue(starting_type: Type, pt: Zcu.PerThread) !?Value {
                 assert(struct_type.haveFieldTypes(ip));
                 if (struct_type.knownNonOpv(ip))
                     return null;
-                const field_vals = try mod.gpa.alloc(InternPool.Index, struct_type.field_types.len);
-                defer mod.gpa.free(field_vals);
+                const field_vals = try zcu.gpa.alloc(InternPool.Index, struct_type.field_types.len);
+                defer zcu.gpa.free(field_vals);
                 for (field_vals, 0..) |*field_val, i_usize| {
                     const i: u32 = @intCast(i_usize);
                     if (struct_type.fieldIsComptime(ip, i)) {
@@ -2539,8 +2659,8 @@ pub fn onePossibleValue(starting_type: Type, pt: Zcu.PerThread) !?Value {
                 // In this case the struct has all comptime-known fields and
                 // therefore has one possible value.
                 // TODO: write something like getCoercedInts to avoid needing to dupe
-                const duped_values = try mod.gpa.dupe(InternPool.Index, tuple.values.get(ip));
-                defer mod.gpa.free(duped_values);
+                const duped_values = try zcu.gpa.dupe(InternPool.Index, tuple.values.get(ip));
+                defer zcu.gpa.free(duped_values);
                 return Value.fromInterned(try pt.intern(.{ .aggregate = .{
                     .ty = ty.toIntern(),
                     .storage = .{ .elems = duped_values },
@@ -2583,7 +2703,7 @@ pub fn onePossibleValue(starting_type: Type, pt: Zcu.PerThread) !?Value {
                         return null;
                     },
                     .auto, .explicit => {
-                        if (Type.fromInterned(enum_type.tag_ty).hasRuntimeBits(pt)) return null;
+                        if (Type.fromInterned(enum_type.tag_ty).hasRuntimeBits(zcu)) return null;
 
                         switch (enum_type.names.len) {
                             0 => {
@@ -2635,17 +2755,25 @@ pub fn onePossibleValue(starting_type: Type, pt: Zcu.PerThread) !?Value {
     };
 }
 
-/// During semantic analysis, instead call `Sema.typeRequiresComptime` which
+/// During semantic analysis, instead call `ty.comptimeOnlySema` which
 /// resolves field types rather than asserting they are already resolved.
-pub fn comptimeOnly(ty: Type, pt: Zcu.PerThread) bool {
-    return ty.comptimeOnlyAdvanced(pt, .normal) catch unreachable;
+pub fn comptimeOnly(ty: Type, zcu: *Zcu) bool {
+    return ty.comptimeOnlyInner(.normal, zcu, {}) catch unreachable;
+}
+
+pub fn comptimeOnlySema(ty: Type, pt: Zcu.PerThread) SemaError!bool {
+    return try ty.comptimeOnlyInner(.sema, pt.zcu, pt.tid);
 }
 
 /// `generic_poison` will return false.
 /// May return false negatives when structs and unions are having their field types resolved.
-pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: ResolveStrat) SemaError!bool {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+pub fn comptimeOnlyInner(
+    ty: Type,
+    comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) SemaError!bool {
+    const ip = &zcu.intern_pool;
     return switch (ty.toIntern()) {
         .empty_struct_type => false,
 
@@ -2653,20 +2781,20 @@ pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: Resolve
             .int_type => false,
             .ptr_type => |ptr_type| {
                 const child_ty = Type.fromInterned(ptr_type.child);
-                switch (child_ty.zigTypeTag(mod)) {
-                    .Fn => return !try child_ty.fnHasRuntimeBitsAdvanced(pt, strat),
+                switch (child_ty.zigTypeTag(zcu)) {
+                    .Fn => return !try child_ty.fnHasRuntimeBitsInner(strat, zcu, tid),
                     .Opaque => return false,
-                    else => return child_ty.comptimeOnlyAdvanced(pt, strat),
+                    else => return child_ty.comptimeOnlyInner(strat, zcu, tid),
                 }
             },
             .anyframe_type => |child| {
                 if (child == .none) return false;
-                return Type.fromInterned(child).comptimeOnlyAdvanced(pt, strat);
+                return Type.fromInterned(child).comptimeOnlyInner(strat, zcu, tid);
             },
-            .array_type => |array_type| return Type.fromInterned(array_type.child).comptimeOnlyAdvanced(pt, strat),
-            .vector_type => |vector_type| return Type.fromInterned(vector_type.child).comptimeOnlyAdvanced(pt, strat),
-            .opt_type => |child| return Type.fromInterned(child).comptimeOnlyAdvanced(pt, strat),
-            .error_union_type => |error_union_type| return Type.fromInterned(error_union_type.payload_type).comptimeOnlyAdvanced(pt, strat),
+            .array_type => |array_type| return Type.fromInterned(array_type.child).comptimeOnlyInner(strat, zcu, tid),
+            .vector_type => |vector_type| return Type.fromInterned(vector_type.child).comptimeOnlyInner(strat, zcu, tid),
+            .opt_type => |child| return Type.fromInterned(child).comptimeOnlyInner(strat, zcu, tid),
+            .error_union_type => |error_union_type| return Type.fromInterned(error_union_type.payload_type).comptimeOnlyInner(strat, zcu, tid),
 
             .error_set_type,
             .inferred_error_set_type,
@@ -2732,13 +2860,14 @@ pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: Resolve
 
                         errdefer struct_type.setRequiresComptime(ip, .unknown);
 
+                        const pt = strat.pt(zcu, tid);
                         try ty.resolveFields(pt);
 
                         for (0..struct_type.field_types.len) |i_usize| {
                             const i: u32 = @intCast(i_usize);
                             if (struct_type.fieldIsComptime(ip, i)) continue;
                             const field_ty = struct_type.field_types.get(ip)[i];
-                            if (try Type.fromInterned(field_ty).comptimeOnlyAdvanced(pt, strat)) {
+                            if (try Type.fromInterned(field_ty).comptimeOnlyInner(strat, zcu, tid)) {
                                 // Note that this does not cause the layout to
                                 // be considered resolved. Comptime-only types
                                 // still maintain a layout of their
@@ -2757,7 +2886,7 @@ pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: Resolve
             .anon_struct_type => |tuple| {
                 for (tuple.types.get(ip), tuple.values.get(ip)) |field_ty, val| {
                     const have_comptime_val = val != .none;
-                    if (!have_comptime_val and try Type.fromInterned(field_ty).comptimeOnlyAdvanced(pt, strat)) return true;
+                    if (!have_comptime_val and try Type.fromInterned(field_ty).comptimeOnlyInner(strat, zcu, tid)) return true;
                 }
                 return false;
             },
@@ -2778,11 +2907,12 @@ pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: Resolve
 
                         errdefer union_type.setRequiresComptime(ip, .unknown);
 
+                        const pt = strat.pt(zcu, tid);
                         try ty.resolveFields(pt);
 
                         for (0..union_type.field_types.len) |field_idx| {
                             const field_ty = union_type.field_types.get(ip)[field_idx];
-                            if (try Type.fromInterned(field_ty).comptimeOnlyAdvanced(pt, strat)) {
+                            if (try Type.fromInterned(field_ty).comptimeOnlyInner(strat, zcu, tid)) {
                                 union_type.setRequiresComptime(ip, .yes);
                                 return true;
                             }
@@ -2796,7 +2926,7 @@ pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: Resolve
 
             .opaque_type => false,
 
-            .enum_type => return Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).comptimeOnlyAdvanced(pt, strat),
+            .enum_type => return Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty).comptimeOnlyInner(strat, zcu, tid),
 
             // values, not types
             .undef,
@@ -2823,53 +2953,53 @@ pub fn comptimeOnlyAdvanced(ty: Type, pt: Zcu.PerThread, comptime strat: Resolve
     };
 }
 
-pub fn isVector(ty: Type, mod: *const Module) bool {
-    return ty.zigTypeTag(mod) == .Vector;
+pub fn isVector(ty: Type, zcu: *const Zcu) bool {
+    return ty.zigTypeTag(zcu) == .Vector;
 }
 
 /// Returns 0 if not a vector, otherwise returns @bitSizeOf(Element) * vector_len.
-pub fn totalVectorBits(ty: Type, pt: Zcu.PerThread) u64 {
-    if (!ty.isVector(pt.zcu)) return 0;
-    const v = pt.zcu.intern_pool.indexToKey(ty.toIntern()).vector_type;
-    return v.len * Type.fromInterned(v.child).bitSize(pt);
+pub fn totalVectorBits(ty: Type, zcu: *Zcu) u64 {
+    if (!ty.isVector(zcu)) return 0;
+    const v = zcu.intern_pool.indexToKey(ty.toIntern()).vector_type;
+    return v.len * Type.fromInterned(v.child).bitSize(zcu);
 }
 
-pub fn isArrayOrVector(ty: Type, mod: *const Module) bool {
-    return switch (ty.zigTypeTag(mod)) {
+pub fn isArrayOrVector(ty: Type, zcu: *const Zcu) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Array, .Vector => true,
         else => false,
     };
 }
 
-pub fn isIndexable(ty: Type, mod: *Module) bool {
-    return switch (ty.zigTypeTag(mod)) {
+pub fn isIndexable(ty: Type, zcu: *const Zcu) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Array, .Vector => true,
-        .Pointer => switch (ty.ptrSize(mod)) {
+        .Pointer => switch (ty.ptrSize(zcu)) {
             .Slice, .Many, .C => true,
-            .One => switch (ty.childType(mod).zigTypeTag(mod)) {
+            .One => switch (ty.childType(zcu).zigTypeTag(zcu)) {
                 .Array, .Vector => true,
-                .Struct => ty.childType(mod).isTuple(mod),
+                .Struct => ty.childType(zcu).isTuple(zcu),
                 else => false,
             },
         },
-        .Struct => ty.isTuple(mod),
+        .Struct => ty.isTuple(zcu),
         else => false,
     };
 }
 
-pub fn indexableHasLen(ty: Type, mod: *Module) bool {
-    return switch (ty.zigTypeTag(mod)) {
+pub fn indexableHasLen(ty: Type, zcu: *const Zcu) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Array, .Vector => true,
-        .Pointer => switch (ty.ptrSize(mod)) {
+        .Pointer => switch (ty.ptrSize(zcu)) {
             .Many, .C => false,
             .Slice => true,
-            .One => switch (ty.childType(mod).zigTypeTag(mod)) {
+            .One => switch (ty.childType(zcu).zigTypeTag(zcu)) {
                 .Array, .Vector => true,
-                .Struct => ty.childType(mod).isTuple(mod),
+                .Struct => ty.childType(zcu).isTuple(zcu),
                 else => false,
             },
         },
-        .Struct => ty.isTuple(mod),
+        .Struct => ty.isTuple(zcu),
         else => false,
     };
 }
@@ -2973,17 +3103,17 @@ pub fn maxIntScalar(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
 }
 
 /// Asserts the type is an enum or a union.
-pub fn intTagType(ty: Type, mod: *Module) Type {
-    const ip = &mod.intern_pool;
+pub fn intTagType(ty: Type, zcu: *const Zcu) Type {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
-        .union_type => Type.fromInterned(ip.loadUnionType(ty.toIntern()).enum_tag_ty).intTagType(mod),
+        .union_type => Type.fromInterned(ip.loadUnionType(ty.toIntern()).enum_tag_ty).intTagType(zcu),
         .enum_type => Type.fromInterned(ip.loadEnumType(ty.toIntern()).tag_ty),
         else => unreachable,
     };
 }
 
-pub fn isNonexhaustiveEnum(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn isNonexhaustiveEnum(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .enum_type => switch (ip.loadEnumType(ty.toIntern()).tag_mode) {
             .nonexhaustive => true,
@@ -2995,8 +3125,8 @@ pub fn isNonexhaustiveEnum(ty: Type, mod: *Module) bool {
 
 // Asserts that `ty` is an error set and not `anyerror`.
 // Asserts that `ty` is resolved if it is an inferred error set.
-pub fn errorSetNames(ty: Type, mod: *Module) InternPool.NullTerminatedString.Slice {
-    const ip = &mod.intern_pool;
+pub fn errorSetNames(ty: Type, zcu: *const Zcu) InternPool.NullTerminatedString.Slice {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .error_set_type => |x| x.names,
         .inferred_error_set_type => |i| switch (ip.funcIesResolvedUnordered(i)) {
@@ -3008,21 +3138,21 @@ pub fn errorSetNames(ty: Type, mod: *Module) InternPool.NullTerminatedString.Sli
     };
 }
 
-pub fn enumFields(ty: Type, mod: *Module) InternPool.NullTerminatedString.Slice {
-    return mod.intern_pool.loadEnumType(ty.toIntern()).names;
+pub fn enumFields(ty: Type, zcu: *const Zcu) InternPool.NullTerminatedString.Slice {
+    return zcu.intern_pool.loadEnumType(ty.toIntern()).names;
 }
 
-pub fn enumFieldCount(ty: Type, mod: *Module) usize {
-    return mod.intern_pool.loadEnumType(ty.toIntern()).names.len;
+pub fn enumFieldCount(ty: Type, zcu: *const Zcu) usize {
+    return zcu.intern_pool.loadEnumType(ty.toIntern()).names.len;
 }
 
-pub fn enumFieldName(ty: Type, field_index: usize, mod: *Module) InternPool.NullTerminatedString {
-    const ip = &mod.intern_pool;
+pub fn enumFieldName(ty: Type, field_index: usize, zcu: *const Zcu) InternPool.NullTerminatedString {
+    const ip = &zcu.intern_pool;
     return ip.loadEnumType(ty.toIntern()).names.get(ip)[field_index];
 }
 
-pub fn enumFieldIndex(ty: Type, field_name: InternPool.NullTerminatedString, mod: *Module) ?u32 {
-    const ip = &mod.intern_pool;
+pub fn enumFieldIndex(ty: Type, field_name: InternPool.NullTerminatedString, zcu: *const Zcu) ?u32 {
+    const ip = &zcu.intern_pool;
     const enum_type = ip.loadEnumType(ty.toIntern());
     return enum_type.nameIndex(ip, field_name);
 }
@@ -3030,8 +3160,8 @@ pub fn enumFieldIndex(ty: Type, field_name: InternPool.NullTerminatedString, mod
 /// Asserts `ty` is an enum. `enum_tag` can either be `enum_field_index` or
 /// an integer which represents the enum value. Returns the field index in
 /// declaration order, or `null` if `enum_tag` does not match any field.
-pub fn enumTagFieldIndex(ty: Type, enum_tag: Value, mod: *Module) ?u32 {
-    const ip = &mod.intern_pool;
+pub fn enumTagFieldIndex(ty: Type, enum_tag: Value, zcu: *const Zcu) ?u32 {
+    const ip = &zcu.intern_pool;
     const enum_type = ip.loadEnumType(ty.toIntern());
     const int_tag = switch (ip.indexToKey(enum_tag.toIntern())) {
         .int => enum_tag.toIntern(),
@@ -3043,8 +3173,8 @@ pub fn enumTagFieldIndex(ty: Type, enum_tag: Value, mod: *Module) ?u32 {
 }
 
 /// Returns none in the case of a tuple which uses the integer index as the field name.
-pub fn structFieldName(ty: Type, index: usize, mod: *Module) InternPool.OptionalNullTerminatedString {
-    const ip = &mod.intern_pool;
+pub fn structFieldName(ty: Type, index: usize, zcu: *const Zcu) InternPool.OptionalNullTerminatedString {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => ip.loadStructType(ty.toIntern()).fieldName(ip, index),
         .anon_struct_type => |anon_struct| anon_struct.fieldName(ip, index),
@@ -3052,8 +3182,8 @@ pub fn structFieldName(ty: Type, index: usize, mod: *Module) InternPool.Optional
     };
 }
 
-pub fn structFieldCount(ty: Type, mod: *Module) u32 {
-    const ip = &mod.intern_pool;
+pub fn structFieldCount(ty: Type, zcu: *const Zcu) u32 {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => ip.loadStructType(ty.toIntern()).field_types.len,
         .anon_struct_type => |anon_struct| anon_struct.types.len,
@@ -3062,8 +3192,8 @@ pub fn structFieldCount(ty: Type, mod: *Module) u32 {
 }
 
 /// Supports structs and unions.
-pub fn structFieldType(ty: Type, index: usize, mod: *Module) Type {
-    const ip = &mod.intern_pool;
+pub fn structFieldType(ty: Type, index: usize, zcu: *const Zcu) Type {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => Type.fromInterned(ip.loadStructType(ty.toIntern()).field_types.get(ip)[index]),
         .union_type => {
@@ -3075,33 +3205,111 @@ pub fn structFieldType(ty: Type, index: usize, mod: *Module) Type {
     };
 }
 
-pub fn structFieldAlign(ty: Type, index: usize, pt: Zcu.PerThread) Alignment {
-    return ty.structFieldAlignAdvanced(index, pt, .normal) catch unreachable;
+pub fn structFieldAlign(ty: Type, index: usize, zcu: *Zcu) Alignment {
+    return ty.structFieldAlignAdvanced(index, .normal, zcu, {}) catch unreachable;
 }
 
-pub fn structFieldAlignAdvanced(ty: Type, index: usize, pt: Zcu.PerThread, comptime strat: ResolveStrat) !Alignment {
-    const ip = &pt.zcu.intern_pool;
+pub fn structFieldAlignAdvanced(
+    ty: Type,
+    index: usize,
+    comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) !Alignment {
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => {
             const struct_type = ip.loadStructType(ty.toIntern());
             assert(struct_type.layout != .@"packed");
             const explicit_align = struct_type.fieldAlign(ip, index);
             const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[index]);
-            return pt.structFieldAlignmentAdvanced(explicit_align, field_ty, struct_type.layout, strat);
+            return field_ty.structFieldAlignmentAdvanced(
+                explicit_align,
+                struct_type.layout,
+                strat,
+                zcu,
+                tid,
+            );
         },
         .anon_struct_type => |anon_struct| {
-            return (try Type.fromInterned(anon_struct.types.get(ip)[index]).abiAlignmentAdvanced(pt, strat.toLazy())).scalar;
+            return (try Type.fromInterned(anon_struct.types.get(ip)[index]).abiAlignmentInner(
+                strat.toLazy(),
+                zcu,
+                tid,
+            )).scalar;
         },
         .union_type => {
             const union_obj = ip.loadUnionType(ty.toIntern());
-            return pt.unionFieldNormalAlignmentAdvanced(union_obj, @intCast(index), strat);
+            return unionFieldNormalAlignmentAdvanced(
+                union_obj,
+                @intCast(index),
+                strat,
+                zcu,
+                tid,
+            );
         },
         else => unreachable,
     }
 }
 
-pub fn structFieldDefaultValue(ty: Type, index: usize, mod: *Module) Value {
-    const ip = &mod.intern_pool;
+/// Returns the field alignment of a non-packed struct. Asserts the layout is not packed.
+/// If `strat` is `.sema`, may perform type resolution.
+pub fn structFieldAlignmentAdvanced(
+    field_ty: Type,
+    explicit_alignment: InternPool.Alignment,
+    layout: std.builtin.Type.ContainerLayout,
+    comptime strat: Type.ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) Zcu.SemaError!InternPool.Alignment {
+    assert(layout != .@"packed");
+    if (explicit_alignment != .none) return explicit_alignment;
+    const ty_abi_align = (try field_ty.abiAlignmentInner(
+        strat.toLazy(),
+        zcu,
+        tid,
+    )).scalar;
+    switch (layout) {
+        .@"packed" => unreachable,
+        .auto => if (zcu.getTarget().ofmt != .c) return ty_abi_align,
+        .@"extern" => {},
+    }
+    // extern
+    if (field_ty.isAbiInt(zcu) and field_ty.intInfo(zcu).bits >= 128) {
+        return ty_abi_align.maxStrict(.@"16");
+    }
+    return ty_abi_align;
+}
+
+/// Returns the field alignment of a non-packed union. Asserts the layout is not packed.
+pub fn unionFieldNormalAlignment(
+    loaded_union: InternPool.LoadedUnionType,
+    field_index: u32,
+    zcu: *Zcu,
+) InternPool.Alignment {
+    return unionFieldNormalAlignmentAdvanced(loaded_union, field_index, .normal, zcu, {}) catch unreachable;
+}
+
+/// Returns the field alignment of a non-packed union. Asserts the layout is not packed.
+/// If `strat` is `.sema`, may perform type resolution.
+pub fn unionFieldNormalAlignmentAdvanced(
+    loaded_union: InternPool.LoadedUnionType,
+    field_index: u32,
+    comptime strat: Type.ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) Zcu.SemaError!InternPool.Alignment {
+    const ip = &zcu.intern_pool;
+    assert(loaded_union.flagsUnordered(ip).layout != .@"packed");
+    const field_align = loaded_union.fieldAlign(ip, field_index);
+    if (field_align != .none) return field_align;
+    const field_ty = Type.fromInterned(loaded_union.field_types.get(ip)[field_index]);
+    if (field_ty.isNoReturn(zcu)) return .none;
+    return (try field_ty.abiAlignmentInner(strat.toLazy(), zcu, tid)).scalar;
+}
+
+pub fn structFieldDefaultValue(ty: Type, index: usize, zcu: *const Zcu) Value {
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => {
             const struct_type = ip.loadStructType(ty.toIntern());
@@ -3121,8 +3329,8 @@ pub fn structFieldDefaultValue(ty: Type, index: usize, mod: *Module) Value {
 }
 
 pub fn structFieldValueComptime(ty: Type, pt: Zcu.PerThread, index: usize) !?Value {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => {
             const struct_type = ip.loadStructType(ty.toIntern());
@@ -3145,8 +3353,8 @@ pub fn structFieldValueComptime(ty: Type, pt: Zcu.PerThread, index: usize) !?Val
     }
 }
 
-pub fn structFieldIsComptime(ty: Type, index: usize, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn structFieldIsComptime(ty: Type, index: usize, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => ip.loadStructType(ty.toIntern()).fieldIsComptime(ip, index),
         .anon_struct_type => |anon_struct| anon_struct.values.get(ip)[index] != .none,
@@ -3160,9 +3368,12 @@ pub const FieldOffset = struct {
 };
 
 /// Supports structs and unions.
-pub fn structFieldOffset(ty: Type, index: usize, pt: Zcu.PerThread) u64 {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+pub fn structFieldOffset(
+    ty: Type,
+    index: usize,
+    zcu: *Zcu,
+) u64 {
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => {
             const struct_type = ip.loadStructType(ty.toIntern());
@@ -3176,17 +3387,17 @@ pub fn structFieldOffset(ty: Type, index: usize, pt: Zcu.PerThread) u64 {
             var big_align: Alignment = .none;
 
             for (tuple.types.get(ip), tuple.values.get(ip), 0..) |field_ty, field_val, i| {
-                if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(pt)) {
+                if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(zcu)) {
                     // comptime field
                     if (i == index) return offset;
                     continue;
                 }
 
-                const field_align = Type.fromInterned(field_ty).abiAlignment(pt);
+                const field_align = Type.fromInterned(field_ty).abiAlignment(zcu);
                 big_align = big_align.max(field_align);
                 offset = field_align.forward(offset);
                 if (i == index) return offset;
-                offset += Type.fromInterned(field_ty).abiSize(pt);
+                offset += Type.fromInterned(field_ty).abiSize(zcu);
             }
             offset = big_align.max(.@"1").forward(offset);
             return offset;
@@ -3196,7 +3407,7 @@ pub fn structFieldOffset(ty: Type, index: usize, pt: Zcu.PerThread) u64 {
             const union_type = ip.loadUnionType(ty.toIntern());
             if (!union_type.hasTag(ip))
                 return 0;
-            const layout = pt.getUnionLayout(union_type);
+            const layout = union_type.getUnionLayout(zcu);
             if (layout.tag_align.compare(.gte, layout.payload_align)) {
                 // {Tag, Payload}
                 return layout.payload_align.forward(layout.tag_size);
@@ -3210,7 +3421,7 @@ pub fn structFieldOffset(ty: Type, index: usize, pt: Zcu.PerThread) u64 {
     }
 }
 
-pub fn srcLocOrNull(ty: Type, zcu: *Zcu) ?Module.LazySrcLoc {
+pub fn srcLocOrNull(ty: Type, zcu: *Zcu) ?Zcu.LazySrcLoc {
     const ip = &zcu.intern_pool;
     return .{
         .base_node_inst = switch (ip.indexToKey(ty.toIntern())) {
@@ -3222,11 +3433,11 @@ pub fn srcLocOrNull(ty: Type, zcu: *Zcu) ?Module.LazySrcLoc {
             },
             else => return null,
         },
-        .offset = Module.LazySrcLoc.Offset.nodeOffset(0),
+        .offset = Zcu.LazySrcLoc.Offset.nodeOffset(0),
     };
 }
 
-pub fn srcLoc(ty: Type, zcu: *Zcu) Module.LazySrcLoc {
+pub fn srcLoc(ty: Type, zcu: *Zcu) Zcu.LazySrcLoc {
     return ty.srcLocOrNull(zcu).?;
 }
 
@@ -3234,8 +3445,8 @@ pub fn isGenericPoison(ty: Type) bool {
     return ty.toIntern() == .generic_poison_type;
 }
 
-pub fn isTuple(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn isTuple(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => {
             const struct_type = ip.loadStructType(ty.toIntern());
@@ -3248,16 +3459,16 @@ pub fn isTuple(ty: Type, mod: *Module) bool {
     };
 }
 
-pub fn isAnonStruct(ty: Type, mod: *Module) bool {
+pub fn isAnonStruct(ty: Type, zcu: *const Zcu) bool {
     if (ty.toIntern() == .empty_struct_type) return true;
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .anon_struct_type => |anon_struct_type| anon_struct_type.names.len > 0,
         else => false,
     };
 }
 
-pub fn isTupleOrAnonStruct(ty: Type, mod: *Module) bool {
-    const ip = &mod.intern_pool;
+pub fn isTupleOrAnonStruct(ty: Type, zcu: *const Zcu) bool {
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.toIntern())) {
         .struct_type => {
             const struct_type = ip.loadStructType(ty.toIntern());
@@ -3270,15 +3481,15 @@ pub fn isTupleOrAnonStruct(ty: Type, mod: *Module) bool {
     };
 }
 
-pub fn isSimpleTuple(ty: Type, mod: *Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isSimpleTuple(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .anon_struct_type => |anon_struct_type| anon_struct_type.names.len == 0,
         else => false,
     };
 }
 
-pub fn isSimpleTupleOrAnonStruct(ty: Type, mod: *Module) bool {
-    return switch (mod.intern_pool.indexToKey(ty.toIntern())) {
+pub fn isSimpleTupleOrAnonStruct(ty: Type, zcu: *const Zcu) bool {
+    return switch (zcu.intern_pool.indexToKey(ty.toIntern())) {
         .anon_struct_type => true,
         else => false,
     };
@@ -3286,11 +3497,11 @@ pub fn isSimpleTupleOrAnonStruct(ty: Type, mod: *Module) bool {
 
 /// Traverses optional child types and error union payloads until the type
 /// is not a pointer. For `E!?u32`, returns `u32`; for `*u8`, returns `*u8`.
-pub fn optEuBaseType(ty: Type, mod: *Module) Type {
+pub fn optEuBaseType(ty: Type, zcu: *const Zcu) Type {
     var cur = ty;
-    while (true) switch (cur.zigTypeTag(mod)) {
-        .Optional => cur = cur.optionalChild(mod),
-        .ErrorUnion => cur = cur.errorUnionPayload(mod),
+    while (true) switch (cur.zigTypeTag(zcu)) {
+        .Optional => cur = cur.optionalChild(zcu),
+        .ErrorUnion => cur = cur.errorUnionPayload(zcu),
         else => return cur,
     };
 }
@@ -3406,7 +3617,7 @@ pub fn packedStructFieldPtrInfo(struct_ty: Type, parent_ptr_ty: Type, field_idx:
         if (i == field_idx) {
             bit_offset = running_bits;
         }
-        running_bits += @intCast(f_ty.bitSize(pt));
+        running_bits += @intCast(f_ty.bitSize(zcu));
     }
 
     const res_host_size: u16, const res_bit_offset: u16 = if (parent_ptr_info.packed_offset.host_size != 0)
@@ -3423,9 +3634,9 @@ pub fn packedStructFieldPtrInfo(struct_ty: Type, parent_ptr_ty: Type, field_idx:
     // targets before adding the necessary complications to this code. This will not
     // cause miscompilations; it only means the field pointer uses bit masking when it
     // might not be strictly necessary.
-    if (res_bit_offset % 8 == 0 and field_ty.bitSize(pt) == field_ty.abiSize(pt) * 8 and zcu.getTarget().cpu.arch.endian() == .little) {
+    if (res_bit_offset % 8 == 0 and field_ty.bitSize(zcu) == field_ty.abiSize(zcu) * 8 and zcu.getTarget().cpu.arch.endian() == .little) {
         const byte_offset = res_bit_offset / 8;
-        const new_align = Alignment.fromLog2Units(@ctz(byte_offset | parent_ptr_ty.ptrAlignment(pt).toByteUnits().?));
+        const new_align = Alignment.fromLog2Units(@ctz(byte_offset | parent_ptr_ty.ptrAlignment(zcu).toByteUnits().?));
         return .{ .byte_ptr = .{
             .offset = byte_offset,
             .alignment = new_align,
@@ -3768,14 +3979,14 @@ pub fn elemPtrType(ptr_ty: Type, offset: ?usize, pt: Zcu.PerThread) !Type {
         alignment: Alignment = .none,
         vector_index: VI = .none,
     } = if (parent_ty.isVector(zcu) and ptr_info.flags.size == .One) blk: {
-        const elem_bits = elem_ty.bitSize(pt);
+        const elem_bits = elem_ty.bitSize(zcu);
         if (elem_bits == 0) break :blk .{};
         const is_packed = elem_bits < 8 or !std.math.isPowerOfTwo(elem_bits);
         if (!is_packed) break :blk .{};
 
         break :blk .{
             .host_size = @intCast(parent_ty.arrayLen(zcu)),
-            .alignment = parent_ty.abiAlignment(pt),
+            .alignment = parent_ty.abiAlignment(zcu),
             .vector_index = if (offset) |some| @enumFromInt(some) else .runtime,
         };
     } else .{};
@@ -3789,7 +4000,7 @@ pub fn elemPtrType(ptr_ty: Type, offset: ?usize, pt: Zcu.PerThread) !Type {
         }
         // If the addend is not a comptime-known value we can still count on
         // it being a multiple of the type size.
-        const elem_size = (try elem_ty.abiSizeAdvanced(pt, .sema)).scalar;
+        const elem_size = (try elem_ty.abiSizeInner(.sema, zcu, pt.tid)).scalar;
         const addend = if (offset) |off| elem_size * off else elem_size;
 
         // The resulting pointer is aligned to the lcd between the offset (an

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -3028,9 +3028,9 @@ pub fn getParentNamespace(ty: Type, zcu: *Zcu) InternPool.OptionalNamespaceIndex
 
 // Works for vectors and vectors of integers.
 pub fn minInt(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
-    const mod = pt.zcu;
-    const scalar = try minIntScalar(ty.scalarType(mod), pt, dest_ty.scalarType(mod));
-    return if (ty.zigTypeTag(mod) == .Vector) Value.fromInterned(try pt.intern(.{ .aggregate = .{
+    const zcu = pt.zcu;
+    const scalar = try minIntScalar(ty.scalarType(zcu), pt, dest_ty.scalarType(zcu));
+    return if (ty.zigTypeTag(zcu) == .Vector) Value.fromInterned(try pt.intern(.{ .aggregate = .{
         .ty = dest_ty.toIntern(),
         .storage = .{ .repeated_elem = scalar.toIntern() },
     } })) else scalar;
@@ -3038,8 +3038,8 @@ pub fn minInt(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
 
 /// Asserts that the type is an integer.
 pub fn minIntScalar(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
-    const mod = pt.zcu;
-    const info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const info = ty.intInfo(zcu);
     if (info.signedness == .unsigned) return pt.intValue(dest_ty, 0);
     if (info.bits == 0) return pt.intValue(dest_ty, -1);
 
@@ -3048,7 +3048,7 @@ pub fn minIntScalar(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
         return pt.intValue(dest_ty, n);
     }
 
-    var res = try std.math.big.int.Managed.init(mod.gpa);
+    var res = try std.math.big.int.Managed.init(zcu.gpa);
     defer res.deinit();
 
     try res.setTwosCompIntLimit(.min, info.signedness, info.bits);
@@ -3059,9 +3059,9 @@ pub fn minIntScalar(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
 // Works for vectors and vectors of integers.
 /// The returned Value will have type dest_ty.
 pub fn maxInt(ty: Type, pt: Zcu.PerThread, dest_ty: Type) !Value {
-    const mod = pt.zcu;
-    const scalar = try maxIntScalar(ty.scalarType(mod), pt, dest_ty.scalarType(mod));
-    return if (ty.zigTypeTag(mod) == .Vector) Value.fromInterned(try pt.intern(.{ .aggregate = .{
+    const zcu = pt.zcu;
+    const scalar = try maxIntScalar(ty.scalarType(zcu), pt, dest_ty.scalarType(zcu));
+    return if (ty.zigTypeTag(zcu) == .Vector) Value.fromInterned(try pt.intern(.{ .aggregate = .{
         .ty = dest_ty.toIntern(),
         .storage = .{ .repeated_elem = scalar.toIntern() },
     } })) else scalar;
@@ -3546,12 +3546,12 @@ pub fn optEuBaseType(ty: Type, zcu: *const Zcu) Type {
 }
 
 pub fn toUnsigned(ty: Type, pt: Zcu.PerThread) !Type {
-    const mod = pt.zcu;
-    return switch (ty.zigTypeTag(mod)) {
-        .Int => pt.intType(.unsigned, ty.intInfo(mod).bits),
+    const zcu = pt.zcu;
+    return switch (ty.zigTypeTag(zcu)) {
+        .Int => pt.intType(.unsigned, ty.intInfo(zcu).bits),
         .Vector => try pt.vectorType(.{
-            .len = ty.vectorLen(mod),
-            .child = (try ty.childType(mod).toUnsigned(pt)).toIntern(),
+            .len = ty.vectorLen(zcu),
+            .child = (try ty.childType(zcu).toUnsigned(pt)).toIntern(),
         }),
         else => unreachable,
     };

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -65,19 +65,19 @@ pub fn fmtValueSemaFull(ctx: print_value.FormatContext) std.fmt.Formatter(print_
 /// Converts `val` to a null-terminated string stored in the InternPool.
 /// Asserts `val` is an array of `u8`
 pub fn toIpString(val: Value, ty: Type, pt: Zcu.PerThread) !InternPool.NullTerminatedString {
-    const mod = pt.zcu;
-    assert(ty.zigTypeTag(mod) == .Array);
-    assert(ty.childType(mod).toIntern() == .u8_type);
-    const ip = &mod.intern_pool;
-    switch (mod.intern_pool.indexToKey(val.toIntern()).aggregate.storage) {
-        .bytes => |bytes| return bytes.toNullTerminatedString(ty.arrayLen(mod), ip),
-        .elems => return arrayToIpString(val, ty.arrayLen(mod), pt),
+    const zcu = pt.zcu;
+    assert(ty.zigTypeTag(zcu) == .Array);
+    assert(ty.childType(zcu).toIntern() == .u8_type);
+    const ip = &zcu.intern_pool;
+    switch (zcu.intern_pool.indexToKey(val.toIntern()).aggregate.storage) {
+        .bytes => |bytes| return bytes.toNullTerminatedString(ty.arrayLen(zcu), ip),
+        .elems => return arrayToIpString(val, ty.arrayLen(zcu), pt),
         .repeated_elem => |elem| {
-            const byte: u8 = @intCast(Value.fromInterned(elem).toUnsignedInt(pt));
-            const len: u32 = @intCast(ty.arrayLen(mod));
-            const strings = ip.getLocal(pt.tid).getMutableStrings(mod.gpa);
+            const byte: u8 = @intCast(Value.fromInterned(elem).toUnsignedInt(zcu));
+            const len: u32 = @intCast(ty.arrayLen(zcu));
+            const strings = ip.getLocal(pt.tid).getMutableStrings(zcu.gpa);
             try strings.appendNTimes(.{byte}, len);
-            return ip.getOrPutTrailingString(mod.gpa, pt.tid, len, .no_embedded_nulls);
+            return ip.getOrPutTrailingString(zcu.gpa, pt.tid, len, .no_embedded_nulls);
         },
     }
 }
@@ -85,17 +85,17 @@ pub fn toIpString(val: Value, ty: Type, pt: Zcu.PerThread) !InternPool.NullTermi
 /// Asserts that the value is representable as an array of bytes.
 /// Copies the value into a freshly allocated slice of memory, which is owned by the caller.
 pub fn toAllocatedBytes(val: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) ![]u8 {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(val.toIntern())) {
         .enum_literal => |enum_literal| allocator.dupe(u8, enum_literal.toSlice(ip)),
-        .slice => |slice| try arrayToAllocatedBytes(val, Value.fromInterned(slice.len).toUnsignedInt(pt), allocator, pt),
+        .slice => |slice| try arrayToAllocatedBytes(val, Value.fromInterned(slice.len).toUnsignedInt(zcu), allocator, pt),
         .aggregate => |aggregate| switch (aggregate.storage) {
-            .bytes => |bytes| try allocator.dupe(u8, bytes.toSlice(ty.arrayLenIncludingSentinel(mod), ip)),
-            .elems => try arrayToAllocatedBytes(val, ty.arrayLen(mod), allocator, pt),
+            .bytes => |bytes| try allocator.dupe(u8, bytes.toSlice(ty.arrayLenIncludingSentinel(zcu), ip)),
+            .elems => try arrayToAllocatedBytes(val, ty.arrayLen(zcu), allocator, pt),
             .repeated_elem => |elem| {
-                const byte: u8 = @intCast(Value.fromInterned(elem).toUnsignedInt(pt));
-                const result = try allocator.alloc(u8, @intCast(ty.arrayLen(mod)));
+                const byte: u8 = @intCast(Value.fromInterned(elem).toUnsignedInt(zcu));
+                const result = try allocator.alloc(u8, @intCast(ty.arrayLen(zcu)));
                 @memset(result, byte);
                 return result;
             },
@@ -108,15 +108,15 @@ fn arrayToAllocatedBytes(val: Value, len: u64, allocator: Allocator, pt: Zcu.Per
     const result = try allocator.alloc(u8, @intCast(len));
     for (result, 0..) |*elem, i| {
         const elem_val = try val.elemValue(pt, i);
-        elem.* = @intCast(elem_val.toUnsignedInt(pt));
+        elem.* = @intCast(elem_val.toUnsignedInt(pt.zcu));
     }
     return result;
 }
 
 fn arrayToIpString(val: Value, len_u64: u64, pt: Zcu.PerThread) !InternPool.NullTerminatedString {
-    const mod = pt.zcu;
-    const gpa = mod.gpa;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
+    const ip = &zcu.intern_pool;
     const len: u32 = @intCast(len_u64);
     const strings = ip.getLocal(pt.tid).getMutableStrings(gpa);
     try strings.ensureUnusedCapacity(len);
@@ -126,7 +126,7 @@ fn arrayToIpString(val: Value, len_u64: u64, pt: Zcu.PerThread) !InternPool.Null
         const prev_len = strings.mutate.len;
         const elem_val = try val.elemValue(pt, i);
         assert(strings.mutate.len == prev_len);
-        const byte: u8 = @intCast(elem_val.toUnsignedInt(pt));
+        const byte: u8 = @intCast(elem_val.toUnsignedInt(zcu));
         strings.appendAssumeCapacity(.{byte});
     }
     return ip.getOrPutTrailingString(gpa, pt.tid, len, .no_embedded_nulls);
@@ -178,50 +178,55 @@ pub fn intFromEnum(val: Value, ty: Type, pt: Zcu.PerThread) Allocator.Error!Valu
 pub const ResolveStrat = Type.ResolveStrat;
 
 /// Asserts the value is an integer.
-pub fn toBigInt(val: Value, space: *BigIntSpace, pt: Zcu.PerThread) BigIntConst {
-    return val.toBigIntAdvanced(space, pt, .normal) catch unreachable;
+pub fn toBigInt(val: Value, space: *BigIntSpace, zcu: *Zcu) BigIntConst {
+    return val.toBigIntAdvanced(space, .normal, zcu, {}) catch unreachable;
+}
+
+pub fn toBigIntSema(val: Value, space: *BigIntSpace, pt: Zcu.PerThread) !BigIntConst {
+    return try val.toBigIntAdvanced(space, .sema, pt.zcu, pt.tid);
 }
 
 /// Asserts the value is an integer.
 pub fn toBigIntAdvanced(
     val: Value,
     space: *BigIntSpace,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
 ) Module.CompileError!BigIntConst {
     return switch (val.toIntern()) {
         .bool_false => BigIntMutable.init(&space.limbs, 0).toConst(),
         .bool_true => BigIntMutable.init(&space.limbs, 1).toConst(),
         .null_value => BigIntMutable.init(&space.limbs, 0).toConst(),
-        else => switch (pt.zcu.intern_pool.indexToKey(val.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(val.toIntern())) {
             .int => |int| switch (int.storage) {
                 .u64, .i64, .big_int => int.storage.toBigInt(space),
                 .lazy_align, .lazy_size => |ty| {
-                    if (strat == .sema) try Type.fromInterned(ty).resolveLayout(pt);
+                    if (strat == .sema) try Type.fromInterned(ty).resolveLayout(strat.pt(zcu, tid));
                     const x = switch (int.storage) {
                         else => unreachable,
-                        .lazy_align => Type.fromInterned(ty).abiAlignment(pt).toByteUnits() orelse 0,
-                        .lazy_size => Type.fromInterned(ty).abiSize(pt),
+                        .lazy_align => Type.fromInterned(ty).abiAlignment(zcu).toByteUnits() orelse 0,
+                        .lazy_size => Type.fromInterned(ty).abiSize(zcu),
                     };
                     return BigIntMutable.init(&space.limbs, x).toConst();
                 },
             },
-            .enum_tag => |enum_tag| Value.fromInterned(enum_tag.int).toBigIntAdvanced(space, pt, strat),
+            .enum_tag => |enum_tag| Value.fromInterned(enum_tag.int).toBigIntAdvanced(space, strat, zcu, tid),
             .opt, .ptr => BigIntMutable.init(
                 &space.limbs,
-                (try val.getUnsignedIntAdvanced(pt, strat)).?,
+                (try val.getUnsignedIntInner(strat, zcu, tid)).?,
             ).toConst(),
             else => unreachable,
         },
     };
 }
 
-pub fn isFuncBody(val: Value, mod: *Module) bool {
-    return mod.intern_pool.isFuncBody(val.toIntern());
+pub fn isFuncBody(val: Value, zcu: *Module) bool {
+    return zcu.intern_pool.isFuncBody(val.toIntern());
 }
 
-pub fn getFunction(val: Value, mod: *Module) ?InternPool.Key.Func {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn getFunction(val: Value, zcu: *Module) ?InternPool.Key.Func {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .func => |x| x,
         else => null,
     };
@@ -236,40 +241,56 @@ pub fn getVariable(val: Value, mod: *Module) ?InternPool.Key.Variable {
 
 /// If the value fits in a u64, return it, otherwise null.
 /// Asserts not undefined.
-pub fn getUnsignedInt(val: Value, pt: Zcu.PerThread) ?u64 {
-    return getUnsignedIntAdvanced(val, pt, .normal) catch unreachable;
+pub fn getUnsignedInt(val: Value, zcu: *Zcu) ?u64 {
+    return getUnsignedIntInner(val, .normal, zcu, {}) catch unreachable;
+}
+
+/// Asserts the value is an integer and it fits in a u64
+pub fn toUnsignedInt(val: Value, zcu: *Zcu) u64 {
+    return getUnsignedInt(val, zcu).?;
+}
+
+pub fn getUnsignedIntSema(val: Value, pt: Zcu.PerThread) !?u64 {
+    return try val.getUnsignedIntInner(.sema, pt.zcu, pt.tid);
 }
 
 /// If the value fits in a u64, return it, otherwise null.
 /// Asserts not undefined.
-pub fn getUnsignedIntAdvanced(val: Value, pt: Zcu.PerThread, comptime strat: ResolveStrat) !?u64 {
-    const mod = pt.zcu;
+pub fn getUnsignedIntInner(
+    val: Value,
+    comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) !?u64 {
     return switch (val.toIntern()) {
         .undef => unreachable,
         .bool_false => 0,
         .bool_true => 1,
-        else => switch (mod.intern_pool.indexToKey(val.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(val.toIntern())) {
             .undef => unreachable,
             .int => |int| switch (int.storage) {
                 .big_int => |big_int| big_int.to(u64) catch null,
                 .u64 => |x| x,
                 .i64 => |x| std.math.cast(u64, x),
-                .lazy_align => |ty| (try Type.fromInterned(ty).abiAlignmentAdvanced(pt, strat.toLazy())).scalar.toByteUnits() orelse 0,
-                .lazy_size => |ty| (try Type.fromInterned(ty).abiSizeAdvanced(pt, strat.toLazy())).scalar,
+                .lazy_align => |ty| (try Type.fromInterned(ty).abiAlignmentInner(strat.toLazy(), zcu, tid)).scalar.toByteUnits() orelse 0,
+                .lazy_size => |ty| (try Type.fromInterned(ty).abiSizeInner(strat.toLazy(), zcu, tid)).scalar,
             },
             .ptr => |ptr| switch (ptr.base_addr) {
                 .int => ptr.byte_offset,
                 .field => |field| {
-                    const base_addr = (try Value.fromInterned(field.base).getUnsignedIntAdvanced(pt, strat)) orelse return null;
-                    const struct_ty = Value.fromInterned(field.base).typeOf(mod).childType(mod);
-                    if (strat == .sema) try struct_ty.resolveLayout(pt);
-                    return base_addr + struct_ty.structFieldOffset(@intCast(field.index), pt) + ptr.byte_offset;
+                    const base_addr = (try Value.fromInterned(field.base).getUnsignedIntInner(strat, zcu, tid)) orelse return null;
+                    const struct_ty = Value.fromInterned(field.base).typeOf(zcu).childType(zcu);
+                    if (strat == .sema) {
+                        const pt = strat.pt(zcu, tid);
+                        try struct_ty.resolveLayout(pt);
+                    }
+                    return base_addr + struct_ty.structFieldOffset(@intCast(field.index), zcu) + ptr.byte_offset;
                 },
                 else => null,
             },
             .opt => |opt| switch (opt.val) {
                 .none => 0,
-                else => |payload| Value.fromInterned(payload).getUnsignedIntAdvanced(pt, strat),
+                else => |payload| Value.fromInterned(payload).getUnsignedIntInner(strat, zcu, tid),
             },
             else => null,
         },
@@ -277,27 +298,22 @@ pub fn getUnsignedIntAdvanced(val: Value, pt: Zcu.PerThread, comptime strat: Res
 }
 
 /// Asserts the value is an integer and it fits in a u64
-pub fn toUnsignedInt(val: Value, pt: Zcu.PerThread) u64 {
-    return getUnsignedInt(val, pt).?;
-}
-
-/// Asserts the value is an integer and it fits in a u64
 pub fn toUnsignedIntSema(val: Value, pt: Zcu.PerThread) !u64 {
-    return (try getUnsignedIntAdvanced(val, pt, .sema)).?;
+    return (try getUnsignedIntInner(val, .sema, pt.zcu, pt.tid)).?;
 }
 
 /// Asserts the value is an integer and it fits in a i64
-pub fn toSignedInt(val: Value, pt: Zcu.PerThread) i64 {
+pub fn toSignedInt(val: Value, zcu: *Zcu) i64 {
     return switch (val.toIntern()) {
         .bool_false => 0,
         .bool_true => 1,
-        else => switch (pt.zcu.intern_pool.indexToKey(val.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(val.toIntern())) {
             .int => |int| switch (int.storage) {
                 .big_int => |big_int| big_int.to(i64) catch unreachable,
                 .i64 => |x| x,
                 .u64 => |x| @intCast(x),
-                .lazy_align => |ty| @intCast(Type.fromInterned(ty).abiAlignment(pt).toByteUnits() orelse 0),
-                .lazy_size => |ty| @intCast(Type.fromInterned(ty).abiSize(pt)),
+                .lazy_align => |ty| @intCast(Type.fromInterned(ty).abiAlignment(zcu).toByteUnits() orelse 0),
+                .lazy_size => |ty| @intCast(Type.fromInterned(ty).abiSize(zcu)),
             },
             else => unreachable,
         },
@@ -326,41 +342,41 @@ pub fn writeToMemory(val: Value, ty: Type, pt: Zcu.PerThread, buffer: []u8) erro
     Unimplemented,
     OutOfMemory,
 }!void {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const endian = target.cpu.arch.endian();
-    if (val.isUndef(mod)) {
-        const size: usize = @intCast(ty.abiSize(pt));
+    if (val.isUndef(zcu)) {
+        const size: usize = @intCast(ty.abiSize(zcu));
         @memset(buffer[0..size], 0xaa);
         return;
     }
-    const ip = &mod.intern_pool;
-    switch (ty.zigTypeTag(mod)) {
+    const ip = &zcu.intern_pool;
+    switch (ty.zigTypeTag(zcu)) {
         .Void => {},
         .Bool => {
             buffer[0] = @intFromBool(val.toBool());
         },
         .Int, .Enum => {
-            const int_info = ty.intInfo(mod);
+            const int_info = ty.intInfo(zcu);
             const bits = int_info.bits;
             const byte_count: u16 = @intCast((@as(u17, bits) + 7) / 8);
 
             var bigint_buffer: BigIntSpace = undefined;
-            const bigint = val.toBigInt(&bigint_buffer, pt);
+            const bigint = val.toBigInt(&bigint_buffer, zcu);
             bigint.writeTwosComplement(buffer[0..byte_count], endian);
         },
         .Float => switch (ty.floatBits(target)) {
-            16 => std.mem.writeInt(u16, buffer[0..2], @bitCast(val.toFloat(f16, pt)), endian),
-            32 => std.mem.writeInt(u32, buffer[0..4], @bitCast(val.toFloat(f32, pt)), endian),
-            64 => std.mem.writeInt(u64, buffer[0..8], @bitCast(val.toFloat(f64, pt)), endian),
-            80 => std.mem.writeInt(u80, buffer[0..10], @bitCast(val.toFloat(f80, pt)), endian),
-            128 => std.mem.writeInt(u128, buffer[0..16], @bitCast(val.toFloat(f128, pt)), endian),
+            16 => std.mem.writeInt(u16, buffer[0..2], @bitCast(val.toFloat(f16, zcu)), endian),
+            32 => std.mem.writeInt(u32, buffer[0..4], @bitCast(val.toFloat(f32, zcu)), endian),
+            64 => std.mem.writeInt(u64, buffer[0..8], @bitCast(val.toFloat(f64, zcu)), endian),
+            80 => std.mem.writeInt(u80, buffer[0..10], @bitCast(val.toFloat(f80, zcu)), endian),
+            128 => std.mem.writeInt(u128, buffer[0..16], @bitCast(val.toFloat(f128, zcu)), endian),
             else => unreachable,
         },
         .Array => {
-            const len = ty.arrayLen(mod);
-            const elem_ty = ty.childType(mod);
-            const elem_size: usize = @intCast(elem_ty.abiSize(pt));
+            const len = ty.arrayLen(zcu);
+            const elem_ty = ty.childType(zcu);
+            const elem_size: usize = @intCast(elem_ty.abiSize(zcu));
             var elem_i: usize = 0;
             var buf_off: usize = 0;
             while (elem_i < len) : (elem_i += 1) {
@@ -372,15 +388,15 @@ pub fn writeToMemory(val: Value, ty: Type, pt: Zcu.PerThread, buffer: []u8) erro
         .Vector => {
             // We use byte_count instead of abi_size here, so that any padding bytes
             // follow the data bytes, on both big- and little-endian systems.
-            const byte_count = (@as(usize, @intCast(ty.bitSize(pt))) + 7) / 8;
+            const byte_count = (@as(usize, @intCast(ty.bitSize(zcu))) + 7) / 8;
             return writeToPackedMemory(val, ty, pt, buffer[0..byte_count], 0);
         },
         .Struct => {
-            const struct_type = mod.typeToStruct(ty) orelse return error.IllDefinedMemoryLayout;
+            const struct_type = zcu.typeToStruct(ty) orelse return error.IllDefinedMemoryLayout;
             switch (struct_type.layout) {
                 .auto => return error.IllDefinedMemoryLayout,
                 .@"extern" => for (0..struct_type.field_types.len) |field_index| {
-                    const off: usize = @intCast(ty.structFieldOffset(field_index, pt));
+                    const off: usize = @intCast(ty.structFieldOffset(field_index, zcu));
                     const field_val = Value.fromInterned(switch (ip.indexToKey(val.toIntern()).aggregate.storage) {
                         .bytes => |bytes| {
                             buffer[off] = bytes.at(field_index, ip);
@@ -393,13 +409,13 @@ pub fn writeToMemory(val: Value, ty: Type, pt: Zcu.PerThread, buffer: []u8) erro
                     try writeToMemory(field_val, field_ty, pt, buffer[off..]);
                 },
                 .@"packed" => {
-                    const byte_count = (@as(usize, @intCast(ty.bitSize(pt))) + 7) / 8;
+                    const byte_count = (@as(usize, @intCast(ty.bitSize(zcu))) + 7) / 8;
                     return writeToPackedMemory(val, ty, pt, buffer[0..byte_count], 0);
                 },
             }
         },
         .ErrorSet => {
-            const bits = mod.errorSetBits();
+            const bits = zcu.errorSetBits();
             const byte_count: u16 = @intCast((@as(u17, bits) + 7) / 8);
 
             const name = switch (ip.indexToKey(val.toIntern())) {
@@ -414,37 +430,37 @@ pub fn writeToMemory(val: Value, ty: Type, pt: Zcu.PerThread, buffer: []u8) erro
             ).toConst();
             bigint.writeTwosComplement(buffer[0..byte_count], endian);
         },
-        .Union => switch (ty.containerLayout(mod)) {
+        .Union => switch (ty.containerLayout(zcu)) {
             .auto => return error.IllDefinedMemoryLayout, // Sema is supposed to have emitted a compile error already
             .@"extern" => {
-                if (val.unionTag(mod)) |union_tag| {
-                    const union_obj = mod.typeToUnion(ty).?;
-                    const field_index = mod.unionTagFieldIndex(union_obj, union_tag).?;
+                if (val.unionTag(zcu)) |union_tag| {
+                    const union_obj = zcu.typeToUnion(ty).?;
+                    const field_index = zcu.unionTagFieldIndex(union_obj, union_tag).?;
                     const field_type = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
                     const field_val = try val.fieldValue(pt, field_index);
-                    const byte_count: usize = @intCast(field_type.abiSize(pt));
+                    const byte_count: usize = @intCast(field_type.abiSize(zcu));
                     return writeToMemory(field_val, field_type, pt, buffer[0..byte_count]);
                 } else {
                     const backing_ty = try ty.unionBackingType(pt);
-                    const byte_count: usize = @intCast(backing_ty.abiSize(pt));
-                    return writeToMemory(val.unionValue(mod), backing_ty, pt, buffer[0..byte_count]);
+                    const byte_count: usize = @intCast(backing_ty.abiSize(zcu));
+                    return writeToMemory(val.unionValue(zcu), backing_ty, pt, buffer[0..byte_count]);
                 }
             },
             .@"packed" => {
                 const backing_ty = try ty.unionBackingType(pt);
-                const byte_count: usize = @intCast(backing_ty.abiSize(pt));
+                const byte_count: usize = @intCast(backing_ty.abiSize(zcu));
                 return writeToPackedMemory(val, ty, pt, buffer[0..byte_count], 0);
             },
         },
         .Pointer => {
-            if (ty.isSlice(mod)) return error.IllDefinedMemoryLayout;
-            if (!val.ptrHasIntAddr(mod)) return error.ReinterpretDeclRef;
+            if (ty.isSlice(zcu)) return error.IllDefinedMemoryLayout;
+            if (!val.ptrHasIntAddr(zcu)) return error.ReinterpretDeclRef;
             return val.writeToMemory(Type.usize, pt, buffer);
         },
         .Optional => {
-            if (!ty.isPtrLikeOptional(mod)) return error.IllDefinedMemoryLayout;
-            const child = ty.optionalChild(mod);
-            const opt_val = val.optionalValue(mod);
+            if (!ty.isPtrLikeOptional(zcu)) return error.IllDefinedMemoryLayout;
+            const child = ty.optionalChild(zcu);
+            const opt_val = val.optionalValue(zcu);
             if (opt_val) |some| {
                 return some.writeToMemory(child, pt, buffer);
             } else {
@@ -466,18 +482,18 @@ pub fn writeToPackedMemory(
     buffer: []u8,
     bit_offset: usize,
 ) error{ ReinterpretDeclRef, OutOfMemory }!void {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const target = zcu.getTarget();
     const endian = target.cpu.arch.endian();
-    if (val.isUndef(mod)) {
-        const bit_size: usize = @intCast(ty.bitSize(pt));
+    if (val.isUndef(zcu)) {
+        const bit_size: usize = @intCast(ty.bitSize(zcu));
         if (bit_size != 0) {
             std.mem.writeVarPackedInt(buffer, bit_offset, bit_size, @as(u1, 0), endian);
         }
         return;
     }
-    switch (ty.zigTypeTag(mod)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Void => {},
         .Bool => {
             const byte_index = switch (endian) {
@@ -492,34 +508,34 @@ pub fn writeToPackedMemory(
         },
         .Int, .Enum => {
             if (buffer.len == 0) return;
-            const bits = ty.intInfo(mod).bits;
+            const bits = ty.intInfo(zcu).bits;
             if (bits == 0) return;
 
             switch (ip.indexToKey((try val.intFromEnum(ty, pt)).toIntern()).int.storage) {
                 inline .u64, .i64 => |int| std.mem.writeVarPackedInt(buffer, bit_offset, bits, int, endian),
                 .big_int => |bigint| bigint.writePackedTwosComplement(buffer, bit_offset, bits, endian),
                 .lazy_align => |lazy_align| {
-                    const num = Type.fromInterned(lazy_align).abiAlignment(pt).toByteUnits() orelse 0;
+                    const num = Type.fromInterned(lazy_align).abiAlignment(zcu).toByteUnits() orelse 0;
                     std.mem.writeVarPackedInt(buffer, bit_offset, bits, num, endian);
                 },
                 .lazy_size => |lazy_size| {
-                    const num = Type.fromInterned(lazy_size).abiSize(pt);
+                    const num = Type.fromInterned(lazy_size).abiSize(zcu);
                     std.mem.writeVarPackedInt(buffer, bit_offset, bits, num, endian);
                 },
             }
         },
         .Float => switch (ty.floatBits(target)) {
-            16 => std.mem.writePackedInt(u16, buffer, bit_offset, @bitCast(val.toFloat(f16, pt)), endian),
-            32 => std.mem.writePackedInt(u32, buffer, bit_offset, @bitCast(val.toFloat(f32, pt)), endian),
-            64 => std.mem.writePackedInt(u64, buffer, bit_offset, @bitCast(val.toFloat(f64, pt)), endian),
-            80 => std.mem.writePackedInt(u80, buffer, bit_offset, @bitCast(val.toFloat(f80, pt)), endian),
-            128 => std.mem.writePackedInt(u128, buffer, bit_offset, @bitCast(val.toFloat(f128, pt)), endian),
+            16 => std.mem.writePackedInt(u16, buffer, bit_offset, @bitCast(val.toFloat(f16, zcu)), endian),
+            32 => std.mem.writePackedInt(u32, buffer, bit_offset, @bitCast(val.toFloat(f32, zcu)), endian),
+            64 => std.mem.writePackedInt(u64, buffer, bit_offset, @bitCast(val.toFloat(f64, zcu)), endian),
+            80 => std.mem.writePackedInt(u80, buffer, bit_offset, @bitCast(val.toFloat(f80, zcu)), endian),
+            128 => std.mem.writePackedInt(u128, buffer, bit_offset, @bitCast(val.toFloat(f128, zcu)), endian),
             else => unreachable,
         },
         .Vector => {
-            const elem_ty = ty.childType(mod);
-            const elem_bit_size: u16 = @intCast(elem_ty.bitSize(pt));
-            const len: usize = @intCast(ty.arrayLen(mod));
+            const elem_ty = ty.childType(zcu);
+            const elem_bit_size: u16 = @intCast(elem_ty.bitSize(zcu));
+            const len: usize = @intCast(ty.arrayLen(zcu));
 
             var bits: u16 = 0;
             var elem_i: usize = 0;
@@ -544,37 +560,37 @@ pub fn writeToPackedMemory(
                     .repeated_elem => |elem| elem,
                 });
                 const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
-                const field_bits: u16 = @intCast(field_ty.bitSize(pt));
+                const field_bits: u16 = @intCast(field_ty.bitSize(zcu));
                 try field_val.writeToPackedMemory(field_ty, pt, buffer, bit_offset + bits);
                 bits += field_bits;
             }
         },
         .Union => {
-            const union_obj = mod.typeToUnion(ty).?;
+            const union_obj = zcu.typeToUnion(ty).?;
             switch (union_obj.flagsUnordered(ip).layout) {
                 .auto, .@"extern" => unreachable, // Handled in non-packed writeToMemory
                 .@"packed" => {
-                    if (val.unionTag(mod)) |union_tag| {
-                        const field_index = mod.unionTagFieldIndex(union_obj, union_tag).?;
+                    if (val.unionTag(zcu)) |union_tag| {
+                        const field_index = zcu.unionTagFieldIndex(union_obj, union_tag).?;
                         const field_type = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
                         const field_val = try val.fieldValue(pt, field_index);
                         return field_val.writeToPackedMemory(field_type, pt, buffer, bit_offset);
                     } else {
                         const backing_ty = try ty.unionBackingType(pt);
-                        return val.unionValue(mod).writeToPackedMemory(backing_ty, pt, buffer, bit_offset);
+                        return val.unionValue(zcu).writeToPackedMemory(backing_ty, pt, buffer, bit_offset);
                     }
                 },
             }
         },
         .Pointer => {
-            assert(!ty.isSlice(mod)); // No well defined layout.
-            if (!val.ptrHasIntAddr(mod)) return error.ReinterpretDeclRef;
+            assert(!ty.isSlice(zcu)); // No well defined layout.
+            if (!val.ptrHasIntAddr(zcu)) return error.ReinterpretDeclRef;
             return val.writeToPackedMemory(Type.usize, pt, buffer, bit_offset);
         },
         .Optional => {
-            assert(ty.isPtrLikeOptional(mod));
-            const child = ty.optionalChild(mod);
-            const opt_val = val.optionalValue(mod);
+            assert(ty.isPtrLikeOptional(zcu));
+            const child = ty.optionalChild(zcu);
+            const opt_val = val.optionalValue(zcu);
             if (opt_val) |some| {
                 return some.writeToPackedMemory(child, pt, buffer, bit_offset);
             } else {
@@ -599,11 +615,11 @@ pub fn readFromMemory(
     Unimplemented,
     OutOfMemory,
 }!Value {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const target = zcu.getTarget();
     const endian = target.cpu.arch.endian();
-    switch (ty.zigTypeTag(mod)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Void => return Value.void,
         .Bool => {
             if (buffer[0] == 0) {
@@ -615,24 +631,24 @@ pub fn readFromMemory(
         .Int, .Enum => |ty_tag| {
             const int_ty = switch (ty_tag) {
                 .Int => ty,
-                .Enum => ty.intTagType(mod),
+                .Enum => ty.intTagType(zcu),
                 else => unreachable,
             };
-            const int_info = int_ty.intInfo(mod);
+            const int_info = int_ty.intInfo(zcu);
             const bits = int_info.bits;
             const byte_count: u16 = @intCast((@as(u17, bits) + 7) / 8);
-            if (bits == 0 or buffer.len == 0) return mod.getCoerced(try mod.intValue(int_ty, 0), ty);
+            if (bits == 0 or buffer.len == 0) return zcu.getCoerced(try zcu.intValue(int_ty, 0), ty);
 
             if (bits <= 64) switch (int_info.signedness) { // Fast path for integers <= u64
                 .signed => {
                     const val = std.mem.readVarInt(i64, buffer[0..byte_count], endian);
                     const result = (val << @as(u6, @intCast(64 - bits))) >> @as(u6, @intCast(64 - bits));
-                    return mod.getCoerced(try mod.intValue(int_ty, result), ty);
+                    return zcu.getCoerced(try zcu.intValue(int_ty, result), ty);
                 },
                 .unsigned => {
                     const val = std.mem.readVarInt(u64, buffer[0..byte_count], endian);
                     const result = (val << @as(u6, @intCast(64 - bits))) >> @as(u6, @intCast(64 - bits));
-                    return mod.getCoerced(try mod.intValue(int_ty, result), ty);
+                    return zcu.getCoerced(try zcu.intValue(int_ty, result), ty);
                 },
             } else { // Slow path, we have to construct a big-int
                 const Limb = std.math.big.Limb;
@@ -641,7 +657,7 @@ pub fn readFromMemory(
 
                 var bigint = BigIntMutable.init(limbs_buffer, 0);
                 bigint.readTwosComplement(buffer[0..byte_count], bits, endian, int_info.signedness);
-                return mod.getCoerced(try mod.intValue_big(int_ty, bigint.toConst()), ty);
+                return zcu.getCoerced(try zcu.intValue_big(int_ty, bigint.toConst()), ty);
             }
         },
         .Float => return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -656,12 +672,12 @@ pub fn readFromMemory(
             },
         } })),
         .Array => {
-            const elem_ty = ty.childType(mod);
-            const elem_size = elem_ty.abiSize(pt);
-            const elems = try arena.alloc(InternPool.Index, @intCast(ty.arrayLen(mod)));
+            const elem_ty = ty.childType(zcu);
+            const elem_size = elem_ty.abiSize(zcu);
+            const elems = try arena.alloc(InternPool.Index, @intCast(ty.arrayLen(zcu)));
             var offset: usize = 0;
             for (elems) |*elem| {
-                elem.* = (try readFromMemory(elem_ty, mod, buffer[offset..], arena)).toIntern();
+                elem.* = (try readFromMemory(elem_ty, zcu, buffer[offset..], arena)).toIntern();
                 offset += @intCast(elem_size);
             }
             return Value.fromInterned(try pt.intern(.{ .aggregate = .{
@@ -672,11 +688,11 @@ pub fn readFromMemory(
         .Vector => {
             // We use byte_count instead of abi_size here, so that any padding bytes
             // follow the data bytes, on both big- and little-endian systems.
-            const byte_count = (@as(usize, @intCast(ty.bitSize(pt))) + 7) / 8;
-            return readFromPackedMemory(ty, mod, buffer[0..byte_count], 0, arena);
+            const byte_count = (@as(usize, @intCast(ty.bitSize(zcu))) + 7) / 8;
+            return readFromPackedMemory(ty, zcu, buffer[0..byte_count], 0, arena);
         },
         .Struct => {
-            const struct_type = mod.typeToStruct(ty).?;
+            const struct_type = zcu.typeToStruct(ty).?;
             switch (struct_type.layout) {
                 .auto => unreachable, // Sema is supposed to have emitted a compile error already
                 .@"extern" => {
@@ -684,9 +700,9 @@ pub fn readFromMemory(
                     const field_vals = try arena.alloc(InternPool.Index, field_types.len);
                     for (field_vals, 0..) |*field_val, i| {
                         const field_ty = Type.fromInterned(field_types.get(ip)[i]);
-                        const off: usize = @intCast(ty.structFieldOffset(i, mod));
-                        const sz: usize = @intCast(field_ty.abiSize(pt));
-                        field_val.* = (try readFromMemory(field_ty, mod, buffer[off..(off + sz)], arena)).toIntern();
+                        const off: usize = @intCast(ty.structFieldOffset(i, zcu));
+                        const sz: usize = @intCast(field_ty.abiSize(zcu));
+                        field_val.* = (try readFromMemory(field_ty, zcu, buffer[off..(off + sz)], arena)).toIntern();
                     }
                     return Value.fromInterned(try pt.intern(.{ .aggregate = .{
                         .ty = ty.toIntern(),
@@ -694,29 +710,29 @@ pub fn readFromMemory(
                     } }));
                 },
                 .@"packed" => {
-                    const byte_count = (@as(usize, @intCast(ty.bitSize(pt))) + 7) / 8;
-                    return readFromPackedMemory(ty, mod, buffer[0..byte_count], 0, arena);
+                    const byte_count = (@as(usize, @intCast(ty.bitSize(zcu))) + 7) / 8;
+                    return readFromPackedMemory(ty, zcu, buffer[0..byte_count], 0, arena);
                 },
             }
         },
         .ErrorSet => {
-            const bits = mod.errorSetBits();
+            const bits = zcu.errorSetBits();
             const byte_count: u16 = @intCast((@as(u17, bits) + 7) / 8);
             const int = std.mem.readVarInt(u64, buffer[0..byte_count], endian);
             const index = (int << @as(u6, @intCast(64 - bits))) >> @as(u6, @intCast(64 - bits));
-            const name = mod.global_error_set.keys()[@intCast(index)];
+            const name = zcu.global_error_set.keys()[@intCast(index)];
 
             return Value.fromInterned(try pt.intern(.{ .err = .{
                 .ty = ty.toIntern(),
                 .name = name,
             } }));
         },
-        .Union => switch (ty.containerLayout(mod)) {
+        .Union => switch (ty.containerLayout(zcu)) {
             .auto => return error.IllDefinedMemoryLayout,
             .@"extern" => {
-                const union_size = ty.abiSize(pt);
-                const array_ty = try mod.arrayType(.{ .len = union_size, .child = .u8_type });
-                const val = (try readFromMemory(array_ty, mod, buffer, arena)).toIntern();
+                const union_size = ty.abiSize(zcu);
+                const array_ty = try zcu.arrayType(.{ .len = union_size, .child = .u8_type });
+                const val = (try readFromMemory(array_ty, zcu, buffer, arena)).toIntern();
                 return Value.fromInterned(try pt.intern(.{ .un = .{
                     .ty = ty.toIntern(),
                     .tag = .none,
@@ -724,23 +740,23 @@ pub fn readFromMemory(
                 } }));
             },
             .@"packed" => {
-                const byte_count = (@as(usize, @intCast(ty.bitSize(pt))) + 7) / 8;
-                return readFromPackedMemory(ty, mod, buffer[0..byte_count], 0, arena);
+                const byte_count = (@as(usize, @intCast(ty.bitSize(zcu))) + 7) / 8;
+                return readFromPackedMemory(ty, zcu, buffer[0..byte_count], 0, arena);
             },
         },
         .Pointer => {
-            assert(!ty.isSlice(mod)); // No well defined layout.
-            const int_val = try readFromMemory(Type.usize, mod, buffer, arena);
+            assert(!ty.isSlice(zcu)); // No well defined layout.
+            const int_val = try readFromMemory(Type.usize, zcu, buffer, arena);
             return Value.fromInterned(try pt.intern(.{ .ptr = .{
                 .ty = ty.toIntern(),
                 .base_addr = .int,
-                .byte_offset = int_val.toUnsignedInt(pt),
+                .byte_offset = int_val.toUnsignedInt(zcu),
             } }));
         },
         .Optional => {
-            assert(ty.isPtrLikeOptional(mod));
-            const child_ty = ty.optionalChild(mod);
-            const child_val = try readFromMemory(child_ty, mod, buffer, arena);
+            assert(ty.isPtrLikeOptional(zcu));
+            const child_ty = ty.optionalChild(zcu);
+            const child_val = try readFromMemory(child_ty, zcu, buffer, arena);
             return Value.fromInterned(try pt.intern(.{ .opt = .{
                 .ty = ty.toIntern(),
                 .val = switch (child_val.orderAgainstZero(pt)) {
@@ -768,11 +784,11 @@ pub fn readFromPackedMemory(
     IllDefinedMemoryLayout,
     OutOfMemory,
 }!Value {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const target = zcu.getTarget();
     const endian = target.cpu.arch.endian();
-    switch (ty.zigTypeTag(mod)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Void => return Value.void,
         .Bool => {
             const byte = switch (endian) {
@@ -787,7 +803,7 @@ pub fn readFromPackedMemory(
         },
         .Int => {
             if (buffer.len == 0) return pt.intValue(ty, 0);
-            const int_info = ty.intInfo(mod);
+            const int_info = ty.intInfo(zcu);
             const bits = int_info.bits;
             if (bits == 0) return pt.intValue(ty, 0);
 
@@ -800,7 +816,7 @@ pub fn readFromPackedMemory(
             };
 
             // Slow path, we have to construct a big-int
-            const abi_size: usize = @intCast(ty.abiSize(pt));
+            const abi_size: usize = @intCast(ty.abiSize(zcu));
             const Limb = std.math.big.Limb;
             const limb_count = (abi_size + @sizeOf(Limb) - 1) / @sizeOf(Limb);
             const limbs_buffer = try arena.alloc(Limb, limb_count);
@@ -810,7 +826,7 @@ pub fn readFromPackedMemory(
             return pt.intValue_big(ty, bigint.toConst());
         },
         .Enum => {
-            const int_ty = ty.intTagType(mod);
+            const int_ty = ty.intTagType(zcu);
             const int_val = try Value.readFromPackedMemory(int_ty, pt, buffer, bit_offset, arena);
             return pt.getCoerced(int_val, ty);
         },
@@ -826,11 +842,11 @@ pub fn readFromPackedMemory(
             },
         } })),
         .Vector => {
-            const elem_ty = ty.childType(mod);
-            const elems = try arena.alloc(InternPool.Index, @intCast(ty.arrayLen(mod)));
+            const elem_ty = ty.childType(zcu);
+            const elems = try arena.alloc(InternPool.Index, @intCast(ty.arrayLen(zcu)));
 
             var bits: u16 = 0;
-            const elem_bit_size: u16 = @intCast(elem_ty.bitSize(pt));
+            const elem_bit_size: u16 = @intCast(elem_ty.bitSize(zcu));
             for (elems, 0..) |_, i| {
                 // On big-endian systems, LLVM reverses the element order of vectors by default
                 const tgt_elem_i = if (endian == .big) elems.len - i - 1 else i;
@@ -845,12 +861,12 @@ pub fn readFromPackedMemory(
         .Struct => {
             // Sema is supposed to have emitted a compile error already for Auto layout structs,
             // and Extern is handled by non-packed readFromMemory.
-            const struct_type = mod.typeToPackedStruct(ty).?;
+            const struct_type = zcu.typeToPackedStruct(ty).?;
             var bits: u16 = 0;
             const field_vals = try arena.alloc(InternPool.Index, struct_type.field_types.len);
             for (field_vals, 0..) |*field_val, i| {
                 const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
-                const field_bits: u16 = @intCast(field_ty.bitSize(pt));
+                const field_bits: u16 = @intCast(field_ty.bitSize(zcu));
                 field_val.* = (try readFromPackedMemory(field_ty, pt, buffer, bit_offset + bits, arena)).toIntern();
                 bits += field_bits;
             }
@@ -859,7 +875,7 @@ pub fn readFromPackedMemory(
                 .storage = .{ .elems = field_vals },
             } }));
         },
-        .Union => switch (ty.containerLayout(mod)) {
+        .Union => switch (ty.containerLayout(zcu)) {
             .auto, .@"extern" => unreachable, // Handled by non-packed readFromMemory
             .@"packed" => {
                 const backing_ty = try ty.unionBackingType(pt);
@@ -872,21 +888,21 @@ pub fn readFromPackedMemory(
             },
         },
         .Pointer => {
-            assert(!ty.isSlice(mod)); // No well defined layout.
+            assert(!ty.isSlice(zcu)); // No well defined layout.
             const int_val = try readFromPackedMemory(Type.usize, pt, buffer, bit_offset, arena);
             return Value.fromInterned(try pt.intern(.{ .ptr = .{
                 .ty = ty.toIntern(),
                 .base_addr = .int,
-                .byte_offset = int_val.toUnsignedInt(pt),
+                .byte_offset = int_val.toUnsignedInt(zcu),
             } }));
         },
         .Optional => {
-            assert(ty.isPtrLikeOptional(mod));
-            const child_ty = ty.optionalChild(mod);
+            assert(ty.isPtrLikeOptional(zcu));
+            const child_ty = ty.optionalChild(zcu);
             const child_val = try readFromPackedMemory(child_ty, pt, buffer, bit_offset, arena);
             return Value.fromInterned(try pt.intern(.{ .opt = .{
                 .ty = ty.toIntern(),
-                .val = switch (child_val.orderAgainstZero(pt)) {
+                .val = switch (child_val.orderAgainstZero(zcu)) {
                     .lt => unreachable,
                     .eq => .none,
                     .gt => child_val.toIntern(),
@@ -898,8 +914,8 @@ pub fn readFromPackedMemory(
 }
 
 /// Asserts that the value is a float or an integer.
-pub fn toFloat(val: Value, comptime T: type, pt: Zcu.PerThread) T {
-    return switch (pt.zcu.intern_pool.indexToKey(val.toIntern())) {
+pub fn toFloat(val: Value, comptime T: type, zcu: *Zcu) T {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .int => |int| switch (int.storage) {
             .big_int => |big_int| @floatCast(bigIntToFloat(big_int.limbs, big_int.positive)),
             inline .u64, .i64 => |x| {
@@ -908,8 +924,8 @@ pub fn toFloat(val: Value, comptime T: type, pt: Zcu.PerThread) T {
                 }
                 return @floatFromInt(x);
             },
-            .lazy_align => |ty| @floatFromInt(Type.fromInterned(ty).abiAlignment(pt).toByteUnits() orelse 0),
-            .lazy_size => |ty| @floatFromInt(Type.fromInterned(ty).abiSize(pt)),
+            .lazy_align => |ty| @floatFromInt(Type.fromInterned(ty).abiAlignment(zcu).toByteUnits() orelse 0),
+            .lazy_size => |ty| @floatFromInt(Type.fromInterned(ty).abiSize(zcu)),
         },
         .float => |float| switch (float.storage) {
             inline else => |x| @floatCast(x),
@@ -937,30 +953,30 @@ fn bigIntToFloat(limbs: []const std.math.big.Limb, positive: bool) f128 {
     }
 }
 
-pub fn clz(val: Value, ty: Type, pt: Zcu.PerThread) u64 {
+pub fn clz(val: Value, ty: Type, zcu: *Zcu) u64 {
     var bigint_buf: BigIntSpace = undefined;
-    const bigint = val.toBigInt(&bigint_buf, pt);
-    return bigint.clz(ty.intInfo(pt.zcu).bits);
+    const bigint = val.toBigInt(&bigint_buf, zcu);
+    return bigint.clz(ty.intInfo(zcu).bits);
 }
 
-pub fn ctz(val: Value, ty: Type, pt: Zcu.PerThread) u64 {
+pub fn ctz(val: Value, ty: Type, zcu: *Zcu) u64 {
     var bigint_buf: BigIntSpace = undefined;
-    const bigint = val.toBigInt(&bigint_buf, pt);
-    return bigint.ctz(ty.intInfo(pt.zcu).bits);
+    const bigint = val.toBigInt(&bigint_buf, zcu);
+    return bigint.ctz(ty.intInfo(zcu).bits);
 }
 
-pub fn popCount(val: Value, ty: Type, pt: Zcu.PerThread) u64 {
+pub fn popCount(val: Value, ty: Type, zcu: *Zcu) u64 {
     var bigint_buf: BigIntSpace = undefined;
-    const bigint = val.toBigInt(&bigint_buf, pt);
-    return @intCast(bigint.popCount(ty.intInfo(pt.zcu).bits));
+    const bigint = val.toBigInt(&bigint_buf, zcu);
+    return @intCast(bigint.popCount(ty.intInfo(zcu).bits));
 }
 
 pub fn bitReverse(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) !Value {
-    const mod = pt.zcu;
-    const info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const info = ty.intInfo(zcu);
 
     var buffer: Value.BigIntSpace = undefined;
-    const operand_bigint = val.toBigInt(&buffer, pt);
+    const operand_bigint = val.toBigInt(&buffer, zcu);
 
     const limbs = try arena.alloc(
         std.math.big.Limb,
@@ -973,14 +989,14 @@ pub fn bitReverse(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) !Va
 }
 
 pub fn byteSwap(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) !Value {
-    const mod = pt.zcu;
-    const info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const info = ty.intInfo(zcu);
 
     // Bit count must be evenly divisible by 8
     assert(info.bits % 8 == 0);
 
     var buffer: Value.BigIntSpace = undefined;
-    const operand_bigint = val.toBigInt(&buffer, pt);
+    const operand_bigint = val.toBigInt(&buffer, zcu);
 
     const limbs = try arena.alloc(
         std.math.big.Limb,
@@ -994,33 +1010,34 @@ pub fn byteSwap(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) !Valu
 
 /// Asserts the value is an integer and not undefined.
 /// Returns the number of bits the value requires to represent stored in twos complement form.
-pub fn intBitCountTwosComp(self: Value, pt: Zcu.PerThread) usize {
+pub fn intBitCountTwosComp(self: Value, zcu: *Zcu) usize {
     var buffer: BigIntSpace = undefined;
-    const big_int = self.toBigInt(&buffer, pt);
+    const big_int = self.toBigInt(&buffer, zcu);
     return big_int.bitCountTwosComp();
 }
 
 /// Converts an integer or a float to a float. May result in a loss of information.
 /// Caller can find out by equality checking the result against the operand.
 pub fn floatCast(val: Value, dest_ty: Type, pt: Zcu.PerThread) !Value {
-    const target = pt.zcu.getTarget();
-    if (val.isUndef(pt.zcu)) return pt.undefValue(dest_ty);
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
+    if (val.isUndef(zcu)) return pt.undefValue(dest_ty);
     return Value.fromInterned(try pt.intern(.{ .float = .{
         .ty = dest_ty.toIntern(),
         .storage = switch (dest_ty.floatBits(target)) {
-            16 => .{ .f16 = val.toFloat(f16, pt) },
-            32 => .{ .f32 = val.toFloat(f32, pt) },
-            64 => .{ .f64 = val.toFloat(f64, pt) },
-            80 => .{ .f80 = val.toFloat(f80, pt) },
-            128 => .{ .f128 = val.toFloat(f128, pt) },
+            16 => .{ .f16 = val.toFloat(f16, zcu) },
+            32 => .{ .f32 = val.toFloat(f32, zcu) },
+            64 => .{ .f64 = val.toFloat(f64, zcu) },
+            80 => .{ .f80 = val.toFloat(f80, zcu) },
+            128 => .{ .f128 = val.toFloat(f128, zcu) },
             else => unreachable,
         },
     } }));
 }
 
 /// Asserts the value is a float
-pub fn floatHasFraction(self: Value, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(self.toIntern())) {
+pub fn floatHasFraction(self: Value, zcu: *const Module) bool {
+    return switch (zcu.intern_pool.indexToKey(self.toIntern())) {
         .float => |float| switch (float.storage) {
             inline else => |x| @rem(x, 1) != 0,
         },
@@ -1028,19 +1045,24 @@ pub fn floatHasFraction(self: Value, mod: *const Module) bool {
     };
 }
 
-pub fn orderAgainstZero(lhs: Value, pt: Zcu.PerThread) std.math.Order {
-    return orderAgainstZeroAdvanced(lhs, pt, .normal) catch unreachable;
+pub fn orderAgainstZero(lhs: Value, zcu: *Zcu) std.math.Order {
+    return orderAgainstZeroInner(lhs, .normal, zcu, {}) catch unreachable;
 }
 
-pub fn orderAgainstZeroAdvanced(
+pub fn orderAgainstZeroSema(lhs: Value, pt: Zcu.PerThread) !std.math.Order {
+    return try orderAgainstZeroInner(lhs, .sema, pt.zcu, pt.tid);
+}
+
+pub fn orderAgainstZeroInner(
     lhs: Value,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
 ) Module.CompileError!std.math.Order {
     return switch (lhs.toIntern()) {
         .bool_false => .eq,
         .bool_true => .gt,
-        else => switch (pt.zcu.intern_pool.indexToKey(lhs.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(lhs.toIntern())) {
             .ptr => |ptr| if (ptr.byte_offset > 0) .gt else switch (ptr.base_addr) {
                 .nav, .comptime_alloc, .comptime_field => .gt,
                 .int => .eq,
@@ -1050,16 +1072,17 @@ pub fn orderAgainstZeroAdvanced(
                 .big_int => |big_int| big_int.orderAgainstScalar(0),
                 inline .u64, .i64 => |x| std.math.order(x, 0),
                 .lazy_align => .gt, // alignment is never 0
-                .lazy_size => |ty| return if (Type.fromInterned(ty).hasRuntimeBitsAdvanced(
-                    pt,
+                .lazy_size => |ty| return if (Type.fromInterned(ty).hasRuntimeBitsInner(
                     false,
                     strat.toLazy(),
+                    zcu,
+                    tid,
                 ) catch |err| switch (err) {
                     error.NeedLazy => unreachable,
                     else => |e| return e,
                 }) .gt else .eq,
             },
-            .enum_tag => |enum_tag| Value.fromInterned(enum_tag.int).orderAgainstZeroAdvanced(pt, strat),
+            .enum_tag => |enum_tag| Value.fromInterned(enum_tag.int).orderAgainstZeroInner(strat, zcu, tid),
             .float => |float| switch (float.storage) {
                 inline else => |x| std.math.order(x, 0),
             },
@@ -1069,14 +1092,20 @@ pub fn orderAgainstZeroAdvanced(
 }
 
 /// Asserts the value is comparable.
-pub fn order(lhs: Value, rhs: Value, pt: Zcu.PerThread) std.math.Order {
-    return orderAdvanced(lhs, rhs, pt, .normal) catch unreachable;
+pub fn order(lhs: Value, rhs: Value, zcu: *Zcu) std.math.Order {
+    return orderAdvanced(lhs, rhs, .normal, zcu, {}) catch unreachable;
 }
 
 /// Asserts the value is comparable.
-pub fn orderAdvanced(lhs: Value, rhs: Value, pt: Zcu.PerThread, comptime strat: ResolveStrat) !std.math.Order {
-    const lhs_against_zero = try lhs.orderAgainstZeroAdvanced(pt, strat);
-    const rhs_against_zero = try rhs.orderAgainstZeroAdvanced(pt, strat);
+pub fn orderAdvanced(
+    lhs: Value,
+    rhs: Value,
+    comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
+) !std.math.Order {
+    const lhs_against_zero = try lhs.orderAgainstZeroInner(strat, zcu, tid);
+    const rhs_against_zero = try rhs.orderAgainstZeroInner(strat, zcu, tid);
     switch (lhs_against_zero) {
         .lt => if (rhs_against_zero != .lt) return .lt,
         .eq => return rhs_against_zero.invert(),
@@ -1088,34 +1117,39 @@ pub fn orderAdvanced(lhs: Value, rhs: Value, pt: Zcu.PerThread, comptime strat: 
         .gt => {},
     }
 
-    if (lhs.isFloat(pt.zcu) or rhs.isFloat(pt.zcu)) {
-        const lhs_f128 = lhs.toFloat(f128, pt);
-        const rhs_f128 = rhs.toFloat(f128, pt);
+    if (lhs.isFloat(zcu) or rhs.isFloat(zcu)) {
+        const lhs_f128 = lhs.toFloat(f128, zcu);
+        const rhs_f128 = rhs.toFloat(f128, zcu);
         return std.math.order(lhs_f128, rhs_f128);
     }
 
     var lhs_bigint_space: BigIntSpace = undefined;
     var rhs_bigint_space: BigIntSpace = undefined;
-    const lhs_bigint = try lhs.toBigIntAdvanced(&lhs_bigint_space, pt, strat);
-    const rhs_bigint = try rhs.toBigIntAdvanced(&rhs_bigint_space, pt, strat);
+    const lhs_bigint = try lhs.toBigIntAdvanced(&lhs_bigint_space, strat, zcu, tid);
+    const rhs_bigint = try rhs.toBigIntAdvanced(&rhs_bigint_space, strat, zcu, tid);
     return lhs_bigint.order(rhs_bigint);
 }
 
 /// Asserts the value is comparable. Does not take a type parameter because it supports
 /// comparisons between heterogeneous types.
-pub fn compareHetero(lhs: Value, op: std.math.CompareOperator, rhs: Value, pt: Zcu.PerThread) bool {
-    return compareHeteroAdvanced(lhs, op, rhs, pt, .normal) catch unreachable;
+pub fn compareHetero(lhs: Value, op: std.math.CompareOperator, rhs: Value, zcu: *Zcu) bool {
+    return compareHeteroAdvanced(lhs, op, rhs, .normal, zcu, {}) catch unreachable;
+}
+
+pub fn compareHeteroSema(lhs: Value, op: std.math.CompareOperator, rhs: Value, pt: Zcu.PerThread) !bool {
+    return try compareHeteroAdvanced(lhs, op, rhs, .sema, pt.zcu, pt.tid);
 }
 
 pub fn compareHeteroAdvanced(
     lhs: Value,
     op: std.math.CompareOperator,
     rhs: Value,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
 ) !bool {
-    if (lhs.pointerNav(pt.zcu)) |lhs_nav| {
-        if (rhs.pointerNav(pt.zcu)) |rhs_nav| {
+    if (lhs.pointerNav(zcu)) |lhs_nav| {
+        if (rhs.pointerNav(zcu)) |rhs_nav| {
             switch (op) {
                 .eq => return lhs_nav == rhs_nav,
                 .neq => return lhs_nav != rhs_nav,
@@ -1128,32 +1162,32 @@ pub fn compareHeteroAdvanced(
                 else => {},
             }
         }
-    } else if (rhs.pointerNav(pt.zcu)) |_| {
+    } else if (rhs.pointerNav(zcu)) |_| {
         switch (op) {
             .eq => return false,
             .neq => return true,
             else => {},
         }
     }
-    return (try orderAdvanced(lhs, rhs, pt, strat)).compare(op);
+    return (try orderAdvanced(lhs, rhs, strat, zcu, tid)).compare(op);
 }
 
 /// Asserts the values are comparable. Both operands have type `ty`.
 /// For vectors, returns true if comparison is true for ALL elements.
 pub fn compareAll(lhs: Value, op: std.math.CompareOperator, rhs: Value, ty: Type, pt: Zcu.PerThread) !bool {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const scalar_ty = ty.scalarType(mod);
-        for (0..ty.vectorLen(mod)) |i| {
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const scalar_ty = ty.scalarType(zcu);
+        for (0..ty.vectorLen(zcu)) |i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
-            if (!compareScalar(lhs_elem, op, rhs_elem, scalar_ty, pt)) {
+            if (!compareScalar(lhs_elem, op, rhs_elem, scalar_ty, zcu)) {
                 return false;
             }
         }
         return true;
     }
-    return compareScalar(lhs, op, rhs, ty, pt);
+    return compareScalar(lhs, op, rhs, ty, zcu);
 }
 
 /// Asserts the values are comparable. Both operands have type `ty`.
@@ -1162,12 +1196,12 @@ pub fn compareScalar(
     op: std.math.CompareOperator,
     rhs: Value,
     ty: Type,
-    pt: Zcu.PerThread,
+    zcu: *Zcu,
 ) bool {
     return switch (op) {
-        .eq => lhs.eql(rhs, ty, pt.zcu),
-        .neq => !lhs.eql(rhs, ty, pt.zcu),
-        else => compareHetero(lhs, op, rhs, pt),
+        .eq => lhs.eql(rhs, ty, zcu),
+        .neq => !lhs.eql(rhs, ty, zcu),
+        else => compareHetero(lhs, op, rhs, zcu),
     };
 }
 
@@ -1176,8 +1210,8 @@ pub fn compareScalar(
 /// Returns `false` if the value or any vector element is undefined.
 ///
 /// Note that `!compareAllWithZero(.eq, ...) != compareAllWithZero(.neq, ...)`
-pub fn compareAllWithZero(lhs: Value, op: std.math.CompareOperator, pt: Zcu.PerThread) bool {
-    return compareAllWithZeroAdvancedExtra(lhs, op, pt, .normal) catch unreachable;
+pub fn compareAllWithZero(lhs: Value, op: std.math.CompareOperator, zcu: *Zcu) bool {
+    return compareAllWithZeroAdvancedExtra(lhs, op, .normal, zcu, {}) catch unreachable;
 }
 
 pub fn compareAllWithZeroSema(
@@ -1185,47 +1219,47 @@ pub fn compareAllWithZeroSema(
     op: std.math.CompareOperator,
     pt: Zcu.PerThread,
 ) Module.CompileError!bool {
-    return compareAllWithZeroAdvancedExtra(lhs, op, pt, .sema);
+    return compareAllWithZeroAdvancedExtra(lhs, op, .sema, pt.zcu, pt.tid);
 }
 
 pub fn compareAllWithZeroAdvancedExtra(
     lhs: Value,
     op: std.math.CompareOperator,
-    pt: Zcu.PerThread,
     comptime strat: ResolveStrat,
+    zcu: *Zcu,
+    tid: strat.Tid(),
 ) Module.CompileError!bool {
-    const mod = pt.zcu;
-    if (lhs.isInf(mod)) {
+    if (lhs.isInf(zcu)) {
         switch (op) {
             .neq => return true,
             .eq => return false,
-            .gt, .gte => return !lhs.isNegativeInf(mod),
-            .lt, .lte => return lhs.isNegativeInf(mod),
+            .gt, .gte => return !lhs.isNegativeInf(zcu),
+            .lt, .lte => return lhs.isNegativeInf(zcu),
         }
     }
 
-    switch (mod.intern_pool.indexToKey(lhs.toIntern())) {
+    switch (zcu.intern_pool.indexToKey(lhs.toIntern())) {
         .float => |float| switch (float.storage) {
             inline else => |x| if (std.math.isNan(x)) return op == .neq,
         },
         .aggregate => |aggregate| return switch (aggregate.storage) {
-            .bytes => |bytes| for (bytes.toSlice(lhs.typeOf(mod).arrayLenIncludingSentinel(mod), &mod.intern_pool)) |byte| {
+            .bytes => |bytes| for (bytes.toSlice(lhs.typeOf(zcu).arrayLenIncludingSentinel(zcu), &zcu.intern_pool)) |byte| {
                 if (!std.math.order(byte, 0).compare(op)) break false;
             } else true,
             .elems => |elems| for (elems) |elem| {
-                if (!try Value.fromInterned(elem).compareAllWithZeroAdvancedExtra(op, pt, strat)) break false;
+                if (!try Value.fromInterned(elem).compareAllWithZeroAdvancedExtra(op, strat, zcu, tid)) break false;
             } else true,
-            .repeated_elem => |elem| Value.fromInterned(elem).compareAllWithZeroAdvancedExtra(op, pt, strat),
+            .repeated_elem => |elem| Value.fromInterned(elem).compareAllWithZeroAdvancedExtra(op, strat, zcu, tid),
         },
         .undef => return false,
         else => {},
     }
-    return (try orderAgainstZeroAdvanced(lhs, pt, strat)).compare(op);
+    return (try orderAgainstZeroInner(lhs, strat, zcu, tid)).compare(op);
 }
 
-pub fn eql(a: Value, b: Value, ty: Type, mod: *Module) bool {
-    assert(mod.intern_pool.typeOf(a.toIntern()) == ty.toIntern());
-    assert(mod.intern_pool.typeOf(b.toIntern()) == ty.toIntern());
+pub fn eql(a: Value, b: Value, ty: Type, zcu: *Module) bool {
+    assert(zcu.intern_pool.typeOf(a.toIntern()) == ty.toIntern());
+    assert(zcu.intern_pool.typeOf(b.toIntern()) == ty.toIntern());
     return a.toIntern() == b.toIntern();
 }
 
@@ -1260,8 +1294,8 @@ pub fn canMutateComptimeVarState(val: Value, zcu: *Zcu) bool {
 /// Gets the `Nav` referenced by this pointer.  If the pointer does not point
 /// to a `Nav`, or if it points to some part of one (like a field or element),
 /// returns null.
-pub fn pointerNav(val: Value, mod: *Module) ?InternPool.Nav.Index {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn pointerNav(val: Value, zcu: *Zcu) ?InternPool.Nav.Index {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         // TODO: these 3 cases are weird; these aren't pointer values!
         .variable => |v| v.owner_nav,
         .@"extern" => |e| e.owner_nav,
@@ -1277,8 +1311,8 @@ pub fn pointerNav(val: Value, mod: *Module) ?InternPool.Nav.Index {
 pub const slice_ptr_index = 0;
 pub const slice_len_index = 1;
 
-pub fn slicePtr(val: Value, mod: *Module) Value {
-    return Value.fromInterned(mod.intern_pool.slicePtr(val.toIntern()));
+pub fn slicePtr(val: Value, zcu: *Module) Value {
+    return Value.fromInterned(zcu.intern_pool.slicePtr(val.toIntern()));
 }
 
 /// Gets the `len` field of a slice value as a `u64`.
@@ -1312,15 +1346,15 @@ pub fn elemValue(val: Value, pt: Zcu.PerThread, index: usize) Allocator.Error!Va
     }
 }
 
-pub fn isLazyAlign(val: Value, mod: *Module) bool {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn isLazyAlign(val: Value, zcu: *Module) bool {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .int => |int| int.storage == .lazy_align,
         else => false,
     };
 }
 
-pub fn isLazySize(val: Value, mod: *Module) bool {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn isLazySize(val: Value, zcu: *Module) bool {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .int => |int| int.storage == .lazy_size,
         else => false,
     };
@@ -1377,15 +1411,15 @@ pub fn sliceArray(
 }
 
 pub fn fieldValue(val: Value, pt: Zcu.PerThread, index: usize) !Value {
-    const mod = pt.zcu;
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+    const zcu = pt.zcu;
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .undef => |ty| Value.fromInterned(try pt.intern(.{
-            .undef = Type.fromInterned(ty).structFieldType(index, mod).toIntern(),
+            .undef = Type.fromInterned(ty).structFieldType(index, zcu).toIntern(),
         })),
         .aggregate => |aggregate| Value.fromInterned(switch (aggregate.storage) {
             .bytes => |bytes| try pt.intern(.{ .int = .{
                 .ty = .u8_type,
-                .storage = .{ .u64 = bytes.at(index, &mod.intern_pool) },
+                .storage = .{ .u64 = bytes.at(index, &zcu.intern_pool) },
             } }),
             .elems => |elems| elems[index],
             .repeated_elem => |elem| elem,
@@ -1396,40 +1430,40 @@ pub fn fieldValue(val: Value, pt: Zcu.PerThread, index: usize) !Value {
     };
 }
 
-pub fn unionTag(val: Value, mod: *Module) ?Value {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn unionTag(val: Value, zcu: *Module) ?Value {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .undef, .enum_tag => val,
         .un => |un| if (un.tag != .none) Value.fromInterned(un.tag) else return null,
         else => unreachable,
     };
 }
 
-pub fn unionValue(val: Value, mod: *Module) Value {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn unionValue(val: Value, zcu: *Module) Value {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .un => |un| Value.fromInterned(un.val),
         else => unreachable,
     };
 }
 
-pub fn isUndef(val: Value, mod: *Module) bool {
-    return mod.intern_pool.isUndef(val.toIntern());
+pub fn isUndef(val: Value, zcu: *Module) bool {
+    return zcu.intern_pool.isUndef(val.toIntern());
 }
 
 /// TODO: check for cases such as array that is not marked undef but all the element
 /// values are marked undef, or struct that is not marked undef but all fields are marked
 /// undef, etc.
-pub fn isUndefDeep(val: Value, mod: *Module) bool {
-    return val.isUndef(mod);
+pub fn isUndefDeep(val: Value, zcu: *Module) bool {
+    return val.isUndef(zcu);
 }
 
 /// Asserts the value is not undefined and not unreachable.
 /// C pointers with an integer value of 0 are also considered null.
-pub fn isNull(val: Value, mod: *Module) bool {
+pub fn isNull(val: Value, zcu: *Module) bool {
     return switch (val.toIntern()) {
         .undef => unreachable,
         .unreachable_value => unreachable,
         .null_value => true,
-        else => return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+        else => return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
             .undef => unreachable,
             .ptr => |ptr| switch (ptr.base_addr) {
                 .int => ptr.byte_offset == 0,
@@ -1442,8 +1476,8 @@ pub fn isNull(val: Value, mod: *Module) bool {
 }
 
 /// Valid only for error (union) types. Asserts the value is not undefined and not unreachable.
-pub fn getErrorName(val: Value, mod: *const Module) InternPool.OptionalNullTerminatedString {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn getErrorName(val: Value, zcu: *const Module) InternPool.OptionalNullTerminatedString {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .err => |err| err.name.toOptional(),
         .error_union => |error_union| switch (error_union.val) {
             .err_name => |err_name| err_name.toOptional(),
@@ -1462,13 +1496,13 @@ pub fn getErrorInt(val: Value, zcu: *Zcu) Module.ErrorInt {
 
 /// Assumes the type is an error union. Returns true if and only if the value is
 /// the error union payload, not an error.
-pub fn errorUnionIsPayload(val: Value, mod: *const Module) bool {
-    return mod.intern_pool.indexToKey(val.toIntern()).error_union.val == .payload;
+pub fn errorUnionIsPayload(val: Value, zcu: *const Module) bool {
+    return zcu.intern_pool.indexToKey(val.toIntern()).error_union.val == .payload;
 }
 
 /// Value of the optional, null if optional has no payload.
-pub fn optionalValue(val: Value, mod: *const Module) ?Value {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn optionalValue(val: Value, zcu: *const Module) ?Value {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .opt => |opt| switch (opt.val) {
             .none => null,
             else => |payload| Value.fromInterned(payload),
@@ -1479,10 +1513,10 @@ pub fn optionalValue(val: Value, mod: *const Module) ?Value {
 }
 
 /// Valid for all types. Asserts the value is not undefined.
-pub fn isFloat(self: Value, mod: *const Module) bool {
+pub fn isFloat(self: Value, zcu: *const Module) bool {
     return switch (self.toIntern()) {
         .undef => unreachable,
-        else => switch (mod.intern_pool.indexToKey(self.toIntern())) {
+        else => switch (zcu.intern_pool.indexToKey(self.toIntern())) {
             .undef => unreachable,
             .float => true,
             else => false,
@@ -1490,8 +1524,8 @@ pub fn isFloat(self: Value, mod: *const Module) bool {
     };
 }
 
-pub fn floatFromInt(val: Value, arena: Allocator, int_ty: Type, float_ty: Type, mod: *Module) !Value {
-    return floatFromIntAdvanced(val, arena, int_ty, float_ty, mod, .normal) catch |err| switch (err) {
+pub fn floatFromInt(val: Value, arena: Allocator, int_ty: Type, float_ty: Type, zcu: *Module) !Value {
+    return floatFromIntAdvanced(val, arena, int_ty, float_ty, zcu, .normal) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable,
     };
@@ -1505,10 +1539,10 @@ pub fn floatFromIntAdvanced(
     pt: Zcu.PerThread,
     comptime strat: ResolveStrat,
 ) !Value {
-    const mod = pt.zcu;
-    if (int_ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, int_ty.vectorLen(mod));
-        const scalar_ty = float_ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (int_ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, int_ty.vectorLen(zcu));
+        const scalar_ty = float_ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try floatFromIntScalar(elem_val, scalar_ty, pt, strat)).toIntern();
@@ -1522,8 +1556,8 @@ pub fn floatFromIntAdvanced(
 }
 
 pub fn floatFromIntScalar(val: Value, float_ty: Type, pt: Zcu.PerThread, comptime strat: ResolveStrat) !Value {
-    const mod = pt.zcu;
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+    const zcu = pt.zcu;
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .undef => try pt.undefValue(float_ty),
         .int => |int| switch (int.storage) {
             .big_int => |big_int| {
@@ -1531,8 +1565,8 @@ pub fn floatFromIntScalar(val: Value, float_ty: Type, pt: Zcu.PerThread, comptim
                 return pt.floatValue(float_ty, float);
             },
             inline .u64, .i64 => |x| floatFromIntInner(x, float_ty, pt),
-            .lazy_align => |ty| return floatFromIntInner((try Type.fromInterned(ty).abiAlignmentAdvanced(pt, strat.toLazy())).scalar.toByteUnits() orelse 0, float_ty, pt),
-            .lazy_size => |ty| return floatFromIntInner((try Type.fromInterned(ty).abiSizeAdvanced(pt, strat.toLazy())).scalar, float_ty, pt),
+            .lazy_align => |ty| return floatFromIntInner((try Type.fromInterned(ty).abiAlignmentInner(strat.toLazy(), pt.zcu, pt.tid)).scalar.toByteUnits() orelse 0, float_ty, pt),
+            .lazy_size => |ty| return floatFromIntInner((try Type.fromInterned(ty).abiSizeInner(strat.toLazy(), pt.zcu, pt.tid)).scalar, float_ty, pt),
         },
         else => unreachable,
     };
@@ -1600,15 +1634,16 @@ pub fn intAddSatScalar(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    assert(!lhs.isUndef(pt.zcu));
-    assert(!rhs.isUndef(pt.zcu));
+    const zcu = pt.zcu;
+    assert(!lhs.isUndef(zcu));
+    assert(!rhs.isUndef(zcu));
 
-    const info = ty.intInfo(pt.zcu);
+    const info = ty.intInfo(zcu);
 
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         std.math.big.int.calcTwosCompLimbCount(info.bits),
@@ -1650,15 +1685,17 @@ pub fn intSubSatScalar(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    assert(!lhs.isUndef(pt.zcu));
-    assert(!rhs.isUndef(pt.zcu));
+    const zcu = pt.zcu;
 
-    const info = ty.intInfo(pt.zcu);
+    assert(!lhs.isUndef(zcu));
+    assert(!rhs.isUndef(zcu));
+
+    const info = ty.intInfo(zcu);
 
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         std.math.big.int.calcTwosCompLimbCount(info.bits),
@@ -1675,12 +1712,12 @@ pub fn intMulWithOverflow(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !OverflowArithmeticResult {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const vec_len = ty.vectorLen(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const vec_len = ty.vectorLen(zcu);
         const overflowed_data = try arena.alloc(InternPool.Index, vec_len);
         const result_data = try arena.alloc(InternPool.Index, vec_len);
-        const scalar_ty = ty.scalarType(mod);
+        const scalar_ty = ty.scalarType(zcu);
         for (overflowed_data, result_data, 0..) |*of, *scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -1709,10 +1746,10 @@ pub fn intMulWithOverflowScalar(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !OverflowArithmeticResult {
-    const mod = pt.zcu;
-    const info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const info = ty.intInfo(zcu);
 
-    if (lhs.isUndef(mod) or rhs.isUndef(mod)) {
+    if (lhs.isUndef(zcu) or rhs.isUndef(zcu)) {
         return .{
             .overflow_bit = try pt.undefValue(Type.u1),
             .wrapped_result = try pt.undefValue(ty),
@@ -1721,8 +1758,8 @@ pub fn intMulWithOverflowScalar(
 
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len + rhs_bigint.limbs.len,
@@ -1753,10 +1790,10 @@ pub fn numberMulWrap(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -1778,10 +1815,10 @@ pub fn numberMulWrapScalar(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (lhs.isUndef(mod) or rhs.isUndef(mod)) return Value.undef;
+    const zcu = pt.zcu;
+    if (lhs.isUndef(zcu) or rhs.isUndef(zcu)) return Value.undef;
 
-    if (ty.zigTypeTag(mod) == .ComptimeInt) {
+    if (ty.zigTypeTag(zcu) == .ComptimeInt) {
         return intMul(lhs, rhs, ty, undefined, arena, pt);
     }
 
@@ -1825,15 +1862,17 @@ pub fn intMulSatScalar(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    assert(!lhs.isUndef(pt.zcu));
-    assert(!rhs.isUndef(pt.zcu));
+    const zcu = pt.zcu;
 
-    const info = ty.intInfo(pt.zcu);
+    assert(!lhs.isUndef(zcu));
+    assert(!rhs.isUndef(zcu));
+
+    const info = ty.intInfo(zcu);
 
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         @max(
@@ -1853,24 +1892,24 @@ pub fn intMulSatScalar(
 }
 
 /// Supports both floats and ints; handles undefined.
-pub fn numberMax(lhs: Value, rhs: Value, pt: Zcu.PerThread) Value {
-    if (lhs.isUndef(pt.zcu) or rhs.isUndef(pt.zcu)) return undef;
-    if (lhs.isNan(pt.zcu)) return rhs;
-    if (rhs.isNan(pt.zcu)) return lhs;
+pub fn numberMax(lhs: Value, rhs: Value, zcu: *Zcu) Value {
+    if (lhs.isUndef(zcu) or rhs.isUndef(zcu)) return undef;
+    if (lhs.isNan(zcu)) return rhs;
+    if (rhs.isNan(zcu)) return lhs;
 
-    return switch (order(lhs, rhs, pt)) {
+    return switch (order(lhs, rhs, zcu)) {
         .lt => rhs,
         .gt, .eq => lhs,
     };
 }
 
 /// Supports both floats and ints; handles undefined.
-pub fn numberMin(lhs: Value, rhs: Value, pt: Zcu.PerThread) Value {
-    if (lhs.isUndef(pt.zcu) or rhs.isUndef(pt.zcu)) return undef;
-    if (lhs.isNan(pt.zcu)) return rhs;
-    if (rhs.isNan(pt.zcu)) return lhs;
+pub fn numberMin(lhs: Value, rhs: Value, zcu: *Zcu) Value {
+    if (lhs.isUndef(zcu) or rhs.isUndef(zcu)) return undef;
+    if (lhs.isNan(zcu)) return rhs;
+    if (rhs.isNan(zcu)) return lhs;
 
-    return switch (order(lhs, rhs, pt)) {
+    return switch (order(lhs, rhs, zcu)) {
         .lt => lhs,
         .gt, .eq => rhs,
     };
@@ -1878,10 +1917,10 @@ pub fn numberMin(lhs: Value, rhs: Value, pt: Zcu.PerThread) Value {
 
 /// operands must be (vectors of) integers; handles undefined scalars.
 pub fn bitwiseNot(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try bitwiseNotScalar(elem_val, scalar_ty, arena, pt)).toIntern();
@@ -1896,11 +1935,11 @@ pub fn bitwiseNot(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Va
 
 /// operands must be integers; handles undefined.
 pub fn bitwiseNotScalar(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (val.isUndef(mod)) return Value.fromInterned(try pt.intern(.{ .undef = ty.toIntern() }));
+    const zcu = pt.zcu;
+    if (val.isUndef(zcu)) return Value.fromInterned(try pt.intern(.{ .undef = ty.toIntern() }));
     if (ty.toIntern() == .bool_type) return makeBool(!val.toBool());
 
-    const info = ty.intInfo(mod);
+    const info = ty.intInfo(zcu);
 
     if (info.bits == 0) {
         return val;
@@ -1909,7 +1948,7 @@ pub fn bitwiseNotScalar(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThrea
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
     var val_space: Value.BigIntSpace = undefined;
-    const val_bigint = val.toBigInt(&val_space, pt);
+    const val_bigint = val.toBigInt(&val_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         std.math.big.int.calcTwosCompLimbCount(info.bits),
@@ -1922,10 +1961,10 @@ pub fn bitwiseNotScalar(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThrea
 
 /// operands must be (vectors of) integers; handles undefined scalars.
 pub fn bitwiseAnd(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -1962,8 +2001,8 @@ pub fn bitwiseAndScalar(orig_lhs: Value, orig_rhs: Value, ty: Type, arena: Alloc
     // resorting to BigInt first.
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         // + 1 for negatives
@@ -1995,10 +2034,10 @@ fn intValueAa(ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
 
 /// operands must be (vectors of) integers; handles undefined scalars.
 pub fn bitwiseNand(lhs: Value, rhs: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2014,21 +2053,21 @@ pub fn bitwiseNand(lhs: Value, rhs: Value, ty: Type, arena: Allocator, pt: Zcu.P
 
 /// operands must be integers; handles undefined.
 pub fn bitwiseNandScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (lhs.isUndef(mod) or rhs.isUndef(mod)) return Value.fromInterned(try pt.intern(.{ .undef = ty.toIntern() }));
+    const zcu = pt.zcu;
+    if (lhs.isUndef(zcu) or rhs.isUndef(zcu)) return Value.fromInterned(try pt.intern(.{ .undef = ty.toIntern() }));
     if (ty.toIntern() == .bool_type) return makeBool(!(lhs.toBool() and rhs.toBool()));
 
     const anded = try bitwiseAnd(lhs, rhs, ty, arena, pt);
-    const all_ones = if (ty.isSignedInt(mod)) try pt.intValue(ty, -1) else try ty.maxIntScalar(pt, ty);
+    const all_ones = if (ty.isSignedInt(zcu)) try pt.intValue(ty, -1) else try ty.maxIntScalar(pt, ty);
     return bitwiseXor(anded, all_ones, ty, arena, pt);
 }
 
 /// operands must be (vectors of) integers; handles undefined scalars.
 pub fn bitwiseOr(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2047,9 +2086,10 @@ pub fn bitwiseOrScalar(orig_lhs: Value, orig_rhs: Value, ty: Type, arena: Alloca
     // If one operand is defined, we turn the other into `0xAA` so the bitwise AND can
     // still zero out some bits.
     // TODO: ideally we'd still like tracking for the undef bits. Related: #19634.
+    const zcu = pt.zcu;
     const lhs: Value, const rhs: Value = make_defined: {
-        const lhs_undef = orig_lhs.isUndef(pt.zcu);
-        const rhs_undef = orig_rhs.isUndef(pt.zcu);
+        const lhs_undef = orig_lhs.isUndef(zcu);
+        const rhs_undef = orig_rhs.isUndef(zcu);
         break :make_defined switch ((@as(u2, @intFromBool(lhs_undef)) << 1) | @intFromBool(rhs_undef)) {
             0b00 => .{ orig_lhs, orig_rhs },
             0b01 => .{ orig_lhs, try intValueAa(ty, arena, pt) },
@@ -2064,8 +2104,8 @@ pub fn bitwiseOrScalar(orig_lhs: Value, orig_rhs: Value, ty: Type, arena: Alloca
     // resorting to BigInt first.
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         @max(lhs_bigint.limbs.len, rhs_bigint.limbs.len),
@@ -2077,10 +2117,10 @@ pub fn bitwiseOrScalar(orig_lhs: Value, orig_rhs: Value, ty: Type, arena: Alloca
 
 /// operands must be (vectors of) integers; handles undefined scalars.
 pub fn bitwiseXor(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2096,16 +2136,16 @@ pub fn bitwiseXor(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zc
 
 /// operands must be integers; handles undefined.
 pub fn bitwiseXorScalar(lhs: Value, rhs: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (lhs.isUndef(mod) or rhs.isUndef(mod)) return Value.fromInterned(try pt.intern(.{ .undef = ty.toIntern() }));
+    const zcu = pt.zcu;
+    if (lhs.isUndef(zcu) or rhs.isUndef(zcu)) return Value.fromInterned(try pt.intern(.{ .undef = ty.toIntern() }));
     if (ty.toIntern() == .bool_type) return makeBool(lhs.toBool() != rhs.toBool());
 
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try arena.alloc(
         std.math.big.Limb,
         // + 1 for negatives
@@ -2164,10 +2204,11 @@ fn intDivInner(lhs: Value, rhs: Value, ty: Type, overflow_idx: *usize, allocator
 pub fn intDivScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
+    const zcu = pt.zcu;
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs_q = try allocator.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len,
@@ -2212,10 +2253,11 @@ pub fn intDivFloor(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Z
 pub fn intDivFloorScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
+    const zcu = pt.zcu;
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs_q = try allocator.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len,
@@ -2254,10 +2296,11 @@ pub fn intMod(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.Pe
 pub fn intModScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
+    const zcu = pt.zcu;
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs_q = try allocator.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len,
@@ -2277,8 +2320,8 @@ pub fn intModScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: 
 }
 
 /// Returns true if the value is a floating point type and is NaN. Returns false otherwise.
-pub fn isNan(val: Value, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn isNan(val: Value, zcu: *const Module) bool {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .float => |float| switch (float.storage) {
             inline else => |x| std.math.isNan(x),
         },
@@ -2287,8 +2330,8 @@ pub fn isNan(val: Value, mod: *const Module) bool {
 }
 
 /// Returns true if the value is a floating point type and is infinite. Returns false otherwise.
-pub fn isInf(val: Value, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn isInf(val: Value, zcu: *const Module) bool {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .float => |float| switch (float.storage) {
             inline else => |x| std.math.isInf(x),
         },
@@ -2296,8 +2339,8 @@ pub fn isInf(val: Value, mod: *const Module) bool {
     };
 }
 
-pub fn isNegativeInf(val: Value, mod: *const Module) bool {
-    return switch (mod.intern_pool.indexToKey(val.toIntern())) {
+pub fn isNegativeInf(val: Value, zcu: *const Module) bool {
+    return switch (zcu.intern_pool.indexToKey(val.toIntern())) {
         .float => |float| switch (float.storage) {
             inline else => |x| std.math.isNegativeInf(x),
         },
@@ -2323,13 +2366,14 @@ pub fn floatRem(lhs: Value, rhs: Value, float_type: Type, arena: Allocator, pt: 
 }
 
 pub fn floatRemScalar(lhs: Value, rhs: Value, float_type: Type, pt: Zcu.PerThread) !Value {
+    const zcu = pt.zcu;
     const target = pt.zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @rem(lhs.toFloat(f16, pt), rhs.toFloat(f16, pt)) },
-        32 => .{ .f32 = @rem(lhs.toFloat(f32, pt), rhs.toFloat(f32, pt)) },
-        64 => .{ .f64 = @rem(lhs.toFloat(f64, pt), rhs.toFloat(f64, pt)) },
-        80 => .{ .f80 = @rem(lhs.toFloat(f80, pt), rhs.toFloat(f80, pt)) },
-        128 => .{ .f128 = @rem(lhs.toFloat(f128, pt), rhs.toFloat(f128, pt)) },
+        16 => .{ .f16 = @rem(lhs.toFloat(f16, zcu), rhs.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @rem(lhs.toFloat(f32, zcu), rhs.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @rem(lhs.toFloat(f64, zcu), rhs.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @rem(lhs.toFloat(f80, zcu), rhs.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @rem(lhs.toFloat(f128, zcu), rhs.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2356,13 +2400,14 @@ pub fn floatMod(lhs: Value, rhs: Value, float_type: Type, arena: Allocator, pt: 
 }
 
 pub fn floatModScalar(lhs: Value, rhs: Value, float_type: Type, pt: Zcu.PerThread) !Value {
-    const target = pt.zcu.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @mod(lhs.toFloat(f16, pt), rhs.toFloat(f16, pt)) },
-        32 => .{ .f32 = @mod(lhs.toFloat(f32, pt), rhs.toFloat(f32, pt)) },
-        64 => .{ .f64 = @mod(lhs.toFloat(f64, pt), rhs.toFloat(f64, pt)) },
-        80 => .{ .f80 = @mod(lhs.toFloat(f80, pt), rhs.toFloat(f80, pt)) },
-        128 => .{ .f128 = @mod(lhs.toFloat(f128, pt), rhs.toFloat(f128, pt)) },
+        16 => .{ .f16 = @mod(lhs.toFloat(f16, zcu), rhs.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @mod(lhs.toFloat(f32, zcu), rhs.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @mod(lhs.toFloat(f64, zcu), rhs.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @mod(lhs.toFloat(f80, zcu), rhs.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @mod(lhs.toFloat(f128, zcu), rhs.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2374,14 +2419,14 @@ pub fn floatModScalar(lhs: Value, rhs: Value, float_type: Type, pt: Zcu.PerThrea
 /// If the value overflowed the type, returns a comptime_int (or vector thereof) instead, setting
 /// overflow_idx to the vector index the overflow was at (or 0 for a scalar).
 pub fn intMul(lhs: Value, rhs: Value, ty: Type, overflow_idx: *?usize, allocator: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     var overflow: usize = undefined;
     return intMulInner(lhs, rhs, ty, &overflow, allocator, pt) catch |err| switch (err) {
         error.Overflow => {
-            const is_vec = ty.isVector(mod);
+            const is_vec = ty.isVector(zcu);
             overflow_idx.* = if (is_vec) overflow else 0;
             const safe_ty = if (is_vec) try pt.vectorType(.{
-                .len = ty.vectorLen(mod),
+                .len = ty.vectorLen(zcu),
                 .child = .comptime_int_type,
             }) else Type.comptime_int;
             return intMulInner(lhs, rhs, safe_ty, undefined, allocator, pt) catch |err1| switch (err1) {
@@ -2394,10 +2439,10 @@ pub fn intMul(lhs: Value, rhs: Value, ty: Type, overflow_idx: *?usize, allocator
 }
 
 fn intMulInner(lhs: Value, rhs: Value, ty: Type, overflow_idx: *usize, allocator: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2419,17 +2464,18 @@ fn intMulInner(lhs: Value, rhs: Value, ty: Type, overflow_idx: *usize, allocator
 }
 
 pub fn intMulScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
+    const zcu = pt.zcu;
     if (ty.toIntern() != .comptime_int_type) {
         const res = try intMulWithOverflowScalar(lhs, rhs, ty, allocator, pt);
-        if (res.overflow_bit.compareAllWithZero(.neq, pt)) return error.Overflow;
+        if (res.overflow_bit.compareAllWithZero(.neq, zcu)) return error.Overflow;
         return res.wrapped_result;
     }
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
     var lhs_space: Value.BigIntSpace = undefined;
     var rhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const rhs_bigint = rhs.toBigInt(&rhs_space, pt);
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const rhs_bigint = rhs.toBigInt(&rhs_space, zcu);
     const limbs = try allocator.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len + rhs_bigint.limbs.len,
@@ -2445,10 +2491,10 @@ pub fn intMulScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: 
 }
 
 pub fn intTrunc(val: Value, ty: Type, allocator: Allocator, signedness: std.builtin.Signedness, bits: u16, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try intTruncScalar(elem_val, scalar_ty, allocator, signedness, bits, pt)).toIntern();
@@ -2470,20 +2516,21 @@ pub fn intTruncBitsAsValue(
     bits: Value,
     pt: Zcu.PerThread,
 ) !Value {
-    if (ty.zigTypeTag(pt.zcu) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(pt.zcu));
-        const scalar_ty = ty.scalarType(pt.zcu);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             const bits_elem = try bits.elemValue(pt, i);
-            scalar.* = (try intTruncScalar(elem_val, scalar_ty, allocator, signedness, @intCast(bits_elem.toUnsignedInt(pt)), pt)).toIntern();
+            scalar.* = (try intTruncScalar(elem_val, scalar_ty, allocator, signedness, @intCast(bits_elem.toUnsignedInt(zcu)), pt)).toIntern();
         }
         return Value.fromInterned(try pt.intern(.{ .aggregate = .{
             .ty = ty.toIntern(),
             .storage = .{ .elems = result_data },
         } }));
     }
-    return intTruncScalar(val, ty, allocator, signedness, @intCast(bits.toUnsignedInt(pt)), pt);
+    return intTruncScalar(val, ty, allocator, signedness, @intCast(bits.toUnsignedInt(zcu)), pt);
 }
 
 pub fn intTruncScalar(
@@ -2500,7 +2547,7 @@ pub fn intTruncScalar(
     if (val.isUndef(zcu)) return pt.undefValue(ty);
 
     var val_space: Value.BigIntSpace = undefined;
-    const val_bigint = val.toBigInt(&val_space, pt);
+    const val_bigint = val.toBigInt(&val_space, zcu);
 
     const limbs = try allocator.alloc(
         std.math.big.Limb,
@@ -2513,10 +2560,10 @@ pub fn intTruncScalar(
 }
 
 pub fn shl(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try allocator.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2533,9 +2580,10 @@ pub fn shl(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerTh
 pub fn shlScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
+    const zcu = pt.zcu;
     var lhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const shift: usize = @intCast(rhs.toUnsignedInt(pt));
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const shift: usize = @intCast(rhs.toUnsignedInt(zcu));
     const limbs = try allocator.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len + (shift / (@sizeOf(std.math.big.Limb) * 8)) + 1,
@@ -2547,7 +2595,7 @@ pub fn shlScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu
     };
     result_bigint.shiftLeft(lhs_bigint, shift);
     if (ty.toIntern() != .comptime_int_type) {
-        const int_info = ty.intInfo(pt.zcu);
+        const int_info = ty.intInfo(zcu);
         result_bigint.truncate(result_bigint.toConst(), int_info.signedness, int_info.bits);
     }
 
@@ -2594,10 +2642,11 @@ pub fn shlWithOverflowScalar(
     allocator: Allocator,
     pt: Zcu.PerThread,
 ) !OverflowArithmeticResult {
-    const info = ty.intInfo(pt.zcu);
+    const zcu = pt.zcu;
+    const info = ty.intInfo(zcu);
     var lhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const shift: usize = @intCast(rhs.toUnsignedInt(pt));
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const shift: usize = @intCast(rhs.toUnsignedInt(zcu));
     const limbs = try allocator.alloc(
         std.math.big.Limb,
         lhs_bigint.limbs.len + (shift / (@sizeOf(std.math.big.Limb) * 8)) + 1,
@@ -2650,11 +2699,12 @@ pub fn shlSatScalar(
 ) !Value {
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
-    const info = ty.intInfo(pt.zcu);
+    const zcu = pt.zcu;
+    const info = ty.intInfo(zcu);
 
     var lhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const shift: usize = @intCast(rhs.toUnsignedInt(pt));
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const shift: usize = @intCast(rhs.toUnsignedInt(zcu));
     const limbs = try arena.alloc(
         std.math.big.Limb,
         std.math.big.int.calcTwosCompLimbCount(info.bits) + 1,
@@ -2724,9 +2774,10 @@ pub fn shr(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerTh
 pub fn shrScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: Zcu.PerThread) !Value {
     // TODO is this a performance issue? maybe we should try the operation without
     // resorting to BigInt first.
+    const zcu = pt.zcu;
     var lhs_space: Value.BigIntSpace = undefined;
-    const lhs_bigint = lhs.toBigInt(&lhs_space, pt);
-    const shift: usize = @intCast(rhs.toUnsignedInt(pt));
+    const lhs_bigint = lhs.toBigInt(&lhs_space, zcu);
+    const shift: usize = @intCast(rhs.toUnsignedInt(zcu));
 
     const result_limbs = lhs_bigint.limbs.len -| (shift / (@sizeOf(std.math.big.Limb) * 8));
     if (result_limbs == 0) {
@@ -2758,10 +2809,10 @@ pub fn floatNeg(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try floatNegScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -2775,13 +2826,14 @@ pub fn floatNeg(
 }
 
 pub fn floatNegScalar(val: Value, float_type: Type, pt: Zcu.PerThread) !Value {
-    const target = pt.zcu.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = -val.toFloat(f16, pt) },
-        32 => .{ .f32 = -val.toFloat(f32, pt) },
-        64 => .{ .f64 = -val.toFloat(f64, pt) },
-        80 => .{ .f80 = -val.toFloat(f80, pt) },
-        128 => .{ .f128 = -val.toFloat(f128, pt) },
+        16 => .{ .f16 = -val.toFloat(f16, zcu) },
+        32 => .{ .f32 = -val.toFloat(f32, zcu) },
+        64 => .{ .f64 = -val.toFloat(f64, zcu) },
+        80 => .{ .f80 = -val.toFloat(f80, zcu) },
+        128 => .{ .f128 = -val.toFloat(f128, zcu) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2797,10 +2849,10 @@ pub fn floatAdd(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2820,14 +2872,14 @@ pub fn floatAddScalar(
     float_type: Type,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = lhs.toFloat(f16, pt) + rhs.toFloat(f16, pt) },
-        32 => .{ .f32 = lhs.toFloat(f32, pt) + rhs.toFloat(f32, pt) },
-        64 => .{ .f64 = lhs.toFloat(f64, pt) + rhs.toFloat(f64, pt) },
-        80 => .{ .f80 = lhs.toFloat(f80, pt) + rhs.toFloat(f80, pt) },
-        128 => .{ .f128 = lhs.toFloat(f128, pt) + rhs.toFloat(f128, pt) },
+        16 => .{ .f16 = lhs.toFloat(f16, zcu) + rhs.toFloat(f16, zcu) },
+        32 => .{ .f32 = lhs.toFloat(f32, zcu) + rhs.toFloat(f32, zcu) },
+        64 => .{ .f64 = lhs.toFloat(f64, zcu) + rhs.toFloat(f64, zcu) },
+        80 => .{ .f80 = lhs.toFloat(f80, zcu) + rhs.toFloat(f80, zcu) },
+        128 => .{ .f128 = lhs.toFloat(f128, zcu) + rhs.toFloat(f128, zcu) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2843,10 +2895,10 @@ pub fn floatSub(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -2866,14 +2918,14 @@ pub fn floatSubScalar(
     float_type: Type,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = lhs.toFloat(f16, pt) - rhs.toFloat(f16, pt) },
-        32 => .{ .f32 = lhs.toFloat(f32, pt) - rhs.toFloat(f32, pt) },
-        64 => .{ .f64 = lhs.toFloat(f64, pt) - rhs.toFloat(f64, pt) },
-        80 => .{ .f80 = lhs.toFloat(f80, pt) - rhs.toFloat(f80, pt) },
-        128 => .{ .f128 = lhs.toFloat(f128, pt) - rhs.toFloat(f128, pt) },
+        16 => .{ .f16 = lhs.toFloat(f16, zcu) - rhs.toFloat(f16, zcu) },
+        32 => .{ .f32 = lhs.toFloat(f32, zcu) - rhs.toFloat(f32, zcu) },
+        64 => .{ .f64 = lhs.toFloat(f64, zcu) - rhs.toFloat(f64, zcu) },
+        80 => .{ .f80 = lhs.toFloat(f80, zcu) - rhs.toFloat(f80, zcu) },
+        128 => .{ .f128 = lhs.toFloat(f128, zcu) - rhs.toFloat(f128, zcu) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2911,13 +2963,14 @@ pub fn floatDivScalar(
     float_type: Type,
     pt: Zcu.PerThread,
 ) !Value {
-    const target = pt.zcu.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = lhs.toFloat(f16, pt) / rhs.toFloat(f16, pt) },
-        32 => .{ .f32 = lhs.toFloat(f32, pt) / rhs.toFloat(f32, pt) },
-        64 => .{ .f64 = lhs.toFloat(f64, pt) / rhs.toFloat(f64, pt) },
-        80 => .{ .f80 = lhs.toFloat(f80, pt) / rhs.toFloat(f80, pt) },
-        128 => .{ .f128 = lhs.toFloat(f128, pt) / rhs.toFloat(f128, pt) },
+        16 => .{ .f16 = lhs.toFloat(f16, zcu) / rhs.toFloat(f16, zcu) },
+        32 => .{ .f32 = lhs.toFloat(f32, zcu) / rhs.toFloat(f32, zcu) },
+        64 => .{ .f64 = lhs.toFloat(f64, zcu) / rhs.toFloat(f64, zcu) },
+        80 => .{ .f80 = lhs.toFloat(f80, zcu) / rhs.toFloat(f80, zcu) },
+        128 => .{ .f128 = lhs.toFloat(f128, zcu) / rhs.toFloat(f128, zcu) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2955,13 +3008,14 @@ pub fn floatDivFloorScalar(
     float_type: Type,
     pt: Zcu.PerThread,
 ) !Value {
-    const target = pt.zcu.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @divFloor(lhs.toFloat(f16, pt), rhs.toFloat(f16, pt)) },
-        32 => .{ .f32 = @divFloor(lhs.toFloat(f32, pt), rhs.toFloat(f32, pt)) },
-        64 => .{ .f64 = @divFloor(lhs.toFloat(f64, pt), rhs.toFloat(f64, pt)) },
-        80 => .{ .f80 = @divFloor(lhs.toFloat(f80, pt), rhs.toFloat(f80, pt)) },
-        128 => .{ .f128 = @divFloor(lhs.toFloat(f128, pt), rhs.toFloat(f128, pt)) },
+        16 => .{ .f16 = @divFloor(lhs.toFloat(f16, zcu), rhs.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @divFloor(lhs.toFloat(f32, zcu), rhs.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @divFloor(lhs.toFloat(f64, zcu), rhs.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @divFloor(lhs.toFloat(f80, zcu), rhs.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @divFloor(lhs.toFloat(f128, zcu), rhs.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -2999,13 +3053,14 @@ pub fn floatDivTruncScalar(
     float_type: Type,
     pt: Zcu.PerThread,
 ) !Value {
-    const target = pt.zcu.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @divTrunc(lhs.toFloat(f16, pt), rhs.toFloat(f16, pt)) },
-        32 => .{ .f32 = @divTrunc(lhs.toFloat(f32, pt), rhs.toFloat(f32, pt)) },
-        64 => .{ .f64 = @divTrunc(lhs.toFloat(f64, pt), rhs.toFloat(f64, pt)) },
-        80 => .{ .f80 = @divTrunc(lhs.toFloat(f80, pt), rhs.toFloat(f80, pt)) },
-        128 => .{ .f128 = @divTrunc(lhs.toFloat(f128, pt), rhs.toFloat(f128, pt)) },
+        16 => .{ .f16 = @divTrunc(lhs.toFloat(f16, zcu), rhs.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @divTrunc(lhs.toFloat(f32, zcu), rhs.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @divTrunc(lhs.toFloat(f64, zcu), rhs.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @divTrunc(lhs.toFloat(f80, zcu), rhs.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @divTrunc(lhs.toFloat(f128, zcu), rhs.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3021,10 +3076,10 @@ pub fn floatMul(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const lhs_elem = try lhs.elemValue(pt, i);
             const rhs_elem = try rhs.elemValue(pt, i);
@@ -3044,14 +3099,14 @@ pub fn floatMulScalar(
     float_type: Type,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = lhs.toFloat(f16, pt) * rhs.toFloat(f16, pt) },
-        32 => .{ .f32 = lhs.toFloat(f32, pt) * rhs.toFloat(f32, pt) },
-        64 => .{ .f64 = lhs.toFloat(f64, pt) * rhs.toFloat(f64, pt) },
-        80 => .{ .f80 = lhs.toFloat(f80, pt) * rhs.toFloat(f80, pt) },
-        128 => .{ .f128 = lhs.toFloat(f128, pt) * rhs.toFloat(f128, pt) },
+        16 => .{ .f16 = lhs.toFloat(f16, zcu) * rhs.toFloat(f16, zcu) },
+        32 => .{ .f32 = lhs.toFloat(f32, zcu) * rhs.toFloat(f32, zcu) },
+        64 => .{ .f64 = lhs.toFloat(f64, zcu) * rhs.toFloat(f64, zcu) },
+        80 => .{ .f80 = lhs.toFloat(f80, zcu) * rhs.toFloat(f80, zcu) },
+        128 => .{ .f128 = lhs.toFloat(f128, zcu) * rhs.toFloat(f128, zcu) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3077,14 +3132,14 @@ pub fn sqrt(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !
 }
 
 pub fn sqrtScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @sqrt(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @sqrt(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @sqrt(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @sqrt(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @sqrt(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @sqrt(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @sqrt(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @sqrt(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @sqrt(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @sqrt(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3094,10 +3149,10 @@ pub fn sqrtScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Err
 }
 
 pub fn sin(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try sinScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3111,14 +3166,14 @@ pub fn sin(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !V
 }
 
 pub fn sinScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @sin(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @sin(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @sin(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @sin(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @sin(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @sin(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @sin(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @sin(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @sin(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @sin(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3128,10 +3183,10 @@ pub fn sinScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Erro
 }
 
 pub fn cos(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try cosScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3145,14 +3200,14 @@ pub fn cos(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !V
 }
 
 pub fn cosScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @cos(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @cos(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @cos(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @cos(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @cos(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @cos(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @cos(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @cos(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @cos(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @cos(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3162,10 +3217,10 @@ pub fn cosScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Erro
 }
 
 pub fn tan(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try tanScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3179,14 +3234,14 @@ pub fn tan(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !V
 }
 
 pub fn tanScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @tan(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @tan(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @tan(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @tan(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @tan(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @tan(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @tan(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @tan(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @tan(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @tan(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3196,10 +3251,10 @@ pub fn tanScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Erro
 }
 
 pub fn exp(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try expScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3213,14 +3268,14 @@ pub fn exp(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !V
 }
 
 pub fn expScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @exp(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @exp(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @exp(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @exp(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @exp(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @exp(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @exp(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @exp(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @exp(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @exp(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3230,10 +3285,10 @@ pub fn expScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Erro
 }
 
 pub fn exp2(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try exp2Scalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3247,14 +3302,14 @@ pub fn exp2(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !
 }
 
 pub fn exp2Scalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @exp2(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @exp2(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @exp2(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @exp2(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @exp2(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @exp2(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @exp2(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @exp2(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @exp2(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @exp2(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3264,10 +3319,10 @@ pub fn exp2Scalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Err
 }
 
 pub fn log(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try logScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3281,14 +3336,14 @@ pub fn log(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !V
 }
 
 pub fn logScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @log(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @log(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @log(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @log(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @log(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @log(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @log(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @log(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @log(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @log(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3298,10 +3353,10 @@ pub fn logScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Erro
 }
 
 pub fn log2(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try log2Scalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3315,14 +3370,14 @@ pub fn log2(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !
 }
 
 pub fn log2Scalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @log2(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @log2(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @log2(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @log2(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @log2(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @log2(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @log2(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @log2(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @log2(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @log2(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3332,10 +3387,10 @@ pub fn log2Scalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Err
 }
 
 pub fn log10(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try log10Scalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3349,14 +3404,14 @@ pub fn log10(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) 
 }
 
 pub fn log10Scalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @log10(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @log10(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @log10(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @log10(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @log10(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @log10(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @log10(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @log10(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @log10(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @log10(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3366,10 +3421,10 @@ pub fn log10Scalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Er
 }
 
 pub fn abs(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(mod));
-        const scalar_ty = ty.scalarType(mod);
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, ty.vectorLen(zcu));
+        const scalar_ty = ty.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try absScalar(elem_val, scalar_ty, pt, arena)).toIntern();
@@ -3383,30 +3438,30 @@ pub fn abs(val: Value, ty: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
 }
 
 pub fn absScalar(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) Allocator.Error!Value {
-    const mod = pt.zcu;
-    switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (ty.zigTypeTag(zcu)) {
         .Int => {
             var buffer: Value.BigIntSpace = undefined;
-            var operand_bigint = try val.toBigInt(&buffer, pt).toManaged(arena);
+            var operand_bigint = try val.toBigInt(&buffer, zcu).toManaged(arena);
             operand_bigint.abs();
 
             return pt.intValue_big(try ty.toUnsigned(pt), operand_bigint.toConst());
         },
         .ComptimeInt => {
             var buffer: Value.BigIntSpace = undefined;
-            var operand_bigint = try val.toBigInt(&buffer, pt).toManaged(arena);
+            var operand_bigint = try val.toBigInt(&buffer, zcu).toManaged(arena);
             operand_bigint.abs();
 
             return pt.intValue_big(ty, operand_bigint.toConst());
         },
         .ComptimeFloat, .Float => {
-            const target = mod.getTarget();
+            const target = zcu.getTarget();
             const storage: InternPool.Key.Float.Storage = switch (ty.floatBits(target)) {
-                16 => .{ .f16 = @abs(val.toFloat(f16, pt)) },
-                32 => .{ .f32 = @abs(val.toFloat(f32, pt)) },
-                64 => .{ .f64 = @abs(val.toFloat(f64, pt)) },
-                80 => .{ .f80 = @abs(val.toFloat(f80, pt)) },
-                128 => .{ .f128 = @abs(val.toFloat(f128, pt)) },
+                16 => .{ .f16 = @abs(val.toFloat(f16, zcu)) },
+                32 => .{ .f32 = @abs(val.toFloat(f32, zcu)) },
+                64 => .{ .f64 = @abs(val.toFloat(f64, zcu)) },
+                80 => .{ .f80 = @abs(val.toFloat(f80, zcu)) },
+                128 => .{ .f128 = @abs(val.toFloat(f128, zcu)) },
                 else => unreachable,
             };
             return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3419,10 +3474,10 @@ pub fn absScalar(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) Allo
 }
 
 pub fn floor(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try floorScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3436,14 +3491,14 @@ pub fn floor(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) 
 }
 
 pub fn floorScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @floor(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @floor(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @floor(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @floor(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @floor(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @floor(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @floor(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @floor(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @floor(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @floor(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3453,10 +3508,10 @@ pub fn floorScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Er
 }
 
 pub fn ceil(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try ceilScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3470,14 +3525,14 @@ pub fn ceil(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !
 }
 
 pub fn ceilScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @ceil(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @ceil(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @ceil(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @ceil(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @ceil(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @ceil(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @ceil(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @ceil(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @ceil(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @ceil(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3487,10 +3542,10 @@ pub fn ceilScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Err
 }
 
 pub fn round(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try roundScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3504,14 +3559,14 @@ pub fn round(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) 
 }
 
 pub fn roundScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @round(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @round(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @round(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @round(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @round(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @round(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @round(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @round(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @round(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @round(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3521,10 +3576,10 @@ pub fn roundScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Er
 }
 
 pub fn trunc(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const elem_val = try val.elemValue(pt, i);
             scalar.* = (try truncScalar(elem_val, scalar_ty, pt)).toIntern();
@@ -3538,14 +3593,14 @@ pub fn trunc(val: Value, float_type: Type, arena: Allocator, pt: Zcu.PerThread) 
 }
 
 pub fn truncScalar(val: Value, float_type: Type, pt: Zcu.PerThread) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @trunc(val.toFloat(f16, pt)) },
-        32 => .{ .f32 = @trunc(val.toFloat(f32, pt)) },
-        64 => .{ .f64 = @trunc(val.toFloat(f64, pt)) },
-        80 => .{ .f80 = @trunc(val.toFloat(f80, pt)) },
-        128 => .{ .f128 = @trunc(val.toFloat(f128, pt)) },
+        16 => .{ .f16 = @trunc(val.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @trunc(val.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @trunc(val.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @trunc(val.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @trunc(val.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3562,10 +3617,10 @@ pub fn mulAdd(
     arena: Allocator,
     pt: Zcu.PerThread,
 ) !Value {
-    const mod = pt.zcu;
-    if (float_type.zigTypeTag(mod) == .Vector) {
-        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(mod));
-        const scalar_ty = float_type.scalarType(mod);
+    const zcu = pt.zcu;
+    if (float_type.zigTypeTag(zcu) == .Vector) {
+        const result_data = try arena.alloc(InternPool.Index, float_type.vectorLen(zcu));
+        const scalar_ty = float_type.scalarType(zcu);
         for (result_data, 0..) |*scalar, i| {
             const mulend1_elem = try mulend1.elemValue(pt, i);
             const mulend2_elem = try mulend2.elemValue(pt, i);
@@ -3587,14 +3642,14 @@ pub fn mulAddScalar(
     addend: Value,
     pt: Zcu.PerThread,
 ) Allocator.Error!Value {
-    const mod = pt.zcu;
-    const target = mod.getTarget();
+    const zcu = pt.zcu;
+    const target = zcu.getTarget();
     const storage: InternPool.Key.Float.Storage = switch (float_type.floatBits(target)) {
-        16 => .{ .f16 = @mulAdd(f16, mulend1.toFloat(f16, pt), mulend2.toFloat(f16, pt), addend.toFloat(f16, pt)) },
-        32 => .{ .f32 = @mulAdd(f32, mulend1.toFloat(f32, pt), mulend2.toFloat(f32, pt), addend.toFloat(f32, pt)) },
-        64 => .{ .f64 = @mulAdd(f64, mulend1.toFloat(f64, pt), mulend2.toFloat(f64, pt), addend.toFloat(f64, pt)) },
-        80 => .{ .f80 = @mulAdd(f80, mulend1.toFloat(f80, pt), mulend2.toFloat(f80, pt), addend.toFloat(f80, pt)) },
-        128 => .{ .f128 = @mulAdd(f128, mulend1.toFloat(f128, pt), mulend2.toFloat(f128, pt), addend.toFloat(f128, pt)) },
+        16 => .{ .f16 = @mulAdd(f16, mulend1.toFloat(f16, zcu), mulend2.toFloat(f16, zcu), addend.toFloat(f16, zcu)) },
+        32 => .{ .f32 = @mulAdd(f32, mulend1.toFloat(f32, zcu), mulend2.toFloat(f32, zcu), addend.toFloat(f32, zcu)) },
+        64 => .{ .f64 = @mulAdd(f64, mulend1.toFloat(f64, zcu), mulend2.toFloat(f64, zcu), addend.toFloat(f64, zcu)) },
+        80 => .{ .f80 = @mulAdd(f80, mulend1.toFloat(f80, zcu), mulend2.toFloat(f80, zcu), addend.toFloat(f80, zcu)) },
+        128 => .{ .f128 = @mulAdd(f128, mulend1.toFloat(f128, zcu), mulend2.toFloat(f128, zcu), addend.toFloat(f128, zcu)) },
         else => unreachable,
     };
     return Value.fromInterned(try pt.intern(.{ .float = .{
@@ -3606,10 +3661,11 @@ pub fn mulAddScalar(
 /// If the value is represented in-memory as a series of bytes that all
 /// have the same value, return that byte value, otherwise null.
 pub fn hasRepeatedByteRepr(val: Value, ty: Type, pt: Zcu.PerThread) !?u8 {
-    const abi_size = std.math.cast(usize, ty.abiSize(pt)) orelse return null;
+    const zcu = pt.zcu;
+    const abi_size = std.math.cast(usize, ty.abiSize(zcu)) orelse return null;
     assert(abi_size >= 1);
-    const byte_buffer = try pt.zcu.gpa.alloc(u8, abi_size);
-    defer pt.zcu.gpa.free(byte_buffer);
+    const byte_buffer = try zcu.gpa.alloc(u8, abi_size);
+    defer zcu.gpa.free(byte_buffer);
 
     writeToMemory(val, ty, pt, byte_buffer) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -3756,13 +3812,13 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
         .Struct => field: {
             const field_ty = aggregate_ty.structFieldType(field_idx, zcu);
             switch (aggregate_ty.containerLayout(zcu)) {
-                .auto => break :field .{ field_ty, try aggregate_ty.structFieldAlignAdvanced(@intCast(field_idx), pt, .sema) },
+                .auto => break :field .{ field_ty, try aggregate_ty.structFieldAlignAdvanced(@intCast(field_idx), .sema, zcu, pt.tid) },
                 .@"extern" => {
                     // Well-defined layout, so just offset the pointer appropriately.
-                    const byte_off = aggregate_ty.structFieldOffset(field_idx, pt);
+                    const byte_off = aggregate_ty.structFieldOffset(field_idx, zcu);
                     const field_align = a: {
                         const parent_align = if (parent_ptr_info.flags.alignment == .none) pa: {
-                            break :pa (try aggregate_ty.abiAlignmentAdvanced(pt, .sema)).scalar;
+                            break :pa try aggregate_ty.abiAlignmentSema(pt);
                         } else parent_ptr_info.flags.alignment;
                         break :a InternPool.Alignment.fromLog2Units(@min(parent_align.toLog2Units(), @ctz(byte_off)));
                     };
@@ -3781,7 +3837,7 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
                             new.packed_offset = packed_offset;
                             new.child = field_ty.toIntern();
                             if (new.flags.alignment == .none) {
-                                new.flags.alignment = (try aggregate_ty.abiAlignmentAdvanced(pt, .sema)).scalar;
+                                new.flags.alignment = try aggregate_ty.abiAlignmentSema(pt);
                             }
                             break :info new;
                         });
@@ -3807,7 +3863,7 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
             const union_obj = zcu.typeToUnion(aggregate_ty).?;
             const field_ty = Type.fromInterned(union_obj.field_types.get(&zcu.intern_pool)[field_idx]);
             switch (aggregate_ty.containerLayout(zcu)) {
-                .auto => break :field .{ field_ty, try aggregate_ty.structFieldAlignAdvanced(@intCast(field_idx), pt, .sema) },
+                .auto => break :field .{ field_ty, try aggregate_ty.structFieldAlignAdvanced(@intCast(field_idx), .sema, zcu, pt.tid) },
                 .@"extern" => {
                     // Point to the same address.
                     const result_ty = try pt.ptrTypeSema(info: {
@@ -3820,17 +3876,17 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
                 .@"packed" => {
                     // If the field has an ABI size matching its bit size, then we can continue to use a
                     // non-bit pointer if the parent pointer is also a non-bit pointer.
-                    if (parent_ptr_info.packed_offset.host_size == 0 and (try field_ty.abiSizeAdvanced(pt, .sema)).scalar * 8 == try field_ty.bitSizeAdvanced(pt, .sema)) {
+                    if (parent_ptr_info.packed_offset.host_size == 0 and (try field_ty.abiSizeInner(.sema, zcu, pt.tid)).scalar * 8 == try field_ty.bitSizeSema(pt)) {
                         // We must offset the pointer on big-endian targets, since the bits of packed memory don't align nicely.
                         const byte_offset = switch (zcu.getTarget().cpu.arch.endian()) {
                             .little => 0,
-                            .big => (try aggregate_ty.abiSizeAdvanced(pt, .sema)).scalar - (try field_ty.abiSizeAdvanced(pt, .sema)).scalar,
+                            .big => (try aggregate_ty.abiSizeInner(.sema, zcu, pt.tid)).scalar - (try field_ty.abiSizeInner(.sema, zcu, pt.tid)).scalar,
                         };
                         const result_ty = try pt.ptrTypeSema(info: {
                             var new = parent_ptr_info;
                             new.child = field_ty.toIntern();
                             new.flags.alignment = InternPool.Alignment.fromLog2Units(
-                                @ctz(byte_offset | (try parent_ptr_ty.ptrAlignmentAdvanced(pt, .sema)).toByteUnits().?),
+                                @ctz(byte_offset | (try parent_ptr_ty.ptrAlignmentSema(pt)).toByteUnits().?),
                             );
                             break :info new;
                         });
@@ -3841,7 +3897,7 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
                             var new = parent_ptr_info;
                             new.child = field_ty.toIntern();
                             if (new.packed_offset.host_size == 0) {
-                                new.packed_offset.host_size = @intCast(((try aggregate_ty.bitSizeAdvanced(pt, .sema)) + 7) / 8);
+                                new.packed_offset.host_size = @intCast(((try aggregate_ty.bitSizeSema(pt)) + 7) / 8);
                                 assert(new.packed_offset.bit_offset == 0);
                             }
                             break :info new;
@@ -3854,8 +3910,8 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
         .Pointer => field_ty: {
             assert(aggregate_ty.isSlice(zcu));
             break :field_ty switch (field_idx) {
-                Value.slice_ptr_index => .{ aggregate_ty.slicePtrFieldType(zcu), Type.usize.abiAlignment(pt) },
-                Value.slice_len_index => .{ Type.usize, Type.usize.abiAlignment(pt) },
+                Value.slice_ptr_index => .{ aggregate_ty.slicePtrFieldType(zcu), Type.usize.abiAlignment(zcu) },
+                Value.slice_len_index => .{ Type.usize, Type.usize.abiAlignment(zcu) },
                 else => unreachable,
             };
         },
@@ -3863,7 +3919,7 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
     };
 
     const new_align: InternPool.Alignment = if (parent_ptr_info.flags.alignment != .none) a: {
-        const ty_align = (try field_ty.abiAlignmentAdvanced(pt, .sema)).scalar;
+        const ty_align = (try field_ty.abiAlignmentInner(.sema, zcu, pt.tid)).scalar;
         const true_field_align = if (field_align == .none) ty_align else field_align;
         const new_align = true_field_align.min(parent_ptr_info.flags.alignment);
         if (new_align == ty_align) break :a .none;
@@ -3919,21 +3975,21 @@ pub fn ptrElem(orig_parent_ptr: Value, field_idx: u64, pt: Zcu.PerThread) !Value
 
     const strat: PtrStrat = switch (parent_ptr_ty.ptrSize(zcu)) {
         .One => switch (elem_ty.zigTypeTag(zcu)) {
-            .Vector => .{ .offset = field_idx * @divExact(try elem_ty.childType(zcu).bitSizeAdvanced(pt, .sema), 8) },
+            .Vector => .{ .offset = field_idx * @divExact(try elem_ty.childType(zcu).bitSizeSema(pt), 8) },
             .Array => strat: {
                 const arr_elem_ty = elem_ty.childType(zcu);
-                if (try arr_elem_ty.comptimeOnlyAdvanced(pt, .sema)) {
+                if (try arr_elem_ty.comptimeOnlySema(pt)) {
                     break :strat .{ .elem_ptr = arr_elem_ty };
                 }
-                break :strat .{ .offset = field_idx * (try arr_elem_ty.abiSizeAdvanced(pt, .sema)).scalar };
+                break :strat .{ .offset = field_idx * (try arr_elem_ty.abiSizeInner(.sema, zcu, pt.tid)).scalar };
             },
             else => unreachable,
         },
 
-        .Many, .C => if (try elem_ty.comptimeOnlyAdvanced(pt, .sema))
+        .Many, .C => if (try elem_ty.comptimeOnlySema(pt))
             .{ .elem_ptr = elem_ty }
         else
-            .{ .offset = field_idx * (try elem_ty.abiSizeAdvanced(pt, .sema)).scalar },
+            .{ .offset = field_idx * (try elem_ty.abiSizeInner(.sema, zcu, pt.tid)).scalar },
 
         .Slice => unreachable,
     };
@@ -4142,22 +4198,32 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
             const base_ptr_ty = base_ptr.typeOf(zcu);
             const agg_ty = base_ptr_ty.childType(zcu);
             const field_ty, const field_align = switch (agg_ty.zigTypeTag(zcu)) {
-                .Struct => .{ agg_ty.structFieldType(@intCast(field.index), zcu), try agg_ty.structFieldAlignAdvanced(@intCast(field.index), pt, if (have_sema) .sema else .normal) },
-                .Union => .{ agg_ty.unionFieldTypeByIndex(@intCast(field.index), zcu), try agg_ty.structFieldAlignAdvanced(@intCast(field.index), pt, if (have_sema) .sema else .normal) },
+                .Struct => .{ agg_ty.structFieldType(@intCast(field.index), zcu), try agg_ty.structFieldAlignAdvanced(
+                    @intCast(field.index),
+                    if (have_sema) .sema else .normal,
+                    pt.zcu,
+                    if (have_sema) pt.tid else {},
+                ) },
+                .Union => .{ agg_ty.unionFieldTypeByIndex(@intCast(field.index), zcu), try agg_ty.structFieldAlignAdvanced(
+                    @intCast(field.index),
+                    if (have_sema) .sema else .normal,
+                    pt.zcu,
+                    if (have_sema) pt.tid else {},
+                ) },
                 .Pointer => .{ switch (field.index) {
                     Value.slice_ptr_index => agg_ty.slicePtrFieldType(zcu),
                     Value.slice_len_index => Type.usize,
                     else => unreachable,
-                }, Type.usize.abiAlignment(pt) },
+                }, Type.usize.abiAlignment(zcu) },
                 else => unreachable,
             };
-            const base_align = base_ptr_ty.ptrAlignment(pt);
+            const base_align = base_ptr_ty.ptrAlignment(zcu);
             const result_align = field_align.minStrict(base_align);
             const result_ty = try pt.ptrType(.{
                 .child = field_ty.toIntern(),
                 .flags = flags: {
                     var flags = base_ptr_ty.ptrInfo(zcu).flags;
-                    if (result_align == field_ty.abiAlignment(pt)) {
+                    if (result_align == field_ty.abiAlignment(zcu)) {
                         flags.alignment = .none;
                     } else {
                         flags.alignment = result_align;
@@ -4198,7 +4264,7 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
     }
 
     const need_child = Type.fromInterned(ptr.ty).childType(zcu);
-    if (need_child.comptimeOnly(pt)) {
+    if (need_child.comptimeOnly(zcu)) {
         // No refinement can happen - this pointer is presumably invalid.
         // Just offset it.
         const parent = try arena.create(PointerDeriveStep);
@@ -4209,7 +4275,7 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
             .new_ptr_ty = Type.fromInterned(ptr.ty),
         } };
     }
-    const need_bytes = need_child.abiSize(pt);
+    const need_bytes = need_child.abiSize(zcu);
 
     var cur_derive = base_derive;
     var cur_offset = ptr.byte_offset;
@@ -4248,7 +4314,7 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
 
             .Array => {
                 const elem_ty = cur_ty.childType(zcu);
-                const elem_size = elem_ty.abiSize(pt);
+                const elem_size = elem_ty.abiSize(zcu);
                 const start_idx = cur_offset / elem_size;
                 const end_idx = (cur_offset + need_bytes + elem_size - 1) / elem_size;
                 if (end_idx == start_idx + 1) {
@@ -4279,11 +4345,11 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
                 .auto, .@"packed" => break,
                 .@"extern" => for (0..cur_ty.structFieldCount(zcu)) |field_idx| {
                     const field_ty = cur_ty.structFieldType(field_idx, zcu);
-                    const start_off = cur_ty.structFieldOffset(field_idx, pt);
-                    const end_off = start_off + field_ty.abiSize(pt);
+                    const start_off = cur_ty.structFieldOffset(field_idx, zcu);
+                    const end_off = start_off + field_ty.abiSize(zcu);
                     if (cur_offset >= start_off and cur_offset + need_bytes <= end_off) {
                         const old_ptr_ty = try cur_derive.ptrType(pt);
-                        const parent_align = old_ptr_ty.ptrAlignment(pt);
+                        const parent_align = old_ptr_ty.ptrAlignment(zcu);
                         const field_align = InternPool.Alignment.fromLog2Units(@min(parent_align.toLog2Units(), @ctz(start_off)));
                         const parent = try arena.create(PointerDeriveStep);
                         parent.* = cur_derive;
@@ -4291,7 +4357,7 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
                             .child = field_ty.toIntern(),
                             .flags = flags: {
                                 var flags = old_ptr_ty.ptrInfo(zcu).flags;
-                                if (field_align == field_ty.abiAlignment(pt)) {
+                                if (field_align == field_ty.abiAlignment(zcu)) {
                                     flags.alignment = .none;
                                 } else {
                                     flags.alignment = field_align;
@@ -4325,13 +4391,17 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
     } };
 }
 
-pub fn resolveLazy(val: Value, arena: Allocator, pt: Zcu.PerThread) Zcu.SemaError!Value {
+pub fn resolveLazy(
+    val: Value,
+    arena: Allocator,
+    pt: Zcu.PerThread,
+) Zcu.SemaError!Value {
     switch (pt.zcu.intern_pool.indexToKey(val.toIntern())) {
         .int => |int| switch (int.storage) {
             .u64, .i64, .big_int => return val,
             .lazy_align, .lazy_size => return pt.intValue(
                 Type.fromInterned(int.ty),
-                (try val.getUnsignedIntAdvanced(pt, .sema)).?,
+                (try val.getUnsignedIntInner(.sema, pt.zcu, pt.tid)).?,
             ),
         },
         .slice => |slice| {

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -4196,14 +4196,14 @@ pub fn pointerDerivationAdvanced(ptr_val: Value, arena: Allocator, pt: Zcu.PerTh
             const base_ptr_ty = base_ptr.typeOf(zcu);
             const agg_ty = base_ptr_ty.childType(zcu);
             const field_ty, const field_align = switch (agg_ty.zigTypeTag(zcu)) {
-                .Struct => .{ agg_ty.fieldType(field.index, zcu), try agg_ty.fieldAlignmentInner(
-                    field.index,
+                .Struct => .{ agg_ty.fieldType(@intCast(field.index), zcu), try agg_ty.fieldAlignmentInner(
+                    @intCast(field.index),
                     if (have_sema) .sema else .normal,
                     pt.zcu,
                     if (have_sema) pt.tid else {},
                 ) },
-                .Union => .{ agg_ty.unionFieldTypeByIndex(field.index, zcu), try agg_ty.fieldAlignmentInner(
-                    field.index,
+                .Union => .{ agg_ty.unionFieldTypeByIndex(@intCast(field.index), zcu), try agg_ty.fieldAlignmentInner(
+                    @intCast(field.index),
                     if (have_sema) .sema else .normal,
                     pt.zcu,
                     if (have_sema) pt.tid else {},

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2109,9 +2109,9 @@ pub const CompileError = error{
     ComptimeBreak,
 };
 
-pub fn init(mod: *Zcu, thread_count: usize) !void {
-    const gpa = mod.gpa;
-    try mod.intern_pool.init(gpa, thread_count);
+pub fn init(zcu: *Zcu, thread_count: usize) !void {
+    const gpa = zcu.gpa;
+    try zcu.intern_pool.init(gpa, thread_count);
 }
 
 pub fn deinit(zcu: *Zcu) void {
@@ -2204,8 +2204,8 @@ pub fn namespacePtr(zcu: *Zcu, index: Namespace.Index) *Namespace {
     return zcu.intern_pool.namespacePtr(index);
 }
 
-pub fn namespacePtrUnwrap(mod: *Zcu, index: Namespace.OptionalIndex) ?*Namespace {
-    return mod.namespacePtr(index.unwrap() orelse return null);
+pub fn namespacePtrUnwrap(zcu: *Zcu, index: Namespace.OptionalIndex) ?*Namespace {
+    return zcu.namespacePtr(index.unwrap() orelse return null);
 }
 
 // TODO https://github.com/ziglang/zig/issues/8643
@@ -2682,7 +2682,7 @@ pub fn mapOldZirToNew(
 ///
 /// The caller is responsible for ensuring the function decl itself is already
 /// analyzed, and for ensuring it can exist at runtime (see
-/// `sema.fnHasRuntimeBits`). This function does *not* guarantee that the body
+/// `Type.fnHasRuntimeBitsSema`). This function does *not* guarantee that the body
 /// will be analyzed when it returns: for that, see `ensureFuncBodyAnalyzed`.
 pub fn ensureFuncBodyAnalysisQueued(zcu: *Zcu, func_index: InternPool.Index) !void {
     const ip = &zcu.intern_pool;
@@ -2846,16 +2846,16 @@ pub fn errorSetBits(mod: *Zcu) u16 {
 }
 
 pub fn errNote(
-    mod: *Zcu,
+    zcu: *Zcu,
     src_loc: LazySrcLoc,
     parent: *ErrorMsg,
     comptime format: []const u8,
     args: anytype,
 ) error{OutOfMemory}!void {
-    const msg = try std.fmt.allocPrint(mod.gpa, format, args);
-    errdefer mod.gpa.free(msg);
+    const msg = try std.fmt.allocPrint(zcu.gpa, format, args);
+    errdefer zcu.gpa.free(msg);
 
-    parent.notes = try mod.gpa.realloc(parent.notes, parent.notes.len + 1);
+    parent.notes = try zcu.gpa.realloc(parent.notes, parent.notes.len + 1);
     parent.notes[parent.notes.len - 1] = .{
         .src_loc = src_loc,
         .msg = msg,
@@ -2876,14 +2876,14 @@ pub fn optimizeMode(zcu: *const Zcu) std.builtin.OptimizeMode {
     return zcu.root_mod.optimize_mode;
 }
 
-fn lockAndClearFileCompileError(mod: *Zcu, file: *File) void {
+fn lockAndClearFileCompileError(zcu: *Zcu, file: *File) void {
     switch (file.status) {
         .success_zir, .retryable_failure => {},
         .never_loaded, .parse_failure, .astgen_failure => {
-            mod.comp.mutex.lock();
-            defer mod.comp.mutex.unlock();
-            if (mod.failed_files.fetchSwapRemove(file)) |kv| {
-                if (kv.value) |msg| msg.destroy(mod.gpa); // Delete previous error message.
+            zcu.comp.mutex.lock();
+            defer zcu.comp.mutex.unlock();
+            if (zcu.failed_files.fetchSwapRemove(file)) |kv| {
+                if (kv.value) |msg| msg.destroy(zcu.gpa); // Delete previous error message.
             }
         },
     }
@@ -2965,11 +2965,11 @@ pub const AtomicPtrAlignmentDiagnostics = struct {
 // TODO this function does not take into account CPU features, which can affect
 // this value. Audit this!
 pub fn atomicPtrAlignment(
-    mod: *Zcu,
+    zcu: *Zcu,
     ty: Type,
     diags: *AtomicPtrAlignmentDiagnostics,
 ) AtomicPtrAlignmentError!Alignment {
-    const target = mod.getTarget();
+    const target = zcu.getTarget();
     const max_atomic_bits: u16 = switch (target.cpu.arch) {
         .avr,
         .msp430,
@@ -3039,8 +3039,8 @@ pub fn atomicPtrAlignment(
         }
         return .none;
     }
-    if (ty.isAbiInt(mod)) {
-        const bit_count = ty.intInfo(mod).bits;
+    if (ty.isAbiInt(zcu)) {
+        const bit_count = ty.intInfo(zcu).bits;
         if (bit_count > max_atomic_bits) {
             diags.* = .{
                 .bits = bit_count,
@@ -3050,7 +3050,7 @@ pub fn atomicPtrAlignment(
         }
         return .none;
     }
-    if (ty.isPtrAtRuntime(mod)) return .none;
+    if (ty.isPtrAtRuntime(zcu)) return .none;
     return error.BadType;
 }
 
@@ -3058,45 +3058,45 @@ pub fn atomicPtrAlignment(
 /// * `@TypeOf(.{})`
 /// * A struct which has no fields (`struct {}`).
 /// * Not a struct.
-pub fn typeToStruct(mod: *Zcu, ty: Type) ?InternPool.LoadedStructType {
+pub fn typeToStruct(zcu: *Zcu, ty: Type) ?InternPool.LoadedStructType {
     if (ty.ip_index == .none) return null;
-    const ip = &mod.intern_pool;
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.ip_index)) {
         .struct_type => ip.loadStructType(ty.ip_index),
         else => null,
     };
 }
 
-pub fn typeToPackedStruct(mod: *Zcu, ty: Type) ?InternPool.LoadedStructType {
-    const s = mod.typeToStruct(ty) orelse return null;
+pub fn typeToPackedStruct(zcu: *Zcu, ty: Type) ?InternPool.LoadedStructType {
+    const s = zcu.typeToStruct(ty) orelse return null;
     if (s.layout != .@"packed") return null;
     return s;
 }
 
-pub fn typeToUnion(mod: *Zcu, ty: Type) ?InternPool.LoadedUnionType {
+pub fn typeToUnion(zcu: *const Zcu, ty: Type) ?InternPool.LoadedUnionType {
     if (ty.ip_index == .none) return null;
-    const ip = &mod.intern_pool;
+    const ip = &zcu.intern_pool;
     return switch (ip.indexToKey(ty.ip_index)) {
         .union_type => ip.loadUnionType(ty.ip_index),
         else => null,
     };
 }
 
-pub fn typeToFunc(mod: *Zcu, ty: Type) ?InternPool.Key.FuncType {
+pub fn typeToFunc(zcu: *const Zcu, ty: Type) ?InternPool.Key.FuncType {
     if (ty.ip_index == .none) return null;
-    return mod.intern_pool.indexToFuncType(ty.toIntern());
+    return zcu.intern_pool.indexToFuncType(ty.toIntern());
 }
 
 pub fn iesFuncIndex(zcu: *const Zcu, ies_index: InternPool.Index) InternPool.Index {
     return zcu.intern_pool.iesFuncIndex(ies_index);
 }
 
-pub fn funcInfo(mod: *Zcu, func_index: InternPool.Index) InternPool.Key.Func {
-    return mod.intern_pool.indexToKey(func_index).func;
+pub fn funcInfo(zcu: *const Zcu, func_index: InternPool.Index) InternPool.Key.Func {
+    return zcu.intern_pool.indexToKey(func_index).func;
 }
 
-pub fn toEnum(mod: *Zcu, comptime E: type, val: Value) E {
-    return mod.intern_pool.toEnum(E, val.toIntern());
+pub fn toEnum(zcu: *const Zcu, comptime E: type, val: Value) E {
+    return zcu.intern_pool.toEnum(E, val.toIntern());
 }
 
 pub const UnionLayout = struct {
@@ -3121,8 +3121,8 @@ pub const UnionLayout = struct {
 };
 
 /// Returns the index of the active field, given the current tag value
-pub fn unionTagFieldIndex(mod: *Zcu, loaded_union: InternPool.LoadedUnionType, enum_tag: Value) ?u32 {
-    const ip = &mod.intern_pool;
+pub fn unionTagFieldIndex(zcu: *const Zcu, loaded_union: InternPool.LoadedUnionType, enum_tag: Value) ?u32 {
+    const ip = &zcu.intern_pool;
     if (enum_tag.toIntern() == .none) return null;
     assert(ip.typeOf(enum_tag.toIntern()) == loaded_union.enum_tag_ty);
     return loaded_union.loadTagType(ip).tagValueIndex(ip, enum_tag.toIntern());
@@ -3348,7 +3348,7 @@ pub fn resolveReferences(zcu: *Zcu) !std.AutoHashMapUnmanaged(AnalUnit, ?Resolve
     return result;
 }
 
-pub fn fileByIndex(zcu: *Zcu, file_index: File.Index) *File {
+pub fn fileByIndex(zcu: *const Zcu, file_index: File.Index) *File {
     return zcu.intern_pool.filePtr(file_index);
 }
 

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2840,9 +2840,9 @@ pub fn addTypeReference(zcu: *Zcu, src_unit: AnalUnit, referenced_type: InternPo
     gop.value_ptr.* = @intCast(ref_idx);
 }
 
-pub fn errorSetBits(mod: *Zcu) u16 {
-    if (mod.error_limit == 0) return 0;
-    return @as(u16, std.math.log2_int(ErrorInt, mod.error_limit)) + 1;
+pub fn errorSetBits(zcu: *const Zcu) u16 {
+    if (zcu.error_limit == 0) return 0;
+    return @as(u16, std.math.log2_int(ErrorInt, zcu.error_limit)) + 1;
 }
 
 pub fn errNote(

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2923,10 +2923,23 @@ pub fn addGlobalAssembly(zcu: *Zcu, cau: InternPool.Cau.Index, source: []const u
 }
 
 pub const Feature = enum {
+    /// When this feature is enabled, Sema will emit calls to `std.builtin.panic`
+    /// for things like safety checks and unreachables. Otherwise traps will be emitted.
     panic_fn,
+    /// When this feature is enabled, Sema will emit calls to `std.builtin.panicUnwrapError`.
+    /// This error message requires more advanced formatting, hence it being seperate from `panic_fn`.
+    /// Otherwise traps will be emitted.
     panic_unwrap_error,
+    /// When this feature is enabled, Sema will emit calls to the more complex panic functions
+    /// that use formatting to add detail to error messages. Similar to `panic_unwrap_error`.
+    /// Otherwise traps will be emitted.
     safety_check_formatted,
+    /// When this feature is enabled, Sema will insert tracer functions for gathering a stack
+    /// trace for error returns.
     error_return_trace,
+    /// When this feature is enabled, Sema will emit the `is_named_enum_value` AIR instructions
+    /// and use it to check for corrupt switches. Backends currently need to implement their own
+    /// logic to determine whether an enum value is in the set of named values.
     is_named_enum_value,
     error_set_has_value,
     field_reordering,

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -3040,38 +3040,6 @@ pub fn intBitsForValue(pt: Zcu.PerThread, val: Value, sign: bool) u16 {
     }
 }
 
-/// Returns 0 if the union is represented with 0 bits at runtime.
-pub fn unionAbiAlignment(pt: Zcu.PerThread, loaded_union: InternPool.LoadedUnionType) InternPool.Alignment {
-    const zcu = pt.zcu;
-    const ip = &zcu.intern_pool;
-    const have_tag = loaded_union.flagsPtr(ip).runtime_tag.hasTag();
-    var max_align: InternPool.Alignment = .none;
-    if (have_tag) max_align = Type.fromInterned(loaded_union.enum_tag_ty).abiAlignment(zcu);
-    for (loaded_union.field_types.get(ip), 0..) |field_ty, field_index| {
-        if (!Type.fromInterned(field_ty).hasRuntimeBits(zcu)) continue;
-
-        const field_align = zcu.unionFieldNormalAlignment(loaded_union, @intCast(field_index));
-        max_align = max_align.max(field_align);
-    }
-    return max_align;
-}
-
-/// Returns the field alignment of a non-packed struct. Asserts the layout is not packed.
-pub fn structFieldAlignment(
-    pt: Zcu.PerThread,
-    explicit_alignment: InternPool.Alignment,
-    field_ty: Type,
-    layout: std.builtin.Type.ContainerLayout,
-) InternPool.Alignment {
-    return field_ty.structFieldAlignmentAdvanced(
-        explicit_alignment,
-        layout,
-        .normal,
-        pt.zcu,
-        {},
-    ) catch unreachable;
-}
-
 /// https://github.com/ziglang/zig/issues/17178 explored storing these bit offsets
 /// into the packed struct InternPool data rather than computing this on the
 /// fly, however it was found to perform worse when measured on real world

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -1326,7 +1326,7 @@ fn semaCau(pt: Zcu.PerThread, cau_index: InternPool.Cau.Index) !SemaCauResult {
             try decl_ty.resolveFully(pt);
         }
 
-        if (!resolve_type or !decl_ty.hasRuntimeBits(pt)) {
+        if (!resolve_type or !decl_ty.hasRuntimeBits(zcu)) {
             if (zcu.comp.config.use_llvm) break :queue_codegen;
             if (file.mod.strip) break :queue_codegen;
         }

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2756,7 +2756,7 @@ pub fn ptrType(pt: Zcu.PerThread, info: InternPool.Key.PtrType) Allocator.Error!
     // pointee type needs to be resolved more, that needs to be done before calling
     // this ptr() function.
     if (info.flags.alignment != .none and
-        info.flags.alignment == Type.fromInterned(info.child).abiAlignment(pt))
+        info.flags.alignment == Type.fromInterned(info.child).abiAlignment(pt.zcu))
     {
         canon_info.flags.alignment = .none;
     }
@@ -2766,7 +2766,7 @@ pub fn ptrType(pt: Zcu.PerThread, info: InternPool.Key.PtrType) Allocator.Error!
         // we change it to 0 here. If this causes an assertion trip, the pointee type
         // needs to be resolved before calling this ptr() function.
         .none => if (info.packed_offset.host_size != 0) {
-            const elem_bit_size = Type.fromInterned(info.child).bitSize(pt);
+            const elem_bit_size = Type.fromInterned(info.child).bitSize(pt.zcu);
             assert(info.packed_offset.bit_offset + elem_bit_size <= info.packed_offset.host_size * 8);
             if (info.packed_offset.host_size * 8 == elem_bit_size) {
                 canon_info.packed_offset.host_size = 0;
@@ -2784,7 +2784,7 @@ pub fn ptrType(pt: Zcu.PerThread, info: InternPool.Key.PtrType) Allocator.Error!
 /// In general, prefer this function during semantic analysis.
 pub fn ptrTypeSema(pt: Zcu.PerThread, info: InternPool.Key.PtrType) Zcu.SemaError!Type {
     if (info.flags.alignment != .none) {
-        _ = try Type.fromInterned(info.child).abiAlignmentAdvanced(pt, .sema);
+        _ = try Type.fromInterned(info.child).abiAlignmentSema(pt);
     }
     return pt.ptrType(info);
 }
@@ -2984,15 +2984,15 @@ pub fn smallestUnsignedInt(pt: Zcu.PerThread, max: u64) Allocator.Error!Type {
 /// `max`. Asserts that neither value is undef.
 /// TODO: if #3806 is implemented, this becomes trivial
 pub fn intFittingRange(pt: Zcu.PerThread, min: Value, max: Value) !Type {
-    const mod = pt.zcu;
-    assert(!min.isUndef(mod));
-    assert(!max.isUndef(mod));
+    const zcu = pt.zcu;
+    assert(!min.isUndef(zcu));
+    assert(!max.isUndef(zcu));
 
     if (std.debug.runtime_safety) {
-        assert(Value.order(min, max, pt).compare(.lte));
+        assert(Value.order(min, max, zcu).compare(.lte));
     }
 
-    const sign = min.orderAgainstZero(pt) == .lt;
+    const sign = min.orderAgainstZero(zcu) == .lt;
 
     const min_val_bits = pt.intBitsForValue(min, sign);
     const max_val_bits = pt.intBitsForValue(max, sign);
@@ -3032,118 +3032,28 @@ pub fn intBitsForValue(pt: Zcu.PerThread, val: Value, sign: bool) u16 {
             return @as(u16, @intCast(big.bitCountTwosComp()));
         },
         .lazy_align => |lazy_ty| {
-            return Type.smallestUnsignedBits(Type.fromInterned(lazy_ty).abiAlignment(pt).toByteUnits() orelse 0) + @intFromBool(sign);
+            return Type.smallestUnsignedBits(Type.fromInterned(lazy_ty).abiAlignment(pt.zcu).toByteUnits() orelse 0) + @intFromBool(sign);
         },
         .lazy_size => |lazy_ty| {
-            return Type.smallestUnsignedBits(Type.fromInterned(lazy_ty).abiSize(pt)) + @intFromBool(sign);
+            return Type.smallestUnsignedBits(Type.fromInterned(lazy_ty).abiSize(pt.zcu)) + @intFromBool(sign);
         },
     }
-}
-
-pub fn getUnionLayout(pt: Zcu.PerThread, loaded_union: InternPool.LoadedUnionType) Zcu.UnionLayout {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    assert(loaded_union.haveLayout(ip));
-    var most_aligned_field: u32 = undefined;
-    var most_aligned_field_size: u64 = undefined;
-    var biggest_field: u32 = undefined;
-    var payload_size: u64 = 0;
-    var payload_align: InternPool.Alignment = .@"1";
-    for (loaded_union.field_types.get(ip), 0..) |field_ty, field_index| {
-        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(pt)) continue;
-
-        const explicit_align = loaded_union.fieldAlign(ip, field_index);
-        const field_align = if (explicit_align != .none)
-            explicit_align
-        else
-            Type.fromInterned(field_ty).abiAlignment(pt);
-        const field_size = Type.fromInterned(field_ty).abiSize(pt);
-        if (field_size > payload_size) {
-            payload_size = field_size;
-            biggest_field = @intCast(field_index);
-        }
-        if (field_align.compare(.gte, payload_align)) {
-            payload_align = field_align;
-            most_aligned_field = @intCast(field_index);
-            most_aligned_field_size = field_size;
-        }
-    }
-    const have_tag = loaded_union.flagsUnordered(ip).runtime_tag.hasTag();
-    if (!have_tag or !Type.fromInterned(loaded_union.enum_tag_ty).hasRuntimeBits(pt)) {
-        return .{
-            .abi_size = payload_align.forward(payload_size),
-            .abi_align = payload_align,
-            .most_aligned_field = most_aligned_field,
-            .most_aligned_field_size = most_aligned_field_size,
-            .biggest_field = biggest_field,
-            .payload_size = payload_size,
-            .payload_align = payload_align,
-            .tag_align = .none,
-            .tag_size = 0,
-            .padding = 0,
-        };
-    }
-
-    const tag_size = Type.fromInterned(loaded_union.enum_tag_ty).abiSize(pt);
-    const tag_align = Type.fromInterned(loaded_union.enum_tag_ty).abiAlignment(pt).max(.@"1");
-    return .{
-        .abi_size = loaded_union.sizeUnordered(ip),
-        .abi_align = tag_align.max(payload_align),
-        .most_aligned_field = most_aligned_field,
-        .most_aligned_field_size = most_aligned_field_size,
-        .biggest_field = biggest_field,
-        .payload_size = payload_size,
-        .payload_align = payload_align,
-        .tag_align = tag_align,
-        .tag_size = tag_size,
-        .padding = loaded_union.paddingUnordered(ip),
-    };
-}
-
-pub fn unionAbiSize(mod: *Module, loaded_union: InternPool.LoadedUnionType) u64 {
-    return mod.getUnionLayout(loaded_union).abi_size;
 }
 
 /// Returns 0 if the union is represented with 0 bits at runtime.
 pub fn unionAbiAlignment(pt: Zcu.PerThread, loaded_union: InternPool.LoadedUnionType) InternPool.Alignment {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const have_tag = loaded_union.flagsPtr(ip).runtime_tag.hasTag();
     var max_align: InternPool.Alignment = .none;
-    if (have_tag) max_align = Type.fromInterned(loaded_union.enum_tag_ty).abiAlignment(pt);
+    if (have_tag) max_align = Type.fromInterned(loaded_union.enum_tag_ty).abiAlignment(zcu);
     for (loaded_union.field_types.get(ip), 0..) |field_ty, field_index| {
-        if (!Type.fromInterned(field_ty).hasRuntimeBits(pt)) continue;
+        if (!Type.fromInterned(field_ty).hasRuntimeBits(zcu)) continue;
 
-        const field_align = mod.unionFieldNormalAlignment(loaded_union, @intCast(field_index));
+        const field_align = zcu.unionFieldNormalAlignment(loaded_union, @intCast(field_index));
         max_align = max_align.max(field_align);
     }
     return max_align;
-}
-
-/// Returns the field alignment of a non-packed union. Asserts the layout is not packed.
-pub fn unionFieldNormalAlignment(
-    pt: Zcu.PerThread,
-    loaded_union: InternPool.LoadedUnionType,
-    field_index: u32,
-) InternPool.Alignment {
-    return pt.unionFieldNormalAlignmentAdvanced(loaded_union, field_index, .normal) catch unreachable;
-}
-
-/// Returns the field alignment of a non-packed union. Asserts the layout is not packed.
-/// If `strat` is `.sema`, may perform type resolution.
-pub fn unionFieldNormalAlignmentAdvanced(
-    pt: Zcu.PerThread,
-    loaded_union: InternPool.LoadedUnionType,
-    field_index: u32,
-    comptime strat: Type.ResolveStrat,
-) Zcu.SemaError!InternPool.Alignment {
-    const ip = &pt.zcu.intern_pool;
-    assert(loaded_union.flagsUnordered(ip).layout != .@"packed");
-    const field_align = loaded_union.fieldAlign(ip, field_index);
-    if (field_align != .none) return field_align;
-    const field_ty = Type.fromInterned(loaded_union.field_types.get(ip)[field_index]);
-    if (field_ty.isNoReturn(pt.zcu)) return .none;
-    return (try field_ty.abiAlignmentAdvanced(pt, strat.toLazy())).scalar;
 }
 
 /// Returns the field alignment of a non-packed struct. Asserts the layout is not packed.
@@ -3153,31 +3063,13 @@ pub fn structFieldAlignment(
     field_ty: Type,
     layout: std.builtin.Type.ContainerLayout,
 ) InternPool.Alignment {
-    return pt.structFieldAlignmentAdvanced(explicit_alignment, field_ty, layout, .normal) catch unreachable;
-}
-
-/// Returns the field alignment of a non-packed struct. Asserts the layout is not packed.
-/// If `strat` is `.sema`, may perform type resolution.
-pub fn structFieldAlignmentAdvanced(
-    pt: Zcu.PerThread,
-    explicit_alignment: InternPool.Alignment,
-    field_ty: Type,
-    layout: std.builtin.Type.ContainerLayout,
-    comptime strat: Type.ResolveStrat,
-) Zcu.SemaError!InternPool.Alignment {
-    assert(layout != .@"packed");
-    if (explicit_alignment != .none) return explicit_alignment;
-    const ty_abi_align = (try field_ty.abiAlignmentAdvanced(pt, strat.toLazy())).scalar;
-    switch (layout) {
-        .@"packed" => unreachable,
-        .auto => if (pt.zcu.getTarget().ofmt != .c) return ty_abi_align,
-        .@"extern" => {},
-    }
-    // extern
-    if (field_ty.isAbiInt(pt.zcu) and field_ty.intInfo(pt.zcu).bits >= 128) {
-        return ty_abi_align.maxStrict(.@"16");
-    }
-    return ty_abi_align;
+    return field_ty.structFieldAlignmentAdvanced(
+        explicit_alignment,
+        layout,
+        .normal,
+        pt.zcu,
+        {},
+    ) catch unreachable;
 }
 
 /// https://github.com/ziglang/zig/issues/17178 explored storing these bit offsets
@@ -3189,8 +3081,8 @@ pub fn structPackedFieldBitOffset(
     struct_type: InternPool.LoadedStructType,
     field_index: u32,
 ) u16 {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     assert(struct_type.layout == .@"packed");
     assert(struct_type.haveLayout(ip));
     var bit_sum: u64 = 0;
@@ -3199,7 +3091,7 @@ pub fn structPackedFieldBitOffset(
             return @intCast(bit_sum);
         }
         const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[i]);
-        bit_sum += field_ty.bitSize(pt);
+        bit_sum += field_ty.bitSize(zcu);
     }
     unreachable; // index out of bounds
 }
@@ -3244,7 +3136,7 @@ pub fn navPtrType(pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) Allocator.
     return pt.ptrType(.{
         .child = ty.toIntern(),
         .flags = .{
-            .alignment = if (r.alignment == ty.abiAlignment(pt))
+            .alignment = if (r.alignment == ty.abiAlignment(zcu))
                 .none
             else
                 r.alignment,
@@ -3274,7 +3166,7 @@ pub fn navAlignment(pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) InternPo
     const zcu = pt.zcu;
     const r = zcu.intern_pool.getNav(nav_index).status.resolved;
     if (r.alignment != .none) return r.alignment;
-    return Value.fromInterned(r.val).typeOf(zcu).abiAlignment(pt);
+    return Value.fromInterned(r.val).typeOf(zcu).abiAlignment(zcu);
 }
 
 /// Given a container type requiring resolution, ensures that it is up-to-date.

--- a/src/arch/aarch64/CodeGen.zig
+++ b/src/arch/aarch64/CodeGen.zig
@@ -4144,7 +4144,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
         const zcu = pt.zcu;
         const mcv = try self.resolveInst(operand);
         const struct_ty = self.typeOf(operand);
-        const struct_field_ty = struct_ty.structFieldType(index, zcu);
+        const struct_field_ty = struct_ty.fieldType(index, zcu);
         const struct_field_offset = @as(u32, @intCast(struct_ty.structFieldOffset(index, zcu)));
 
         switch (mcv) {
@@ -5473,10 +5473,10 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
             const reg_lock = self.register_manager.lockReg(rwo.reg);
             defer if (reg_lock) |locked_reg| self.register_manager.unlockReg(locked_reg);
 
-            const wrapped_ty = ty.structFieldType(0, zcu);
+            const wrapped_ty = ty.fieldType(0, zcu);
             try self.genSetStack(wrapped_ty, stack_offset, .{ .register = rwo.reg });
 
-            const overflow_bit_ty = ty.structFieldType(1, zcu);
+            const overflow_bit_ty = ty.fieldType(1, zcu);
             const overflow_bit_offset = @as(u32, @intCast(ty.structFieldOffset(1, zcu)));
             const raw_cond_reg = try self.register_manager.allocReg(null, gp);
             const cond_reg = self.registerAlias(raw_cond_reg, overflow_bit_ty);

--- a/src/arch/aarch64/abi.zig
+++ b/src/arch/aarch64/abi.zig
@@ -95,7 +95,7 @@ fn countFloats(ty: Type, zcu: *Zcu, maybe_float_bits: *?u16) u8 {
             var count: u8 = 0;
             var i: u32 = 0;
             while (i < fields_len) : (i += 1) {
-                const field_ty = ty.structFieldType(i, zcu);
+                const field_ty = ty.fieldType(i, zcu);
                 const field_count = countFloats(field_ty, zcu, maybe_float_bits);
                 if (field_count == invalid) return invalid;
                 count += field_count;
@@ -130,7 +130,7 @@ pub fn getFloatArrayType(ty: Type, zcu: *Zcu) ?Type {
             const fields_len = ty.structFieldCount(zcu);
             var i: u32 = 0;
             while (i < fields_len) : (i += 1) {
-                const field_ty = ty.structFieldType(i, zcu);
+                const field_ty = ty.fieldType(i, zcu);
                 if (getFloatArrayType(field_ty, zcu)) |some| return some;
             }
             return null;

--- a/src/arch/aarch64/abi.zig
+++ b/src/arch/aarch64/abi.zig
@@ -15,44 +15,44 @@ pub const Class = union(enum) {
 };
 
 /// For `float_array` the second element will be the amount of floats.
-pub fn classifyType(ty: Type, pt: Zcu.PerThread) Class {
-    std.debug.assert(ty.hasRuntimeBitsIgnoreComptime(pt));
+pub fn classifyType(ty: Type, zcu: *Zcu) Class {
+    std.debug.assert(ty.hasRuntimeBitsIgnoreComptime(zcu));
 
     var maybe_float_bits: ?u16 = null;
-    switch (ty.zigTypeTag(pt.zcu)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Struct => {
-            if (ty.containerLayout(pt.zcu) == .@"packed") return .byval;
-            const float_count = countFloats(ty, pt.zcu, &maybe_float_bits);
+            if (ty.containerLayout(zcu) == .@"packed") return .byval;
+            const float_count = countFloats(ty, zcu, &maybe_float_bits);
             if (float_count <= sret_float_count) return .{ .float_array = float_count };
 
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             if (bit_size > 128) return .memory;
             if (bit_size > 64) return .double_integer;
             return .integer;
         },
         .Union => {
-            if (ty.containerLayout(pt.zcu) == .@"packed") return .byval;
-            const float_count = countFloats(ty, pt.zcu, &maybe_float_bits);
+            if (ty.containerLayout(zcu) == .@"packed") return .byval;
+            const float_count = countFloats(ty, zcu, &maybe_float_bits);
             if (float_count <= sret_float_count) return .{ .float_array = float_count };
 
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             if (bit_size > 128) return .memory;
             if (bit_size > 64) return .double_integer;
             return .integer;
         },
         .Int, .Enum, .ErrorSet, .Float, .Bool => return .byval,
         .Vector => {
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             // TODO is this controlled by a cpu feature?
             if (bit_size > 128) return .memory;
             return .byval;
         },
         .Optional => {
-            std.debug.assert(ty.isPtrLikeOptional(pt.zcu));
+            std.debug.assert(ty.isPtrLikeOptional(zcu));
             return .byval;
         },
         .Pointer => {
-            std.debug.assert(!ty.isSlice(pt.zcu));
+            std.debug.assert(!ty.isSlice(zcu));
             return .byval;
         },
         .ErrorUnion,

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -2926,7 +2926,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
         const mcv = try self.resolveInst(operand);
         const struct_ty = self.typeOf(operand);
         const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(index, zcu));
-        const struct_field_ty = struct_ty.structFieldType(index, zcu);
+        const struct_field_ty = struct_ty.fieldType(index, zcu);
 
         switch (mcv) {
             .dead, .unreach => unreachable,
@@ -5434,10 +5434,10 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
             const reg_lock = self.register_manager.lockReg(reg);
             defer if (reg_lock) |locked_reg| self.register_manager.unlockReg(locked_reg);
 
-            const wrapped_ty = ty.structFieldType(0, zcu);
+            const wrapped_ty = ty.fieldType(0, zcu);
             try self.genSetStack(wrapped_ty, stack_offset, .{ .register = reg });
 
-            const overflow_bit_ty = ty.structFieldType(1, zcu);
+            const overflow_bit_ty = ty.fieldType(1, zcu);
             const overflow_bit_offset: u32 = @intCast(ty.structFieldOffset(1, zcu));
             const cond_reg = try self.register_manager.allocReg(null, gp);
 

--- a/src/arch/arm/CodeGen.zig
+++ b/src/arch/arm/CodeGen.zig
@@ -474,8 +474,8 @@ pub fn addExtraAssumeCapacity(self: *Self, extra: anytype) u32 {
 
 fn gen(self: *Self) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const cc = self.fn_type.fnCallingConvention(mod);
+    const zcu = pt.zcu;
+    const cc = self.fn_type.fnCallingConvention(zcu);
     if (cc != .Naked) {
         // push {fp, lr}
         const push_reloc = try self.addNop();
@@ -518,8 +518,8 @@ fn gen(self: *Self) !void {
 
                     const ty = self.typeOfIndex(inst);
 
-                    const abi_size: u32 = @intCast(ty.abiSize(pt));
-                    const abi_align = ty.abiAlignment(pt);
+                    const abi_size: u32 = @intCast(ty.abiSize(zcu));
+                    const abi_align = ty.abiAlignment(zcu);
                     const stack_offset = try self.allocMem(abi_size, abi_align, inst);
                     try self.genSetStack(ty, stack_offset, MCValue{ .register = reg });
 
@@ -635,8 +635,8 @@ fn gen(self: *Self) !void {
 
 fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const air_tags = self.air.instructions.items(.tag);
 
     for (body) |inst| {
@@ -999,10 +999,10 @@ fn allocMem(
 /// Use a pointer instruction as the basis for allocating stack memory.
 fn allocMemPtr(self: *Self, inst: Air.Inst.Index) !u32 {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const elem_ty = self.typeOfIndex(inst).childType(mod);
+    const zcu = pt.zcu;
+    const elem_ty = self.typeOfIndex(inst).childType(zcu);
 
-    if (!elem_ty.hasRuntimeBits(pt)) {
+    if (!elem_ty.hasRuntimeBits(zcu)) {
         // As this stack item will never be dereferenced at runtime,
         // return the stack offset 0. Stack offset 0 will be where all
         // zero-sized stack allocations live as non-zero-sized
@@ -1010,21 +1010,21 @@ fn allocMemPtr(self: *Self, inst: Air.Inst.Index) !u32 {
         return 0;
     }
 
-    const abi_size = math.cast(u32, elem_ty.abiSize(pt)) orelse {
+    const abi_size = math.cast(u32, elem_ty.abiSize(zcu)) orelse {
         return self.fail("type '{}' too big to fit into stack frame", .{elem_ty.fmt(pt)});
     };
     // TODO swap this for inst.ty.ptrAlign
-    const abi_align = elem_ty.abiAlignment(pt);
+    const abi_align = elem_ty.abiAlignment(zcu);
 
     return self.allocMem(abi_size, abi_align, inst);
 }
 
 fn allocRegOrMem(self: *Self, elem_ty: Type, reg_ok: bool, maybe_inst: ?Air.Inst.Index) !MCValue {
     const pt = self.pt;
-    const abi_size = math.cast(u32, elem_ty.abiSize(pt)) orelse {
+    const abi_size = math.cast(u32, elem_ty.abiSize(pt.zcu)) orelse {
         return self.fail("type '{}' too big to fit into stack frame", .{elem_ty.fmt(pt)});
     };
-    const abi_align = elem_ty.abiAlignment(pt);
+    const abi_align = elem_ty.abiAlignment(pt.zcu);
 
     if (reg_ok) {
         // Make sure the type can fit in a register before we try to allocate one.
@@ -1108,13 +1108,13 @@ fn airAlloc(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airRetPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = switch (self.ret_mcv) {
         .none, .register => .{ .ptr_stack_offset = try self.allocMemPtr(inst) },
         .stack_offset => blk: {
             // self.ret_mcv is an address to where this function
             // should store its result into
-            const ret_ty = self.fn_type.fnReturnType(mod);
+            const ret_ty = self.fn_type.fnReturnType(zcu);
             const ptr_ty = try pt.singleMutPtrType(ret_ty);
 
             // addr_reg will contain the address of where to store the
@@ -1142,7 +1142,7 @@ fn airFpext(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIntCast(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     if (self.liveness.isUnused(inst))
         return self.finishAir(inst, .dead, .{ ty_op.operand, .none, .none });
@@ -1151,10 +1151,10 @@ fn airIntCast(self: *Self, inst: Air.Inst.Index) !void {
     const operand_ty = self.typeOf(ty_op.operand);
     const dest_ty = self.typeOfIndex(inst);
 
-    const operand_abi_size = operand_ty.abiSize(pt);
-    const dest_abi_size = dest_ty.abiSize(pt);
-    const info_a = operand_ty.intInfo(mod);
-    const info_b = dest_ty.intInfo(mod);
+    const operand_abi_size = operand_ty.abiSize(zcu);
+    const dest_abi_size = dest_ty.abiSize(zcu);
+    const info_a = operand_ty.intInfo(zcu);
+    const info_b = dest_ty.intInfo(zcu);
 
     const dst_mcv: MCValue = blk: {
         if (info_a.bits == info_b.bits) {
@@ -1209,9 +1209,9 @@ fn trunc(
     dest_ty: Type,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const info_a = operand_ty.intInfo(mod);
-    const info_b = dest_ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const info_a = operand_ty.intInfo(zcu);
+    const info_b = dest_ty.intInfo(zcu);
 
     if (info_b.bits <= 32) {
         if (info_a.bits > 32) {
@@ -1274,7 +1274,7 @@ fn airIntFromBool(self: *Self, inst: Air.Inst.Index) !void {
 fn airNot(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const operand_bind: ReadArg.Bind = .{ .inst = ty_op.operand };
         const operand_ty = self.typeOf(ty_op.operand);
@@ -1283,7 +1283,7 @@ fn airNot(self: *Self, inst: Air.Inst.Index) !void {
             .unreach => unreachable,
             .cpsr_flags => |cond| break :result MCValue{ .cpsr_flags = cond.negate() },
             else => {
-                switch (operand_ty.zigTypeTag(mod)) {
+                switch (operand_ty.zigTypeTag(zcu)) {
                     .Bool => {
                         var op_reg: Register = undefined;
                         var dest_reg: Register = undefined;
@@ -1316,7 +1316,7 @@ fn airNot(self: *Self, inst: Air.Inst.Index) !void {
                     },
                     .Vector => return self.fail("TODO bitwise not for vectors", .{}),
                     .Int => {
-                        const int_info = operand_ty.intInfo(mod);
+                        const int_info = operand_ty.intInfo(zcu);
                         if (int_info.bits <= 32) {
                             var op_reg: Register = undefined;
                             var dest_reg: Register = undefined;
@@ -1371,13 +1371,13 @@ fn minMax(
     maybe_inst: ?Air.Inst.Index,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM min/max on floats", .{}),
         .Vector => return self.fail("TODO ARM min/max on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 var lhs_reg: Register = undefined;
                 var rhs_reg: Register = undefined;
@@ -1581,7 +1581,7 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const lhs_bind: ReadArg.Bind = .{ .inst = extra.lhs };
         const rhs_bind: ReadArg.Bind = .{ .inst = extra.rhs };
@@ -1589,15 +1589,15 @@ fn airOverflow(self: *Self, inst: Air.Inst.Index) !void {
         const rhs_ty = self.typeOf(extra.rhs);
 
         const tuple_ty = self.typeOfIndex(inst);
-        const tuple_size: u32 = @intCast(tuple_ty.abiSize(pt));
-        const tuple_align = tuple_ty.abiAlignment(pt);
-        const overflow_bit_offset: u32 = @intCast(tuple_ty.structFieldOffset(1, pt));
+        const tuple_size: u32 = @intCast(tuple_ty.abiSize(zcu));
+        const tuple_align = tuple_ty.abiAlignment(zcu);
+        const overflow_bit_offset: u32 = @intCast(tuple_ty.structFieldOffset(1, zcu));
 
-        switch (lhs_ty.zigTypeTag(mod)) {
+        switch (lhs_ty.zigTypeTag(zcu)) {
             .Vector => return self.fail("TODO implement add_with_overflow/sub_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
-                const int_info = lhs_ty.intInfo(mod);
+                assert(lhs_ty.eql(rhs_ty, zcu));
+                const int_info = lhs_ty.intInfo(zcu);
                 if (int_info.bits < 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
 
@@ -1695,7 +1695,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
     if (self.liveness.isUnused(inst)) return self.finishAir(inst, .dead, .{ extra.lhs, extra.rhs, .none });
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = result: {
         const lhs_bind: ReadArg.Bind = .{ .inst = extra.lhs };
         const rhs_bind: ReadArg.Bind = .{ .inst = extra.rhs };
@@ -1703,15 +1703,15 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
         const rhs_ty = self.typeOf(extra.rhs);
 
         const tuple_ty = self.typeOfIndex(inst);
-        const tuple_size: u32 = @intCast(tuple_ty.abiSize(pt));
-        const tuple_align = tuple_ty.abiAlignment(pt);
-        const overflow_bit_offset: u32 = @intCast(tuple_ty.structFieldOffset(1, pt));
+        const tuple_size: u32 = @intCast(tuple_ty.abiSize(zcu));
+        const tuple_align = tuple_ty.abiAlignment(zcu);
+        const overflow_bit_offset: u32 = @intCast(tuple_ty.structFieldOffset(1, zcu));
 
-        switch (lhs_ty.zigTypeTag(mod)) {
+        switch (lhs_ty.zigTypeTag(zcu)) {
             .Vector => return self.fail("TODO implement mul_with_overflow for vectors", .{}),
             .Int => {
-                assert(lhs_ty.eql(rhs_ty, mod));
-                const int_info = lhs_ty.intInfo(mod);
+                assert(lhs_ty.eql(rhs_ty, zcu));
+                const int_info = lhs_ty.intInfo(zcu);
                 if (int_info.bits <= 16) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
 
@@ -1860,20 +1860,20 @@ fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
     if (self.liveness.isUnused(inst)) return self.finishAir(inst, .dead, .{ extra.lhs, extra.rhs, .none });
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = result: {
         const lhs_ty = self.typeOf(extra.lhs);
         const rhs_ty = self.typeOf(extra.rhs);
 
         const tuple_ty = self.typeOfIndex(inst);
-        const tuple_size: u32 = @intCast(tuple_ty.abiSize(pt));
-        const tuple_align = tuple_ty.abiAlignment(pt);
-        const overflow_bit_offset: u32 = @intCast(tuple_ty.structFieldOffset(1, pt));
+        const tuple_size: u32 = @intCast(tuple_ty.abiSize(zcu));
+        const tuple_align = tuple_ty.abiAlignment(zcu);
+        const overflow_bit_offset: u32 = @intCast(tuple_ty.structFieldOffset(1, zcu));
 
-        switch (lhs_ty.zigTypeTag(mod)) {
+        switch (lhs_ty.zigTypeTag(zcu)) {
             .Vector => return self.fail("TODO implement shl_with_overflow for vectors", .{}),
             .Int => {
-                const int_info = lhs_ty.intInfo(mod);
+                const int_info = lhs_ty.intInfo(zcu);
                 if (int_info.bits <= 32) {
                     const stack_offset = try self.allocMem(tuple_size, tuple_align, inst);
 
@@ -2020,7 +2020,7 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const optional_ty = self.typeOfIndex(inst);
-        const abi_size: u32 = @intCast(optional_ty.abiSize(pt));
+        const abi_size: u32 = @intCast(optional_ty.abiSize(pt.zcu));
 
         // Optional with a zero-bit payload type is just a boolean true
         if (abi_size == 1) {
@@ -2040,17 +2040,17 @@ fn errUnionErr(
     maybe_inst: ?Air.Inst.Index,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const err_ty = error_union_ty.errorUnionSet(mod);
-    const payload_ty = error_union_ty.errorUnionPayload(mod);
-    if (err_ty.errorSetIsEmpty(mod)) {
+    const zcu = pt.zcu;
+    const err_ty = error_union_ty.errorUnionSet(zcu);
+    const payload_ty = error_union_ty.errorUnionPayload(zcu);
+    if (err_ty.errorSetIsEmpty(zcu)) {
         return MCValue{ .immediate = 0 };
     }
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return try error_union_bind.resolveToMcv(self);
     }
 
-    const err_offset: u32 = @intCast(errUnionErrorOffset(payload_ty, pt));
+    const err_offset: u32 = @intCast(errUnionErrorOffset(payload_ty, zcu));
     switch (try error_union_bind.resolveToMcv(self)) {
         .register => {
             var operand_reg: Register = undefined;
@@ -2072,7 +2072,7 @@ fn errUnionErr(
             );
 
             const err_bit_offset = err_offset * 8;
-            const err_bit_size: u32 = @intCast(err_ty.abiSize(pt) * 8);
+            const err_bit_size: u32 = @intCast(err_ty.abiSize(zcu) * 8);
 
             _ = try self.addInst(.{
                 .tag = .ubfx, // errors are unsigned integers
@@ -2118,17 +2118,17 @@ fn errUnionPayload(
     maybe_inst: ?Air.Inst.Index,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const err_ty = error_union_ty.errorUnionSet(mod);
-    const payload_ty = error_union_ty.errorUnionPayload(mod);
-    if (err_ty.errorSetIsEmpty(mod)) {
+    const zcu = pt.zcu;
+    const err_ty = error_union_ty.errorUnionSet(zcu);
+    const payload_ty = error_union_ty.errorUnionPayload(zcu);
+    if (err_ty.errorSetIsEmpty(zcu)) {
         return try error_union_bind.resolveToMcv(self);
     }
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return MCValue.none;
     }
 
-    const payload_offset: u32 = @intCast(errUnionPayloadOffset(payload_ty, pt));
+    const payload_offset: u32 = @intCast(errUnionPayloadOffset(payload_ty, zcu));
     switch (try error_union_bind.resolveToMcv(self)) {
         .register => {
             var operand_reg: Register = undefined;
@@ -2150,10 +2150,10 @@ fn errUnionPayload(
             );
 
             const payload_bit_offset = payload_offset * 8;
-            const payload_bit_size: u32 = @intCast(payload_ty.abiSize(pt) * 8);
+            const payload_bit_size: u32 = @intCast(payload_ty.abiSize(zcu) * 8);
 
             _ = try self.addInst(.{
-                .tag = if (payload_ty.isSignedInt(mod)) Mir.Inst.Tag.sbfx else .ubfx,
+                .tag = if (payload_ty.isSignedInt(zcu)) Mir.Inst.Tag.sbfx else .ubfx,
                 .data = .{ .rr_lsb_width = .{
                     .rd = dest_reg,
                     .rn = operand_reg,
@@ -2229,20 +2229,20 @@ fn airSaveErrReturnTraceIndex(self: *Self, inst: Air.Inst.Index) !void {
 /// T to E!T
 fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const error_union_ty = ty_op.ty.toType();
-        const error_ty = error_union_ty.errorUnionSet(mod);
-        const payload_ty = error_union_ty.errorUnionPayload(mod);
+        const error_ty = error_union_ty.errorUnionSet(zcu);
+        const payload_ty = error_union_ty.errorUnionPayload(zcu);
         const operand = try self.resolveInst(ty_op.operand);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result operand;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result operand;
 
-        const abi_size: u32 = @intCast(error_union_ty.abiSize(pt));
-        const abi_align = error_union_ty.abiAlignment(pt);
+        const abi_size: u32 = @intCast(error_union_ty.abiSize(zcu));
+        const abi_align = error_union_ty.abiAlignment(zcu);
         const stack_offset: u32 = @intCast(try self.allocMem(abi_size, abi_align, inst));
-        const payload_off = errUnionPayloadOffset(payload_ty, pt);
-        const err_off = errUnionErrorOffset(payload_ty, pt);
+        const payload_off = errUnionPayloadOffset(payload_ty, zcu);
+        const err_off = errUnionErrorOffset(payload_ty, zcu);
         try self.genSetStack(payload_ty, stack_offset - @as(u32, @intCast(payload_off)), operand);
         try self.genSetStack(error_ty, stack_offset - @as(u32, @intCast(err_off)), .{ .immediate = 0 });
 
@@ -2254,20 +2254,20 @@ fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) !void {
 /// E to E!T
 fn airWrapErrUnionErr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const error_union_ty = ty_op.ty.toType();
-        const error_ty = error_union_ty.errorUnionSet(mod);
-        const payload_ty = error_union_ty.errorUnionPayload(mod);
+        const error_ty = error_union_ty.errorUnionSet(zcu);
+        const payload_ty = error_union_ty.errorUnionPayload(zcu);
         const operand = try self.resolveInst(ty_op.operand);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result operand;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result operand;
 
-        const abi_size: u32 = @intCast(error_union_ty.abiSize(pt));
-        const abi_align = error_union_ty.abiAlignment(pt);
+        const abi_size: u32 = @intCast(error_union_ty.abiSize(zcu));
+        const abi_align = error_union_ty.abiAlignment(zcu);
         const stack_offset: u32 = @intCast(try self.allocMem(abi_size, abi_align, inst));
-        const payload_off = errUnionPayloadOffset(payload_ty, pt);
-        const err_off = errUnionErrorOffset(payload_ty, pt);
+        const payload_off = errUnionPayloadOffset(payload_ty, zcu);
+        const err_off = errUnionErrorOffset(payload_ty, zcu);
         try self.genSetStack(error_ty, stack_offset - @as(u32, @intCast(err_off)), operand);
         try self.genSetStack(payload_ty, stack_offset - @as(u32, @intCast(payload_off)), .undef);
 
@@ -2372,9 +2372,9 @@ fn ptrElemVal(
     maybe_inst: ?Air.Inst.Index,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const elem_ty = ptr_ty.childType(mod);
-    const elem_size: u32 = @intCast(elem_ty.abiSize(pt));
+    const zcu = pt.zcu;
+    const elem_ty = ptr_ty.childType(zcu);
+    const elem_size: u32 = @intCast(elem_ty.abiSize(zcu));
 
     switch (elem_size) {
         1, 4 => {
@@ -2432,11 +2432,11 @@ fn ptrElemVal(
 
 fn airSliceElemVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const slice_ty = self.typeOf(bin_op.lhs);
-    const result: MCValue = if (!slice_ty.isVolatilePtr(mod) and self.liveness.isUnused(inst)) .dead else result: {
-        const ptr_ty = slice_ty.slicePtrFieldType(mod);
+    const result: MCValue = if (!slice_ty.isVolatilePtr(zcu) and self.liveness.isUnused(inst)) .dead else result: {
+        const ptr_ty = slice_ty.slicePtrFieldType(zcu);
 
         const slice_mcv = try self.resolveInst(bin_op.lhs);
         const base_mcv = slicePtr(slice_mcv);
@@ -2476,8 +2476,8 @@ fn arrayElemVal(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const elem_ty = array_ty.childType(mod);
+    const zcu = pt.zcu;
+    const elem_ty = array_ty.childType(zcu);
 
     const mcv = try array_bind.resolveToMcv(self);
     switch (mcv) {
@@ -2533,10 +2533,10 @@ fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airPtrElemVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const ptr_ty = self.typeOf(bin_op.lhs);
-    const result: MCValue = if (!ptr_ty.isVolatilePtr(mod) and self.liveness.isUnused(inst)) .dead else result: {
+    const result: MCValue = if (!ptr_ty.isVolatilePtr(zcu) and self.liveness.isUnused(inst)) .dead else result: {
         const base_bind: ReadArg.Bind = .{ .inst = bin_op.lhs };
         const index_bind: ReadArg.Bind = .{ .inst = bin_op.rhs };
 
@@ -2668,9 +2668,9 @@ fn reuseOperand(
 
 fn load(self: *Self, dst_mcv: MCValue, ptr: MCValue, ptr_ty: Type) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const elem_ty = ptr_ty.childType(mod);
-    const elem_size: u32 = @intCast(elem_ty.abiSize(pt));
+    const zcu = pt.zcu;
+    const elem_ty = ptr_ty.childType(zcu);
+    const elem_size: u32 = @intCast(elem_ty.abiSize(zcu));
 
     switch (ptr) {
         .none => unreachable,
@@ -2746,20 +2746,20 @@ fn load(self: *Self, dst_mcv: MCValue, ptr: MCValue, ptr_ty: Type) InnerError!vo
 
 fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const elem_ty = self.typeOfIndex(inst);
     const result: MCValue = result: {
-        if (!elem_ty.hasRuntimeBits(pt))
+        if (!elem_ty.hasRuntimeBits(zcu))
             break :result MCValue.none;
 
         const ptr = try self.resolveInst(ty_op.operand);
-        const is_volatile = self.typeOf(ty_op.operand).isVolatilePtr(mod);
+        const is_volatile = self.typeOf(ty_op.operand).isVolatilePtr(zcu);
         if (self.liveness.isUnused(inst) and !is_volatile)
             break :result MCValue.dead;
 
         const dest_mcv: MCValue = blk: {
-            const ptr_fits_dest = elem_ty.abiSize(pt) <= 4;
+            const ptr_fits_dest = elem_ty.abiSize(zcu) <= 4;
             if (ptr_fits_dest and self.reuseOperand(inst, ty_op.operand, 0, ptr)) {
                 // The MCValue that holds the pointer can be re-used as the value.
                 break :blk ptr;
@@ -2776,7 +2776,7 @@ fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
 
 fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type) InnerError!void {
     const pt = self.pt;
-    const elem_size: u32 = @intCast(value_ty.abiSize(pt));
+    const elem_size: u32 = @intCast(value_ty.abiSize(pt.zcu));
 
     switch (ptr) {
         .none => unreachable,
@@ -2896,11 +2896,11 @@ fn airStructFieldPtrIndex(self: *Self, inst: Air.Inst.Index, index: u8) !void {
 fn structFieldPtr(self: *Self, inst: Air.Inst.Index, operand: Air.Inst.Ref, index: u32) !MCValue {
     return if (self.liveness.isUnused(inst)) .dead else result: {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const mcv = try self.resolveInst(operand);
         const ptr_ty = self.typeOf(operand);
-        const struct_ty = ptr_ty.childType(mod);
-        const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(index, pt));
+        const struct_ty = ptr_ty.childType(zcu);
+        const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(index, zcu));
         switch (mcv) {
             .ptr_stack_offset => |off| {
                 break :result MCValue{ .ptr_stack_offset = off - struct_field_offset };
@@ -2921,12 +2921,12 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
     const operand = extra.struct_operand;
     const index = extra.field_index;
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const mcv = try self.resolveInst(operand);
         const struct_ty = self.typeOf(operand);
-        const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(index, pt));
-        const struct_field_ty = struct_ty.structFieldType(index, mod);
+        const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(index, zcu));
+        const struct_field_ty = struct_ty.structFieldType(index, zcu);
 
         switch (mcv) {
             .dead, .unreach => unreachable,
@@ -2989,10 +2989,10 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
                 );
 
                 const field_bit_offset = struct_field_offset * 8;
-                const field_bit_size: u32 = @intCast(struct_field_ty.abiSize(pt) * 8);
+                const field_bit_size: u32 = @intCast(struct_field_ty.abiSize(zcu) * 8);
 
                 _ = try self.addInst(.{
-                    .tag = if (struct_field_ty.isSignedInt(mod)) Mir.Inst.Tag.sbfx else .ubfx,
+                    .tag = if (struct_field_ty.isSignedInt(zcu)) Mir.Inst.Tag.sbfx else .ubfx,
                     .data = .{ .rr_lsb_width = .{
                         .rd = dest_reg,
                         .rn = operand_reg,
@@ -3012,18 +3012,18 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.FieldParentPtr, ty_pl.payload).data;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const field_ptr = try self.resolveInst(extra.field_ptr);
-        const struct_ty = ty_pl.ty.toType().childType(mod);
+        const struct_ty = ty_pl.ty.toType().childType(zcu);
 
-        if (struct_ty.zigTypeTag(mod) == .Union) {
+        if (struct_ty.zigTypeTag(zcu) == .Union) {
             return self.fail("TODO implement @fieldParentPtr codegen for unions", .{});
         }
 
-        const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(extra.field_index, pt));
+        const struct_field_offset: u32 = @intCast(struct_ty.structFieldOffset(extra.field_index, zcu));
         switch (field_ptr) {
             .ptr_stack_offset => |off| {
                 break :result MCValue{ .ptr_stack_offset = off + struct_field_offset };
@@ -3407,13 +3407,13 @@ fn addSub(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
                 const rhs_immediate = try rhs_bind.resolveToImmediate(self);
@@ -3464,13 +3464,13 @@ fn mul(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 // TODO add optimisations for multiplication
                 // with immediates, for example a * 2 can be
@@ -3498,8 +3498,8 @@ fn divFloat(
     _ = maybe_inst;
 
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         else => unreachable,
@@ -3515,13 +3515,13 @@ fn divTrunc(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
                     .signed => {
@@ -3559,13 +3559,13 @@ fn divFloor(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
                     .signed => {
@@ -3608,8 +3608,8 @@ fn divExact(
     _ = maybe_inst;
 
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => return self.fail("TODO ARM div_exact", .{}),
@@ -3626,17 +3626,17 @@ fn rem(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 switch (int_info.signedness) {
                     .signed => {
-                        return self.fail("TODO ARM signed integer mod", .{});
+                        return self.fail("TODO ARM signed integer zcu", .{});
                     },
                     .unsigned => {
                         const rhs_immediate = try rhs_bind.resolveToImmediate(self);
@@ -3667,10 +3667,10 @@ fn rem(
 
                                 return MCValue{ .register = dest_reg };
                             } else {
-                                return self.fail("TODO ARM integer mod by constants", .{});
+                                return self.fail("TODO ARM integer zcu by constants", .{});
                             }
                         } else {
-                            return self.fail("TODO ARM integer mod", .{});
+                            return self.fail("TODO ARM integer zcu", .{});
                         }
                     },
                 }
@@ -3696,11 +3696,11 @@ fn modulo(
     _ = maybe_inst;
 
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Float => return self.fail("TODO ARM binary operations on floats", .{}),
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
-        .Int => return self.fail("TODO ARM mod", .{}),
+        .Int => return self.fail("TODO ARM zcu", .{}),
         else => unreachable,
     }
 }
@@ -3715,11 +3715,11 @@ fn wrappingArithmetic(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            const int_info = lhs_ty.intInfo(mod);
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 // Generate an add/sub/mul
                 const result: MCValue = switch (tag) {
@@ -3754,12 +3754,12 @@ fn bitwise(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            assert(lhs_ty.eql(rhs_ty, mod));
-            const int_info = lhs_ty.intInfo(mod);
+            assert(lhs_ty.eql(rhs_ty, zcu));
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 const lhs_immediate = try lhs_bind.resolveToImmediate(self);
                 const rhs_immediate = try rhs_bind.resolveToImmediate(self);
@@ -3800,17 +3800,17 @@ fn shiftExact(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            const int_info = lhs_ty.intInfo(mod);
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 const rhs_immediate = try rhs_bind.resolveToImmediate(self);
 
                 const mir_tag: Mir.Inst.Tag = switch (tag) {
                     .shl_exact => .lsl,
-                    .shr_exact => switch (lhs_ty.intInfo(mod).signedness) {
+                    .shr_exact => switch (lhs_ty.intInfo(zcu).signedness) {
                         .signed => Mir.Inst.Tag.asr,
                         .unsigned => Mir.Inst.Tag.lsr,
                     },
@@ -3840,11 +3840,11 @@ fn shiftNormal(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Vector => return self.fail("TODO ARM binary operations on vectors", .{}),
         .Int => {
-            const int_info = lhs_ty.intInfo(mod);
+            const int_info = lhs_ty.intInfo(zcu);
             if (int_info.bits <= 32) {
                 // Generate a shl_exact/shr_exact
                 const result: MCValue = switch (tag) {
@@ -3884,8 +3884,8 @@ fn booleanOp(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Bool => {
             const lhs_immediate = try lhs_bind.resolveToImmediate(self);
             const rhs_immediate = try rhs_bind.resolveToImmediate(self);
@@ -3919,17 +3919,17 @@ fn ptrArithmetic(
     maybe_inst: ?Air.Inst.Index,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Pointer => {
-            assert(rhs_ty.eql(Type.usize, mod));
+            assert(rhs_ty.eql(Type.usize, zcu));
 
             const ptr_ty = lhs_ty;
-            const elem_ty = switch (ptr_ty.ptrSize(mod)) {
-                .One => ptr_ty.childType(mod).childType(mod), // ptr to array, so get array element type
-                else => ptr_ty.childType(mod),
+            const elem_ty = switch (ptr_ty.ptrSize(zcu)) {
+                .One => ptr_ty.childType(zcu).childType(zcu), // ptr to array, so get array element type
+                else => ptr_ty.childType(zcu),
             };
-            const elem_size: u32 = @intCast(elem_ty.abiSize(pt));
+            const elem_size: u32 = @intCast(elem_ty.abiSize(zcu));
 
             const base_tag: Air.Inst.Tag = switch (tag) {
                 .ptr_add => .add,
@@ -3957,12 +3957,12 @@ fn ptrArithmetic(
 
 fn genLdrRegister(self: *Self, dest_reg: Register, addr_reg: Register, ty: Type) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size = ty.abiSize(pt);
+    const zcu = pt.zcu;
+    const abi_size = ty.abiSize(zcu);
 
     const tag: Mir.Inst.Tag = switch (abi_size) {
-        1 => if (ty.isSignedInt(mod)) Mir.Inst.Tag.ldrsb else .ldrb,
-        2 => if (ty.isSignedInt(mod)) Mir.Inst.Tag.ldrsh else .ldrh,
+        1 => if (ty.isSignedInt(zcu)) Mir.Inst.Tag.ldrsb else .ldrb,
+        2 => if (ty.isSignedInt(zcu)) Mir.Inst.Tag.ldrsh else .ldrh,
         3, 4 => .ldr,
         else => unreachable,
     };
@@ -3979,7 +3979,7 @@ fn genLdrRegister(self: *Self, dest_reg: Register, addr_reg: Register, ty: Type)
     } };
 
     const data: Mir.Inst.Data = switch (abi_size) {
-        1 => if (ty.isSignedInt(mod)) rr_extra_offset else rr_offset,
+        1 => if (ty.isSignedInt(zcu)) rr_extra_offset else rr_offset,
         2 => rr_extra_offset,
         3, 4 => rr_offset,
         else => unreachable,
@@ -3993,7 +3993,7 @@ fn genLdrRegister(self: *Self, dest_reg: Register, addr_reg: Register, ty: Type)
 
 fn genStrRegister(self: *Self, source_reg: Register, addr_reg: Register, ty: Type) !void {
     const pt = self.pt;
-    const abi_size = ty.abiSize(pt);
+    const abi_size = ty.abiSize(pt.zcu);
 
     const tag: Mir.Inst.Tag = switch (abi_size) {
         1 => .strb,
@@ -4253,12 +4253,12 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
     const args: []const Air.Inst.Ref = @ptrCast(self.air.extra[extra.end..][0..extra.data.args_len]);
     const ty = self.typeOf(callee);
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
 
-    const fn_ty = switch (ty.zigTypeTag(mod)) {
+    const fn_ty = switch (ty.zigTypeTag(zcu)) {
         .Fn => ty,
-        .Pointer => ty.childType(mod),
+        .Pointer => ty.childType(zcu),
         else => unreachable,
     };
 
@@ -4283,9 +4283,9 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
     // untouched by the parameter passing code
     const r0_lock: ?RegisterLock = if (info.return_value == .stack_offset) blk: {
         log.debug("airCall: return by reference", .{});
-        const ret_ty = fn_ty.fnReturnType(mod);
-        const ret_abi_size: u32 = @intCast(ret_ty.abiSize(pt));
-        const ret_abi_align = ret_ty.abiAlignment(pt);
+        const ret_ty = fn_ty.fnReturnType(zcu);
+        const ret_abi_size: u32 = @intCast(ret_ty.abiSize(zcu));
+        const ret_abi_align = ret_ty.abiAlignment(zcu);
         const stack_offset = try self.allocMem(ret_abi_size, ret_abi_align, inst);
 
         const ptr_ty = try pt.singleMutPtrType(ret_ty);
@@ -4335,7 +4335,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
             return self.fail("TODO implement calling bitcasted functions", .{});
         },
     } else {
-        assert(ty.zigTypeTag(mod) == .Pointer);
+        assert(ty.zigTypeTag(zcu) == .Pointer);
         const mcv = try self.resolveInst(callee);
 
         try self.genSetReg(Type.usize, .lr, mcv);
@@ -4370,7 +4370,7 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
                 if (RegisterManager.indexOfRegIntoTracked(reg) == null) {
                     // Save function return value into a tracked register
                     log.debug("airCall: copying {} as it is not tracked", .{reg});
-                    const new_reg = try self.copyToTmpRegister(fn_ty.fnReturnType(mod), info.return_value);
+                    const new_reg = try self.copyToTmpRegister(fn_ty.fnReturnType(zcu), info.return_value);
                     break :result MCValue{ .register = new_reg };
                 }
             },
@@ -4395,15 +4395,15 @@ fn airCall(self: *Self, inst: Air.Inst.Index, modifier: std.builtin.CallModifier
 
 fn airRet(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const operand = try self.resolveInst(un_op);
-    const ret_ty = self.fn_type.fnReturnType(mod);
+    const ret_ty = self.fn_type.fnReturnType(zcu);
 
     switch (self.ret_mcv) {
         .none => {},
         .immediate => {
-            assert(ret_ty.isError(mod));
+            assert(ret_ty.isError(zcu));
         },
         .register => |reg| {
             // Return result by value
@@ -4428,11 +4428,11 @@ fn airRet(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airRetLoad(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const ptr = try self.resolveInst(un_op);
     const ptr_ty = self.typeOf(un_op);
-    const ret_ty = self.fn_type.fnReturnType(mod);
+    const ret_ty = self.fn_type.fnReturnType(zcu);
 
     switch (self.ret_mcv) {
         .none => {},
@@ -4452,8 +4452,8 @@ fn airRetLoad(self: *Self, inst: Air.Inst.Index) !void {
             // location.
             const op_inst = un_op.toIndex().?;
             if (self.air.instructions.items(.tag)[@intFromEnum(op_inst)] != .ret_ptr) {
-                const abi_size: u32 = @intCast(ret_ty.abiSize(pt));
-                const abi_align = ret_ty.abiAlignment(pt);
+                const abi_size: u32 = @intCast(ret_ty.abiSize(zcu));
+                const abi_align = ret_ty.abiAlignment(zcu);
 
                 const offset = try self.allocMem(abi_size, abi_align, null);
 
@@ -4490,20 +4490,20 @@ fn cmp(
     op: math.CompareOperator,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const int_ty = switch (lhs_ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const int_ty = switch (lhs_ty.zigTypeTag(zcu)) {
         .Optional => blk: {
-            const payload_ty = lhs_ty.optionalChild(mod);
-            if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            const payload_ty = lhs_ty.optionalChild(zcu);
+            if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 break :blk Type.u1;
-            } else if (lhs_ty.isPtrLikeOptional(mod)) {
+            } else if (lhs_ty.isPtrLikeOptional(zcu)) {
                 break :blk Type.usize;
             } else {
                 return self.fail("TODO ARM cmp non-pointer optionals", .{});
             }
         },
         .Float => return self.fail("TODO ARM cmp floats", .{}),
-        .Enum => lhs_ty.intTagType(mod),
+        .Enum => lhs_ty.intTagType(zcu),
         .Int => lhs_ty,
         .Bool => Type.u1,
         .Pointer => Type.usize,
@@ -4511,7 +4511,7 @@ fn cmp(
         else => unreachable,
     };
 
-    const int_info = int_ty.intInfo(mod);
+    const int_info = int_ty.intInfo(zcu);
     if (int_info.bits <= 32) {
         try self.spillCompareFlagsIfOccupied();
 
@@ -4597,10 +4597,10 @@ fn airDbgStmt(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airDbgInlineBlock(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.DbgInlineBlock, ty_pl.payload);
-    const func = mod.funcInfo(extra.data.func);
+    const func = zcu.funcInfo(extra.data.func);
     // TODO emit debug info for function change
     _ = func;
     try self.lowerBlock(inst, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
@@ -4810,9 +4810,9 @@ fn isNull(
     operand_ty: Type,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    if (operand_ty.isPtrLikeOptional(mod)) {
-        assert(operand_ty.abiSize(pt) == 4);
+    const zcu = pt.zcu;
+    if (operand_ty.isPtrLikeOptional(zcu)) {
+        assert(operand_ty.abiSize(zcu) == 4);
 
         const imm_bind: ReadArg.Bind = .{ .mcv = .{ .immediate = 0 } };
         return self.cmp(operand_bind, imm_bind, Type.usize, .eq);
@@ -4845,12 +4845,12 @@ fn airIsNull(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIsNullPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const operand_ptr = try self.resolveInst(un_op);
         const ptr_ty = self.typeOf(un_op);
-        const elem_ty = ptr_ty.childType(mod);
+        const elem_ty = ptr_ty.childType(zcu);
 
         const operand = try self.allocRegOrMem(elem_ty, true, null);
         try self.load(operand, operand_ptr, ptr_ty);
@@ -4873,12 +4873,12 @@ fn airIsNonNull(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIsNonNullPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const operand_ptr = try self.resolveInst(un_op);
         const ptr_ty = self.typeOf(un_op);
-        const elem_ty = ptr_ty.childType(mod);
+        const elem_ty = ptr_ty.childType(zcu);
 
         const operand = try self.allocRegOrMem(elem_ty, true, null);
         try self.load(operand, operand_ptr, ptr_ty);
@@ -4894,10 +4894,10 @@ fn isErr(
     error_union_ty: Type,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const error_type = error_union_ty.errorUnionSet(mod);
+    const zcu = pt.zcu;
+    const error_type = error_union_ty.errorUnionSet(zcu);
 
-    if (error_type.errorSetIsEmpty(mod)) {
+    if (error_type.errorSetIsEmpty(zcu)) {
         return MCValue{ .immediate = 0 }; // always false
     }
 
@@ -4937,12 +4937,12 @@ fn airIsErr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIsErrPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const operand_ptr = try self.resolveInst(un_op);
         const ptr_ty = self.typeOf(un_op);
-        const elem_ty = ptr_ty.childType(mod);
+        const elem_ty = ptr_ty.childType(zcu);
 
         const operand = try self.allocRegOrMem(elem_ty, true, null);
         try self.load(operand, operand_ptr, ptr_ty);
@@ -4965,12 +4965,12 @@ fn airIsNonErr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIsNonErrPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const operand_ptr = try self.resolveInst(un_op);
         const ptr_ty = self.typeOf(un_op);
-        const elem_ty = ptr_ty.childType(mod);
+        const elem_ty = ptr_ty.childType(zcu);
 
         const operand = try self.allocRegOrMem(elem_ty, true, null);
         try self.load(operand, operand_ptr, ptr_ty);
@@ -5184,10 +5184,10 @@ fn airBr(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn br(self: *Self, block: Air.Inst.Index, operand: Air.Inst.Ref) !void {
-    const pt = self.pt;
+    const zcu = self.pt.zcu;
     const block_data = self.blocks.getPtr(block).?;
 
-    if (self.typeOf(operand).hasRuntimeBits(pt)) {
+    if (self.typeOf(operand).hasRuntimeBits(zcu)) {
         const operand_mcv = try self.resolveInst(operand);
         const block_mcv = block_data.mcv;
         if (block_mcv == .none) {
@@ -5356,8 +5356,8 @@ fn setRegOrMem(self: *Self, ty: Type, loc: MCValue, val: MCValue) !void {
 
 fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const zcu = pt.zcu;
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
     switch (mcv) {
         .dead => unreachable,
         .unreach, .none => return, // Nothing to do.
@@ -5434,11 +5434,11 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
             const reg_lock = self.register_manager.lockReg(reg);
             defer if (reg_lock) |locked_reg| self.register_manager.unlockReg(locked_reg);
 
-            const wrapped_ty = ty.structFieldType(0, mod);
+            const wrapped_ty = ty.structFieldType(0, zcu);
             try self.genSetStack(wrapped_ty, stack_offset, .{ .register = reg });
 
-            const overflow_bit_ty = ty.structFieldType(1, mod);
-            const overflow_bit_offset: u32 = @intCast(ty.structFieldOffset(1, pt));
+            const overflow_bit_ty = ty.structFieldType(1, zcu);
+            const overflow_bit_offset: u32 = @intCast(ty.structFieldOffset(1, zcu));
             const cond_reg = try self.register_manager.allocReg(null, gp);
 
             // C flag: movcs reg, #1
@@ -5519,7 +5519,7 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
 
 fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     switch (mcv) {
         .dead => unreachable,
         .unreach, .none => return, // Nothing to do.
@@ -5694,17 +5694,17 @@ fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void
         },
         .stack_offset => |off| {
             // TODO: maybe addressing from sp instead of fp
-            const abi_size: u32 = @intCast(ty.abiSize(pt));
+            const abi_size: u32 = @intCast(ty.abiSize(zcu));
 
             const tag: Mir.Inst.Tag = switch (abi_size) {
-                1 => if (ty.isSignedInt(mod)) Mir.Inst.Tag.ldrsb else .ldrb,
-                2 => if (ty.isSignedInt(mod)) Mir.Inst.Tag.ldrsh else .ldrh,
+                1 => if (ty.isSignedInt(zcu)) Mir.Inst.Tag.ldrsb else .ldrb,
+                2 => if (ty.isSignedInt(zcu)) Mir.Inst.Tag.ldrsh else .ldrh,
                 3, 4 => .ldr,
                 else => unreachable,
             };
 
             const extra_offset = switch (abi_size) {
-                1 => ty.isSignedInt(mod),
+                1 => ty.isSignedInt(zcu),
                 2 => true,
                 3, 4 => false,
                 else => unreachable,
@@ -5745,11 +5745,11 @@ fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void
             }
         },
         .stack_argument_offset => |off| {
-            const abi_size = ty.abiSize(pt);
+            const abi_size = ty.abiSize(zcu);
 
             const tag: Mir.Inst.Tag = switch (abi_size) {
-                1 => if (ty.isSignedInt(mod)) Mir.Inst.Tag.ldrsb_stack_argument else .ldrb_stack_argument,
-                2 => if (ty.isSignedInt(mod)) Mir.Inst.Tag.ldrsh_stack_argument else .ldrh_stack_argument,
+                1 => if (ty.isSignedInt(zcu)) Mir.Inst.Tag.ldrsb_stack_argument else .ldrb_stack_argument,
+                2 => if (ty.isSignedInt(zcu)) Mir.Inst.Tag.ldrsh_stack_argument else .ldrh_stack_argument,
                 3, 4 => .ldr_stack_argument,
                 else => unreachable,
             };
@@ -5767,7 +5767,7 @@ fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void
 
 fn genSetStackArgument(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const abi_size: u32 = @intCast(ty.abiSize(pt.zcu));
     switch (mcv) {
         .dead => unreachable,
         .none, .unreach => return,
@@ -5923,13 +5923,13 @@ fn airBitCast(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airArrayToSlice(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const ptr_ty = self.typeOf(ty_op.operand);
         const ptr = try self.resolveInst(ty_op.operand);
-        const array_ty = ptr_ty.childType(mod);
-        const array_len: u32 = @intCast(array_ty.arrayLen(mod));
+        const array_ty = ptr_ty.childType(zcu);
+        const array_len: u32 = @intCast(array_ty.arrayLen(zcu));
 
         const stack_offset = try self.allocMem(8, .@"8", inst);
         try self.genSetStack(ptr_ty, stack_offset, ptr);
@@ -6043,9 +6043,9 @@ fn airReduce(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const vector_ty = self.typeOfIndex(inst);
-    const len = vector_ty.vectorLen(mod);
+    const len = vector_ty.vectorLen(zcu);
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const elements: []const Air.Inst.Ref = @ptrCast(self.air.extra[ty_pl.payload..][0..len]);
     const result: MCValue = res: {
@@ -6095,8 +6095,8 @@ fn airTry(self: *Self, inst: Air.Inst.Index) !void {
     const result: MCValue = result: {
         const error_union_bind: ReadArg.Bind = .{ .inst = pl_op.operand };
         const error_union_ty = self.typeOf(pl_op.operand);
-        const error_union_size: u32 = @intCast(error_union_ty.abiSize(pt));
-        const error_union_align = error_union_ty.abiAlignment(pt);
+        const error_union_size: u32 = @intCast(error_union_ty.abiSize(pt.zcu));
+        const error_union_align = error_union_ty.abiAlignment(pt.zcu);
 
         // The error union will die in the body. However, we need the
         // error union after the body in order to extract the payload
@@ -6126,11 +6126,11 @@ fn airTryPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn resolveInst(self: *Self, inst: Air.Inst.Ref) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
     // If the type has no codegen bits, no need to store it.
     const inst_ty = self.typeOf(inst);
-    if (!inst_ty.hasRuntimeBitsIgnoreComptime(pt) and !inst_ty.isError(mod))
+    if (!inst_ty.hasRuntimeBitsIgnoreComptime(zcu) and !inst_ty.isError(zcu))
         return MCValue{ .none = {} };
 
     const inst_index = inst.toIndex() orelse return self.genTypedValue((try self.air.value(inst, pt)).?);
@@ -6189,9 +6189,9 @@ const CallMCValues = struct {
 /// Caller must call `CallMCValues.deinit`.
 fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const fn_info = mod.typeToFunc(fn_ty).?;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const fn_info = zcu.typeToFunc(fn_ty).?;
     const cc = fn_info.cc;
     var result: CallMCValues = .{
         .args = try self.gpa.alloc(MCValue, fn_info.param_types.len),
@@ -6202,7 +6202,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
     };
     errdefer self.gpa.free(result.args);
 
-    const ret_ty = fn_ty.fnReturnType(mod);
+    const ret_ty = fn_ty.fnReturnType(zcu);
 
     switch (cc) {
         .Naked => {
@@ -6217,12 +6217,12 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             var ncrn: usize = 0; // Next Core Register Number
             var nsaa: u32 = 0; // Next stacked argument address
 
-            if (ret_ty.zigTypeTag(mod) == .NoReturn) {
+            if (ret_ty.zigTypeTag(zcu) == .NoReturn) {
                 result.return_value = .{ .unreach = {} };
-            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 result.return_value = .{ .none = {} };
             } else {
-                const ret_ty_size: u32 = @intCast(ret_ty.abiSize(pt));
+                const ret_ty_size: u32 = @intCast(ret_ty.abiSize(zcu));
                 // TODO handle cases where multiple registers are used
                 if (ret_ty_size <= 4) {
                     result.return_value = .{ .register = c_abi_int_return_regs[0] };
@@ -6237,10 +6237,10 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             }
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                if (Type.fromInterned(ty).abiAlignment(pt) == .@"8")
+                if (Type.fromInterned(ty).abiAlignment(zcu) == .@"8")
                     ncrn = std.mem.alignForward(usize, ncrn, 2);
 
-                const param_size: u32 = @intCast(Type.fromInterned(ty).abiSize(pt));
+                const param_size: u32 = @intCast(Type.fromInterned(ty).abiSize(zcu));
                 if (std.math.divCeil(u32, param_size, 4) catch unreachable <= 4 - ncrn) {
                     if (param_size <= 4) {
                         result_arg.* = .{ .register = c_abi_int_param_regs[ncrn] };
@@ -6252,7 +6252,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
                     return self.fail("TODO MCValues split between registers and stack", .{});
                 } else {
                     ncrn = 4;
-                    if (Type.fromInterned(ty).abiAlignment(pt) == .@"8")
+                    if (Type.fromInterned(ty).abiAlignment(zcu) == .@"8")
                         nsaa = std.mem.alignForward(u32, nsaa, 8);
 
                     result_arg.* = .{ .stack_argument_offset = nsaa };
@@ -6264,14 +6264,14 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             result.stack_align = 8;
         },
         .Unspecified => {
-            if (ret_ty.zigTypeTag(mod) == .NoReturn) {
+            if (ret_ty.zigTypeTag(zcu) == .NoReturn) {
                 result.return_value = .{ .unreach = {} };
-            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt) and !ret_ty.isError(mod)) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu) and !ret_ty.isError(zcu)) {
                 result.return_value = .{ .none = {} };
             } else {
-                const ret_ty_size: u32 = @intCast(ret_ty.abiSize(pt));
+                const ret_ty_size: u32 = @intCast(ret_ty.abiSize(zcu));
                 if (ret_ty_size == 0) {
-                    assert(ret_ty.isError(mod));
+                    assert(ret_ty.isError(zcu));
                     result.return_value = .{ .immediate = 0 };
                 } else if (ret_ty_size <= 4) {
                     result.return_value = .{ .register = .r0 };
@@ -6287,9 +6287,9 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type) !CallMCValues {
             var stack_offset: u32 = 0;
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                if (Type.fromInterned(ty).abiSize(pt) > 0) {
-                    const param_size: u32 = @intCast(Type.fromInterned(ty).abiSize(pt));
-                    const param_alignment = Type.fromInterned(ty).abiAlignment(pt);
+                if (Type.fromInterned(ty).abiSize(zcu) > 0) {
+                    const param_size: u32 = @intCast(Type.fromInterned(ty).abiSize(zcu));
+                    const param_alignment = Type.fromInterned(ty).abiAlignment(zcu);
 
                     stack_offset = @intCast(param_alignment.forward(stack_offset));
                     result_arg.* = .{ .stack_argument_offset = stack_offset };

--- a/src/arch/arm/abi.zig
+++ b/src/arch/arm/abi.zig
@@ -24,29 +24,29 @@ pub const Class = union(enum) {
 
 pub const Context = enum { ret, arg };
 
-pub fn classifyType(ty: Type, pt: Zcu.PerThread, ctx: Context) Class {
-    assert(ty.hasRuntimeBitsIgnoreComptime(pt));
+pub fn classifyType(ty: Type, zcu: *Zcu, ctx: Context) Class {
+    assert(ty.hasRuntimeBitsIgnoreComptime(zcu));
 
     var maybe_float_bits: ?u16 = null;
     const max_byval_size = 512;
-    const ip = &pt.zcu.intern_pool;
-    switch (ty.zigTypeTag(pt.zcu)) {
+    const ip = &zcu.intern_pool;
+    switch (ty.zigTypeTag(zcu)) {
         .Struct => {
-            const bit_size = ty.bitSize(pt);
-            if (ty.containerLayout(pt.zcu) == .@"packed") {
+            const bit_size = ty.bitSize(zcu);
+            if (ty.containerLayout(zcu) == .@"packed") {
                 if (bit_size > 64) return .memory;
                 return .byval;
             }
             if (bit_size > max_byval_size) return .memory;
-            const float_count = countFloats(ty, pt.zcu, &maybe_float_bits);
+            const float_count = countFloats(ty, zcu, &maybe_float_bits);
             if (float_count <= byval_float_count) return .byval;
 
-            const fields = ty.structFieldCount(pt.zcu);
+            const fields = ty.structFieldCount(zcu);
             var i: u32 = 0;
             while (i < fields) : (i += 1) {
-                const field_ty = ty.structFieldType(i, pt.zcu);
-                const field_alignment = ty.structFieldAlign(i, pt);
-                const field_size = field_ty.bitSize(pt);
+                const field_ty = ty.structFieldType(i, zcu);
+                const field_alignment = ty.structFieldAlign(i, zcu);
+                const field_size = field_ty.bitSize(zcu);
                 if (field_size > 32 or field_alignment.compare(.gt, .@"32")) {
                     return Class.arrSize(bit_size, 64);
                 }
@@ -54,19 +54,19 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread, ctx: Context) Class {
             return Class.arrSize(bit_size, 32);
         },
         .Union => {
-            const bit_size = ty.bitSize(pt);
-            const union_obj = pt.zcu.typeToUnion(ty).?;
+            const bit_size = ty.bitSize(zcu);
+            const union_obj = zcu.typeToUnion(ty).?;
             if (union_obj.flagsUnordered(ip).layout == .@"packed") {
                 if (bit_size > 64) return .memory;
                 return .byval;
             }
             if (bit_size > max_byval_size) return .memory;
-            const float_count = countFloats(ty, pt.zcu, &maybe_float_bits);
+            const float_count = countFloats(ty, zcu, &maybe_float_bits);
             if (float_count <= byval_float_count) return .byval;
 
             for (union_obj.field_types.get(ip), 0..) |field_ty, field_index| {
-                if (Type.fromInterned(field_ty).bitSize(pt) > 32 or
-                    pt.unionFieldNormalAlignment(union_obj, @intCast(field_index)).compare(.gt, .@"32"))
+                if (Type.fromInterned(field_ty).bitSize(zcu) > 32 or
+                    Type.unionFieldNormalAlignment(union_obj, @intCast(field_index), zcu).compare(.gt, .@"32"))
                 {
                     return Class.arrSize(bit_size, 64);
                 }
@@ -77,28 +77,28 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread, ctx: Context) Class {
         .Int => {
             // TODO this is incorrect for _BitInt(128) but implementing
             // this correctly makes implementing compiler-rt impossible.
-            // const bit_size = ty.bitSize(pt);
+            // const bit_size = ty.bitSize(zcu);
             // if (bit_size > 64) return .memory;
             return .byval;
         },
         .Enum, .ErrorSet => {
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             if (bit_size > 64) return .memory;
             return .byval;
         },
         .Vector => {
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             // TODO is this controlled by a cpu feature?
             if (ctx == .ret and bit_size > 128) return .memory;
             if (bit_size > 512) return .memory;
             return .byval;
         },
         .Optional => {
-            assert(ty.isPtrLikeOptional(pt.zcu));
+            assert(ty.isPtrLikeOptional(zcu));
             return .byval;
         },
         .Pointer => {
-            assert(!ty.isSlice(pt.zcu));
+            assert(!ty.isSlice(zcu));
             return .byval;
         },
         .ErrorUnion,

--- a/src/arch/arm/abi.zig
+++ b/src/arch/arm/abi.zig
@@ -44,8 +44,8 @@ pub fn classifyType(ty: Type, zcu: *Zcu, ctx: Context) Class {
             const fields = ty.structFieldCount(zcu);
             var i: u32 = 0;
             while (i < fields) : (i += 1) {
-                const field_ty = ty.structFieldType(i, zcu);
-                const field_alignment = ty.structFieldAlign(i, zcu);
+                const field_ty = ty.fieldType(i, zcu);
+                const field_alignment = ty.fieldAlignment(i, zcu);
                 const field_size = field_ty.bitSize(zcu);
                 if (field_size > 32 or field_alignment.compare(.gt, .@"32")) {
                     return Class.arrSize(bit_size, 64);
@@ -66,7 +66,7 @@ pub fn classifyType(ty: Type, zcu: *Zcu, ctx: Context) Class {
 
             for (union_obj.field_types.get(ip), 0..) |field_ty, field_index| {
                 if (Type.fromInterned(field_ty).bitSize(zcu) > 32 or
-                    Type.unionFieldNormalAlignment(union_obj, @intCast(field_index), zcu).compare(.gt, .@"32"))
+                    ty.fieldAlignment(field_index, zcu).compare(.gt, .@"32"))
                 {
                     return Class.arrSize(bit_size, 64);
                 }
@@ -141,7 +141,7 @@ fn countFloats(ty: Type, zcu: *Zcu, maybe_float_bits: *?u16) u32 {
             var count: u32 = 0;
             var i: u32 = 0;
             while (i < fields_len) : (i += 1) {
-                const field_ty = ty.structFieldType(i, zcu);
+                const field_ty = ty.fieldType(i, zcu);
                 const field_count = countFloats(field_ty, zcu, maybe_float_bits);
                 if (field_count == invalid) return invalid;
                 count += field_count;

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -591,14 +591,14 @@ const FrameAlloc = struct {
             .ref_count = 0,
         };
     }
-    fn initType(ty: Type, pt: Zcu.PerThread) FrameAlloc {
+    fn initType(ty: Type, zcu: *Zcu) FrameAlloc {
         return init(.{
-            .size = ty.abiSize(pt),
-            .alignment = ty.abiAlignment(pt),
+            .size = ty.abiSize(zcu),
+            .alignment = ty.abiAlignment(zcu),
         });
     }
-    fn initSpill(ty: Type, pt: Zcu.PerThread) FrameAlloc {
-        const abi_size = ty.abiSize(pt);
+    fn initSpill(ty: Type, zcu: *Zcu) FrameAlloc {
+        const abi_size = ty.abiSize(zcu);
         const spill_size = if (abi_size < 8)
             math.ceilPowerOfTwoAssert(u64, abi_size)
         else
@@ -606,7 +606,7 @@ const FrameAlloc = struct {
         return init(.{
             .size = spill_size,
             .pad = @intCast(spill_size - abi_size),
-            .alignment = ty.abiAlignment(pt).maxStrict(
+            .alignment = ty.abiAlignment(zcu).maxStrict(
                 Alignment.fromNonzeroByteUnits(@min(spill_size, 8)),
             ),
         });
@@ -835,11 +835,11 @@ pub fn generate(
     function.args = call_info.args;
     function.ret_mcv = call_info.return_value;
     function.frame_allocs.set(@intFromEnum(FrameIndex.ret_addr), FrameAlloc.init(.{
-        .size = Type.u64.abiSize(pt),
-        .alignment = Type.u64.abiAlignment(pt).min(call_info.stack_align),
+        .size = Type.u64.abiSize(zcu),
+        .alignment = Type.u64.abiAlignment(zcu).min(call_info.stack_align),
     }));
     function.frame_allocs.set(@intFromEnum(FrameIndex.base_ptr), FrameAlloc.init(.{
-        .size = Type.u64.abiSize(pt),
+        .size = Type.u64.abiSize(zcu),
         .alignment = Alignment.min(
             call_info.stack_align,
             Alignment.fromNonzeroByteUnits(function.target.stackAlignment()),
@@ -851,7 +851,7 @@ pub fn generate(
     }));
     function.frame_allocs.set(@intFromEnum(FrameIndex.spill_frame), FrameAlloc.init(.{
         .size = 0,
-        .alignment = Type.u64.abiAlignment(pt),
+        .alignment = Type.u64.abiAlignment(zcu),
     }));
 
     function.gen() catch |err| switch (err) {
@@ -1245,7 +1245,7 @@ fn gen(func: *Func) !void {
                 // The address where to store the return value for the caller is in a
                 // register which the callee is free to clobber. Therefore, we purposely
                 // spill it to stack immediately.
-                const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(Type.u64, pt));
+                const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(Type.u64, zcu));
                 try func.genSetMem(
                     .{ .frame = frame_index },
                     0,
@@ -1379,9 +1379,9 @@ fn gen(func: *Func) !void {
 
 fn genLazy(func: *Func, lazy_sym: link.File.LazySymbol) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    switch (Type.fromInterned(lazy_sym.ty).zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    switch (Type.fromInterned(lazy_sym.ty).zigTypeTag(zcu)) {
         .Enum => {
             const enum_ty = Type.fromInterned(lazy_sym.ty);
             wip_mir_log.debug("{}.@tagName:", .{enum_ty.fmt(pt)});
@@ -1390,7 +1390,7 @@ fn genLazy(func: *Func, lazy_sym: link.File.LazySymbol) InnerError!void {
             const ret_reg = param_regs[0];
             const enum_mcv: MCValue = .{ .register = param_regs[1] };
 
-            const exitlude_jump_relocs = try func.gpa.alloc(Mir.Inst.Index, enum_ty.enumFieldCount(mod));
+            const exitlude_jump_relocs = try func.gpa.alloc(Mir.Inst.Index, enum_ty.enumFieldCount(zcu));
             defer func.gpa.free(exitlude_jump_relocs);
 
             const data_reg, const data_lock = try func.allocReg(.int);
@@ -1410,7 +1410,7 @@ fn genLazy(func: *Func, lazy_sym: link.File.LazySymbol) InnerError!void {
             defer func.register_manager.unlockReg(cmp_lock);
 
             var data_off: i32 = 0;
-            const tag_names = enum_ty.enumFields(mod);
+            const tag_names = enum_ty.enumFields(zcu);
             for (exitlude_jump_relocs, 0..) |*exitlude_jump_reloc, tag_index| {
                 const tag_name_len = tag_names.get(ip)[tag_index].length(ip);
                 const tag_val = try pt.enumValueFieldIndex(enum_ty, @intCast(tag_index));
@@ -1944,32 +1944,32 @@ fn memSize(func: *Func, ty: Type) Memory.Size {
     const zcu = pt.zcu;
     return switch (ty.zigTypeTag(zcu)) {
         .Float => Memory.Size.fromBitSize(ty.floatBits(func.target.*)),
-        else => Memory.Size.fromByteSize(ty.abiSize(pt)),
+        else => Memory.Size.fromByteSize(ty.abiSize(zcu)),
     };
 }
 
 fn splitType(func: *Func, ty: Type) ![2]Type {
-    const pt = func.pt;
-    const classes = mem.sliceTo(&abi.classifySystem(ty, pt), .none);
+    const zcu = func.pt.zcu;
+    const classes = mem.sliceTo(&abi.classifySystem(ty, zcu), .none);
     var parts: [2]Type = undefined;
     if (classes.len == 2) for (&parts, classes, 0..) |*part, class, part_i| {
         part.* = switch (class) {
             .integer => switch (part_i) {
                 0 => Type.u64,
                 1 => part: {
-                    const elem_size = ty.abiAlignment(pt).minStrict(.@"8").toByteUnits().?;
-                    const elem_ty = try pt.intType(.unsigned, @intCast(elem_size * 8));
-                    break :part switch (@divExact(ty.abiSize(pt) - 8, elem_size)) {
+                    const elem_size = ty.abiAlignment(zcu).minStrict(.@"8").toByteUnits().?;
+                    const elem_ty = try func.pt.intType(.unsigned, @intCast(elem_size * 8));
+                    break :part switch (@divExact(ty.abiSize(zcu) - 8, elem_size)) {
                         1 => elem_ty,
-                        else => |len| try pt.arrayType(.{ .len = len, .child = elem_ty.toIntern() }),
+                        else => |len| try func.pt.arrayType(.{ .len = len, .child = elem_ty.toIntern() }),
                     };
                 },
                 else => unreachable,
             },
             else => return func.fail("TODO: splitType class {}", .{class}),
         };
-    } else if (parts[0].abiSize(pt) + parts[1].abiSize(pt) == ty.abiSize(pt)) return parts;
-    return func.fail("TODO implement splitType for {}", .{ty.fmt(pt)});
+    } else if (parts[0].abiSize(zcu) + parts[1].abiSize(zcu) == ty.abiSize(zcu)) return parts;
+    return func.fail("TODO implement splitType for {}", .{ty.fmt(func.pt)});
 }
 
 /// Truncates the value in the register in place.
@@ -1979,7 +1979,7 @@ fn truncateRegister(func: *Func, ty: Type, reg: Register) !void {
     const zcu = pt.zcu;
     const int_info = if (ty.isAbiInt(zcu)) ty.intInfo(zcu) else std.builtin.Type.Int{
         .signedness = .unsigned,
-        .bits = @intCast(ty.bitSize(pt)),
+        .bits = @intCast(ty.bitSize(zcu)),
     };
     assert(reg.class() == .int);
 
@@ -2081,10 +2081,10 @@ fn allocMemPtr(func: *Func, inst: Air.Inst.Index) !FrameIndex {
     const ptr_ty = func.typeOfIndex(inst);
     const val_ty = ptr_ty.childType(zcu);
     return func.allocFrameIndex(FrameAlloc.init(.{
-        .size = math.cast(u32, val_ty.abiSize(pt)) orelse {
+        .size = math.cast(u32, val_ty.abiSize(zcu)) orelse {
             return func.fail("type '{}' too big to fit into stack frame", .{val_ty.fmt(pt)});
         },
-        .alignment = ptr_ty.ptrAlignment(pt).max(.@"1"),
+        .alignment = ptr_ty.ptrAlignment(zcu).max(.@"1"),
     }));
 }
 
@@ -2118,7 +2118,7 @@ fn allocRegOrMem(func: *Func, elem_ty: Type, inst: ?Air.Inst.Index, reg_ok: bool
     const pt = func.pt;
     const zcu = pt.zcu;
 
-    const bit_size = elem_ty.bitSize(pt);
+    const bit_size = elem_ty.bitSize(zcu);
     const min_size: u64 = switch (elem_ty.zigTypeTag(zcu)) {
         .Float => if (func.hasFeature(.d)) 64 else 32,
         .Vector => 256, // TODO: calculate it from avl * vsew
@@ -2133,7 +2133,7 @@ fn allocRegOrMem(func: *Func, elem_ty: Type, inst: ?Air.Inst.Index, reg_ok: bool
         return func.fail("did you forget to extend vector registers before allocating", .{});
     }
 
-    const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(elem_ty, pt));
+    const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(elem_ty, zcu));
     return .{ .load_frame = .{ .index = frame_index } };
 }
 
@@ -2368,7 +2368,7 @@ fn airNot(func: *Func, inst: Air.Inst.Index) !void {
                 });
             },
             .Int => {
-                const size = ty.bitSize(pt);
+                const size = ty.bitSize(zcu);
                 if (!math.isPowerOfTwo(size))
                     return func.fail("TODO: airNot non-pow 2 int size", .{});
 
@@ -2399,11 +2399,12 @@ fn airNot(func: *Func, inst: Air.Inst.Index) !void {
 
 fn airSlice(func: *Func, inst: Air.Inst.Index) !void {
     const pt = func.pt;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = func.air.extraData(Air.Bin, ty_pl.payload).data;
 
     const slice_ty = func.typeOfIndex(inst);
-    const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(slice_ty, pt));
+    const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(slice_ty, zcu));
 
     const ptr_ty = func.typeOf(bin_op.lhs);
     try func.genSetMem(.{ .frame = frame_index }, 0, ptr_ty, .{ .air_ref = bin_op.lhs });
@@ -2411,7 +2412,7 @@ fn airSlice(func: *Func, inst: Air.Inst.Index) !void {
     const len_ty = func.typeOf(bin_op.rhs);
     try func.genSetMem(
         .{ .frame = frame_index },
-        @intCast(ptr_ty.abiSize(pt)),
+        @intCast(ptr_ty.abiSize(zcu)),
         len_ty,
         .{ .air_ref = bin_op.rhs },
     );
@@ -2428,8 +2429,8 @@ fn airBinOp(func: *Func, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
 
     const dst_ty = func.typeOfIndex(inst);
     if (dst_ty.isAbiInt(zcu)) {
-        const abi_size: u32 = @intCast(dst_ty.abiSize(pt));
-        const bit_size: u32 = @intCast(dst_ty.bitSize(pt));
+        const abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
+        const bit_size: u32 = @intCast(dst_ty.bitSize(zcu));
         if (abi_size * 8 > bit_size) {
             const dst_lock = switch (dst_mcv) {
                 .register => |dst_reg| func.register_manager.lockRegAssumeUnused(dst_reg),
@@ -2443,7 +2444,7 @@ fn airBinOp(func: *Func, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
                 const tmp_reg, const tmp_lock = try func.allocReg(.int);
                 defer func.register_manager.unlockReg(tmp_lock);
 
-                const hi_ty = try pt.intType(.unsigned, @intCast((dst_ty.bitSize(pt) - 1) % 64 + 1));
+                const hi_ty = try pt.intType(.unsigned, @intCast((dst_ty.bitSize(zcu) - 1) % 64 + 1));
                 const hi_mcv = dst_mcv.address().offset(@intCast(bit_size / 64 * 8)).deref();
                 try func.genSetReg(hi_ty, tmp_reg, hi_mcv);
                 try func.truncateRegister(dst_ty, tmp_reg);
@@ -2464,6 +2465,7 @@ fn binOp(
 ) !MCValue {
     _ = maybe_inst;
     const pt = func.pt;
+    const zcu = pt.zcu;
     const lhs_ty = func.typeOf(lhs_air);
     const rhs_ty = func.typeOf(rhs_air);
 
@@ -2480,9 +2482,9 @@ fn binOp(
     }
 
     // don't have support for certain sizes of addition
-    switch (lhs_ty.zigTypeTag(pt.zcu)) {
+    switch (lhs_ty.zigTypeTag(zcu)) {
         .Vector => {}, // works differently and fails in a different place
-        else => if (lhs_ty.bitSize(pt) > 64) return func.fail("TODO: binOp >= 64 bits", .{}),
+        else => if (lhs_ty.bitSize(zcu) > 64) return func.fail("TODO: binOp >= 64 bits", .{}),
     }
 
     const lhs_mcv = try func.resolveInst(lhs_air);
@@ -2533,7 +2535,7 @@ fn genBinOp(
 ) !void {
     const pt = func.pt;
     const zcu = pt.zcu;
-    const bit_size = lhs_ty.bitSize(pt);
+    const bit_size = lhs_ty.bitSize(zcu);
 
     const is_unsigned = lhs_ty.isUnsignedInt(zcu);
 
@@ -2646,7 +2648,7 @@ fn genBinOp(
                 },
                 .Vector => {
                     const num_elem = lhs_ty.vectorLen(zcu);
-                    const elem_size = lhs_ty.childType(zcu).bitSize(pt);
+                    const elem_size = lhs_ty.childType(zcu).bitSize(zcu);
 
                     const child_ty = lhs_ty.childType(zcu);
 
@@ -2753,7 +2755,7 @@ fn genBinOp(
             defer func.register_manager.unlockReg(tmp_lock);
 
             // RISC-V has no immediate mul, so we copy the size to a temporary register
-            const elem_size = lhs_ty.elemType2(zcu).abiSize(pt);
+            const elem_size = lhs_ty.elemType2(zcu).abiSize(zcu);
             const elem_size_reg = try func.copyToTmpRegister(Type.u64, .{ .immediate = elem_size });
 
             try func.genBinOp(
@@ -2990,7 +2992,7 @@ fn airAddWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
                     try func.genSetMem(
                         .{ .frame = offset.index },
-                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(0, pt))),
+                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(0, zcu))),
                         lhs_ty,
                         add_result,
                     );
@@ -3016,7 +3018,7 @@ fn airAddWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
                     try func.genSetMem(
                         .{ .frame = offset.index },
-                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, pt))),
+                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, zcu))),
                         Type.u1,
                         .{ .register = overflow_reg },
                     );
@@ -3053,7 +3055,7 @@ fn airAddWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
                     try func.genSetMem(
                         .{ .frame = offset.index },
-                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(0, pt))),
+                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(0, zcu))),
                         lhs_ty,
                         add_result,
                     );
@@ -3079,7 +3081,7 @@ fn airAddWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
                     try func.genSetMem(
                         .{ .frame = offset.index },
-                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, pt))),
+                        offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, zcu))),
                         Type.u1,
                         .{ .register = overflow_reg },
                     );
@@ -3126,7 +3128,7 @@ fn airSubWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
         try func.genSetMem(
             .{ .frame = offset.index },
-            offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(0, pt))),
+            offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(0, zcu))),
             lhs_ty,
             .{ .register = dest_reg },
         );
@@ -3155,7 +3157,7 @@ fn airSubWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
                 try func.genSetMem(
                     .{ .frame = offset.index },
-                    offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, pt))),
+                    offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, zcu))),
                     Type.u1,
                     .{ .register = overflow_reg },
                 );
@@ -3203,7 +3205,7 @@ fn airSubWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
 
                         try func.genSetMem(
                             .{ .frame = offset.index },
-                            offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, pt))),
+                            offset.off + @as(i32, @intCast(tuple_ty.structFieldOffset(1, zcu))),
                             Type.u1,
                             .{ .register = overflow_reg },
                         );
@@ -3236,8 +3238,8 @@ fn airMulWithOverflow(func: *Func, inst: Air.Inst.Index) !void {
         // genSetReg needs to support register_offset src_mcv for this to be true.
         const result_mcv = try func.allocRegOrMem(tuple_ty, inst, false);
 
-        const result_off: i32 = @intCast(tuple_ty.structFieldOffset(0, pt));
-        const overflow_off: i32 = @intCast(tuple_ty.structFieldOffset(1, pt));
+        const result_off: i32 = @intCast(tuple_ty.structFieldOffset(0, zcu));
+        const overflow_off: i32 = @intCast(tuple_ty.structFieldOffset(1, zcu));
 
         const dest_reg, const dest_lock = try func.allocReg(.int);
         defer func.register_manager.unlockReg(dest_lock);
@@ -3320,11 +3322,11 @@ fn airShlSat(func: *Func, inst: Air.Inst.Index) !void {
 }
 
 fn airOptionalPayload(func: *Func, inst: Air.Inst.Index) !void {
-    const pt = func.pt;
+    const zcu = func.pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = result: {
         const pl_ty = func.typeOfIndex(inst);
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const opt_mcv = try func.resolveInst(ty_op.operand);
         if (func.reuseOperand(inst, ty_op.operand, 0, opt_mcv)) {
@@ -3368,11 +3370,11 @@ fn airUnwrapErrErr(func: *Func, inst: Air.Inst.Index) !void {
             break :result .{ .immediate = 0 };
         }
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             break :result operand;
         }
 
-        const err_off: u32 = @intCast(errUnionErrorOffset(payload_ty, pt));
+        const err_off: u32 = @intCast(errUnionErrorOffset(payload_ty, zcu));
 
         switch (operand) {
             .register => |reg| {
@@ -3421,9 +3423,9 @@ fn genUnwrapErrUnionPayloadMir(
     const payload_ty = err_union_ty.errorUnionPayload(zcu);
 
     const result: MCValue = result: {
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
-        const payload_off: u31 = @intCast(errUnionPayloadOffset(payload_ty, pt));
+        const payload_off: u31 = @intCast(errUnionPayloadOffset(payload_ty, zcu));
         switch (err_union) {
             .load_frame => |frame_addr| break :result .{ .load_frame = .{
                 .index = frame_addr.index,
@@ -3497,7 +3499,7 @@ fn airWrapOptional(func: *Func, inst: Air.Inst.Index) !void {
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = result: {
         const pl_ty = func.typeOf(ty_op.operand);
-        if (!pl_ty.hasRuntimeBits(pt)) break :result .{ .immediate = 1 };
+        if (!pl_ty.hasRuntimeBits(zcu)) break :result .{ .immediate = 1 };
 
         const opt_ty = func.typeOfIndex(inst);
         const pl_mcv = try func.resolveInst(ty_op.operand);
@@ -3514,7 +3516,7 @@ fn airWrapOptional(func: *Func, inst: Air.Inst.Index) !void {
         try func.genCopy(pl_ty, opt_mcv, pl_mcv);
 
         if (!same_repr) {
-            const pl_abi_size: i32 = @intCast(pl_ty.abiSize(pt));
+            const pl_abi_size: i32 = @intCast(pl_ty.abiSize(zcu));
             switch (opt_mcv) {
                 .load_frame => |frame_addr| {
                     try func.genCopy(pl_ty, opt_mcv, pl_mcv);
@@ -3545,11 +3547,11 @@ fn airWrapErrUnionPayload(func: *Func, inst: Air.Inst.Index) !void {
     const operand = try func.resolveInst(ty_op.operand);
 
     const result: MCValue = result: {
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .{ .immediate = 0 };
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .{ .immediate = 0 };
 
-        const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(eu_ty, pt));
-        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, pt));
-        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, pt));
+        const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(eu_ty, zcu));
+        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, zcu));
+        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
         try func.genSetMem(.{ .frame = frame_index }, pl_off, pl_ty, operand);
         try func.genSetMem(.{ .frame = frame_index }, err_off, err_ty, .{ .immediate = 0 });
         break :result .{ .load_frame = .{ .index = frame_index } };
@@ -3569,11 +3571,11 @@ fn airWrapErrUnionErr(func: *Func, inst: Air.Inst.Index) !void {
     const err_ty = eu_ty.errorUnionSet(zcu);
 
     const result: MCValue = result: {
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result try func.resolveInst(ty_op.operand);
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result try func.resolveInst(ty_op.operand);
 
-        const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(eu_ty, pt));
-        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, pt));
-        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, pt));
+        const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(eu_ty, zcu));
+        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, zcu));
+        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
         try func.genSetMem(.{ .frame = frame_index }, pl_off, pl_ty, .{ .undef = null });
         const operand = try func.resolveInst(ty_op.operand);
         try func.genSetMem(.{ .frame = frame_index }, err_off, err_ty, operand);
@@ -3717,7 +3719,7 @@ fn airSliceElemVal(func: *Func, inst: Air.Inst.Index) !void {
 
     const result: MCValue = result: {
         const elem_ty = func.typeOfIndex(inst);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const slice_ty = func.typeOf(bin_op.lhs);
         const slice_ptr_field_type = slice_ty.slicePtrFieldType(zcu);
@@ -3748,7 +3750,7 @@ fn genSliceElemPtr(func: *Func, lhs: Air.Inst.Ref, rhs: Air.Inst.Ref) !MCValue {
     defer if (slice_mcv_lock) |lock| func.register_manager.unlockReg(lock);
 
     const elem_ty = slice_ty.childType(zcu);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_size = elem_ty.abiSize(zcu);
 
     const index_ty = func.typeOf(rhs);
     const index_mcv = try func.resolveInst(rhs);
@@ -3792,14 +3794,14 @@ fn airArrayElemVal(func: *Func, inst: Air.Inst.Index) !void {
         const index_ty = func.typeOf(bin_op.rhs);
 
         const elem_ty = array_ty.childType(zcu);
-        const elem_abi_size = elem_ty.abiSize(pt);
+        const elem_abi_size = elem_ty.abiSize(zcu);
 
         const addr_reg, const addr_reg_lock = try func.allocReg(.int);
         defer func.register_manager.unlockReg(addr_reg_lock);
 
         switch (array_mcv) {
             .register => {
-                const frame_index = try func.allocFrameIndex(FrameAlloc.initType(array_ty, pt));
+                const frame_index = try func.allocFrameIndex(FrameAlloc.initType(array_ty, zcu));
                 try func.genSetMem(.{ .frame = frame_index }, 0, array_ty, array_mcv);
                 try func.genSetReg(Type.u64, addr_reg, .{ .lea_frame = .{ .index = frame_index } });
             },
@@ -3870,7 +3872,7 @@ fn airPtrElemVal(func: *Func, inst: Air.Inst.Index) !void {
 
     const result: MCValue = if (!is_volatile and func.liveness.isUnused(inst)) .unreach else result: {
         const elem_ty = base_ptr_ty.elemType2(zcu);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const base_ptr_mcv = try func.resolveInst(bin_op.lhs);
         const base_ptr_lock: ?RegisterLock = switch (base_ptr_mcv) {
@@ -3970,11 +3972,12 @@ fn airSetUnionTag(func: *Func, inst: Air.Inst.Index) !void {
 
 fn airGetUnionTag(func: *Func, inst: Air.Inst.Index) !void {
     const pt = func.pt;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const tag_ty = func.typeOfIndex(inst);
     const union_ty = func.typeOf(ty_op.operand);
-    const layout = union_ty.unionGetLayout(pt);
+    const layout = union_ty.unionGetLayout(zcu);
 
     if (layout.tag_size == 0) {
         return func.finishAir(inst, .none, .{ ty_op.operand, .none, .none });
@@ -3985,7 +3988,7 @@ fn airGetUnionTag(func: *Func, inst: Air.Inst.Index) !void {
     const frame_mcv = try func.allocRegOrMem(union_ty, null, false);
     try func.genCopy(union_ty, frame_mcv, operand);
 
-    const tag_abi_size = tag_ty.abiSize(pt);
+    const tag_abi_size = tag_ty.abiSize(zcu);
     const result_reg, const result_lock = try func.allocReg(.int);
     defer func.register_manager.unlockReg(result_lock);
 
@@ -4034,7 +4037,7 @@ fn airClz(func: *Func, inst: Air.Inst.Index) !void {
         else
             (try func.allocRegOrMem(func.typeOfIndex(inst), inst, true)).register;
 
-        const bit_size = ty.bitSize(func.pt);
+        const bit_size = ty.bitSize(func.pt.zcu);
         if (!math.isPowerOfTwo(bit_size)) try func.truncateRegister(ty, src_reg);
 
         if (bit_size > 64) {
@@ -4081,6 +4084,7 @@ fn airPopcount(func: *Func, inst: Air.Inst.Index) !void {
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (func.liveness.isUnused(inst)) .unreach else result: {
         const pt = func.pt;
+        const zcu = pt.zcu;
 
         const operand = try func.resolveInst(ty_op.operand);
         const src_ty = func.typeOf(ty_op.operand);
@@ -4090,7 +4094,7 @@ fn airPopcount(func: *Func, inst: Air.Inst.Index) !void {
         const dst_reg, const dst_lock = try func.allocReg(.int);
         defer func.register_manager.unlockReg(dst_lock);
 
-        const bit_size = src_ty.bitSize(pt);
+        const bit_size = src_ty.bitSize(zcu);
         switch (bit_size) {
             32, 64 => {},
             1...31, 33...63 => try func.truncateRegister(src_ty, operand_reg),
@@ -4283,12 +4287,13 @@ fn airBitReverse(func: *Func, inst: Air.Inst.Index) !void {
 
 fn airUnaryMath(func: *Func, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
     const pt = func.pt;
+    const zcu = pt.zcu;
     const un_op = func.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const result: MCValue = if (func.liveness.isUnused(inst)) .unreach else result: {
         const ty = func.typeOf(un_op);
 
         const operand = try func.resolveInst(un_op);
-        const operand_bit_size = ty.bitSize(pt);
+        const operand_bit_size = ty.bitSize(zcu);
 
         if (!math.isPowerOfTwo(operand_bit_size))
             return func.fail("TODO: airUnaryMath non-pow 2", .{});
@@ -4300,7 +4305,7 @@ fn airUnaryMath(func: *Func, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
         const dst_reg, const dst_lock = try func.allocReg(dst_class);
         defer func.register_manager.unlockReg(dst_lock);
 
-        switch (ty.zigTypeTag(pt.zcu)) {
+        switch (ty.zigTypeTag(zcu)) {
             .Float => {
                 assert(dst_class == .float);
 
@@ -4397,7 +4402,7 @@ fn airLoad(func: *Func, inst: Air.Inst.Index) !void {
     const elem_ty = func.typeOfIndex(inst);
 
     const result: MCValue = result: {
-        if (!elem_ty.hasRuntimeBits(pt))
+        if (!elem_ty.hasRuntimeBits(zcu))
             break :result .none;
 
         const ptr = try func.resolveInst(ty_op.operand);
@@ -4405,7 +4410,7 @@ fn airLoad(func: *Func, inst: Air.Inst.Index) !void {
         if (func.liveness.isUnused(inst) and !is_volatile)
             break :result .unreach;
 
-        const elem_size = elem_ty.abiSize(pt);
+        const elem_size = elem_ty.abiSize(zcu);
 
         const dst_mcv: MCValue = blk: {
             // The MCValue that holds the pointer can be re-used as the value.
@@ -4544,7 +4549,7 @@ fn structFieldPtr(func: *Func, inst: Air.Inst.Index, operand: Air.Inst.Ref, inde
     const container_ty = ptr_container_ty.childType(zcu);
 
     const field_offset: i32 = switch (container_ty.containerLayout(zcu)) {
-        .auto, .@"extern" => @intCast(container_ty.structFieldOffset(index, pt)),
+        .auto, .@"extern" => @intCast(container_ty.structFieldOffset(index, zcu)),
         .@"packed" => @divExact(@as(i32, ptr_container_ty.ptrInfo(zcu).packed_offset.bit_offset) +
             (if (zcu.typeToStruct(container_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, index) else 0) -
             ptr_field_ty.ptrInfo(zcu).packed_offset.bit_offset, 8),
@@ -4572,10 +4577,10 @@ fn airStructFieldVal(func: *Func, inst: Air.Inst.Index) !void {
         const src_mcv = try func.resolveInst(operand);
         const struct_ty = func.typeOf(operand);
         const field_ty = struct_ty.structFieldType(index, zcu);
-        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const field_off: u32 = switch (struct_ty.containerLayout(zcu)) {
-            .auto, .@"extern" => @intCast(struct_ty.structFieldOffset(index, pt) * 8),
+            .auto, .@"extern" => @intCast(struct_ty.structFieldOffset(index, zcu) * 8),
             .@"packed" => if (zcu.typeToStruct(struct_ty)) |struct_type|
                 pt.structPackedFieldBitOffset(struct_type, index)
             else
@@ -4615,11 +4620,11 @@ fn airStructFieldVal(func: *Func, inst: Air.Inst.Index) !void {
                 break :result if (field_off == 0) dst_mcv else try func.copyToNewRegister(inst, dst_mcv);
             },
             .load_frame => {
-                const field_abi_size: u32 = @intCast(field_ty.abiSize(pt));
+                const field_abi_size: u32 = @intCast(field_ty.abiSize(zcu));
                 if (field_off % 8 == 0) {
                     const field_byte_off = @divExact(field_off, 8);
                     const off_mcv = src_mcv.address().offset(@intCast(field_byte_off)).deref();
-                    const field_bit_size = field_ty.bitSize(pt);
+                    const field_bit_size = field_ty.bitSize(zcu);
 
                     if (field_abi_size <= 8) {
                         const int_ty = try pt.intType(
@@ -4635,7 +4640,7 @@ fn airStructFieldVal(func: *Func, inst: Air.Inst.Index) !void {
                         break :result try func.copyToNewRegister(inst, dst_mcv);
                     }
 
-                    const container_abi_size: u32 = @intCast(struct_ty.abiSize(pt));
+                    const container_abi_size: u32 = @intCast(struct_ty.abiSize(zcu));
                     const dst_mcv = if (field_byte_off + field_abi_size <= container_abi_size and
                         func.reuseOperand(inst, operand, 0, src_mcv))
                         off_mcv
@@ -4880,7 +4885,7 @@ fn genCall(
                 try reg_locks.appendSlice(&func.register_manager.lockRegs(2, regs));
             },
             .indirect => |reg_off| {
-                frame_index.* = try func.allocFrameIndex(FrameAlloc.initType(arg_ty, pt));
+                frame_index.* = try func.allocFrameIndex(FrameAlloc.initType(arg_ty, zcu));
                 try func.genSetMem(.{ .frame = frame_index.* }, 0, arg_ty, src_arg);
                 try func.register_manager.getReg(reg_off.reg, null);
                 try reg_locks.append(func.register_manager.lockReg(reg_off.reg));
@@ -4893,7 +4898,7 @@ fn genCall(
         .none, .unreach => {},
         .indirect => |reg_off| {
             const ret_ty = Type.fromInterned(fn_info.return_type);
-            const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(ret_ty, pt));
+            const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(ret_ty, zcu));
             try func.genSetReg(Type.u64, reg_off.reg, .{
                 .lea_frame = .{ .index = frame_index, .off = -reg_off.off },
             });
@@ -5013,7 +5018,7 @@ fn airRet(func: *Func, inst: Air.Inst.Index, safety: bool) !void {
         .register_pair,
         => {
             if (ret_ty.isVector(zcu)) {
-                const bit_size = ret_ty.totalVectorBits(pt);
+                const bit_size = ret_ty.totalVectorBits(zcu);
 
                 // set the vtype to hold the entire vector's contents in a single element
                 try func.setVl(.zero, 0, .{
@@ -5113,7 +5118,7 @@ fn airCmp(func: *Func, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
                     .ErrorSet => Type.anyerror,
                     .Optional => blk: {
                         const payload_ty = lhs_ty.optionalChild(zcu);
-                        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                             break :blk Type.u1;
                         } else if (lhs_ty.isPtrLikeOptional(zcu)) {
                             break :blk Type.u64;
@@ -5289,7 +5294,7 @@ fn isNull(func: *Func, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MC
     const some_info: struct { off: i32, ty: Type } = if (opt_ty.optionalReprIsPayload(zcu))
         .{ .off = 0, .ty = if (pl_ty.isSlice(zcu)) pl_ty.slicePtrFieldType(zcu) else pl_ty }
     else
-        .{ .off = @intCast(pl_ty.abiSize(pt)), .ty = Type.bool };
+        .{ .off = @intCast(pl_ty.abiSize(zcu)), .ty = Type.bool };
 
     const return_mcv = try func.allocRegOrMem(func.typeOfIndex(inst), inst, true);
     assert(return_mcv == .register); // should not be larger 8 bytes
@@ -5472,11 +5477,10 @@ fn airIsErrPtr(func: *Func, inst: Air.Inst.Index) !void {
 /// Result is in the return register.
 fn isErr(func: *Func, maybe_inst: ?Air.Inst.Index, eu_ty: Type, eu_mcv: MCValue) !MCValue {
     _ = maybe_inst;
-    const pt = func.pt;
-    const zcu = pt.zcu;
+    const zcu = func.pt.zcu;
     const err_ty = eu_ty.errorUnionSet(zcu);
     if (err_ty.errorSetIsEmpty(zcu)) return MCValue{ .immediate = 0 }; // always false
-    const err_off: u31 = @intCast(errUnionErrorOffset(eu_ty.errorUnionPayload(zcu), pt));
+    const err_off: u31 = @intCast(errUnionErrorOffset(eu_ty.errorUnionPayload(zcu), zcu));
 
     const return_reg, const return_lock = try func.allocReg(.int);
     defer func.register_manager.unlockReg(return_lock);
@@ -5769,12 +5773,12 @@ fn performReloc(func: *Func, inst: Mir.Inst.Index) void {
 }
 
 fn airBr(func: *Func, inst: Air.Inst.Index) !void {
-    const pt = func.pt;
+    const zcu = func.pt.zcu;
     const br = func.air.instructions.items(.data)[@intFromEnum(inst)].br;
 
     const block_ty = func.typeOfIndex(br.block_inst);
     const block_unused =
-        !block_ty.hasRuntimeBitsIgnoreComptime(pt) or func.liveness.isUnused(br.block_inst);
+        !block_ty.hasRuntimeBitsIgnoreComptime(zcu) or func.liveness.isUnused(br.block_inst);
     const block_tracking = func.inst_tracking.getPtr(br.block_inst).?;
     const block_data = func.blocks.getPtr(br.block_inst).?;
     const first_br = block_data.relocs.items.len == 0;
@@ -6354,6 +6358,8 @@ fn genCopy(func: *Func, ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !void {
         return std.debug.panic("tried to genCopy immutable: {s}", .{@tagName(dst_mcv)});
     }
 
+    const zcu = func.pt.zcu;
+
     switch (dst_mcv) {
         .register => |reg| return func.genSetReg(ty, reg, src_mcv),
         .register_offset => |dst_reg_off| try func.genSetReg(ty, dst_reg_off.reg, switch (src_mcv) {
@@ -6425,7 +6431,7 @@ fn genCopy(func: *Func, ty: Type, dst_mcv: MCValue, src_mcv: MCValue) !void {
                     } },
                     else => unreachable,
                 });
-                part_disp += @intCast(dst_ty.abiSize(func.pt));
+                part_disp += @intCast(dst_ty.abiSize(zcu));
             }
         },
         else => return std.debug.panic("TODO: genCopy to {s} from {s}", .{ @tagName(dst_mcv), @tagName(src_mcv) }),
@@ -6622,7 +6628,7 @@ fn genInlineMemset(
 fn genSetReg(func: *Func, ty: Type, reg: Register, src_mcv: MCValue) InnerError!void {
     const pt = func.pt;
     const zcu = pt.zcu;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
 
     const max_size: u32 = switch (reg.class()) {
         .int => 64,
@@ -6729,7 +6735,7 @@ fn genSetReg(func: *Func, ty: Type, reg: Register, src_mcv: MCValue) InnerError!
             // size to the total size of the vector, and vmv.x.s will work then
             if (src_reg.class() == .vector) {
                 try func.setVl(.zero, 0, .{
-                    .vsew = switch (ty.totalVectorBits(pt)) {
+                    .vsew = switch (ty.totalVectorBits(zcu)) {
                         8 => .@"8",
                         16 => .@"16",
                         32 => .@"32",
@@ -6848,7 +6854,7 @@ fn genSetReg(func: *Func, ty: Type, reg: Register, src_mcv: MCValue) InnerError!
                     // and load from it.
                     const len = ty.vectorLen(zcu);
                     const elem_ty = ty.childType(zcu);
-                    const elem_size = elem_ty.abiSize(pt);
+                    const elem_size = elem_ty.abiSize(zcu);
 
                     try func.setVl(.zero, len, .{
                         .vsew = switch (elem_size) {
@@ -6945,7 +6951,7 @@ fn genSetMem(
     const pt = func.pt;
     const zcu = pt.zcu;
 
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
     const dst_ptr_mcv: MCValue = switch (base) {
         .reg => |base_reg| .{ .register_offset = .{ .reg = base_reg, .off = disp } },
         .frame => |base_frame_index| .{ .lea_frame = .{ .index = base_frame_index, .off = disp } },
@@ -6995,7 +7001,7 @@ fn genSetMem(
                 const addr_reg = try func.copyToTmpRegister(Type.u64, dst_ptr_mcv);
 
                 const num_elem = ty.vectorLen(zcu);
-                const elem_size = ty.childType(zcu).bitSize(pt);
+                const elem_size = ty.childType(zcu).bitSize(zcu);
 
                 try func.setVl(.zero, num_elem, .{
                     .vsew = switch (elem_size) {
@@ -7083,7 +7089,7 @@ fn genSetMem(
             var part_disp: i32 = disp;
             for (try func.splitType(ty), src_regs) |src_ty, src_reg| {
                 try func.genSetMem(base, part_disp, src_ty, .{ .register = src_reg });
-                part_disp += @intCast(src_ty.abiSize(pt));
+                part_disp += @intCast(src_ty.abiSize(zcu));
             }
         },
         .immediate => {
@@ -7128,10 +7134,10 @@ fn airBitCast(func: *Func, inst: Air.Inst.Index) !void {
         const src_lock = if (src_mcv.getReg()) |reg| func.register_manager.lockReg(reg) else null;
         defer if (src_lock) |lock| func.register_manager.unlockReg(lock);
 
-        const dst_mcv = if (dst_ty.abiSize(pt) <= src_ty.abiSize(pt) and src_mcv != .register_pair and
+        const dst_mcv = if (dst_ty.abiSize(zcu) <= src_ty.abiSize(zcu) and src_mcv != .register_pair and
             func.reuseOperand(inst, ty_op.operand, 0, src_mcv)) src_mcv else dst: {
             const dst_mcv = try func.allocRegOrMem(dst_ty, inst, true);
-            try func.genCopy(switch (math.order(dst_ty.abiSize(pt), src_ty.abiSize(pt))) {
+            try func.genCopy(switch (math.order(dst_ty.abiSize(zcu), src_ty.abiSize(zcu))) {
                 .lt => dst_ty,
                 .eq => if (!dst_mcv.isMemory() or src_mcv.isMemory()) dst_ty else src_ty,
                 .gt => src_ty,
@@ -7142,8 +7148,8 @@ fn airBitCast(func: *Func, inst: Air.Inst.Index) !void {
         if (dst_ty.isAbiInt(zcu) and src_ty.isAbiInt(zcu) and
             dst_ty.intInfo(zcu).signedness == src_ty.intInfo(zcu).signedness) break :result dst_mcv;
 
-        const abi_size = dst_ty.abiSize(pt);
-        const bit_size = dst_ty.bitSize(pt);
+        const abi_size = dst_ty.abiSize(zcu);
+        const bit_size = dst_ty.bitSize(zcu);
         if (abi_size * 8 <= bit_size) break :result dst_mcv;
 
         return func.fail("TODO: airBitCast {} to {}", .{ src_ty.fmt(pt), dst_ty.fmt(pt) });
@@ -7162,11 +7168,11 @@ fn airArrayToSlice(func: *Func, inst: Air.Inst.Index) !void {
     const array_ty = ptr_ty.childType(zcu);
     const array_len = array_ty.arrayLen(zcu);
 
-    const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(slice_ty, pt));
+    const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(slice_ty, zcu));
     try func.genSetMem(.{ .frame = frame_index }, 0, ptr_ty, ptr);
     try func.genSetMem(
         .{ .frame = frame_index },
-        @intCast(ptr_ty.abiSize(pt)),
+        @intCast(ptr_ty.abiSize(zcu)),
         Type.u64,
         .{ .immediate = array_len },
     );
@@ -7190,21 +7196,21 @@ fn airFloatFromInt(func: *Func, inst: Air.Inst.Index) !void {
         defer if (src_lock) |lock| func.register_manager.unlockReg(lock);
 
         const is_unsigned = dst_ty.isUnsignedInt(zcu);
-        const src_bits = src_ty.bitSize(pt);
-        const dst_bits = dst_ty.bitSize(pt);
+        const src_bits = src_ty.bitSize(zcu);
+        const dst_bits = dst_ty.bitSize(zcu);
 
         switch (src_bits) {
             32, 64 => {},
             else => try func.truncateRegister(src_ty, src_reg),
         }
 
-        const int_mod: Mir.FcvtOp = switch (src_bits) {
+        const int_zcu: Mir.FcvtOp = switch (src_bits) {
             8, 16, 32 => if (is_unsigned) .wu else .w,
             64 => if (is_unsigned) .lu else .l,
             else => return func.fail("TODO: airFloatFromInt src size: {d}", .{src_bits}),
         };
 
-        const float_mod: enum { s, d } = switch (dst_bits) {
+        const float_zcu: enum { s, d } = switch (dst_bits) {
             32 => .s,
             64 => .d,
             else => return func.fail("TODO: airFloatFromInt dst size {d}", .{dst_bits}),
@@ -7214,14 +7220,14 @@ fn airFloatFromInt(func: *Func, inst: Air.Inst.Index) !void {
         defer func.register_manager.unlockReg(dst_lock);
 
         _ = try func.addInst(.{
-            .tag = switch (float_mod) {
-                .s => switch (int_mod) {
+            .tag = switch (float_zcu) {
+                .s => switch (int_zcu) {
                     .l => .fcvtsl,
                     .lu => .fcvtslu,
                     .w => .fcvtsw,
                     .wu => .fcvtswu,
                 },
-                .d => switch (int_mod) {
+                .d => switch (int_zcu) {
                     .l => .fcvtdl,
                     .lu => .fcvtdlu,
                     .w => .fcvtdw,
@@ -7250,16 +7256,16 @@ fn airIntFromFloat(func: *Func, inst: Air.Inst.Index) !void {
         const dst_ty = ty_op.ty.toType();
 
         const is_unsigned = dst_ty.isUnsignedInt(zcu);
-        const src_bits = src_ty.bitSize(pt);
-        const dst_bits = dst_ty.bitSize(pt);
+        const src_bits = src_ty.bitSize(zcu);
+        const dst_bits = dst_ty.bitSize(zcu);
 
-        const float_mod: enum { s, d } = switch (src_bits) {
+        const float_zcu: enum { s, d } = switch (src_bits) {
             32 => .s,
             64 => .d,
             else => return func.fail("TODO: airIntFromFloat src size {d}", .{src_bits}),
         };
 
-        const int_mod: Mir.FcvtOp = switch (dst_bits) {
+        const int_zcu: Mir.FcvtOp = switch (dst_bits) {
             32 => if (is_unsigned) .wu else .w,
             8, 16, 64 => if (is_unsigned) .lu else .l,
             else => return func.fail("TODO: airIntFromFloat dst size: {d}", .{dst_bits}),
@@ -7272,14 +7278,14 @@ fn airIntFromFloat(func: *Func, inst: Air.Inst.Index) !void {
         defer func.register_manager.unlockReg(dst_lock);
 
         _ = try func.addInst(.{
-            .tag = switch (float_mod) {
-                .s => switch (int_mod) {
+            .tag = switch (float_zcu) {
+                .s => switch (int_zcu) {
                     .l => .fcvtls,
                     .lu => .fcvtlus,
                     .w => .fcvtws,
                     .wu => .fcvtwus,
                 },
-                .d => switch (int_mod) {
+                .d => switch (int_zcu) {
                     .l => .fcvtld,
                     .lu => .fcvtlud,
                     .w => .fcvtwd,
@@ -7301,12 +7307,13 @@ fn airCmpxchg(func: *Func, inst: Air.Inst.Index, strength: enum { weak, strong }
     _ = strength; // TODO: do something with this
 
     const pt = func.pt;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.Cmpxchg, ty_pl.payload).data;
 
     const ptr_ty = func.typeOf(extra.ptr);
     const val_ty = func.typeOf(extra.expected_value);
-    const val_abi_size: u32 = @intCast(val_ty.abiSize(pt));
+    const val_abi_size: u32 = @intCast(val_ty.abiSize(pt.zcu));
 
     switch (val_abi_size) {
         1, 2, 4, 8 => {},
@@ -7364,7 +7371,7 @@ fn airCmpxchg(func: *Func, inst: Air.Inst.Index, strength: enum { weak, strong }
     defer func.register_manager.unlockReg(fallthrough_lock);
 
     const jump_back = try func.addInst(.{
-        .tag = if (val_ty.bitSize(pt) <= 32) .lrw else .lrd,
+        .tag = if (val_ty.bitSize(zcu) <= 32) .lrw else .lrd,
         .data = .{ .amo = .{
             .aq = lr_order.aq,
             .rl = lr_order.rl,
@@ -7385,7 +7392,7 @@ fn airCmpxchg(func: *Func, inst: Air.Inst.Index, strength: enum { weak, strong }
     });
 
     _ = try func.addInst(.{
-        .tag = if (val_ty.bitSize(pt) <= 32) .scw else .scd,
+        .tag = if (val_ty.bitSize(zcu) <= 32) .scw else .scd,
         .data = .{ .amo = .{
             .aq = sc_order.aq,
             .rl = sc_order.rl,
@@ -7449,7 +7456,7 @@ fn airAtomicRmw(func: *Func, inst: Air.Inst.Index) !void {
         const ptr_mcv = try func.resolveInst(pl_op.operand);
 
         const val_ty = func.typeOf(extra.operand);
-        const val_size = val_ty.abiSize(pt);
+        const val_size = val_ty.abiSize(zcu);
         const val_mcv = try func.resolveInst(extra.operand);
 
         if (!math.isPowerOfTwo(val_size))
@@ -7488,7 +7495,7 @@ fn airAtomicRmw(func: *Func, inst: Air.Inst.Index) !void {
 
         switch (method) {
             .amo => {
-                const is_d = val_ty.abiSize(pt) == 8;
+                const is_d = val_ty.abiSize(zcu) == 8;
                 const is_un = val_ty.isUnsignedInt(zcu);
 
                 const mnem: Mnemonic = switch (op) {
@@ -7587,7 +7594,7 @@ fn airAtomicLoad(func: *Func, inst: Air.Inst.Index) !void {
     const elem_ty = ptr_ty.childType(zcu);
     const ptr_mcv = try func.resolveInst(atomic_load.ptr);
 
-    const bit_size = elem_ty.bitSize(pt);
+    const bit_size = elem_ty.bitSize(zcu);
     if (bit_size > 64) return func.fail("TODO: airAtomicStore > 64 bits", .{});
 
     const result_mcv = try func.allocRegOrMem(elem_ty, inst, true);
@@ -7634,7 +7641,7 @@ fn airAtomicStore(func: *Func, inst: Air.Inst.Index, order: std.builtin.AtomicOr
     const val_ty = func.typeOf(bin_op.rhs);
     const val_mcv = try func.resolveInst(bin_op.rhs);
 
-    const bit_size = val_ty.bitSize(func.pt);
+    const bit_size = val_ty.bitSize(func.pt.zcu);
     if (bit_size > 64) return func.fail("TODO: airAtomicStore > 64 bits", .{});
 
     switch (order) {
@@ -7679,7 +7686,7 @@ fn airMemset(func: *Func, inst: Air.Inst.Index, safety: bool) !void {
         };
         defer if (src_val_lock) |lock| func.register_manager.unlockReg(lock);
 
-        const elem_abi_size: u31 = @intCast(elem_ty.abiSize(pt));
+        const elem_abi_size: u31 = @intCast(elem_ty.abiSize(zcu));
 
         if (elem_abi_size == 1) {
             const ptr: MCValue = switch (dst_ptr_ty.ptrSize(zcu)) {
@@ -7751,7 +7758,7 @@ fn airMemcpy(func: *Func, inst: Air.Inst.Index) !void {
             const len_reg, const len_lock = try func.allocReg(.int);
             defer func.register_manager.unlockReg(len_lock);
 
-            const elem_size = dst_ty.childType(zcu).abiSize(pt);
+            const elem_size = dst_ty.childType(zcu).abiSize(zcu);
             try func.genBinOp(
                 .mul,
                 .{ .immediate = elem_size },
@@ -7764,7 +7771,7 @@ fn airMemcpy(func: *Func, inst: Air.Inst.Index) !void {
         },
         .One => len: {
             const array_ty = dst_ty.childType(zcu);
-            break :len .{ .immediate = array_ty.arrayLen(zcu) * array_ty.childType(zcu).abiSize(pt) };
+            break :len .{ .immediate = array_ty.arrayLen(zcu) * array_ty.childType(zcu).abiSize(zcu) };
         },
         else => |size| return func.fail("TODO: airMemcpy size {s}", .{@tagName(size)}),
     };
@@ -7862,13 +7869,13 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
     const result: MCValue = result: {
         switch (result_ty.zigTypeTag(zcu)) {
             .Struct => {
-                const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(result_ty, pt));
+                const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(result_ty, zcu));
                 if (result_ty.containerLayout(zcu) == .@"packed") {
                     const struct_obj = zcu.typeToStruct(result_ty).?;
                     try func.genInlineMemset(
                         .{ .lea_frame = .{ .index = frame_index } },
                         .{ .immediate = 0 },
-                        .{ .immediate = result_ty.abiSize(pt) },
+                        .{ .immediate = result_ty.abiSize(zcu) },
                     );
 
                     for (elements, 0..) |elem, elem_i_usize| {
@@ -7876,7 +7883,7 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
                         if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
                         const elem_ty = result_ty.structFieldType(elem_i, zcu);
-                        const elem_bit_size: u32 = @intCast(elem_ty.bitSize(pt));
+                        const elem_bit_size: u32 = @intCast(elem_ty.bitSize(zcu));
                         if (elem_bit_size > 64) {
                             return func.fail(
                                 "TODO airAggregateInit implement packed structs with large fields",
@@ -7884,7 +7891,7 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
                             );
                         }
 
-                        const elem_abi_size: u32 = @intCast(elem_ty.abiSize(pt));
+                        const elem_abi_size: u32 = @intCast(elem_ty.abiSize(zcu));
                         const elem_abi_bits = elem_abi_size * 8;
                         const elem_off = pt.structPackedFieldBitOffset(struct_obj, elem_i);
                         const elem_byte_off: i32 = @intCast(elem_off / elem_abi_bits * elem_abi_size);
@@ -7910,7 +7917,7 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
                     if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
                     const elem_ty = result_ty.structFieldType(elem_i, zcu);
-                    const elem_off: i32 = @intCast(result_ty.structFieldOffset(elem_i, pt));
+                    const elem_off: i32 = @intCast(result_ty.structFieldOffset(elem_i, zcu));
                     const elem_mcv = try func.resolveInst(elem);
                     try func.genSetMem(.{ .frame = frame_index }, elem_off, elem_ty, elem_mcv);
                 }
@@ -7918,8 +7925,8 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
             },
             .Array => {
                 const elem_ty = result_ty.childType(zcu);
-                const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(result_ty, pt));
-                const elem_size: u32 = @intCast(elem_ty.abiSize(pt));
+                const frame_index = try func.allocFrameIndex(FrameAlloc.initSpill(result_ty, zcu));
+                const elem_size: u32 = @intCast(elem_ty.abiSize(zcu));
 
                 for (elements, 0..) |elem, elem_i| {
                     const elem_mcv = try func.resolveInst(elem);
@@ -7979,10 +7986,11 @@ fn airMulAdd(func: *Func, inst: Air.Inst.Index) !void {
 
 fn resolveInst(func: *Func, ref: Air.Inst.Ref) InnerError!MCValue {
     const pt = func.pt;
+    const zcu = pt.zcu;
 
     // If the type has no codegen bits, no need to store it.
     const inst_ty = func.typeOf(ref);
-    if (!inst_ty.hasRuntimeBits(pt))
+    if (!inst_ty.hasRuntimeBits(zcu))
         return .none;
 
     const mcv = if (ref.toIndex()) |inst| mcv: {
@@ -8100,14 +8108,14 @@ fn resolveCallingConventionValues(
             // Return values
             if (ret_ty.zigTypeTag(zcu) == .NoReturn) {
                 result.return_value = InstTracking.init(.unreach);
-            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 result.return_value = InstTracking.init(.none);
             } else {
                 var ret_tracking: [2]InstTracking = undefined;
                 var ret_tracking_i: usize = 0;
                 var ret_float_reg_i: usize = 0;
 
-                const classes = mem.sliceTo(&abi.classifySystem(ret_ty, pt), .none);
+                const classes = mem.sliceTo(&abi.classifySystem(ret_ty, zcu), .none);
 
                 for (classes) |class| switch (class) {
                     .integer => {
@@ -8151,7 +8159,7 @@ fn resolveCallingConventionValues(
             var param_float_reg_i: usize = 0;
 
             for (param_types, result.args) |ty, *arg| {
-                if (!ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     assert(cc == .Unspecified);
                     arg.* = .none;
                     continue;
@@ -8160,7 +8168,7 @@ fn resolveCallingConventionValues(
                 var arg_mcv: [2]MCValue = undefined;
                 var arg_mcv_i: usize = 0;
 
-                const classes = mem.sliceTo(&abi.classifySystem(ty, pt), .none);
+                const classes = mem.sliceTo(&abi.classifySystem(ty, zcu), .none);
 
                 for (classes) |class| switch (class) {
                     .integer => {
@@ -8244,8 +8252,7 @@ fn typeOf(func: *Func, inst: Air.Inst.Ref) Type {
 }
 
 fn typeOfIndex(func: *Func, inst: Air.Inst.Index) Type {
-    const pt = func.pt;
-    const zcu = pt.zcu;
+    const zcu = func.pt.zcu;
     return func.air.typeOfIndex(inst, &zcu.intern_pool);
 }
 
@@ -8253,23 +8260,23 @@ fn hasFeature(func: *Func, feature: Target.riscv.Feature) bool {
     return Target.riscv.featureSetHas(func.target.cpu.features, feature);
 }
 
-pub fn errUnionPayloadOffset(payload_ty: Type, pt: Zcu.PerThread) u64 {
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) return 0;
-    const payload_align = payload_ty.abiAlignment(pt);
-    const error_align = Type.anyerror.abiAlignment(pt);
-    if (payload_align.compare(.gte, error_align) or !payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+pub fn errUnionPayloadOffset(payload_ty: Type, zcu: *Zcu) u64 {
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) return 0;
+    const payload_align = payload_ty.abiAlignment(zcu);
+    const error_align = Type.anyerror.abiAlignment(zcu);
+    if (payload_align.compare(.gte, error_align) or !payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return 0;
     } else {
-        return payload_align.forward(Type.anyerror.abiSize(pt));
+        return payload_align.forward(Type.anyerror.abiSize(zcu));
     }
 }
 
-pub fn errUnionErrorOffset(payload_ty: Type, pt: Zcu.PerThread) u64 {
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) return 0;
-    const payload_align = payload_ty.abiAlignment(pt);
-    const error_align = Type.anyerror.abiAlignment(pt);
-    if (payload_align.compare(.gte, error_align) and payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-        return error_align.forward(payload_ty.abiSize(pt));
+pub fn errUnionErrorOffset(payload_ty: Type, zcu: *Zcu) u64 {
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) return 0;
+    const payload_align = payload_ty.abiAlignment(zcu);
+    const error_align = Type.anyerror.abiAlignment(zcu);
+    if (payload_align.compare(.gte, error_align) and payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+        return error_align.forward(payload_ty.abiSize(zcu));
     } else {
         return 0;
     }

--- a/src/arch/riscv64/CodeGen.zig
+++ b/src/arch/riscv64/CodeGen.zig
@@ -4576,7 +4576,7 @@ fn airStructFieldVal(func: *Func, inst: Air.Inst.Index) !void {
     const result: MCValue = if (func.liveness.isUnused(inst)) .unreach else result: {
         const src_mcv = try func.resolveInst(operand);
         const struct_ty = func.typeOf(operand);
-        const field_ty = struct_ty.structFieldType(index, zcu);
+        const field_ty = struct_ty.fieldType(index, zcu);
         if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const field_off: u32 = switch (struct_ty.containerLayout(zcu)) {
@@ -7882,7 +7882,7 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
                         const elem_i: u32 = @intCast(elem_i_usize);
                         if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
-                        const elem_ty = result_ty.structFieldType(elem_i, zcu);
+                        const elem_ty = result_ty.fieldType(elem_i, zcu);
                         const elem_bit_size: u32 = @intCast(elem_ty.bitSize(zcu));
                         if (elem_bit_size > 64) {
                             return func.fail(
@@ -7916,7 +7916,7 @@ fn airAggregateInit(func: *Func, inst: Air.Inst.Index) !void {
                 } else for (elements, 0..) |elem, elem_i| {
                     if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
-                    const elem_ty = result_ty.structFieldType(elem_i, zcu);
+                    const elem_ty = result_ty.fieldType(elem_i, zcu);
                     const elem_off: i32 = @intCast(result_ty.structFieldOffset(elem_i, zcu));
                     const elem_mcv = try func.resolveInst(elem);
                     try func.genSetMem(.{ .frame = frame_index }, elem_off, elem_ty, elem_mcv);

--- a/src/arch/riscv64/Lower.zig
+++ b/src/arch/riscv64/Lower.zig
@@ -49,6 +49,7 @@ pub fn lowerMir(lower: *Lower, index: Mir.Inst.Index, options: struct {
     relocs: []const Reloc,
 } {
     const pt = lower.pt;
+    const zcu = pt.zcu;
 
     lower.result_insts = undefined;
     lower.result_relocs = undefined;
@@ -308,11 +309,11 @@ pub fn lowerMir(lower: *Lower, index: Mir.Inst.Index, options: struct {
 
             const class = rs1.class();
             const ty = compare.ty;
-            const size = std.math.ceilPowerOfTwo(u64, ty.bitSize(pt)) catch {
-                return lower.fail("pseudo_compare size {}", .{ty.bitSize(pt)});
+            const size = std.math.ceilPowerOfTwo(u64, ty.bitSize(zcu)) catch {
+                return lower.fail("pseudo_compare size {}", .{ty.bitSize(zcu)});
             };
 
-            const is_unsigned = ty.isUnsignedInt(pt.zcu);
+            const is_unsigned = ty.isUnsignedInt(zcu);
             const less_than: Mnemonic = if (is_unsigned) .sltu else .slt;
 
             switch (class) {

--- a/src/arch/riscv64/abi.zig
+++ b/src/arch/riscv64/abi.zig
@@ -9,15 +9,15 @@ const assert = std.debug.assert;
 
 pub const Class = enum { memory, byval, integer, double_integer, fields };
 
-pub fn classifyType(ty: Type, pt: Zcu.PerThread) Class {
-    const target = pt.zcu.getTarget();
-    std.debug.assert(ty.hasRuntimeBitsIgnoreComptime(pt));
+pub fn classifyType(ty: Type, zcu: *Zcu) Class {
+    const target = zcu.getTarget();
+    std.debug.assert(ty.hasRuntimeBitsIgnoreComptime(zcu));
 
     const max_byval_size = target.ptrBitWidth() * 2;
-    switch (ty.zigTypeTag(pt.zcu)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Struct => {
-            const bit_size = ty.bitSize(pt);
-            if (ty.containerLayout(pt.zcu) == .@"packed") {
+            const bit_size = ty.bitSize(zcu);
+            if (ty.containerLayout(zcu) == .@"packed") {
                 if (bit_size > max_byval_size) return .memory;
                 return .byval;
             }
@@ -25,12 +25,12 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread) Class {
             if (std.Target.riscv.featureSetHas(target.cpu.features, .d)) fields: {
                 var any_fp = false;
                 var field_count: usize = 0;
-                for (0..ty.structFieldCount(pt.zcu)) |field_index| {
-                    const field_ty = ty.structFieldType(field_index, pt.zcu);
-                    if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                for (0..ty.structFieldCount(zcu)) |field_index| {
+                    const field_ty = ty.structFieldType(field_index, zcu);
+                    if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
                     if (field_ty.isRuntimeFloat())
                         any_fp = true
-                    else if (!field_ty.isAbiInt(pt.zcu))
+                    else if (!field_ty.isAbiInt(zcu))
                         break :fields;
                     field_count += 1;
                     if (field_count > 2) break :fields;
@@ -45,8 +45,8 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread) Class {
             return .integer;
         },
         .Union => {
-            const bit_size = ty.bitSize(pt);
-            if (ty.containerLayout(pt.zcu) == .@"packed") {
+            const bit_size = ty.bitSize(zcu);
+            if (ty.containerLayout(zcu) == .@"packed") {
                 if (bit_size > max_byval_size) return .memory;
                 return .byval;
             }
@@ -58,21 +58,21 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread) Class {
         .Bool => return .integer,
         .Float => return .byval,
         .Int, .Enum, .ErrorSet => {
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             if (bit_size > max_byval_size) return .memory;
             return .byval;
         },
         .Vector => {
-            const bit_size = ty.bitSize(pt);
+            const bit_size = ty.bitSize(zcu);
             if (bit_size > max_byval_size) return .memory;
             return .integer;
         },
         .Optional => {
-            std.debug.assert(ty.isPtrLikeOptional(pt.zcu));
+            std.debug.assert(ty.isPtrLikeOptional(zcu));
             return .byval;
         },
         .Pointer => {
-            std.debug.assert(!ty.isSlice(pt.zcu));
+            std.debug.assert(!ty.isSlice(zcu));
             return .byval;
         },
         .ErrorUnion,
@@ -97,19 +97,18 @@ pub const SystemClass = enum { integer, float, memory, none };
 
 /// There are a maximum of 8 possible return slots. Returned values are in
 /// the beginning of the array; unused slots are filled with .none.
-pub fn classifySystem(ty: Type, pt: Zcu.PerThread) [8]SystemClass {
-    const zcu = pt.zcu;
+pub fn classifySystem(ty: Type, zcu: *Zcu) [8]SystemClass {
     var result = [1]SystemClass{.none} ** 8;
     const memory_class = [_]SystemClass{
         .memory, .none, .none, .none,
         .none,   .none, .none, .none,
     };
-    switch (ty.zigTypeTag(pt.zcu)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Bool, .Void, .NoReturn => {
             result[0] = .integer;
             return result;
         },
-        .Pointer => switch (ty.ptrSize(pt.zcu)) {
+        .Pointer => switch (ty.ptrSize(zcu)) {
             .Slice => {
                 result[0] = .integer;
                 result[1] = .integer;
@@ -121,14 +120,14 @@ pub fn classifySystem(ty: Type, pt: Zcu.PerThread) [8]SystemClass {
             },
         },
         .Optional => {
-            if (ty.isPtrLikeOptional(pt.zcu)) {
+            if (ty.isPtrLikeOptional(zcu)) {
                 result[0] = .integer;
                 return result;
             }
             return memory_class;
         },
         .Int, .Enum, .ErrorSet => {
-            const int_bits = ty.intInfo(pt.zcu).bits;
+            const int_bits = ty.intInfo(zcu).bits;
             if (int_bits <= 64) {
                 result[0] = .integer;
                 return result;
@@ -153,8 +152,8 @@ pub fn classifySystem(ty: Type, pt: Zcu.PerThread) [8]SystemClass {
             unreachable; // support split float args
         },
         .ErrorUnion => {
-            const payload_ty = ty.errorUnionPayload(pt.zcu);
-            const payload_bits = payload_ty.bitSize(pt);
+            const payload_ty = ty.errorUnionPayload(zcu);
+            const payload_bits = payload_ty.bitSize(zcu);
 
             // the error union itself
             result[0] = .integer;
@@ -165,8 +164,8 @@ pub fn classifySystem(ty: Type, pt: Zcu.PerThread) [8]SystemClass {
             return memory_class;
         },
         .Struct, .Union => {
-            const layout = ty.containerLayout(pt.zcu);
-            const ty_size = ty.abiSize(pt);
+            const layout = ty.containerLayout(zcu);
+            const ty_size = ty.abiSize(zcu);
 
             if (layout == .@"packed") {
                 assert(ty_size <= 16);
@@ -178,7 +177,7 @@ pub fn classifySystem(ty: Type, pt: Zcu.PerThread) [8]SystemClass {
             return memory_class;
         },
         .Array => {
-            const ty_size = ty.abiSize(pt);
+            const ty_size = ty.abiSize(zcu);
             if (ty_size <= 8) {
                 result[0] = .integer;
                 return result;
@@ -192,7 +191,7 @@ pub fn classifySystem(ty: Type, pt: Zcu.PerThread) [8]SystemClass {
         },
         .Vector => {
             // we pass vectors through integer registers if they are small enough to fit.
-            const vec_bits = ty.totalVectorBits(pt);
+            const vec_bits = ty.totalVectorBits(zcu);
             if (vec_bits <= 64) {
                 result[0] = .integer;
                 return result;

--- a/src/arch/riscv64/abi.zig
+++ b/src/arch/riscv64/abi.zig
@@ -26,7 +26,7 @@ pub fn classifyType(ty: Type, zcu: *Zcu) Class {
                 var any_fp = false;
                 var field_count: usize = 0;
                 for (0..ty.structFieldCount(zcu)) |field_index| {
-                    const field_ty = ty.structFieldType(field_index, zcu);
+                    const field_ty = ty.fieldType(field_index, zcu);
                     if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
                     if (field_ty.isRuntimeFloat())
                         any_fp = true

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -3980,10 +3980,10 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
             const reg_lock = self.register_manager.lockReg(rwo.reg);
             defer if (reg_lock) |locked_reg| self.register_manager.unlockReg(locked_reg);
 
-            const wrapped_ty = ty.structFieldType(0, zcu);
+            const wrapped_ty = ty.fieldType(0, zcu);
             try self.genSetStack(wrapped_ty, stack_offset, .{ .register = rwo.reg });
 
-            const overflow_bit_ty = ty.structFieldType(1, zcu);
+            const overflow_bit_ty = ty.fieldType(1, zcu);
             const overflow_bit_offset = @as(u32, @intCast(ty.structFieldOffset(1, zcu)));
             const cond_reg = try self.register_manager.allocReg(null, gp);
 

--- a/src/arch/sparc64/CodeGen.zig
+++ b/src/arch/sparc64/CodeGen.zig
@@ -1012,6 +1012,7 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airArg(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
+    const zcu = pt.zcu;
     const arg_index = self.arg_index;
     self.arg_index += 1;
 
@@ -1021,7 +1022,7 @@ fn airArg(self: *Self, inst: Air.Inst.Index) !void {
     const mcv = blk: {
         switch (arg) {
             .stack_offset => |off| {
-                const abi_size = math.cast(u32, ty.abiSize(pt)) orelse {
+                const abi_size = math.cast(u32, ty.abiSize(zcu)) orelse {
                     return self.fail("type '{}' too big to fit into stack frame", .{ty.fmt(pt)});
                 };
                 const offset = off + abi_size;
@@ -1211,7 +1212,7 @@ fn airBreakpoint(self: *Self) !void {
 
 fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     // We have hardware byteswapper in SPARCv9, don't let mainstream compilers mislead you.
@@ -1227,14 +1228,14 @@ fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        switch (operand_ty.zigTypeTag(mod)) {
+        switch (operand_ty.zigTypeTag(zcu)) {
             .Vector => return self.fail("TODO byteswap for vectors", .{}),
             .Int => {
-                const int_info = operand_ty.intInfo(mod);
+                const int_info = operand_ty.intInfo(zcu);
                 if (int_info.bits == 8) break :result operand;
 
                 const abi_size = int_info.bits >> 3;
-                const abi_align = operand_ty.abiAlignment(pt);
+                const abi_align = operand_ty.abiAlignment(zcu);
                 const opposite_endian_asi = switch (self.target.cpu.arch.endian()) {
                     Endian.big => ASI.asi_primary_little,
                     Endian.little => ASI.asi_primary,
@@ -1409,24 +1410,24 @@ fn airClz(self: *Self, inst: Air.Inst.Index) !void {
 fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const lhs_ty = self.typeOf(bin_op.lhs);
 
-        const int_ty = switch (lhs_ty.zigTypeTag(mod)) {
+        const int_ty = switch (lhs_ty.zigTypeTag(zcu)) {
             .Vector => unreachable, // Handled by cmp_vector.
-            .Enum => lhs_ty.intTagType(mod),
+            .Enum => lhs_ty.intTagType(zcu),
             .Int => lhs_ty,
             .Bool => Type.u1,
             .Pointer => Type.usize,
             .ErrorSet => Type.u16,
             .Optional => blk: {
-                const payload_ty = lhs_ty.optionalChild(mod);
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                const payload_ty = lhs_ty.optionalChild(zcu);
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     break :blk Type.u1;
-                } else if (lhs_ty.isPtrLikeOptional(mod)) {
+                } else if (lhs_ty.isPtrLikeOptional(zcu)) {
                     break :blk Type.usize;
                 } else {
                     return self.fail("TODO SPARCv9 cmp non-pointer optionals", .{});
@@ -1436,7 +1437,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
             else => unreachable,
         };
 
-        const int_info = int_ty.intInfo(mod);
+        const int_info = int_ty.intInfo(zcu);
         if (int_info.bits <= 64) {
             _ = try self.binOp(.cmp_eq, lhs, rhs, int_ty, int_ty, BinOpMetadata{
                 .lhs = bin_op.lhs,
@@ -1797,16 +1798,16 @@ fn airIsNonNull(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const elem_ty = self.typeOfIndex(inst);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_size = elem_ty.abiSize(zcu);
     const result: MCValue = result: {
-        if (!elem_ty.hasRuntimeBits(pt))
+        if (!elem_ty.hasRuntimeBits(zcu))
             break :result MCValue.none;
 
         const ptr = try self.resolveInst(ty_op.operand);
-        const is_volatile = self.typeOf(ty_op.operand).isVolatilePtr(mod);
+        const is_volatile = self.typeOf(ty_op.operand).isVolatilePtr(zcu);
         if (self.liveness.isUnused(inst) and !is_volatile)
             break :result MCValue.dead;
 
@@ -2428,7 +2429,7 @@ fn airSlice(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airSliceElemVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const is_volatile = false; // TODO
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
@@ -2438,10 +2439,10 @@ fn airSliceElemVal(self: *Self, inst: Air.Inst.Index) !void {
         const index_mcv = try self.resolveInst(bin_op.rhs);
 
         const slice_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = slice_ty.childType(mod);
-        const elem_size = elem_ty.abiSize(pt);
+        const elem_ty = slice_ty.childType(zcu);
+        const elem_size = elem_ty.abiSize(zcu);
 
-        const slice_ptr_field_type = slice_ty.slicePtrFieldType(mod);
+        const slice_ptr_field_type = slice_ty.slicePtrFieldType(zcu);
 
         const index_lock: ?RegisterLock = if (index_mcv == .register)
             self.register_manager.lockRegAssumeUnused(index_mcv.register)
@@ -2553,10 +2554,10 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
     const operand = extra.struct_operand;
     const index = extra.field_index;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
-        const pt = self.pt;
+        const zcu = self.pt.zcu;
         const mcv = try self.resolveInst(operand);
         const struct_ty = self.typeOf(operand);
-        const struct_field_offset = @as(u32, @intCast(struct_ty.structFieldOffset(index, pt)));
+        const struct_field_offset = @as(u32, @intCast(struct_ty.structFieldOffset(index, zcu)));
 
         switch (mcv) {
             .dead, .unreach => unreachable,
@@ -2687,13 +2688,13 @@ fn airUnionInit(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airUnwrapErrErr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const error_union_ty = self.typeOf(ty_op.operand);
-        const payload_ty = error_union_ty.errorUnionPayload(mod);
+        const payload_ty = error_union_ty.errorUnionPayload(zcu);
         const mcv = try self.resolveInst(ty_op.operand);
-        if (!payload_ty.hasRuntimeBits(pt)) break :result mcv;
+        if (!payload_ty.hasRuntimeBits(zcu)) break :result mcv;
 
         return self.fail("TODO implement unwrap error union error for non-empty payloads", .{});
     };
@@ -2702,12 +2703,12 @@ fn airUnwrapErrErr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airUnwrapErrPayload(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const error_union_ty = self.typeOf(ty_op.operand);
-        const payload_ty = error_union_ty.errorUnionPayload(mod);
-        if (!payload_ty.hasRuntimeBits(pt)) break :result MCValue.none;
+        const payload_ty = error_union_ty.errorUnionPayload(zcu);
+        if (!payload_ty.hasRuntimeBits(zcu)) break :result MCValue.none;
 
         return self.fail("TODO implement unwrap error union payload for non-empty payloads", .{});
     };
@@ -2717,13 +2718,13 @@ fn airUnwrapErrPayload(self: *Self, inst: Air.Inst.Index) !void {
 /// E to E!T
 fn airWrapErrUnionErr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = if (self.liveness.isUnused(inst)) .dead else result: {
         const error_union_ty = ty_op.ty.toType();
-        const payload_ty = error_union_ty.errorUnionPayload(mod);
+        const payload_ty = error_union_ty.errorUnionPayload(zcu);
         const mcv = try self.resolveInst(ty_op.operand);
-        if (!payload_ty.hasRuntimeBits(pt)) break :result mcv;
+        if (!payload_ty.hasRuntimeBits(zcu)) break :result mcv;
 
         return self.fail("TODO implement wrap errunion error for non-empty payloads", .{});
     };
@@ -2744,7 +2745,7 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
         const optional_ty = self.typeOfIndex(inst);
 
         // Optional with a zero-bit payload type is just a boolean true
-        if (optional_ty.abiSize(pt) == 1)
+        if (optional_ty.abiSize(pt.zcu) == 1)
             break :result MCValue{ .immediate = 1 };
 
         return self.fail("TODO implement wrap optional for {}", .{self.target.cpu.arch});
@@ -2779,10 +2780,10 @@ fn allocMem(self: *Self, inst: Air.Inst.Index, abi_size: u32, abi_align: Alignme
 /// Use a pointer instruction as the basis for allocating stack memory.
 fn allocMemPtr(self: *Self, inst: Air.Inst.Index) !u32 {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const elem_ty = self.typeOfIndex(inst).childType(mod);
+    const zcu = pt.zcu;
+    const elem_ty = self.typeOfIndex(inst).childType(zcu);
 
-    if (!elem_ty.hasRuntimeBits(pt)) {
+    if (!elem_ty.hasRuntimeBits(zcu)) {
         // As this stack item will never be dereferenced at runtime,
         // return the stack offset 0. Stack offset 0 will be where all
         // zero-sized stack allocations live as non-zero-sized
@@ -2790,21 +2791,22 @@ fn allocMemPtr(self: *Self, inst: Air.Inst.Index) !u32 {
         return @as(u32, 0);
     }
 
-    const abi_size = math.cast(u32, elem_ty.abiSize(pt)) orelse {
+    const abi_size = math.cast(u32, elem_ty.abiSize(zcu)) orelse {
         return self.fail("type '{}' too big to fit into stack frame", .{elem_ty.fmt(pt)});
     };
     // TODO swap this for inst.ty.ptrAlign
-    const abi_align = elem_ty.abiAlignment(pt);
+    const abi_align = elem_ty.abiAlignment(zcu);
     return self.allocMem(inst, abi_size, abi_align);
 }
 
 fn allocRegOrMem(self: *Self, inst: Air.Inst.Index, reg_ok: bool) !MCValue {
     const pt = self.pt;
+    const zcu = pt.zcu;
     const elem_ty = self.typeOfIndex(inst);
-    const abi_size = math.cast(u32, elem_ty.abiSize(pt)) orelse {
+    const abi_size = math.cast(u32, elem_ty.abiSize(zcu)) orelse {
         return self.fail("type '{}' too big to fit into stack frame", .{elem_ty.fmt(pt)});
     };
-    const abi_align = elem_ty.abiAlignment(pt);
+    const abi_align = elem_ty.abiAlignment(zcu);
     self.stack_align = self.stack_align.max(abi_align);
 
     if (reg_ok) {
@@ -2847,7 +2849,7 @@ fn binOp(
     metadata: ?BinOpMetadata,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     switch (tag) {
         .add,
         .sub,
@@ -2857,12 +2859,12 @@ fn binOp(
         .xor,
         .cmp_eq,
         => {
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Float => return self.fail("TODO binary operations on floats", .{}),
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
-                    const int_info = lhs_ty.intInfo(mod);
+                    assert(lhs_ty.eql(rhs_ty, zcu));
+                    const int_info = lhs_ty.intInfo(zcu);
                     if (int_info.bits <= 64) {
                         // Only say yes if the operation is
                         // commutative, i.e. we can swap both of the
@@ -2931,10 +2933,10 @@ fn binOp(
             const result = try self.binOp(base_tag, lhs, rhs, lhs_ty, rhs_ty, metadata);
 
             // Truncate if necessary
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    const int_info = lhs_ty.intInfo(mod);
+                    const int_info = lhs_ty.intInfo(zcu);
                     if (int_info.bits <= 64) {
                         const result_reg = result.register;
                         try self.truncRegister(result_reg, result_reg, int_info.signedness, int_info.bits);
@@ -2948,11 +2950,11 @@ fn binOp(
         },
 
         .div_trunc => {
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    assert(lhs_ty.eql(rhs_ty, mod));
-                    const int_info = lhs_ty.intInfo(mod);
+                    assert(lhs_ty.eql(rhs_ty, zcu));
+                    const int_info = lhs_ty.intInfo(zcu);
                     if (int_info.bits <= 64) {
                         const rhs_immediate_ok = switch (tag) {
                             .div_trunc => rhs == .immediate and rhs.immediate <= std.math.maxInt(u12),
@@ -2981,14 +2983,14 @@ fn binOp(
         },
 
         .ptr_add => {
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Pointer => {
                     const ptr_ty = lhs_ty;
-                    const elem_ty = switch (ptr_ty.ptrSize(mod)) {
-                        .One => ptr_ty.childType(mod).childType(mod), // ptr to array, so get array element type
-                        else => ptr_ty.childType(mod),
+                    const elem_ty = switch (ptr_ty.ptrSize(zcu)) {
+                        .One => ptr_ty.childType(zcu).childType(zcu), // ptr to array, so get array element type
+                        else => ptr_ty.childType(zcu),
                     };
-                    const elem_size = elem_ty.abiSize(pt);
+                    const elem_size = elem_ty.abiSize(zcu);
 
                     if (elem_size == 1) {
                         const base_tag: Mir.Inst.Tag = switch (tag) {
@@ -3013,7 +3015,7 @@ fn binOp(
         .bool_and,
         .bool_or,
         => {
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Bool => {
                     assert(lhs != .immediate); // should have been handled by Sema
                     assert(rhs != .immediate); // should have been handled by Sema
@@ -3043,10 +3045,10 @@ fn binOp(
             const result = try self.binOp(base_tag, lhs, rhs, lhs_ty, rhs_ty, metadata);
 
             // Truncate if necessary
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    const int_info = lhs_ty.intInfo(mod);
+                    const int_info = lhs_ty.intInfo(zcu);
                     if (int_info.bits <= 64) {
                         // 32 and 64 bit operands doesn't need truncating
                         if (int_info.bits == 32 or int_info.bits == 64) return result;
@@ -3065,10 +3067,10 @@ fn binOp(
         .shl_exact,
         .shr_exact,
         => {
-            switch (lhs_ty.zigTypeTag(mod)) {
+            switch (lhs_ty.zigTypeTag(zcu)) {
                 .Vector => return self.fail("TODO binary operations on vectors", .{}),
                 .Int => {
-                    const int_info = lhs_ty.intInfo(mod);
+                    const int_info = lhs_ty.intInfo(zcu);
                     if (int_info.bits <= 64) {
                         const rhs_immediate_ok = rhs == .immediate;
 
@@ -3388,8 +3390,8 @@ fn binOpRegister(
 fn br(self: *Self, block: Air.Inst.Index, operand: Air.Inst.Ref) !void {
     const block_data = self.blocks.getPtr(block).?;
 
-    const pt = self.pt;
-    if (self.typeOf(operand).hasRuntimeBits(pt)) {
+    const zcu = self.pt.zcu;
+    if (self.typeOf(operand).hasRuntimeBits(zcu)) {
         const operand_mcv = try self.resolveInst(operand);
         const block_mcv = block_data.mcv;
         if (block_mcv == .none) {
@@ -3509,17 +3511,17 @@ fn ensureProcessDeathCapacity(self: *Self, additional_count: usize) !void {
 /// Given an error union, returns the payload
 fn errUnionPayload(self: *Self, error_union_mcv: MCValue, error_union_ty: Type) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const err_ty = error_union_ty.errorUnionSet(mod);
-    const payload_ty = error_union_ty.errorUnionPayload(mod);
-    if (err_ty.errorSetIsEmpty(mod)) {
+    const zcu = pt.zcu;
+    const err_ty = error_union_ty.errorUnionSet(zcu);
+    const payload_ty = error_union_ty.errorUnionPayload(zcu);
+    if (err_ty.errorSetIsEmpty(zcu)) {
         return error_union_mcv;
     }
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return MCValue.none;
     }
 
-    const payload_offset = @as(u32, @intCast(errUnionPayloadOffset(payload_ty, pt)));
+    const payload_offset = @as(u32, @intCast(errUnionPayloadOffset(payload_ty, zcu)));
     switch (error_union_mcv) {
         .register => return self.fail("TODO errUnionPayload for registers", .{}),
         .stack_offset => |off| {
@@ -3731,6 +3733,7 @@ fn genLoadASI(self: *Self, value_reg: Register, addr_reg: Register, off_reg: Reg
 
 fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void {
     const pt = self.pt;
+    const zcu = pt.zcu;
     switch (mcv) {
         .dead => unreachable,
         .unreach, .none => return, // Nothing to do.
@@ -3929,21 +3932,21 @@ fn genSetReg(self: *Self, ty: Type, reg: Register, mcv: MCValue) InnerError!void
             // The value is in memory at a hard-coded address.
             // If the type is a pointer, it means the pointer address is at this memory location.
             try self.genSetReg(ty, reg, .{ .immediate = addr });
-            try self.genLoad(reg, reg, i13, 0, ty.abiSize(pt));
+            try self.genLoad(reg, reg, i13, 0, ty.abiSize(zcu));
         },
         .stack_offset => |off| {
             const real_offset = realStackOffset(off);
             const simm13 = math.cast(i13, real_offset) orelse
                 return self.fail("TODO larger stack offsets: {}", .{real_offset});
-            try self.genLoad(reg, .sp, i13, simm13, ty.abiSize(pt));
+            try self.genLoad(reg, .sp, i13, simm13, ty.abiSize(zcu));
         },
     }
 }
 
 fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size = ty.abiSize(pt);
+    const zcu = pt.zcu;
+    const abi_size = ty.abiSize(zcu);
     switch (mcv) {
         .dead => unreachable,
         .unreach, .none => return, // Nothing to do.
@@ -3951,7 +3954,7 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
             if (!self.wantSafety())
                 return; // The already existing value will do just fine.
             // TODO Upgrade this to a memset call when we have that available.
-            switch (ty.abiSize(pt)) {
+            switch (ty.abiSize(zcu)) {
                 1 => return self.genSetStack(ty, stack_offset, .{ .immediate = 0xaa }),
                 2 => return self.genSetStack(ty, stack_offset, .{ .immediate = 0xaaaa }),
                 4 => return self.genSetStack(ty, stack_offset, .{ .immediate = 0xaaaaaaaa }),
@@ -3977,11 +3980,11 @@ fn genSetStack(self: *Self, ty: Type, stack_offset: u32, mcv: MCValue) InnerErro
             const reg_lock = self.register_manager.lockReg(rwo.reg);
             defer if (reg_lock) |locked_reg| self.register_manager.unlockReg(locked_reg);
 
-            const wrapped_ty = ty.structFieldType(0, mod);
+            const wrapped_ty = ty.structFieldType(0, zcu);
             try self.genSetStack(wrapped_ty, stack_offset, .{ .register = rwo.reg });
 
-            const overflow_bit_ty = ty.structFieldType(1, mod);
-            const overflow_bit_offset = @as(u32, @intCast(ty.structFieldOffset(1, pt)));
+            const overflow_bit_ty = ty.structFieldType(1, zcu);
+            const overflow_bit_offset = @as(u32, @intCast(ty.structFieldOffset(1, zcu)));
             const cond_reg = try self.register_manager.allocReg(null, gp);
 
             // TODO handle floating point CCRs
@@ -4154,14 +4157,14 @@ fn getResolvedInstValue(self: *Self, inst: Air.Inst.Index) MCValue {
 
 fn isErr(self: *Self, ty: Type, operand: MCValue) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const error_type = ty.errorUnionSet(mod);
-    const payload_type = ty.errorUnionPayload(mod);
+    const zcu = pt.zcu;
+    const error_type = ty.errorUnionSet(zcu);
+    const payload_type = ty.errorUnionPayload(zcu);
 
-    if (!error_type.hasRuntimeBits(pt)) {
+    if (!error_type.hasRuntimeBits(zcu)) {
         return MCValue{ .immediate = 0 }; // always false
-    } else if (!payload_type.hasRuntimeBits(pt)) {
-        if (error_type.abiSize(pt) <= 8) {
+    } else if (!payload_type.hasRuntimeBits(zcu)) {
+        if (error_type.abiSize(zcu) <= 8) {
             const reg_mcv: MCValue = switch (operand) {
                 .register => operand,
                 else => .{ .register = try self.copyToTmpRegister(error_type, operand) },
@@ -4253,9 +4256,9 @@ fn jump(self: *Self, inst: Mir.Inst.Index) !void {
 
 fn load(self: *Self, dst_mcv: MCValue, ptr: MCValue, ptr_ty: Type) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const elem_ty = ptr_ty.childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
+    const zcu = pt.zcu;
+    const elem_ty = ptr_ty.childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
 
     switch (ptr) {
         .none => unreachable,
@@ -4446,9 +4449,9 @@ fn realStackOffset(off: u32) u32 {
 /// Caller must call `CallMCValues.deinit`.
 fn resolveCallingConventionValues(self: *Self, fn_ty: Type, role: RegisterView) !CallMCValues {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const fn_info = mod.typeToFunc(fn_ty).?;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const fn_info = zcu.typeToFunc(fn_ty).?;
     const cc = fn_info.cc;
     var result: CallMCValues = .{
         .args = try self.gpa.alloc(MCValue, fn_info.param_types.len),
@@ -4459,7 +4462,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type, role: RegisterView) 
     };
     errdefer self.gpa.free(result.args);
 
-    const ret_ty = fn_ty.fnReturnType(mod);
+    const ret_ty = fn_ty.fnReturnType(zcu);
 
     switch (cc) {
         .Naked => {
@@ -4487,7 +4490,7 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type, role: RegisterView) 
             };
 
             for (fn_info.param_types.get(ip), result.args) |ty, *result_arg| {
-                const param_size = @as(u32, @intCast(Type.fromInterned(ty).abiSize(pt)));
+                const param_size = @as(u32, @intCast(Type.fromInterned(ty).abiSize(zcu)));
                 if (param_size <= 8) {
                     if (next_register < argument_registers.len) {
                         result_arg.* = .{ .register = argument_registers[next_register] };
@@ -4514,12 +4517,12 @@ fn resolveCallingConventionValues(self: *Self, fn_ty: Type, role: RegisterView) 
             result.stack_byte_count = next_stack_offset;
             result.stack_align = .@"16";
 
-            if (ret_ty.zigTypeTag(mod) == .NoReturn) {
+            if (ret_ty.zigTypeTag(zcu) == .NoReturn) {
                 result.return_value = .{ .unreach = {} };
-            } else if (!ret_ty.hasRuntimeBits(pt)) {
+            } else if (!ret_ty.hasRuntimeBits(zcu)) {
                 result.return_value = .{ .none = {} };
             } else {
-                const ret_ty_size: u32 = @intCast(ret_ty.abiSize(pt));
+                const ret_ty_size: u32 = @intCast(ret_ty.abiSize(zcu));
                 // The callee puts the return values in %i0-%i3, which becomes %o0-%o3 inside the caller.
                 if (ret_ty_size <= 8) {
                     result.return_value = switch (role) {
@@ -4542,7 +4545,7 @@ fn resolveInst(self: *Self, ref: Air.Inst.Ref) InnerError!MCValue {
     const ty = self.typeOf(ref);
 
     // If the type has no codegen bits, no need to store it.
-    if (!ty.hasRuntimeBitsIgnoreComptime(pt)) return .none;
+    if (!ty.hasRuntimeBitsIgnoreComptime(pt.zcu)) return .none;
 
     if (ref.toIndex()) |inst| {
         return self.getResolvedInstValue(inst);
@@ -4656,7 +4659,7 @@ pub fn spillInstruction(self: *Self, reg: Register, inst: Air.Inst.Index) !void 
 
 fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type) InnerError!void {
     const pt = self.pt;
-    const abi_size = value_ty.abiSize(pt);
+    const abi_size = value_ty.abiSize(pt.zcu);
 
     switch (ptr) {
         .none => unreachable,
@@ -4698,11 +4701,11 @@ fn store(self: *Self, ptr: MCValue, value: MCValue, ptr_ty: Type, value_ty: Type
 fn structFieldPtr(self: *Self, inst: Air.Inst.Index, operand: Air.Inst.Ref, index: u32) !MCValue {
     return if (self.liveness.isUnused(inst)) .dead else result: {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const mcv = try self.resolveInst(operand);
         const ptr_ty = self.typeOf(operand);
-        const struct_ty = ptr_ty.childType(mod);
-        const struct_field_offset = @as(u32, @intCast(struct_ty.structFieldOffset(index, pt)));
+        const struct_ty = ptr_ty.childType(zcu);
+        const struct_field_offset = @as(u32, @intCast(struct_ty.structFieldOffset(index, zcu)));
         switch (mcv) {
             .ptr_stack_offset => |off| {
                 break :result MCValue{ .ptr_stack_offset = off - struct_field_offset };

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3954,7 +3954,7 @@ fn airStructFieldVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const struct_ty = func.typeOf(struct_field.struct_operand);
     const operand = try func.resolveInst(struct_field.struct_operand);
     const field_index = struct_field.field_index;
-    const field_ty = struct_ty.structFieldType(field_index, zcu);
+    const field_ty = struct_ty.fieldType(field_index, zcu);
     if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) return func.finishAir(inst, .none, &.{struct_field.struct_operand});
 
     const result: WValue = switch (struct_ty.containerLayout(zcu)) {
@@ -5378,7 +5378,7 @@ fn airAggregateInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     for (elements, 0..) |elem, elem_index| {
                         if (try result_ty.structFieldValueComptime(pt, elem_index) != null) continue;
 
-                        const elem_ty = result_ty.structFieldType(elem_index, zcu);
+                        const elem_ty = result_ty.fieldType(elem_index, zcu);
                         const field_offset = result_ty.structFieldOffset(elem_index, zcu);
                         _ = try func.buildPointerOffset(offset, @intCast(field_offset - prev_field_offset), .modify);
                         prev_field_offset = field_offset;

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -788,10 +788,10 @@ fn resolveInst(func: *CodeGen, ref: Air.Inst.Ref) InnerError!WValue {
     assert(!gop.found_existing);
 
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const val = (try func.air.value(ref, pt)).?;
     const ty = func.typeOf(ref);
-    if (!ty.hasRuntimeBitsIgnoreComptime(pt) and !ty.isInt(mod) and !ty.isError(mod)) {
+    if (!ty.hasRuntimeBitsIgnoreComptime(zcu) and !ty.isInt(zcu) and !ty.isError(zcu)) {
         gop.value_ptr.* = .none;
         return gop.value_ptr.*;
     }
@@ -1001,9 +1001,9 @@ fn addExtraAssumeCapacity(func: *CodeGen, extra: anytype) error{OutOfMemory}!u32
 
 /// Using a given `Type`, returns the corresponding valtype for .auto callconv
 fn typeToValtype(ty: Type, pt: Zcu.PerThread, target: std.Target) wasm.Valtype {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    return switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    return switch (ty.zigTypeTag(zcu)) {
         .Float => switch (ty.floatBits(target)) {
             16 => .i32, // stored/loaded as u16
             32 => .f32,
@@ -1011,26 +1011,26 @@ fn typeToValtype(ty: Type, pt: Zcu.PerThread, target: std.Target) wasm.Valtype {
             80, 128 => .i32,
             else => unreachable,
         },
-        .Int, .Enum => switch (ty.intInfo(pt.zcu).bits) {
+        .Int, .Enum => switch (ty.intInfo(zcu).bits) {
             0...32 => .i32,
             33...64 => .i64,
             else => .i32,
         },
         .Struct => blk: {
-            if (pt.zcu.typeToPackedStruct(ty)) |packed_struct| {
+            if (zcu.typeToPackedStruct(ty)) |packed_struct| {
                 const backing_int_ty = Type.fromInterned(packed_struct.backingIntTypeUnordered(ip));
                 break :blk typeToValtype(backing_int_ty, pt, target);
             } else {
                 break :blk .i32;
             }
         },
-        .Vector => switch (determineSimdStoreStrategy(ty, pt, target)) {
+        .Vector => switch (determineSimdStoreStrategy(ty, zcu, target)) {
             .direct => .v128,
             .unrolled => .i32,
         },
-        .Union => switch (ty.containerLayout(pt.zcu)) {
+        .Union => switch (ty.containerLayout(zcu)) {
             .@"packed" => blk: {
-                const int_ty = pt.intType(.unsigned, @as(u16, @intCast(ty.bitSize(pt)))) catch @panic("out of memory");
+                const int_ty = pt.intType(.unsigned, @as(u16, @intCast(ty.bitSize(zcu)))) catch @panic("out of memory");
                 break :blk typeToValtype(int_ty, pt, target);
             },
             else => .i32,
@@ -1148,7 +1148,7 @@ fn genFunctype(
     pt: Zcu.PerThread,
     target: std.Target,
 ) !wasm.Type {
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     var temp_params = std.ArrayList(wasm.Valtype).init(gpa);
     defer temp_params.deinit();
     var returns = std.ArrayList(wasm.Valtype).init(gpa);
@@ -1156,30 +1156,30 @@ fn genFunctype(
 
     if (firstParamSRet(cc, return_type, pt, target)) {
         try temp_params.append(.i32); // memory address is always a 32-bit handle
-    } else if (return_type.hasRuntimeBitsIgnoreComptime(pt)) {
+    } else if (return_type.hasRuntimeBitsIgnoreComptime(zcu)) {
         if (cc == .C) {
-            const res_classes = abi.classifyType(return_type, pt);
+            const res_classes = abi.classifyType(return_type, zcu);
             assert(res_classes[0] == .direct and res_classes[1] == .none);
-            const scalar_type = abi.scalarType(return_type, pt);
+            const scalar_type = abi.scalarType(return_type, zcu);
             try returns.append(typeToValtype(scalar_type, pt, target));
         } else {
             try returns.append(typeToValtype(return_type, pt, target));
         }
-    } else if (return_type.isError(mod)) {
+    } else if (return_type.isError(zcu)) {
         try returns.append(.i32);
     }
 
     // param types
     for (params) |param_type_ip| {
         const param_type = Type.fromInterned(param_type_ip);
-        if (!param_type.hasRuntimeBitsIgnoreComptime(pt)) continue;
+        if (!param_type.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
         switch (cc) {
             .C => {
-                const param_classes = abi.classifyType(param_type, pt);
+                const param_classes = abi.classifyType(param_type, zcu);
                 if (param_classes[1] == .none) {
                     if (param_classes[0] == .direct) {
-                        const scalar_type = abi.scalarType(param_type, pt);
+                        const scalar_type = abi.scalarType(param_type, zcu);
                         try temp_params.append(typeToValtype(scalar_type, pt, target));
                     } else {
                         try temp_params.append(typeToValtype(param_type, pt, target));
@@ -1242,10 +1242,10 @@ pub fn generate(
 
 fn genFunc(func: *CodeGen) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const fn_ty = mod.navValue(func.owner_nav).typeOf(mod);
-    const fn_info = mod.typeToFunc(fn_ty).?;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const fn_ty = zcu.navValue(func.owner_nav).typeOf(zcu);
+    const fn_info = zcu.typeToFunc(fn_ty).?;
     var func_type = try genFunctype(func.gpa, fn_info.cc, fn_info.param_types.get(ip), Type.fromInterned(fn_info.return_type), pt, func.target.*);
     defer func_type.deinit(func.gpa);
     _ = try func.bin_file.storeNavType(func.owner_nav, func_type);
@@ -1273,7 +1273,7 @@ fn genFunc(func: *CodeGen) InnerError!void {
     if (func_type.returns.len != 0 and func.air.instructions.len > 0) {
         const inst: Air.Inst.Index = @enumFromInt(func.air.instructions.len - 1);
         const last_inst_ty = func.typeOfIndex(inst);
-        if (!last_inst_ty.hasRuntimeBitsIgnoreComptime(pt) or last_inst_ty.isNoReturn(mod)) {
+        if (!last_inst_ty.hasRuntimeBitsIgnoreComptime(zcu) or last_inst_ty.isNoReturn(zcu)) {
             try func.addTag(.@"unreachable");
         }
     }
@@ -1356,9 +1356,9 @@ const CallWValues = struct {
 
 fn resolveCallingConventionValues(func: *CodeGen, fn_ty: Type) InnerError!CallWValues {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const fn_info = mod.typeToFunc(fn_ty).?;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const fn_info = zcu.typeToFunc(fn_ty).?;
     const cc = fn_info.cc;
     var result: CallWValues = .{
         .args = &.{},
@@ -1381,7 +1381,7 @@ fn resolveCallingConventionValues(func: *CodeGen, fn_ty: Type) InnerError!CallWV
     switch (cc) {
         .Unspecified => {
             for (fn_info.param_types.get(ip)) |ty| {
-                if (!Type.fromInterned(ty).hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!Type.fromInterned(ty).hasRuntimeBitsIgnoreComptime(zcu)) {
                     continue;
                 }
 
@@ -1391,7 +1391,7 @@ fn resolveCallingConventionValues(func: *CodeGen, fn_ty: Type) InnerError!CallWV
         },
         .C => {
             for (fn_info.param_types.get(ip)) |ty| {
-                const ty_classes = abi.classifyType(Type.fromInterned(ty), pt);
+                const ty_classes = abi.classifyType(Type.fromInterned(ty), zcu);
                 for (ty_classes) |class| {
                     if (class == .none) continue;
                     try args.append(.{ .local = .{ .value = func.local_index, .references = 1 } });
@@ -1409,7 +1409,7 @@ fn firstParamSRet(cc: std.builtin.CallingConvention, return_type: Type, pt: Zcu.
     switch (cc) {
         .Unspecified, .Inline => return isByRef(return_type, pt, target),
         .C => {
-            const ty_classes = abi.classifyType(return_type, pt);
+            const ty_classes = abi.classifyType(return_type, pt.zcu);
             if (ty_classes[0] == .indirect) return true;
             if (ty_classes[0] == .direct and ty_classes[1] == .direct) return true;
             return false;
@@ -1426,16 +1426,16 @@ fn lowerArg(func: *CodeGen, cc: std.builtin.CallingConvention, ty: Type, value: 
     }
 
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ty_classes = abi.classifyType(ty, pt);
+    const zcu = pt.zcu;
+    const ty_classes = abi.classifyType(ty, zcu);
     assert(ty_classes[0] != .none);
-    switch (ty.zigTypeTag(mod)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Struct, .Union => {
             if (ty_classes[0] == .indirect) {
                 return func.lowerToStack(value);
             }
             assert(ty_classes[0] == .direct);
-            const scalar_type = abi.scalarType(ty, pt);
+            const scalar_type = abi.scalarType(ty, zcu);
             switch (value) {
                 .memory,
                 .memory_offset,
@@ -1450,7 +1450,7 @@ fn lowerArg(func: *CodeGen, cc: std.builtin.CallingConvention, ty: Type, value: 
                 return func.lowerToStack(value);
             }
             assert(ty_classes[0] == .direct and ty_classes[1] == .direct);
-            assert(ty.abiSize(pt) == 16);
+            assert(ty.abiSize(zcu) == 16);
             // in this case we have an integer or float that must be lowered as 2 i64's.
             try func.emitWValue(value);
             try func.addMemArg(.i64_load, .{ .offset = value.offset(), .alignment = 8 });
@@ -1517,18 +1517,18 @@ fn restoreStackPointer(func: *CodeGen) !void {
 ///
 /// Asserts Type has codegenbits
 fn allocStack(func: *CodeGen, ty: Type) !WValue {
-    const pt = func.pt;
-    assert(ty.hasRuntimeBitsIgnoreComptime(pt));
+    const zcu = func.pt.zcu;
+    assert(ty.hasRuntimeBitsIgnoreComptime(zcu));
     if (func.initial_stack_value == .none) {
         try func.initializeStack();
     }
 
-    const abi_size = std.math.cast(u32, ty.abiSize(pt)) orelse {
+    const abi_size = std.math.cast(u32, ty.abiSize(zcu)) orelse {
         return func.fail("Type {} with ABI size of {d} exceeds stack frame size", .{
-            ty.fmt(pt), ty.abiSize(pt),
+            ty.fmt(func.pt), ty.abiSize(zcu),
         });
     };
-    const abi_align = ty.abiAlignment(pt);
+    const abi_align = ty.abiAlignment(zcu);
 
     func.stack_alignment = func.stack_alignment.max(abi_align);
 
@@ -1544,22 +1544,22 @@ fn allocStack(func: *CodeGen, ty: Type) !WValue {
 /// if it is set, to ensure the stack alignment will be set correctly.
 fn allocStackPtr(func: *CodeGen, inst: Air.Inst.Index) !WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ptr_ty = func.typeOfIndex(inst);
-    const pointee_ty = ptr_ty.childType(mod);
+    const pointee_ty = ptr_ty.childType(zcu);
 
     if (func.initial_stack_value == .none) {
         try func.initializeStack();
     }
 
-    if (!pointee_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!pointee_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return func.allocStack(Type.usize); // create a value containing just the stack pointer.
     }
 
-    const abi_alignment = ptr_ty.ptrAlignment(pt);
-    const abi_size = std.math.cast(u32, pointee_ty.abiSize(pt)) orelse {
+    const abi_alignment = ptr_ty.ptrAlignment(zcu);
+    const abi_size = std.math.cast(u32, pointee_ty.abiSize(zcu)) orelse {
         return func.fail("Type {} with ABI size of {d} exceeds stack frame size", .{
-            pointee_ty.fmt(pt), pointee_ty.abiSize(pt),
+            pointee_ty.fmt(pt), pointee_ty.abiSize(zcu),
         });
     };
     func.stack_alignment = func.stack_alignment.max(abi_alignment);
@@ -1716,9 +1716,9 @@ fn arch(func: *const CodeGen) std.Target.Cpu.Arch {
 /// For a given `Type`, will return true when the type will be passed
 /// by reference, rather than by value
 fn isByRef(ty: Type, pt: Zcu.PerThread, target: std.Target) bool {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    switch (ty.zigTypeTag(zcu)) {
         .Type,
         .ComptimeInt,
         .ComptimeFloat,
@@ -1738,41 +1738,41 @@ fn isByRef(ty: Type, pt: Zcu.PerThread, target: std.Target) bool {
 
         .Array,
         .Frame,
-        => return ty.hasRuntimeBitsIgnoreComptime(pt),
+        => return ty.hasRuntimeBitsIgnoreComptime(zcu),
         .Union => {
-            if (mod.typeToUnion(ty)) |union_obj| {
+            if (zcu.typeToUnion(ty)) |union_obj| {
                 if (union_obj.flagsUnordered(ip).layout == .@"packed") {
-                    return ty.abiSize(pt) > 8;
+                    return ty.abiSize(zcu) > 8;
                 }
             }
-            return ty.hasRuntimeBitsIgnoreComptime(pt);
+            return ty.hasRuntimeBitsIgnoreComptime(zcu);
         },
         .Struct => {
-            if (mod.typeToPackedStruct(ty)) |packed_struct| {
+            if (zcu.typeToPackedStruct(ty)) |packed_struct| {
                 return isByRef(Type.fromInterned(packed_struct.backingIntTypeUnordered(ip)), pt, target);
             }
-            return ty.hasRuntimeBitsIgnoreComptime(pt);
+            return ty.hasRuntimeBitsIgnoreComptime(zcu);
         },
-        .Vector => return determineSimdStoreStrategy(ty, pt, target) == .unrolled,
-        .Int => return ty.intInfo(mod).bits > 64,
-        .Enum => return ty.intInfo(mod).bits > 64,
+        .Vector => return determineSimdStoreStrategy(ty, zcu, target) == .unrolled,
+        .Int => return ty.intInfo(zcu).bits > 64,
+        .Enum => return ty.intInfo(zcu).bits > 64,
         .Float => return ty.floatBits(target) > 64,
         .ErrorUnion => {
-            const pl_ty = ty.errorUnionPayload(mod);
-            if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            const pl_ty = ty.errorUnionPayload(zcu);
+            if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 return false;
             }
             return true;
         },
         .Optional => {
-            if (ty.isPtrLikeOptional(mod)) return false;
-            const pl_type = ty.optionalChild(mod);
-            if (pl_type.zigTypeTag(mod) == .ErrorSet) return false;
-            return pl_type.hasRuntimeBitsIgnoreComptime(pt);
+            if (ty.isPtrLikeOptional(zcu)) return false;
+            const pl_type = ty.optionalChild(zcu);
+            if (pl_type.zigTypeTag(zcu) == .ErrorSet) return false;
+            return pl_type.hasRuntimeBitsIgnoreComptime(zcu);
         },
         .Pointer => {
             // Slices act like struct and will be passed by reference
-            if (ty.isSlice(mod)) return true;
+            if (ty.isSlice(zcu)) return true;
             return false;
         },
     }
@@ -1787,9 +1787,9 @@ const SimdStoreStrategy = enum {
 /// This means when a given type is 128 bits and either the simd128 or relaxed-simd
 /// features are enabled, the function will return `.direct`. This would allow to store
 /// it using a instruction, rather than an unrolled version.
-fn determineSimdStoreStrategy(ty: Type, pt: Zcu.PerThread, target: std.Target) SimdStoreStrategy {
-    std.debug.assert(ty.zigTypeTag(pt.zcu) == .Vector);
-    if (ty.bitSize(pt) != 128) return .unrolled;
+fn determineSimdStoreStrategy(ty: Type, zcu: *Zcu, target: std.Target) SimdStoreStrategy {
+    std.debug.assert(ty.zigTypeTag(zcu) == .Vector);
+    if (ty.bitSize(zcu) != 128) return .unrolled;
     const hasFeature = std.Target.wasm.featureSetHas;
     const features = target.cpu.features;
     if (hasFeature(features, .relaxed_simd) or hasFeature(features, .simd128)) {
@@ -2069,8 +2069,8 @@ fn genInst(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn genBody(func: *CodeGen, body: []const Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
 
     for (body) |inst| {
         if (func.liveness.isUnused(inst) and !func.air.mustLower(inst, ip)) {
@@ -2091,37 +2091,37 @@ fn genBody(func: *CodeGen, body: []const Air.Inst.Index) InnerError!void {
 
 fn airRet(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = func.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const operand = try func.resolveInst(un_op);
-    const fn_info = mod.typeToFunc(mod.navValue(func.owner_nav).typeOf(mod)).?;
+    const fn_info = zcu.typeToFunc(zcu.navValue(func.owner_nav).typeOf(zcu)).?;
     const ret_ty = Type.fromInterned(fn_info.return_type);
 
     // result must be stored in the stack and we return a pointer
     // to the stack instead
     if (func.return_value != .none) {
         try func.store(func.return_value, operand, ret_ty, 0);
-    } else if (fn_info.cc == .C and ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-        switch (ret_ty.zigTypeTag(mod)) {
+    } else if (fn_info.cc == .C and ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+        switch (ret_ty.zigTypeTag(zcu)) {
             // Aggregate types can be lowered as a singular value
             .Struct, .Union => {
-                const scalar_type = abi.scalarType(ret_ty, pt);
+                const scalar_type = abi.scalarType(ret_ty, zcu);
                 try func.emitWValue(operand);
                 const opcode = buildOpcode(.{
                     .op = .load,
-                    .width = @as(u8, @intCast(scalar_type.abiSize(pt) * 8)),
-                    .signedness = if (scalar_type.isSignedInt(mod)) .signed else .unsigned,
+                    .width = @as(u8, @intCast(scalar_type.abiSize(zcu) * 8)),
+                    .signedness = if (scalar_type.isSignedInt(zcu)) .signed else .unsigned,
                     .valtype1 = typeToValtype(scalar_type, pt, func.target.*),
                 });
                 try func.addMemArg(Mir.Inst.Tag.fromOpcode(opcode), .{
                     .offset = operand.offset(),
-                    .alignment = @intCast(scalar_type.abiAlignment(pt).toByteUnits().?),
+                    .alignment = @intCast(scalar_type.abiAlignment(zcu).toByteUnits().?),
                 });
             },
             else => try func.emitWValue(operand),
         }
     } else {
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt) and ret_ty.isError(mod)) {
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu) and ret_ty.isError(zcu)) {
             try func.addImm32(0);
         } else {
             try func.emitWValue(operand);
@@ -2135,15 +2135,15 @@ fn airRet(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airRetPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const child_type = func.typeOfIndex(inst).childType(mod);
+    const zcu = pt.zcu;
+    const child_type = func.typeOfIndex(inst).childType(zcu);
 
     const result = result: {
-        if (!child_type.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+        if (!child_type.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
             break :result try func.allocStack(Type.usize); // create pointer to void
         }
 
-        const fn_info = mod.typeToFunc(mod.navValue(func.owner_nav).typeOf(mod)).?;
+        const fn_info = zcu.typeToFunc(zcu.navValue(func.owner_nav).typeOf(zcu)).?;
         if (firstParamSRet(fn_info.cc, Type.fromInterned(fn_info.return_type), pt, func.target.*)) {
             break :result func.return_value;
         }
@@ -2156,14 +2156,14 @@ fn airRetPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airRetLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = func.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const operand = try func.resolveInst(un_op);
-    const ret_ty = func.typeOf(un_op).childType(mod);
+    const ret_ty = func.typeOf(un_op).childType(zcu);
 
-    const fn_info = mod.typeToFunc(mod.navValue(func.owner_nav).typeOf(mod)).?;
-    if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-        if (ret_ty.isError(mod)) {
+    const fn_info = zcu.typeToFunc(zcu.navValue(func.owner_nav).typeOf(zcu)).?;
+    if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+        if (ret_ty.isError(zcu)) {
             try func.addImm32(0);
         }
     } else if (!firstParamSRet(fn_info.cc, Type.fromInterned(fn_info.return_type), pt, func.target.*)) {
@@ -2184,15 +2184,15 @@ fn airCall(func: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModif
     const ty = func.typeOf(pl_op.operand);
 
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const fn_ty = switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    const fn_ty = switch (ty.zigTypeTag(zcu)) {
         .Fn => ty,
-        .Pointer => ty.childType(mod),
+        .Pointer => ty.childType(zcu),
         else => unreachable,
     };
-    const ret_ty = fn_ty.fnReturnType(mod);
-    const fn_info = mod.typeToFunc(fn_ty).?;
+    const ret_ty = fn_ty.fnReturnType(zcu);
+    const fn_info = zcu.typeToFunc(fn_ty).?;
     const first_param_sret = firstParamSRet(fn_info.cc, Type.fromInterned(fn_info.return_type), pt, func.target.*);
 
     const callee: ?InternPool.Nav.Index = blk: {
@@ -2205,7 +2205,7 @@ fn airCall(func: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModif
             },
             .@"extern" => |@"extern"| {
                 const ext_nav = ip.getNav(@"extern".owner_nav);
-                const ext_info = mod.typeToFunc(Type.fromInterned(@"extern".ty)).?;
+                const ext_info = zcu.typeToFunc(Type.fromInterned(@"extern".ty)).?;
                 var func_type = try genFunctype(
                     func.gpa,
                     ext_info.cc,
@@ -2248,9 +2248,9 @@ fn airCall(func: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModif
         const arg_val = try func.resolveInst(arg);
 
         const arg_ty = func.typeOf(arg);
-        if (!arg_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+        if (!arg_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
-        try func.lowerArg(mod.typeToFunc(fn_ty).?.cc, arg_ty, arg_val);
+        try func.lowerArg(zcu.typeToFunc(fn_ty).?.cc, arg_ty, arg_val);
     }
 
     if (callee) |direct| {
@@ -2259,7 +2259,7 @@ fn airCall(func: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModif
     } else {
         // in this case we call a function pointer
         // so load its value onto the stack
-        std.debug.assert(ty.zigTypeTag(mod) == .Pointer);
+        std.debug.assert(ty.zigTypeTag(zcu) == .Pointer);
         const operand = try func.resolveInst(pl_op.operand);
         try func.emitWValue(operand);
 
@@ -2271,18 +2271,18 @@ fn airCall(func: *CodeGen, inst: Air.Inst.Index, modifier: std.builtin.CallModif
     }
 
     const result_value = result_value: {
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt) and !ret_ty.isError(mod)) {
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu) and !ret_ty.isError(zcu)) {
             break :result_value .none;
-        } else if (ret_ty.isNoReturn(mod)) {
+        } else if (ret_ty.isNoReturn(zcu)) {
             try func.addTag(.@"unreachable");
             break :result_value .none;
         } else if (first_param_sret) {
             break :result_value sret;
             // TODO: Make this less fragile and optimize
-        } else if (mod.typeToFunc(fn_ty).?.cc == .C and ret_ty.zigTypeTag(mod) == .Struct or ret_ty.zigTypeTag(mod) == .Union) {
+        } else if (zcu.typeToFunc(fn_ty).?.cc == .C and ret_ty.zigTypeTag(zcu) == .Struct or ret_ty.zigTypeTag(zcu) == .Union) {
             const result_local = try func.allocLocal(ret_ty);
             try func.addLabel(.local_set, result_local.local.value);
-            const scalar_type = abi.scalarType(ret_ty, pt);
+            const scalar_type = abi.scalarType(ret_ty, zcu);
             const result = try func.allocStack(scalar_type);
             try func.store(result, result_local, scalar_type, 0);
             break :result_value result;
@@ -2306,7 +2306,7 @@ fn airAlloc(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airStore(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     if (safety) {
         // TODO if the value is undef, write 0xaa bytes to dest
     } else {
@@ -2317,8 +2317,8 @@ fn airStore(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void 
     const lhs = try func.resolveInst(bin_op.lhs);
     const rhs = try func.resolveInst(bin_op.rhs);
     const ptr_ty = func.typeOf(bin_op.lhs);
-    const ptr_info = ptr_ty.ptrInfo(mod);
-    const ty = ptr_ty.childType(mod);
+    const ptr_info = ptr_ty.ptrInfo(zcu);
+    const ty = ptr_ty.childType(zcu);
 
     if (ptr_info.packed_offset.host_size == 0) {
         try func.store(lhs, rhs, ty, 0);
@@ -2331,7 +2331,7 @@ fn airStore(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void 
             return func.fail("TODO: airStore for pointers to bitfields with backing type larger than 64bits", .{});
         }
 
-        var mask = @as(u64, @intCast((@as(u65, 1) << @as(u7, @intCast(ty.bitSize(pt)))) - 1));
+        var mask = @as(u64, @intCast((@as(u65, 1) << @as(u7, @intCast(ty.bitSize(zcu)))) - 1));
         mask <<= @as(u6, @intCast(ptr_info.packed_offset.bit_offset));
         mask ^= ~@as(u64, 0);
         const shift_val: WValue = if (ptr_info.packed_offset.host_size <= 4)
@@ -2343,9 +2343,9 @@ fn airStore(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void 
         else
             .{ .imm64 = mask };
         const wrap_mask_val: WValue = if (ptr_info.packed_offset.host_size <= 4)
-            .{ .imm32 = @truncate(~@as(u64, 0) >> @intCast(64 - ty.bitSize(pt))) }
+            .{ .imm32 = @truncate(~@as(u64, 0) >> @intCast(64 - ty.bitSize(zcu))) }
         else
-            .{ .imm64 = ~@as(u64, 0) >> @intCast(64 - ty.bitSize(pt)) };
+            .{ .imm64 = ~@as(u64, 0) >> @intCast(64 - ty.bitSize(zcu)) };
 
         try func.emitWValue(lhs);
         const loaded = try func.load(lhs, int_elem_ty, 0);
@@ -2366,12 +2366,12 @@ fn airStore(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void 
 fn store(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerError!void {
     assert(!(lhs != .stack and rhs == .stack));
     const pt = func.pt;
-    const mod = pt.zcu;
-    const abi_size = ty.abiSize(pt);
-    switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const abi_size = ty.abiSize(zcu);
+    switch (ty.zigTypeTag(zcu)) {
         .ErrorUnion => {
-            const pl_ty = ty.errorUnionPayload(mod);
-            if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            const pl_ty = ty.errorUnionPayload(zcu);
+            if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 return func.store(lhs, rhs, Type.anyerror, 0);
             }
 
@@ -2379,14 +2379,14 @@ fn store(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerE
             return func.memcpy(lhs, rhs, .{ .imm32 = len });
         },
         .Optional => {
-            if (ty.isPtrLikeOptional(mod)) {
+            if (ty.isPtrLikeOptional(zcu)) {
                 return func.store(lhs, rhs, Type.usize, 0);
             }
-            const pl_ty = ty.optionalChild(mod);
-            if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            const pl_ty = ty.optionalChild(zcu);
+            if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 return func.store(lhs, rhs, Type.u8, 0);
             }
-            if (pl_ty.zigTypeTag(mod) == .ErrorSet) {
+            if (pl_ty.zigTypeTag(zcu) == .ErrorSet) {
                 return func.store(lhs, rhs, Type.anyerror, 0);
             }
 
@@ -2397,7 +2397,7 @@ fn store(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerE
             const len = @as(u32, @intCast(abi_size));
             return func.memcpy(lhs, rhs, .{ .imm32 = len });
         },
-        .Vector => switch (determineSimdStoreStrategy(ty, pt, func.target.*)) {
+        .Vector => switch (determineSimdStoreStrategy(ty, zcu, func.target.*)) {
             .unrolled => {
                 const len: u32 = @intCast(abi_size);
                 return func.memcpy(lhs, rhs, .{ .imm32 = len });
@@ -2411,13 +2411,13 @@ fn store(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerE
                 try func.mir_extra.appendSlice(func.gpa, &[_]u32{
                     std.wasm.simdOpcode(.v128_store),
                     offset + lhs.offset(),
-                    @intCast(ty.abiAlignment(pt).toByteUnits() orelse 0),
+                    @intCast(ty.abiAlignment(zcu).toByteUnits() orelse 0),
                 });
                 return func.addInst(.{ .tag = .simd_prefix, .data = .{ .payload = extra_index } });
             },
         },
         .Pointer => {
-            if (ty.isSlice(mod)) {
+            if (ty.isSlice(zcu)) {
                 // store pointer first
                 // lower it to the stack so we do not have to store rhs into a local first
                 try func.emitWValue(lhs);
@@ -2441,7 +2441,7 @@ fn store(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerE
             try func.store(.stack, msb, Type.u64, 8 + lhs.offset());
             return;
         } else if (abi_size > 16) {
-            try func.memcpy(lhs, rhs, .{ .imm32 = @as(u32, @intCast(ty.abiSize(pt))) });
+            try func.memcpy(lhs, rhs, .{ .imm32 = @as(u32, @intCast(ty.abiSize(zcu))) });
         },
         else => if (abi_size > 8) {
             return func.fail("TODO: `store` for type `{}` with abisize `{d}`", .{
@@ -2467,21 +2467,21 @@ fn store(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, offset: u32) InnerE
         Mir.Inst.Tag.fromOpcode(opcode),
         .{
             .offset = offset + lhs.offset(),
-            .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+            .alignment = @intCast(ty.abiAlignment(zcu).toByteUnits().?),
         },
     );
 }
 
 fn airLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const operand = try func.resolveInst(ty_op.operand);
     const ty = ty_op.ty.toType();
     const ptr_ty = func.typeOf(ty_op.operand);
-    const ptr_info = ptr_ty.ptrInfo(mod);
+    const ptr_info = ptr_ty.ptrInfo(zcu);
 
-    if (!ty.hasRuntimeBitsIgnoreComptime(pt)) return func.finishAir(inst, .none, &.{ty_op.operand});
+    if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) return func.finishAir(inst, .none, &.{ty_op.operand});
 
     const result = result: {
         if (isByRef(ty, pt, func.target.*)) {
@@ -2515,36 +2515,36 @@ fn airLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 /// NOTE: Leaves the value on the stack.
 fn load(func: *CodeGen, operand: WValue, ty: Type, offset: u32) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     // load local's value from memory by its stack position
     try func.emitWValue(operand);
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         // TODO: Add helper functions for simd opcodes
         const extra_index = @as(u32, @intCast(func.mir_extra.items.len));
         // stores as := opcode, offset, alignment (opcode::memarg)
         try func.mir_extra.appendSlice(func.gpa, &[_]u32{
             std.wasm.simdOpcode(.v128_load),
             offset + operand.offset(),
-            @intCast(ty.abiAlignment(pt).toByteUnits().?),
+            @intCast(ty.abiAlignment(zcu).toByteUnits().?),
         });
         try func.addInst(.{ .tag = .simd_prefix, .data = .{ .payload = extra_index } });
         return .stack;
     }
 
-    const abi_size: u8 = @intCast(ty.abiSize(pt));
+    const abi_size: u8 = @intCast(ty.abiSize(zcu));
     const opcode = buildOpcode(.{
         .valtype1 = typeToValtype(ty, pt, func.target.*),
         .width = abi_size * 8,
         .op = .load,
-        .signedness = if (ty.isSignedInt(mod)) .signed else .unsigned,
+        .signedness = if (ty.isSignedInt(zcu)) .signed else .unsigned,
     });
 
     try func.addMemArg(
         Mir.Inst.Tag.fromOpcode(opcode),
         .{
             .offset = offset + operand.offset(),
-            .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+            .alignment = @intCast(ty.abiAlignment(zcu).toByteUnits().?),
         },
     );
 
@@ -2553,13 +2553,13 @@ fn load(func: *CodeGen, operand: WValue, ty: Type, offset: u32) InnerError!WValu
 
 fn airArg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const arg_index = func.arg_index;
     const arg = func.args[arg_index];
-    const cc = mod.typeToFunc(mod.navValue(func.owner_nav).typeOf(mod)).?.cc;
+    const cc = zcu.typeToFunc(zcu.navValue(func.owner_nav).typeOf(zcu)).?.cc;
     const arg_ty = func.typeOfIndex(inst);
     if (cc == .C) {
-        const arg_classes = abi.classifyType(arg_ty, pt);
+        const arg_classes = abi.classifyType(arg_ty, zcu);
         for (arg_classes) |class| {
             if (class != .none) {
                 func.arg_index += 1;
@@ -2569,7 +2569,7 @@ fn airArg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         // When we have an argument that's passed using more than a single parameter,
         // we combine them into a single stack value
         if (arg_classes[0] == .direct and arg_classes[1] == .direct) {
-            if (arg_ty.zigTypeTag(mod) != .Int and arg_ty.zigTypeTag(mod) != .Float) {
+            if (arg_ty.zigTypeTag(zcu) != .Int and arg_ty.zigTypeTag(zcu) != .Float) {
                 return func.fail(
                     "TODO: Implement C-ABI argument for type '{}'",
                     .{arg_ty.fmt(pt)},
@@ -2602,6 +2602,7 @@ fn airArg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     const pt = func.pt;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const lhs = try func.resolveInst(bin_op.lhs);
     const rhs = try func.resolveInst(bin_op.rhs);
@@ -2615,10 +2616,10 @@ fn airBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     // For big integers we can ignore this as we will call into compiler-rt which handles this.
     const result = switch (op) {
         .shr, .shl => result: {
-            const lhs_wasm_bits = toWasmBits(@intCast(lhs_ty.bitSize(pt))) orelse {
+            const lhs_wasm_bits = toWasmBits(@intCast(lhs_ty.bitSize(zcu))) orelse {
                 return func.fail("TODO: implement '{s}' for types larger than 128 bits", .{@tagName(op)});
             };
-            const rhs_wasm_bits = toWasmBits(@intCast(rhs_ty.bitSize(pt))).?;
+            const rhs_wasm_bits = toWasmBits(@intCast(rhs_ty.bitSize(zcu))).?;
             const new_rhs = if (lhs_wasm_bits != rhs_wasm_bits and lhs_wasm_bits != 128)
                 try (try func.intcast(rhs, rhs_ty, lhs_ty)).toLocal(func, lhs_ty)
             else
@@ -2635,7 +2636,7 @@ fn airBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
 /// NOTE: THis leaves the value on top of the stack.
 fn binOp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     assert(!(lhs != .stack and rhs == .stack));
 
     if (ty.isAnyFloat()) {
@@ -2644,7 +2645,7 @@ fn binOp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!
     }
 
     if (isByRef(ty, pt, func.target.*)) {
-        if (ty.zigTypeTag(mod) == .Int) {
+        if (ty.zigTypeTag(zcu) == .Int) {
             return func.binOpBigInt(lhs, rhs, ty, op);
         } else {
             return func.fail(
@@ -2657,7 +2658,7 @@ fn binOp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!
     const opcode: wasm.Opcode = buildOpcode(.{
         .op = op,
         .valtype1 = typeToValtype(ty, pt, func.target.*),
-        .signedness = if (ty.isSignedInt(mod)) .signed else .unsigned,
+        .signedness = if (ty.isSignedInt(zcu)) .signed else .unsigned,
     });
     try func.emitWValue(lhs);
     try func.emitWValue(rhs);
@@ -2669,8 +2670,8 @@ fn binOp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!
 
 fn binOpBigInt(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const int_info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const int_info = ty.intInfo(zcu);
     if (int_info.bits > 128) {
         return func.fail("TODO: Implement binary operation for big integers larger than 128 bits", .{});
     }
@@ -2812,17 +2813,17 @@ const FloatOp = enum {
 
 fn airAbs(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const operand = try func.resolveInst(ty_op.operand);
     const ty = func.typeOf(ty_op.operand);
-    const scalar_ty = ty.scalarType(mod);
+    const scalar_ty = ty.scalarType(zcu);
 
-    switch (scalar_ty.zigTypeTag(mod)) {
-        .Int => if (ty.zigTypeTag(mod) == .Vector) {
+    switch (scalar_ty.zigTypeTag(zcu)) {
+        .Int => if (ty.zigTypeTag(zcu) == .Vector) {
             return func.fail("TODO implement airAbs for {}", .{ty.fmt(pt)});
         } else {
-            const int_bits = ty.intInfo(mod).bits;
+            const int_bits = ty.intInfo(zcu).bits;
             const wasm_bits = toWasmBits(int_bits) orelse {
                 return func.fail("TODO: airAbs for signed integers larger than '{d}' bits", .{int_bits});
             };
@@ -2903,8 +2904,8 @@ fn airUnaryFloatOp(func: *CodeGen, inst: Air.Inst.Index, op: FloatOp) InnerError
 
 fn floatOp(func: *CodeGen, float_op: FloatOp, ty: Type, args: []const WValue) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector) {
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement floatOps for vectors", .{});
     }
 
@@ -3010,7 +3011,7 @@ fn floatNeg(func: *CodeGen, ty: Type, arg: WValue) InnerError!WValue {
 
 fn airWrapBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const lhs = try func.resolveInst(bin_op.lhs);
@@ -3018,7 +3019,7 @@ fn airWrapBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     const lhs_ty = func.typeOf(bin_op.lhs);
     const rhs_ty = func.typeOf(bin_op.rhs);
 
-    if (lhs_ty.zigTypeTag(mod) == .Vector or rhs_ty.zigTypeTag(mod) == .Vector) {
+    if (lhs_ty.zigTypeTag(zcu) == .Vector or rhs_ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement wrapping arithmetic for vectors", .{});
     }
 
@@ -3029,10 +3030,10 @@ fn airWrapBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     // For big integers we can ignore this as we will call into compiler-rt which handles this.
     const result = switch (op) {
         .shr, .shl => result: {
-            const lhs_wasm_bits = toWasmBits(@intCast(lhs_ty.bitSize(pt))) orelse {
+            const lhs_wasm_bits = toWasmBits(@intCast(lhs_ty.bitSize(zcu))) orelse {
                 return func.fail("TODO: implement '{s}' for types larger than 128 bits", .{@tagName(op)});
             };
-            const rhs_wasm_bits = toWasmBits(@intCast(rhs_ty.bitSize(pt))).?;
+            const rhs_wasm_bits = toWasmBits(@intCast(rhs_ty.bitSize(zcu))).?;
             const new_rhs = if (lhs_wasm_bits != rhs_wasm_bits and lhs_wasm_bits != 128)
                 try (try func.intcast(rhs, rhs_ty, lhs_ty)).toLocal(func, lhs_ty)
             else
@@ -3058,9 +3059,9 @@ fn wrapBinOp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerEr
 /// NOTE: When the Type is <= 64 bits, leaves the value on top of the stack, if wrapping was needed.
 fn wrapOperand(func: *CodeGen, operand: WValue, ty: Type) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    assert(ty.abiSize(pt) <= 16);
-    const int_bits: u16 = @intCast(ty.bitSize(pt)); // TODO use ty.intInfo(mod).bits
+    const zcu = pt.zcu;
+    assert(ty.abiSize(zcu) <= 16);
+    const int_bits: u16 = @intCast(ty.bitSize(zcu)); // TODO use ty.intInfo(zcu).bits
     const wasm_bits = toWasmBits(int_bits) orelse {
         return func.fail("TODO: Implement wrapOperand for bitsize '{d}'", .{int_bits});
     };
@@ -3070,7 +3071,7 @@ fn wrapOperand(func: *CodeGen, operand: WValue, ty: Type) InnerError!WValue {
     switch (wasm_bits) {
         32 => {
             try func.emitWValue(operand);
-            if (ty.isSignedInt(mod)) {
+            if (ty.isSignedInt(zcu)) {
                 try func.addImm32(32 - int_bits);
                 try func.addTag(.i32_shl);
                 try func.addImm32(32 - int_bits);
@@ -3083,7 +3084,7 @@ fn wrapOperand(func: *CodeGen, operand: WValue, ty: Type) InnerError!WValue {
         },
         64 => {
             try func.emitWValue(operand);
-            if (ty.isSignedInt(mod)) {
+            if (ty.isSignedInt(zcu)) {
                 try func.addImm64(64 - int_bits);
                 try func.addTag(.i64_shl);
                 try func.addImm64(64 - int_bits);
@@ -3104,7 +3105,7 @@ fn wrapOperand(func: *CodeGen, operand: WValue, ty: Type) InnerError!WValue {
 
             try func.emitWValue(result);
             _ = try func.load(operand, Type.u64, 8);
-            if (ty.isSignedInt(mod)) {
+            if (ty.isSignedInt(zcu)) {
                 try func.addImm64(128 - int_bits);
                 try func.addTag(.i64_shl);
                 try func.addImm64(128 - int_bits);
@@ -3145,13 +3146,13 @@ fn lowerPtr(func: *CodeGen, ptr_val: InternPool.Index, prev_offset: u64) InnerEr
                     };
                 },
                 .Struct => switch (base_ty.containerLayout(zcu)) {
-                    .auto => base_ty.structFieldOffset(@intCast(field.index), pt),
+                    .auto => base_ty.structFieldOffset(@intCast(field.index), zcu),
                     .@"extern", .@"packed" => unreachable,
                 },
                 .Union => switch (base_ty.containerLayout(zcu)) {
                     .auto => off: {
                         // Keep in sync with the `un` case of `generateSymbol`.
-                        const layout = base_ty.unionGetLayout(pt);
+                        const layout = base_ty.unionGetLayout(zcu);
                         if (layout.payload_size == 0) break :off 0;
                         if (layout.tag_size == 0) break :off 0;
                         if (layout.tag_align.compare(.gte, layout.payload_align)) {
@@ -3178,15 +3179,15 @@ fn lowerUavRef(
     offset: u32,
 ) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ty = Type.fromInterned(mod.intern_pool.typeOf(uav.val));
+    const zcu = pt.zcu;
+    const ty = Type.fromInterned(zcu.intern_pool.typeOf(uav.val));
 
-    const is_fn_body = ty.zigTypeTag(mod) == .Fn;
-    if (!is_fn_body and !ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    const is_fn_body = ty.zigTypeTag(zcu) == .Fn;
+    if (!is_fn_body and !ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return .{ .imm32 = 0xaaaaaaaa };
     }
 
-    const decl_align = mod.intern_pool.indexToKey(uav.orig_ty).ptr_type.flags.alignment;
+    const decl_align = zcu.intern_pool.indexToKey(uav.orig_ty).ptr_type.flags.alignment;
     const res = try func.bin_file.lowerUav(pt, uav.val, decl_align, func.src_loc);
     const target_sym_index = switch (res) {
         .mcv => |mcv| mcv.load_symbol,
@@ -3204,19 +3205,19 @@ fn lowerUavRef(
 
 fn lowerNavRef(func: *CodeGen, nav_index: InternPool.Nav.Index, offset: u32) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
 
     // check if decl is an alias to a function, in which case we
     // want to lower the actual decl, rather than the alias itself.
-    const owner_nav = switch (ip.indexToKey(mod.navValue(nav_index).toIntern())) {
+    const owner_nav = switch (ip.indexToKey(zcu.navValue(nav_index).toIntern())) {
         .func => |function| function.owner_nav,
         .variable => |variable| variable.owner_nav,
         .@"extern" => |@"extern"| @"extern".owner_nav,
         else => nav_index,
     };
     const nav_ty = ip.getNav(owner_nav).typeOf(ip);
-    if (!ip.isFunctionType(nav_ty) and !Type.fromInterned(nav_ty).hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!ip.isFunctionType(nav_ty) and !Type.fromInterned(nav_ty).hasRuntimeBitsIgnoreComptime(zcu)) {
         return .{ .imm32 = 0xaaaaaaaa };
     }
 
@@ -3234,10 +3235,10 @@ fn lowerNavRef(func: *CodeGen, nav_index: InternPool.Nav.Index, offset: u32) Inn
 /// Asserts that `isByRef` returns `false` for `ty`.
 fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     assert(!isByRef(ty, pt, func.target.*));
-    const ip = &mod.intern_pool;
-    if (val.isUndefDeep(mod)) return func.emitUndefined(ty);
+    const ip = &zcu.intern_pool;
+    if (val.isUndefDeep(zcu)) return func.emitUndefined(ty);
 
     switch (ip.indexToKey(val.ip_index)) {
         .int_type,
@@ -3280,16 +3281,16 @@ fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
         .empty_enum_value,
         => unreachable, // non-runtime values
         .int => {
-            const int_info = ty.intInfo(mod);
+            const int_info = ty.intInfo(zcu);
             switch (int_info.signedness) {
                 .signed => switch (int_info.bits) {
-                    0...32 => return .{ .imm32 = @bitCast(@as(i32, @intCast(val.toSignedInt(pt)))) },
-                    33...64 => return .{ .imm64 = @bitCast(val.toSignedInt(pt)) },
+                    0...32 => return .{ .imm32 = @bitCast(@as(i32, @intCast(val.toSignedInt(zcu)))) },
+                    33...64 => return .{ .imm64 = @bitCast(val.toSignedInt(zcu)) },
                     else => unreachable,
                 },
                 .unsigned => switch (int_info.bits) {
-                    0...32 => return .{ .imm32 = @intCast(val.toUnsignedInt(pt)) },
-                    33...64 => return .{ .imm64 = val.toUnsignedInt(pt) },
+                    0...32 => return .{ .imm32 = @intCast(val.toUnsignedInt(zcu)) },
+                    33...64 => return .{ .imm64 = val.toUnsignedInt(zcu) },
                     else => unreachable,
                 },
             }
@@ -3302,9 +3303,9 @@ fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
             const err_int_ty = try pt.errorIntType();
             const err_ty, const err_val = switch (error_union.val) {
                 .err_name => |err_name| .{
-                    ty.errorUnionSet(mod),
+                    ty.errorUnionSet(zcu),
                     Value.fromInterned(try pt.intern(.{ .err = .{
-                        .ty = ty.errorUnionSet(mod).toIntern(),
+                        .ty = ty.errorUnionSet(zcu).toIntern(),
                         .name = err_name,
                     } })),
                 },
@@ -3313,8 +3314,8 @@ fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
                     try pt.intValue(err_int_ty, 0),
                 },
             };
-            const payload_type = ty.errorUnionPayload(mod);
-            if (!payload_type.hasRuntimeBitsIgnoreComptime(pt)) {
+            const payload_type = ty.errorUnionPayload(zcu);
+            if (!payload_type.hasRuntimeBitsIgnoreComptime(zcu)) {
                 // We use the error type directly as the type.
                 return func.lowerConstant(err_val, err_ty);
             }
@@ -3339,20 +3340,20 @@ fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
             },
         },
         .ptr => return func.lowerPtr(val.toIntern(), 0),
-        .opt => if (ty.optionalReprIsPayload(mod)) {
-            const pl_ty = ty.optionalChild(mod);
-            if (val.optionalValue(mod)) |payload| {
+        .opt => if (ty.optionalReprIsPayload(zcu)) {
+            const pl_ty = ty.optionalChild(zcu);
+            if (val.optionalValue(zcu)) |payload| {
                 return func.lowerConstant(payload, pl_ty);
             } else {
                 return .{ .imm32 = 0 };
             }
         } else {
-            return .{ .imm32 = @intFromBool(!val.isNull(mod)) };
+            return .{ .imm32 = @intFromBool(!val.isNull(zcu)) };
         },
         .aggregate => switch (ip.indexToKey(ty.ip_index)) {
             .array_type => return func.fail("Wasm TODO: LowerConstant for {}", .{ty.fmt(pt)}),
             .vector_type => {
-                assert(determineSimdStoreStrategy(ty, pt, func.target.*) == .direct);
+                assert(determineSimdStoreStrategy(ty, zcu, func.target.*) == .direct);
                 var buf: [16]u8 = undefined;
                 val.writeToMemory(ty, pt, &buf) catch unreachable;
                 return func.storeSimdImmd(buf);
@@ -3378,8 +3379,8 @@ fn lowerConstant(func: *CodeGen, val: Value, ty: Type) InnerError!WValue {
             const constant_ty = if (un.tag == .none)
                 try ty.unionBackingType(pt)
             else field_ty: {
-                const union_obj = mod.typeToUnion(ty).?;
-                const field_index = mod.unionTagFieldIndex(union_obj, Value.fromInterned(un.tag)).?;
+                const union_obj = zcu.typeToUnion(ty).?;
+                const field_index = zcu.unionTagFieldIndex(union_obj, Value.fromInterned(un.tag)).?;
                 break :field_ty Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
             };
             return func.lowerConstant(Value.fromInterned(un.val), constant_ty);
@@ -3398,11 +3399,11 @@ fn storeSimdImmd(func: *CodeGen, value: [16]u8) !WValue {
 
 fn emitUndefined(func: *CodeGen, ty: Type) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    switch (ty.zigTypeTag(zcu)) {
         .Bool, .ErrorSet => return .{ .imm32 = 0xaaaaaaaa },
-        .Int, .Enum => switch (ty.intInfo(mod).bits) {
+        .Int, .Enum => switch (ty.intInfo(zcu).bits) {
             0...32 => return .{ .imm32 = 0xaaaaaaaa },
             33...64 => return .{ .imm64 = 0xaaaaaaaaaaaaaaaa },
             else => unreachable,
@@ -3419,8 +3420,8 @@ fn emitUndefined(func: *CodeGen, ty: Type) InnerError!WValue {
             else => unreachable,
         },
         .Optional => {
-            const pl_ty = ty.optionalChild(mod);
-            if (ty.optionalReprIsPayload(mod)) {
+            const pl_ty = ty.optionalChild(zcu);
+            if (ty.optionalReprIsPayload(zcu)) {
                 return func.emitUndefined(pl_ty);
             }
             return .{ .imm32 = 0xaaaaaaaa };
@@ -3429,10 +3430,10 @@ fn emitUndefined(func: *CodeGen, ty: Type) InnerError!WValue {
             return .{ .imm32 = 0xaaaaaaaa };
         },
         .Struct => {
-            const packed_struct = mod.typeToPackedStruct(ty).?;
+            const packed_struct = zcu.typeToPackedStruct(ty).?;
             return func.emitUndefined(Type.fromInterned(packed_struct.backingIntTypeUnordered(ip)));
         },
-        else => return func.fail("Wasm TODO: emitUndefined for type: {}\n", .{ty.zigTypeTag(mod)}),
+        else => return func.fail("Wasm TODO: emitUndefined for type: {}\n", .{ty.zigTypeTag(zcu)}),
     }
 }
 
@@ -3441,8 +3442,8 @@ fn emitUndefined(func: *CodeGen, ty: Type) InnerError!WValue {
 /// as an integer value.
 fn valueAsI32(func: *const CodeGen, val: Value) i32 {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
 
     switch (val.toIntern()) {
         .bool_true => return 1,
@@ -3465,12 +3466,13 @@ fn intIndexAsI32(ip: *const InternPool, int: InternPool.Index, pt: Zcu.PerThread
 }
 
 fn intStorageAsI32(storage: InternPool.Key.Int.Storage, pt: Zcu.PerThread) i32 {
+    const zcu = pt.zcu;
     return switch (storage) {
         .i64 => |x| @as(i32, @intCast(x)),
         .u64 => |x| @as(i32, @bitCast(@as(u32, @intCast(x)))),
         .big_int => unreachable,
-        .lazy_align => |ty| @as(i32, @bitCast(@as(u32, @intCast(Type.fromInterned(ty).abiAlignment(pt).toByteUnits() orelse 0)))),
-        .lazy_size => |ty| @as(i32, @bitCast(@as(u32, @intCast(Type.fromInterned(ty).abiSize(pt))))),
+        .lazy_align => |ty| @as(i32, @bitCast(@as(u32, @intCast(Type.fromInterned(ty).abiAlignment(zcu).toByteUnits() orelse 0)))),
+        .lazy_size => |ty| @as(i32, @bitCast(@as(u32, @intCast(Type.fromInterned(ty).abiSize(zcu))))),
     };
 }
 
@@ -3599,10 +3601,10 @@ fn airCmp(func: *CodeGen, inst: Air.Inst.Index, op: std.math.CompareOperator) In
 fn cmp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: std.math.CompareOperator) InnerError!WValue {
     assert(!(lhs != .stack and rhs == .stack));
     const pt = func.pt;
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Optional and !ty.optionalReprIsPayload(mod)) {
-        const payload_ty = ty.optionalChild(mod);
-        if (payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Optional and !ty.optionalReprIsPayload(zcu)) {
+        const payload_ty = ty.optionalChild(zcu);
+        if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             // When we hit this case, we must check the value of optionals
             // that are not pointers. This means first checking against non-null for
             // both lhs and rhs, as well as checking the payload are matching of lhs and rhs
@@ -3616,10 +3618,10 @@ fn cmp(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: std.math.CompareO
 
     const signedness: std.builtin.Signedness = blk: {
         // by default we tell the operand type is unsigned (i.e. bools and enum values)
-        if (ty.zigTypeTag(mod) != .Int) break :blk .unsigned;
+        if (ty.zigTypeTag(zcu) != .Int) break :blk .unsigned;
 
         // incase of an actual integer, we emit the correct signedness
-        break :blk ty.intInfo(mod).signedness;
+        break :blk ty.intInfo(zcu).signedness;
     };
 
     // ensure that when we compare pointers, we emit
@@ -3708,12 +3710,12 @@ fn airCmpLtErrorsLen(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 }
 
 fn airBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
-    const pt = func.pt;
+    const zcu = func.pt.zcu;
     const br = func.air.instructions.items(.data)[@intFromEnum(inst)].br;
     const block = func.blocks.get(br.block_inst).?;
 
     // if operand has codegen bits we should break with a value
-    if (func.typeOf(br.operand).hasRuntimeBitsIgnoreComptime(pt)) {
+    if (func.typeOf(br.operand).hasRuntimeBitsIgnoreComptime(zcu)) {
         const operand = try func.resolveInst(br.operand);
         try func.lowerToStack(operand);
 
@@ -3736,17 +3738,17 @@ fn airNot(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const operand = try func.resolveInst(ty_op.operand);
     const operand_ty = func.typeOf(ty_op.operand);
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
     const result = result: {
-        if (operand_ty.zigTypeTag(mod) == .Bool) {
+        if (operand_ty.zigTypeTag(zcu) == .Bool) {
             try func.emitWValue(operand);
             try func.addTag(.i32_eqz);
             const not_tmp = try func.allocLocal(operand_ty);
             try func.addLabel(.local_set, not_tmp.local.value);
             break :result not_tmp;
         } else {
-            const int_info = operand_ty.intInfo(mod);
+            const int_info = operand_ty.intInfo(zcu);
             const wasm_bits = toWasmBits(int_info.bits) orelse {
                 return func.fail("TODO: Implement binary NOT for {}", .{operand_ty.fmt(pt)});
             };
@@ -3816,14 +3818,14 @@ fn airUnreachable(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airBitcast(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const operand = try func.resolveInst(ty_op.operand);
     const wanted_ty = func.typeOfIndex(inst);
     const given_ty = func.typeOf(ty_op.operand);
 
-    const bit_size = given_ty.bitSize(pt);
-    const needs_wrapping = (given_ty.isSignedInt(mod) != wanted_ty.isSignedInt(mod)) and
+    const bit_size = given_ty.bitSize(zcu);
+    const needs_wrapping = (given_ty.isSignedInt(zcu) != wanted_ty.isSignedInt(zcu)) and
         bit_size != 32 and bit_size != 64 and bit_size != 128;
 
     const result = result: {
@@ -3860,12 +3862,12 @@ fn airBitcast(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn bitcast(func: *CodeGen, wanted_ty: Type, given_ty: Type, operand: WValue) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     // if we bitcast a float to or from an integer we must use the 'reinterpret' instruction
     if (!(wanted_ty.isAnyFloat() or given_ty.isAnyFloat())) return operand;
     if (wanted_ty.ip_index == .f16_type or given_ty.ip_index == .f16_type) return operand;
-    if (wanted_ty.bitSize(pt) > 64) return operand;
-    assert((wanted_ty.isInt(mod) and given_ty.isAnyFloat()) or (wanted_ty.isAnyFloat() and given_ty.isInt(mod)));
+    if (wanted_ty.bitSize(zcu) > 64) return operand;
+    assert((wanted_ty.isInt(zcu) and given_ty.isAnyFloat()) or (wanted_ty.isAnyFloat() and given_ty.isInt(zcu)));
 
     const opcode = buildOpcode(.{
         .op = .reinterpret,
@@ -3879,24 +3881,24 @@ fn bitcast(func: *CodeGen, wanted_ty: Type, given_ty: Type, operand: WValue) Inn
 
 fn airStructFieldPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.StructField, ty_pl.payload);
 
     const struct_ptr = try func.resolveInst(extra.data.struct_operand);
     const struct_ptr_ty = func.typeOf(extra.data.struct_operand);
-    const struct_ty = struct_ptr_ty.childType(mod);
+    const struct_ty = struct_ptr_ty.childType(zcu);
     const result = try func.structFieldPtr(inst, extra.data.struct_operand, struct_ptr, struct_ptr_ty, struct_ty, extra.data.field_index);
     return func.finishAir(inst, result, &.{extra.data.struct_operand});
 }
 
 fn airStructFieldPtrIndex(func: *CodeGen, inst: Air.Inst.Index, index: u32) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const struct_ptr = try func.resolveInst(ty_op.operand);
     const struct_ptr_ty = func.typeOf(ty_op.operand);
-    const struct_ty = struct_ptr_ty.childType(mod);
+    const struct_ty = struct_ptr_ty.childType(zcu);
 
     const result = try func.structFieldPtr(inst, ty_op.operand, struct_ptr, struct_ptr_ty, struct_ty, index);
     return func.finishAir(inst, result, &.{ty_op.operand});
@@ -3912,23 +3914,23 @@ fn structFieldPtr(
     index: u32,
 ) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result_ty = func.typeOfIndex(inst);
-    const struct_ptr_ty_info = struct_ptr_ty.ptrInfo(mod);
+    const struct_ptr_ty_info = struct_ptr_ty.ptrInfo(zcu);
 
-    const offset = switch (struct_ty.containerLayout(mod)) {
-        .@"packed" => switch (struct_ty.zigTypeTag(mod)) {
+    const offset = switch (struct_ty.containerLayout(zcu)) {
+        .@"packed" => switch (struct_ty.zigTypeTag(zcu)) {
             .Struct => offset: {
-                if (result_ty.ptrInfo(mod).packed_offset.host_size != 0) {
+                if (result_ty.ptrInfo(zcu).packed_offset.host_size != 0) {
                     break :offset @as(u32, 0);
                 }
-                const struct_type = mod.typeToStruct(struct_ty).?;
+                const struct_type = zcu.typeToStruct(struct_ty).?;
                 break :offset @divExact(pt.structPackedFieldBitOffset(struct_type, index) + struct_ptr_ty_info.packed_offset.bit_offset, 8);
             },
             .Union => 0,
             else => unreachable,
         },
-        else => struct_ty.structFieldOffset(index, pt),
+        else => struct_ty.structFieldOffset(index, zcu),
     };
     // save a load and store when we can simply reuse the operand
     if (offset == 0) {
@@ -3944,24 +3946,24 @@ fn structFieldPtr(
 
 fn airStructFieldVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const struct_field = func.air.extraData(Air.StructField, ty_pl.payload).data;
 
     const struct_ty = func.typeOf(struct_field.struct_operand);
     const operand = try func.resolveInst(struct_field.struct_operand);
     const field_index = struct_field.field_index;
-    const field_ty = struct_ty.structFieldType(field_index, mod);
-    if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) return func.finishAir(inst, .none, &.{struct_field.struct_operand});
+    const field_ty = struct_ty.structFieldType(field_index, zcu);
+    if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) return func.finishAir(inst, .none, &.{struct_field.struct_operand});
 
-    const result: WValue = switch (struct_ty.containerLayout(mod)) {
-        .@"packed" => switch (struct_ty.zigTypeTag(mod)) {
+    const result: WValue = switch (struct_ty.containerLayout(zcu)) {
+        .@"packed" => switch (struct_ty.zigTypeTag(zcu)) {
             .Struct => result: {
-                const packed_struct = mod.typeToPackedStruct(struct_ty).?;
+                const packed_struct = zcu.typeToPackedStruct(struct_ty).?;
                 const offset = pt.structPackedFieldBitOffset(packed_struct, field_index);
                 const backing_ty = Type.fromInterned(packed_struct.backingIntTypeUnordered(ip));
-                const wasm_bits = toWasmBits(backing_ty.intInfo(mod).bits) orelse {
+                const wasm_bits = toWasmBits(backing_ty.intInfo(zcu).bits) orelse {
                     return func.fail("TODO: airStructFieldVal for packed structs larger than 128 bits", .{});
                 };
                 const const_wvalue: WValue = if (wasm_bits == 32)
@@ -3977,16 +3979,16 @@ fn airStructFieldVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 else
                     try func.binOp(operand, const_wvalue, backing_ty, .shr);
 
-                if (field_ty.zigTypeTag(mod) == .Float) {
-                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(pt))));
+                if (field_ty.zigTypeTag(zcu) == .Float) {
+                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(zcu))));
                     const truncated = try func.trunc(shifted_value, int_type, backing_ty);
                     break :result try func.bitcast(field_ty, int_type, truncated);
-                } else if (field_ty.isPtrAtRuntime(mod) and packed_struct.field_types.len == 1) {
+                } else if (field_ty.isPtrAtRuntime(zcu) and packed_struct.field_types.len == 1) {
                     // In this case we do not have to perform any transformations,
                     // we can simply reuse the operand.
                     break :result func.reuseOperand(struct_field.struct_operand, operand);
-                } else if (field_ty.isPtrAtRuntime(mod)) {
-                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(pt))));
+                } else if (field_ty.isPtrAtRuntime(zcu)) {
+                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(zcu))));
                     break :result try func.trunc(shifted_value, int_type, backing_ty);
                 }
                 break :result try func.trunc(shifted_value, field_ty, backing_ty);
@@ -4002,13 +4004,13 @@ fn airStructFieldVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     }
                 }
 
-                const union_int_type = try pt.intType(.unsigned, @as(u16, @intCast(struct_ty.bitSize(pt))));
-                if (field_ty.zigTypeTag(mod) == .Float) {
-                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(pt))));
+                const union_int_type = try pt.intType(.unsigned, @as(u16, @intCast(struct_ty.bitSize(zcu))));
+                if (field_ty.zigTypeTag(zcu) == .Float) {
+                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(zcu))));
                     const truncated = try func.trunc(operand, int_type, union_int_type);
                     break :result try func.bitcast(field_ty, int_type, truncated);
-                } else if (field_ty.isPtrAtRuntime(mod)) {
-                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(pt))));
+                } else if (field_ty.isPtrAtRuntime(zcu)) {
+                    const int_type = try pt.intType(.unsigned, @as(u16, @intCast(field_ty.bitSize(zcu))));
                     break :result try func.trunc(operand, int_type, union_int_type);
                 }
                 break :result try func.trunc(operand, field_ty, union_int_type);
@@ -4016,7 +4018,7 @@ fn airStructFieldVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             else => unreachable,
         },
         else => result: {
-            const offset = std.math.cast(u32, struct_ty.structFieldOffset(field_index, pt)) orelse {
+            const offset = std.math.cast(u32, struct_ty.structFieldOffset(field_index, zcu)) orelse {
                 return func.fail("Field type '{}' too big to fit into stack frame", .{field_ty.fmt(pt)});
             };
             if (isByRef(field_ty, pt, func.target.*)) {
@@ -4036,7 +4038,7 @@ fn airStructFieldVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airSwitchBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     // result type is always 'noreturn'
     const blocktype = wasm.block_empty;
     const pl_op = func.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
@@ -4093,7 +4095,7 @@ fn airSwitchBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     // When the target is an integer size larger than u32, we have no way to use the value
     // as an index, therefore we also use an if/else-chain for those cases.
     // TODO: Benchmark this to find a proper value, LLVM seems to draw the line at '40~45'.
-    const is_sparse = highest - lowest > 50 or target_ty.bitSize(pt) > 32;
+    const is_sparse = highest - lowest > 50 or target_ty.bitSize(zcu) > 32;
 
     const else_body: []const Air.Inst.Index = @ptrCast(func.air.extra[extra_index..][0..switch_br.data.else_body_len]);
     const has_else_body = else_body.len != 0;
@@ -4138,7 +4140,7 @@ fn airSwitchBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 // for errors that are not present in any branch. This is fine as this default
                 // case will never be hit for those cases but we do save runtime cost and size
                 // by using a jump table for this instead of if-else chains.
-                break :blk if (has_else_body or target_ty.zigTypeTag(mod) == .ErrorSet) case_i else unreachable;
+                break :blk if (has_else_body or target_ty.zigTypeTag(zcu) == .ErrorSet) case_i else unreachable;
             };
             func.mir_extra.appendAssumeCapacity(idx);
         } else if (has_else_body) {
@@ -4149,10 +4151,10 @@ fn airSwitchBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
     const signedness: std.builtin.Signedness = blk: {
         // by default we tell the operand type is unsigned (i.e. bools and enum values)
-        if (target_ty.zigTypeTag(mod) != .Int) break :blk .unsigned;
+        if (target_ty.zigTypeTag(zcu) != .Int) break :blk .unsigned;
 
         // incase of an actual integer, we emit the correct signedness
-        break :blk target_ty.intInfo(mod).signedness;
+        break :blk target_ty.intInfo(zcu).signedness;
     };
 
     try func.branches.ensureUnusedCapacity(func.gpa, case_list.items.len + @intFromBool(has_else_body));
@@ -4217,14 +4219,14 @@ fn airSwitchBr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airIsErr(func: *CodeGen, inst: Air.Inst.Index, opcode: wasm.Opcode) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = func.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const operand = try func.resolveInst(un_op);
     const err_union_ty = func.typeOf(un_op);
-    const pl_ty = err_union_ty.errorUnionPayload(mod);
+    const pl_ty = err_union_ty.errorUnionPayload(zcu);
 
     const result: WValue = result: {
-        if (err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             switch (opcode) {
                 .i32_ne => break :result .{ .imm32 = 0 },
                 .i32_eq => break :result .{ .imm32 = 1 },
@@ -4233,10 +4235,10 @@ fn airIsErr(func: *CodeGen, inst: Air.Inst.Index, opcode: wasm.Opcode) InnerErro
         }
 
         try func.emitWValue(operand);
-        if (pl_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             try func.addMemArg(.i32_load16_u, .{
-                .offset = operand.offset() + @as(u32, @intCast(errUnionErrorOffset(pl_ty, pt))),
-                .alignment = @intCast(Type.anyerror.abiAlignment(pt).toByteUnits().?),
+                .offset = operand.offset() + @as(u32, @intCast(errUnionErrorOffset(pl_ty, zcu))),
+                .alignment = @intCast(Type.anyerror.abiAlignment(zcu).toByteUnits().?),
             });
         }
 
@@ -4250,23 +4252,23 @@ fn airIsErr(func: *CodeGen, inst: Air.Inst.Index, opcode: wasm.Opcode) InnerErro
 
 fn airUnwrapErrUnionPayload(func: *CodeGen, inst: Air.Inst.Index, op_is_ptr: bool) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const op_ty = func.typeOf(ty_op.operand);
-    const err_ty = if (op_is_ptr) op_ty.childType(mod) else op_ty;
-    const payload_ty = err_ty.errorUnionPayload(mod);
+    const err_ty = if (op_is_ptr) op_ty.childType(zcu) else op_ty;
+    const payload_ty = err_ty.errorUnionPayload(zcu);
 
     const result: WValue = result: {
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             if (op_is_ptr) {
                 break :result func.reuseOperand(ty_op.operand, operand);
             }
             break :result .none;
         }
 
-        const pl_offset = @as(u32, @intCast(errUnionPayloadOffset(payload_ty, pt)));
+        const pl_offset = @as(u32, @intCast(errUnionPayloadOffset(payload_ty, zcu)));
         if (op_is_ptr or isByRef(payload_ty, pt, func.target.*)) {
             break :result try func.buildPointerOffset(operand, pl_offset, .new);
         }
@@ -4278,30 +4280,30 @@ fn airUnwrapErrUnionPayload(func: *CodeGen, inst: Air.Inst.Index, op_is_ptr: boo
 
 fn airUnwrapErrUnionError(func: *CodeGen, inst: Air.Inst.Index, op_is_ptr: bool) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const op_ty = func.typeOf(ty_op.operand);
-    const err_ty = if (op_is_ptr) op_ty.childType(mod) else op_ty;
-    const payload_ty = err_ty.errorUnionPayload(mod);
+    const err_ty = if (op_is_ptr) op_ty.childType(zcu) else op_ty;
+    const payload_ty = err_ty.errorUnionPayload(zcu);
 
     const result: WValue = result: {
-        if (err_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (err_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             break :result .{ .imm32 = 0 };
         }
 
-        if (op_is_ptr or !payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (op_is_ptr or !payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             break :result func.reuseOperand(ty_op.operand, operand);
         }
 
-        break :result try func.load(operand, Type.anyerror, @intCast(errUnionErrorOffset(payload_ty, pt)));
+        break :result try func.load(operand, Type.anyerror, @intCast(errUnionErrorOffset(payload_ty, zcu)));
     };
     return func.finishAir(inst, result, &.{ty_op.operand});
 }
 
 fn airWrapErrUnionPayload(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
-    const pt = func.pt;
+    const zcu = func.pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
@@ -4309,18 +4311,18 @@ fn airWrapErrUnionPayload(func: *CodeGen, inst: Air.Inst.Index) InnerError!void 
 
     const pl_ty = func.typeOf(ty_op.operand);
     const result = result: {
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             break :result func.reuseOperand(ty_op.operand, operand);
         }
 
         const err_union = try func.allocStack(err_ty);
-        const payload_ptr = try func.buildPointerOffset(err_union, @as(u32, @intCast(errUnionPayloadOffset(pl_ty, pt))), .new);
+        const payload_ptr = try func.buildPointerOffset(err_union, @as(u32, @intCast(errUnionPayloadOffset(pl_ty, zcu))), .new);
         try func.store(payload_ptr, operand, pl_ty, 0);
 
         // ensure we also write '0' to the error part, so any present stack value gets overwritten by it.
         try func.emitWValue(err_union);
         try func.addImm32(0);
-        const err_val_offset: u32 = @intCast(errUnionErrorOffset(pl_ty, pt));
+        const err_val_offset: u32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
         try func.addMemArg(.i32_store16, .{
             .offset = err_union.offset() + err_val_offset,
             .alignment = 2,
@@ -4332,25 +4334,25 @@ fn airWrapErrUnionPayload(func: *CodeGen, inst: Air.Inst.Index) InnerError!void 
 
 fn airWrapErrUnionErr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const err_ty = ty_op.ty.toType();
-    const pl_ty = err_ty.errorUnionPayload(mod);
+    const pl_ty = err_ty.errorUnionPayload(zcu);
 
     const result = result: {
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             break :result func.reuseOperand(ty_op.operand, operand);
         }
 
         const err_union = try func.allocStack(err_ty);
         // store error value
-        try func.store(err_union, operand, Type.anyerror, @intCast(errUnionErrorOffset(pl_ty, pt)));
+        try func.store(err_union, operand, Type.anyerror, @intCast(errUnionErrorOffset(pl_ty, zcu)));
 
         // write 'undefined' to the payload
-        const payload_ptr = try func.buildPointerOffset(err_union, @as(u32, @intCast(errUnionPayloadOffset(pl_ty, pt))), .new);
-        const len = @as(u32, @intCast(err_ty.errorUnionPayload(mod).abiSize(pt)));
+        const payload_ptr = try func.buildPointerOffset(err_union, @as(u32, @intCast(errUnionPayloadOffset(pl_ty, zcu))), .new);
+        const len = @as(u32, @intCast(err_ty.errorUnionPayload(zcu).abiSize(zcu)));
         try func.memset(Type.u8, payload_ptr, .{ .imm32 = len }, .{ .imm32 = 0xaa });
 
         break :result err_union;
@@ -4365,16 +4367,16 @@ fn airIntcast(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const operand = try func.resolveInst(ty_op.operand);
     const operand_ty = func.typeOf(ty_op.operand);
     const pt = func.pt;
-    const mod = pt.zcu;
-    if (ty.zigTypeTag(mod) == .Vector or operand_ty.zigTypeTag(mod) == .Vector) {
+    const zcu = pt.zcu;
+    if (ty.zigTypeTag(zcu) == .Vector or operand_ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("todo Wasm intcast for vectors", .{});
     }
-    if (ty.abiSize(pt) > 16 or operand_ty.abiSize(pt) > 16) {
+    if (ty.abiSize(zcu) > 16 or operand_ty.abiSize(zcu) > 16) {
         return func.fail("todo Wasm intcast for bitsize > 128", .{});
     }
 
-    const op_bits = toWasmBits(@intCast(operand_ty.bitSize(pt))).?;
-    const wanted_bits = toWasmBits(@intCast(ty.bitSize(pt))).?;
+    const op_bits = toWasmBits(@intCast(operand_ty.bitSize(zcu))).?;
+    const wanted_bits = toWasmBits(@intCast(ty.bitSize(zcu))).?;
     const result = if (op_bits == wanted_bits)
         func.reuseOperand(ty_op.operand, operand)
     else
@@ -4389,9 +4391,9 @@ fn airIntcast(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 /// NOTE: May leave the result on the top of the stack.
 fn intcast(func: *CodeGen, operand: WValue, given: Type, wanted: Type) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const given_bitsize = @as(u16, @intCast(given.bitSize(pt)));
-    const wanted_bitsize = @as(u16, @intCast(wanted.bitSize(pt)));
+    const zcu = pt.zcu;
+    const given_bitsize = @as(u16, @intCast(given.bitSize(zcu)));
+    const wanted_bitsize = @as(u16, @intCast(wanted.bitSize(zcu)));
     assert(given_bitsize <= 128);
     assert(wanted_bitsize <= 128);
 
@@ -4407,7 +4409,7 @@ fn intcast(func: *CodeGen, operand: WValue, given: Type, wanted: Type) InnerErro
         return .stack;
     } else if (op_bits == 32 and wanted_bits == 64) {
         try func.emitWValue(operand);
-        try func.addTag(if (wanted.isSignedInt(mod)) .i64_extend_i32_s else .i64_extend_i32_u);
+        try func.addTag(if (wanted.isSignedInt(zcu)) .i64_extend_i32_s else .i64_extend_i32_u);
         return .stack;
     } else if (wanted_bits == 128) {
         // for 128bit integers we store the integer in the virtual stack, rather than a local
@@ -4417,7 +4419,7 @@ fn intcast(func: *CodeGen, operand: WValue, given: Type, wanted: Type) InnerErro
         // for 32 bit integers, we first coerce the value into a 64 bit integer before storing it
         // meaning less store operations are required.
         const lhs = if (op_bits == 32) blk: {
-            const sign_ty = if (wanted.isSignedInt(mod)) Type.i64 else Type.u64;
+            const sign_ty = if (wanted.isSignedInt(zcu)) Type.i64 else Type.u64;
             break :blk try (try func.intcast(operand, given, sign_ty)).toLocal(func, sign_ty);
         } else operand;
 
@@ -4425,7 +4427,7 @@ fn intcast(func: *CodeGen, operand: WValue, given: Type, wanted: Type) InnerErro
         try func.store(.stack, lhs, Type.u64, 0 + stack_ptr.offset());
 
         // For signed integers we shift lsb by 63 (64bit integer - 1 sign bit) and store remaining value
-        if (wanted.isSignedInt(mod)) {
+        if (wanted.isSignedInt(zcu)) {
             try func.emitWValue(stack_ptr);
             const shr = try func.binOp(lhs, .{ .imm64 = 63 }, Type.i64, .shr);
             try func.store(.stack, shr, Type.u64, 8 + stack_ptr.offset());
@@ -4439,12 +4441,12 @@ fn intcast(func: *CodeGen, operand: WValue, given: Type, wanted: Type) InnerErro
 
 fn airIsNull(func: *CodeGen, inst: Air.Inst.Index, opcode: wasm.Opcode, op_kind: enum { value, ptr }) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = func.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const operand = try func.resolveInst(un_op);
 
     const op_ty = func.typeOf(un_op);
-    const optional_ty = if (op_kind == .ptr) op_ty.childType(mod) else op_ty;
+    const optional_ty = if (op_kind == .ptr) op_ty.childType(zcu) else op_ty;
     const result = try func.isNull(operand, optional_ty, opcode);
     return func.finishAir(inst, result, &.{un_op});
 }
@@ -4453,19 +4455,19 @@ fn airIsNull(func: *CodeGen, inst: Air.Inst.Index, opcode: wasm.Opcode, op_kind:
 /// NOTE: Leaves the result on the stack
 fn isNull(func: *CodeGen, operand: WValue, optional_ty: Type, opcode: wasm.Opcode) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     try func.emitWValue(operand);
-    const payload_ty = optional_ty.optionalChild(mod);
-    if (!optional_ty.optionalReprIsPayload(mod)) {
+    const payload_ty = optional_ty.optionalChild(zcu);
+    if (!optional_ty.optionalReprIsPayload(zcu)) {
         // When payload is zero-bits, we can treat operand as a value, rather than
         // a pointer to the stack value
-        if (payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-            const offset = std.math.cast(u32, payload_ty.abiSize(pt)) orelse {
+        if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+            const offset = std.math.cast(u32, payload_ty.abiSize(zcu)) orelse {
                 return func.fail("Optional type {} too big to fit into stack frame", .{optional_ty.fmt(pt)});
             };
             try func.addMemArg(.i32_load8_u, .{ .offset = operand.offset() + offset, .alignment = 1 });
         }
-    } else if (payload_ty.isSlice(mod)) {
+    } else if (payload_ty.isSlice(zcu)) {
         switch (func.arch()) {
             .wasm32 => try func.addMemArg(.i32_load, .{ .offset = operand.offset(), .alignment = 4 }),
             .wasm64 => try func.addMemArg(.i64_load, .{ .offset = operand.offset(), .alignment = 8 }),
@@ -4482,17 +4484,17 @@ fn isNull(func: *CodeGen, operand: WValue, optional_ty: Type, opcode: wasm.Opcod
 
 fn airOptionalPayload(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const opt_ty = func.typeOf(ty_op.operand);
     const payload_ty = func.typeOfIndex(inst);
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return func.finishAir(inst, .none, &.{ty_op.operand});
     }
 
     const result = result: {
         const operand = try func.resolveInst(ty_op.operand);
-        if (opt_ty.optionalReprIsPayload(mod)) break :result func.reuseOperand(ty_op.operand, operand);
+        if (opt_ty.optionalReprIsPayload(zcu)) break :result func.reuseOperand(ty_op.operand, operand);
 
         if (isByRef(payload_ty, pt, func.target.*)) {
             break :result try func.buildPointerOffset(operand, 0, .new);
@@ -4505,14 +4507,14 @@ fn airOptionalPayload(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airOptionalPayloadPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const operand = try func.resolveInst(ty_op.operand);
-    const opt_ty = func.typeOf(ty_op.operand).childType(mod);
+    const opt_ty = func.typeOf(ty_op.operand).childType(zcu);
 
     const result = result: {
-        const payload_ty = opt_ty.optionalChild(mod);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt) or opt_ty.optionalReprIsPayload(mod)) {
+        const payload_ty = opt_ty.optionalChild(zcu);
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu) or opt_ty.optionalReprIsPayload(zcu)) {
             break :result func.reuseOperand(ty_op.operand, operand);
         }
 
@@ -4523,20 +4525,20 @@ fn airOptionalPayloadPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airOptionalPayloadPtrSet(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const operand = try func.resolveInst(ty_op.operand);
-    const opt_ty = func.typeOf(ty_op.operand).childType(mod);
-    const payload_ty = opt_ty.optionalChild(mod);
-    if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    const opt_ty = func.typeOf(ty_op.operand).childType(zcu);
+    const payload_ty = opt_ty.optionalChild(zcu);
+    if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         return func.fail("TODO: Implement OptionalPayloadPtrSet for optional with zero-sized type {}", .{payload_ty.fmtDebug()});
     }
 
-    if (opt_ty.optionalReprIsPayload(mod)) {
+    if (opt_ty.optionalReprIsPayload(zcu)) {
         return func.finishAir(inst, operand, &.{ty_op.operand});
     }
 
-    const offset = std.math.cast(u32, payload_ty.abiSize(pt)) orelse {
+    const offset = std.math.cast(u32, payload_ty.abiSize(zcu)) orelse {
         return func.fail("Optional type {} too big to fit into stack frame", .{opt_ty.fmt(pt)});
     };
 
@@ -4552,10 +4554,10 @@ fn airWrapOptional(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const payload_ty = func.typeOf(ty_op.operand);
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
     const result = result: {
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             const non_null_bit = try func.allocStack(Type.u1);
             try func.emitWValue(non_null_bit);
             try func.addImm32(1);
@@ -4565,10 +4567,10 @@ fn airWrapOptional(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
         const operand = try func.resolveInst(ty_op.operand);
         const op_ty = func.typeOfIndex(inst);
-        if (op_ty.optionalReprIsPayload(mod)) {
+        if (op_ty.optionalReprIsPayload(zcu)) {
             break :result func.reuseOperand(ty_op.operand, operand);
         }
-        const offset = std.math.cast(u32, payload_ty.abiSize(pt)) orelse {
+        const offset = std.math.cast(u32, payload_ty.abiSize(zcu)) orelse {
             return func.fail("Optional type {} too big to fit into stack frame", .{op_ty.fmt(pt)});
         };
 
@@ -4610,14 +4612,14 @@ fn airSliceLen(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airSliceElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const slice_ty = func.typeOf(bin_op.lhs);
     const slice = try func.resolveInst(bin_op.lhs);
     const index = try func.resolveInst(bin_op.rhs);
-    const elem_ty = slice_ty.childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_ty = slice_ty.childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
 
     // load pointer onto stack
     _ = try func.load(slice, Type.usize, 0);
@@ -4638,12 +4640,12 @@ fn airSliceElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airSliceElemPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = func.air.extraData(Air.Bin, ty_pl.payload).data;
 
-    const elem_ty = ty_pl.ty.toType().childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_ty = ty_pl.ty.toType().childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
 
     const slice = try func.resolveInst(bin_op.lhs);
     const index = try func.resolveInst(bin_op.rhs);
@@ -4682,13 +4684,13 @@ fn airTrunc(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const wanted_ty: Type = ty_op.ty.toType();
     const op_ty = func.typeOf(ty_op.operand);
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
-    if (wanted_ty.zigTypeTag(mod) == .Vector or op_ty.zigTypeTag(mod) == .Vector) {
+    if (wanted_ty.zigTypeTag(zcu) == .Vector or op_ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: trunc for vectors", .{});
     }
 
-    const result = if (op_ty.bitSize(pt) == wanted_ty.bitSize(pt))
+    const result = if (op_ty.bitSize(zcu) == wanted_ty.bitSize(zcu))
         func.reuseOperand(ty_op.operand, operand)
     else
         try func.trunc(operand, wanted_ty, op_ty);
@@ -4700,13 +4702,14 @@ fn airTrunc(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 /// NOTE: Resulting value is left on the stack.
 fn trunc(func: *CodeGen, operand: WValue, wanted_ty: Type, given_ty: Type) InnerError!WValue {
     const pt = func.pt;
-    const given_bits = @as(u16, @intCast(given_ty.bitSize(pt)));
+    const zcu = pt.zcu;
+    const given_bits = @as(u16, @intCast(given_ty.bitSize(zcu)));
     if (toWasmBits(given_bits) == null) {
         return func.fail("TODO: Implement wasm integer truncation for integer bitsize: {d}", .{given_bits});
     }
 
     var result = try func.intcast(operand, given_ty, wanted_ty);
-    const wanted_bits = @as(u16, @intCast(wanted_ty.bitSize(pt)));
+    const wanted_bits = @as(u16, @intCast(wanted_ty.bitSize(zcu)));
     const wasm_bits = toWasmBits(wanted_bits).?;
     if (wasm_bits != wanted_bits) {
         result = try func.wrapOperand(result, wanted_ty);
@@ -4724,23 +4727,23 @@ fn airIntFromBool(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airArrayToSlice(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
-    const array_ty = func.typeOf(ty_op.operand).childType(mod);
+    const array_ty = func.typeOf(ty_op.operand).childType(zcu);
     const slice_ty = ty_op.ty.toType();
 
     // create a slice on the stack
     const slice_local = try func.allocStack(slice_ty);
 
     // store the array ptr in the slice
-    if (array_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (array_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
         try func.store(slice_local, operand, Type.usize, 0);
     }
 
     // store the length of the array in the slice
-    const array_len: u32 = @intCast(array_ty.arrayLen(mod));
+    const array_len: u32 = @intCast(array_ty.arrayLen(zcu));
     try func.store(slice_local, .{ .imm32 = array_len }, Type.usize, func.ptrSize());
 
     return func.finishAir(inst, slice_local, &.{ty_op.operand});
@@ -4748,11 +4751,11 @@ fn airArrayToSlice(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airIntFromPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = func.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const operand = try func.resolveInst(un_op);
     const ptr_ty = func.typeOf(un_op);
-    const result = if (ptr_ty.isSlice(mod))
+    const result = if (ptr_ty.isSlice(zcu))
         try func.slicePtr(operand)
     else switch (operand) {
         // for stack offset, return a pointer to this offset.
@@ -4764,17 +4767,17 @@ fn airIntFromPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airPtrElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const ptr_ty = func.typeOf(bin_op.lhs);
     const ptr = try func.resolveInst(bin_op.lhs);
     const index = try func.resolveInst(bin_op.rhs);
-    const elem_ty = ptr_ty.childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_ty = ptr_ty.childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
 
     // load pointer onto the stack
-    if (ptr_ty.isSlice(mod)) {
+    if (ptr_ty.isSlice(zcu)) {
         _ = try func.load(ptr, Type.usize, 0);
     } else {
         try func.lowerToStack(ptr);
@@ -4796,19 +4799,19 @@ fn airPtrElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airPtrElemPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = func.air.extraData(Air.Bin, ty_pl.payload).data;
 
     const ptr_ty = func.typeOf(bin_op.lhs);
-    const elem_ty = ty_pl.ty.toType().childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_ty = ty_pl.ty.toType().childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
 
     const ptr = try func.resolveInst(bin_op.lhs);
     const index = try func.resolveInst(bin_op.rhs);
 
     // load pointer onto the stack
-    if (ptr_ty.isSlice(mod)) {
+    if (ptr_ty.isSlice(zcu)) {
         _ = try func.load(ptr, Type.usize, 0);
     } else {
         try func.lowerToStack(ptr);
@@ -4825,16 +4828,16 @@ fn airPtrElemPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airPtrBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = func.air.extraData(Air.Bin, ty_pl.payload).data;
 
     const ptr = try func.resolveInst(bin_op.lhs);
     const offset = try func.resolveInst(bin_op.rhs);
     const ptr_ty = func.typeOf(bin_op.lhs);
-    const pointee_ty = switch (ptr_ty.ptrSize(mod)) {
-        .One => ptr_ty.childType(mod).childType(mod), // ptr to array, so get array element type
-        else => ptr_ty.childType(mod),
+    const pointee_ty = switch (ptr_ty.ptrSize(zcu)) {
+        .One => ptr_ty.childType(zcu).childType(zcu), // ptr to array, so get array element type
+        else => ptr_ty.childType(zcu),
     };
 
     const valtype = typeToValtype(Type.usize, pt, func.target.*);
@@ -4843,7 +4846,7 @@ fn airPtrBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
 
     try func.lowerToStack(ptr);
     try func.emitWValue(offset);
-    try func.addImm32(@intCast(pointee_ty.abiSize(pt)));
+    try func.addImm32(@intCast(pointee_ty.abiSize(zcu)));
     try func.addTag(Mir.Inst.Tag.fromOpcode(mul_opcode));
     try func.addTag(Mir.Inst.Tag.fromOpcode(bin_opcode));
 
@@ -4852,7 +4855,7 @@ fn airPtrBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
 
 fn airMemset(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     if (safety) {
         // TODO if the value is undef, write 0xaa bytes to dest
     } else {
@@ -4863,16 +4866,16 @@ fn airMemset(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void
     const ptr = try func.resolveInst(bin_op.lhs);
     const ptr_ty = func.typeOf(bin_op.lhs);
     const value = try func.resolveInst(bin_op.rhs);
-    const len = switch (ptr_ty.ptrSize(mod)) {
+    const len = switch (ptr_ty.ptrSize(zcu)) {
         .Slice => try func.sliceLen(ptr),
-        .One => @as(WValue, .{ .imm32 = @as(u32, @intCast(ptr_ty.childType(mod).arrayLen(mod))) }),
+        .One => @as(WValue, .{ .imm32 = @as(u32, @intCast(ptr_ty.childType(zcu).arrayLen(zcu))) }),
         .C, .Many => unreachable,
     };
 
-    const elem_ty = if (ptr_ty.ptrSize(mod) == .One)
-        ptr_ty.childType(mod).childType(mod)
+    const elem_ty = if (ptr_ty.ptrSize(zcu) == .One)
+        ptr_ty.childType(zcu).childType(zcu)
     else
-        ptr_ty.childType(mod);
+        ptr_ty.childType(zcu);
 
     const dst_ptr = try func.sliceOrArrayPtr(ptr, ptr_ty);
     try func.memset(elem_ty, dst_ptr, len, value);
@@ -4886,7 +4889,7 @@ fn airMemset(func: *CodeGen, inst: Air.Inst.Index, safety: bool) InnerError!void
 /// we implement it manually.
 fn memset(func: *CodeGen, elem_ty: Type, ptr: WValue, len: WValue, value: WValue) InnerError!void {
     const pt = func.pt;
-    const abi_size = @as(u32, @intCast(elem_ty.abiSize(pt)));
+    const abi_size = @as(u32, @intCast(elem_ty.abiSize(pt.zcu)));
 
     // When bulk_memory is enabled, we lower it to wasm's memset instruction.
     // If not, we lower it ourselves.
@@ -4975,14 +4978,14 @@ fn memset(func: *CodeGen, elem_ty: Type, ptr: WValue, len: WValue, value: WValue
 
 fn airArrayElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const array_ty = func.typeOf(bin_op.lhs);
     const array = try func.resolveInst(bin_op.lhs);
     const index = try func.resolveInst(bin_op.rhs);
-    const elem_ty = array_ty.childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
+    const elem_ty = array_ty.childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
 
     if (isByRef(array_ty, pt, func.target.*)) {
         try func.lowerToStack(array);
@@ -4991,15 +4994,15 @@ fn airArrayElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         try func.addTag(.i32_mul);
         try func.addTag(.i32_add);
     } else {
-        std.debug.assert(array_ty.zigTypeTag(mod) == .Vector);
+        std.debug.assert(array_ty.zigTypeTag(zcu) == .Vector);
 
         switch (index) {
             inline .imm32, .imm64 => |lane| {
-                const opcode: wasm.SimdOpcode = switch (elem_ty.bitSize(pt)) {
-                    8 => if (elem_ty.isSignedInt(mod)) .i8x16_extract_lane_s else .i8x16_extract_lane_u,
-                    16 => if (elem_ty.isSignedInt(mod)) .i16x8_extract_lane_s else .i16x8_extract_lane_u,
-                    32 => if (elem_ty.isInt(mod)) .i32x4_extract_lane else .f32x4_extract_lane,
-                    64 => if (elem_ty.isInt(mod)) .i64x2_extract_lane else .f64x2_extract_lane,
+                const opcode: wasm.SimdOpcode = switch (elem_ty.bitSize(zcu)) {
+                    8 => if (elem_ty.isSignedInt(zcu)) .i8x16_extract_lane_s else .i8x16_extract_lane_u,
+                    16 => if (elem_ty.isSignedInt(zcu)) .i16x8_extract_lane_s else .i16x8_extract_lane_u,
+                    32 => if (elem_ty.isInt(zcu)) .i32x4_extract_lane else .f32x4_extract_lane,
+                    64 => if (elem_ty.isInt(zcu)) .i64x2_extract_lane else .f64x2_extract_lane,
                     else => unreachable,
                 };
 
@@ -5037,7 +5040,7 @@ fn airArrayElemVal(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airIntFromFloat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
@@ -5045,7 +5048,7 @@ fn airIntFromFloat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const op_bits = op_ty.floatBits(func.target.*);
 
     const dest_ty = func.typeOfIndex(inst);
-    const dest_info = dest_ty.intInfo(mod);
+    const dest_info = dest_ty.intInfo(zcu);
 
     if (dest_info.bits > 128) {
         return func.fail("TODO: intFromFloat for integers/floats with bitsize {}", .{dest_info.bits});
@@ -5082,12 +5085,12 @@ fn airIntFromFloat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airFloatFromInt(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const op_ty = func.typeOf(ty_op.operand);
-    const op_info = op_ty.intInfo(mod);
+    const op_info = op_ty.intInfo(zcu);
 
     const dest_ty = func.typeOfIndex(inst);
     const dest_bits = dest_ty.floatBits(func.target.*);
@@ -5127,19 +5130,19 @@ fn airFloatFromInt(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airSplat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const operand = try func.resolveInst(ty_op.operand);
     const ty = func.typeOfIndex(inst);
-    const elem_ty = ty.childType(mod);
+    const elem_ty = ty.childType(zcu);
 
-    if (determineSimdStoreStrategy(ty, pt, func.target.*) == .direct) blk: {
+    if (determineSimdStoreStrategy(ty, zcu, func.target.*) == .direct) blk: {
         switch (operand) {
             // when the operand lives in the linear memory section, we can directly
             // load and splat the value at once. Meaning we do not first have to load
             // the scalar value onto the stack.
             .stack_offset, .memory, .memory_offset => {
-                const opcode = switch (elem_ty.bitSize(pt)) {
+                const opcode = switch (elem_ty.bitSize(zcu)) {
                     8 => std.wasm.simdOpcode(.v128_load8_splat),
                     16 => std.wasm.simdOpcode(.v128_load16_splat),
                     32 => std.wasm.simdOpcode(.v128_load32_splat),
@@ -5153,17 +5156,17 @@ fn airSplat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 try func.mir_extra.appendSlice(func.gpa, &[_]u32{
                     opcode,
                     operand.offset(),
-                    @intCast(elem_ty.abiAlignment(pt).toByteUnits().?),
+                    @intCast(elem_ty.abiAlignment(zcu).toByteUnits().?),
                 });
                 try func.addInst(.{ .tag = .simd_prefix, .data = .{ .payload = extra_index } });
                 return func.finishAir(inst, .stack, &.{ty_op.operand});
             },
             .local => {
-                const opcode = switch (elem_ty.bitSize(pt)) {
+                const opcode = switch (elem_ty.bitSize(zcu)) {
                     8 => std.wasm.simdOpcode(.i8x16_splat),
                     16 => std.wasm.simdOpcode(.i16x8_splat),
-                    32 => if (elem_ty.isInt(mod)) std.wasm.simdOpcode(.i32x4_splat) else std.wasm.simdOpcode(.f32x4_splat),
-                    64 => if (elem_ty.isInt(mod)) std.wasm.simdOpcode(.i64x2_splat) else std.wasm.simdOpcode(.f64x2_splat),
+                    32 => if (elem_ty.isInt(zcu)) std.wasm.simdOpcode(.i32x4_splat) else std.wasm.simdOpcode(.f32x4_splat),
+                    64 => if (elem_ty.isInt(zcu)) std.wasm.simdOpcode(.i64x2_splat) else std.wasm.simdOpcode(.f64x2_splat),
                     else => break :blk, // Cannot make use of simd-instructions
                 };
                 try func.emitWValue(operand);
@@ -5175,14 +5178,14 @@ fn airSplat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             else => unreachable,
         }
     }
-    const elem_size = elem_ty.bitSize(pt);
-    const vector_len = @as(usize, @intCast(ty.vectorLen(mod)));
+    const elem_size = elem_ty.bitSize(zcu);
+    const vector_len = @as(usize, @intCast(ty.vectorLen(zcu)));
     if ((!std.math.isPowerOfTwo(elem_size) or elem_size % 8 != 0) and vector_len > 1) {
         return func.fail("TODO: WebAssembly `@splat` for arbitrary element bitsize {d}", .{elem_size});
     }
 
     const result = try func.allocStack(ty);
-    const elem_byte_size = @as(u32, @intCast(elem_ty.abiSize(pt)));
+    const elem_byte_size = @as(u32, @intCast(elem_ty.abiSize(zcu)));
     var index: usize = 0;
     var offset: u32 = 0;
     while (index < vector_len) : (index += 1) {
@@ -5203,7 +5206,7 @@ fn airSelect(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airShuffle(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const inst_ty = func.typeOfIndex(inst);
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.Shuffle, ty_pl.payload).data;
@@ -5213,15 +5216,15 @@ fn airShuffle(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const mask = Value.fromInterned(extra.mask);
     const mask_len = extra.mask_len;
 
-    const child_ty = inst_ty.childType(mod);
-    const elem_size = child_ty.abiSize(pt);
+    const child_ty = inst_ty.childType(zcu);
+    const elem_size = child_ty.abiSize(zcu);
 
     // TODO: One of them could be by ref; handle in loop
     if (isByRef(func.typeOf(extra.a), pt, func.target.*) or isByRef(inst_ty, pt, func.target.*)) {
         const result = try func.allocStack(inst_ty);
 
         for (0..mask_len) |index| {
-            const value = (try mask.elemValue(pt, index)).toSignedInt(pt);
+            const value = (try mask.elemValue(pt, index)).toSignedInt(zcu);
 
             try func.emitWValue(result);
 
@@ -5241,7 +5244,7 @@ fn airShuffle(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
         var lanes = mem.asBytes(operands[1..]);
         for (0..@as(usize, @intCast(mask_len))) |index| {
-            const mask_elem = (try mask.elemValue(pt, index)).toSignedInt(pt);
+            const mask_elem = (try mask.elemValue(pt, index)).toSignedInt(zcu);
             const base_index = if (mask_elem >= 0)
                 @as(u8, @intCast(@as(i64, @intCast(elem_size)) * mask_elem))
             else
@@ -5273,20 +5276,20 @@ fn airReduce(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airAggregateInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const result_ty = func.typeOfIndex(inst);
-    const len = @as(usize, @intCast(result_ty.arrayLen(mod)));
+    const len = @as(usize, @intCast(result_ty.arrayLen(zcu)));
     const elements = @as([]const Air.Inst.Ref, @ptrCast(func.air.extra[ty_pl.payload..][0..len]));
 
     const result: WValue = result_value: {
-        switch (result_ty.zigTypeTag(mod)) {
+        switch (result_ty.zigTypeTag(zcu)) {
             .Array => {
                 const result = try func.allocStack(result_ty);
-                const elem_ty = result_ty.childType(mod);
-                const elem_size = @as(u32, @intCast(elem_ty.abiSize(pt)));
-                const sentinel = if (result_ty.sentinel(mod)) |sent| blk: {
+                const elem_ty = result_ty.childType(zcu);
+                const elem_size = @as(u32, @intCast(elem_ty.abiSize(zcu)));
+                const sentinel = if (result_ty.sentinel(zcu)) |sent| blk: {
                     break :blk try func.lowerConstant(sent, elem_ty);
                 } else null;
 
@@ -5321,18 +5324,18 @@ fn airAggregateInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 }
                 break :result_value result;
             },
-            .Struct => switch (result_ty.containerLayout(mod)) {
+            .Struct => switch (result_ty.containerLayout(zcu)) {
                 .@"packed" => {
                     if (isByRef(result_ty, pt, func.target.*)) {
                         return func.fail("TODO: airAggregateInit for packed structs larger than 64 bits", .{});
                     }
-                    const packed_struct = mod.typeToPackedStruct(result_ty).?;
+                    const packed_struct = zcu.typeToPackedStruct(result_ty).?;
                     const field_types = packed_struct.field_types;
                     const backing_type = Type.fromInterned(packed_struct.backingIntTypeUnordered(ip));
 
                     // ensure the result is zero'd
                     const result = try func.allocLocal(backing_type);
-                    if (backing_type.bitSize(pt) <= 32)
+                    if (backing_type.bitSize(zcu) <= 32)
                         try func.addImm32(0)
                     else
                         try func.addImm64(0);
@@ -5341,15 +5344,15 @@ fn airAggregateInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     var current_bit: u16 = 0;
                     for (elements, 0..) |elem, elem_index| {
                         const field_ty = Type.fromInterned(field_types.get(ip)[elem_index]);
-                        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
-                        const shift_val: WValue = if (backing_type.bitSize(pt) <= 32)
+                        const shift_val: WValue = if (backing_type.bitSize(zcu) <= 32)
                             .{ .imm32 = current_bit }
                         else
                             .{ .imm64 = current_bit };
 
                         const value = try func.resolveInst(elem);
-                        const value_bit_size: u16 = @intCast(field_ty.bitSize(pt));
+                        const value_bit_size: u16 = @intCast(field_ty.bitSize(zcu));
                         const int_ty = try pt.intType(.unsigned, value_bit_size);
 
                         // load our current result on stack so we can perform all transformations
@@ -5375,8 +5378,8 @@ fn airAggregateInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     for (elements, 0..) |elem, elem_index| {
                         if (try result_ty.structFieldValueComptime(pt, elem_index) != null) continue;
 
-                        const elem_ty = result_ty.structFieldType(elem_index, mod);
-                        const field_offset = result_ty.structFieldOffset(elem_index, pt);
+                        const elem_ty = result_ty.structFieldType(elem_index, zcu);
+                        const field_offset = result_ty.structFieldOffset(elem_index, zcu);
                         _ = try func.buildPointerOffset(offset, @intCast(field_offset - prev_field_offset), .modify);
                         prev_field_offset = field_offset;
 
@@ -5404,21 +5407,21 @@ fn airAggregateInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airUnionInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.UnionInit, ty_pl.payload).data;
 
     const result = result: {
         const union_ty = func.typeOfIndex(inst);
-        const layout = union_ty.unionGetLayout(pt);
-        const union_obj = mod.typeToUnion(union_ty).?;
+        const layout = union_ty.unionGetLayout(zcu);
+        const union_obj = zcu.typeToUnion(union_ty).?;
         const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[extra.field_index]);
         const field_name = union_obj.loadTagType(ip).names.get(ip)[extra.field_index];
 
         const tag_int = blk: {
-            const tag_ty = union_ty.unionTagTypeHypothetical(mod);
-            const enum_field_index = tag_ty.enumFieldIndex(field_name, mod).?;
+            const tag_ty = union_ty.unionTagTypeHypothetical(zcu);
+            const enum_field_index = tag_ty.enumFieldIndex(field_name, zcu).?;
             const tag_val = try pt.enumValueFieldIndex(tag_ty, enum_field_index);
             break :blk try func.lowerConstant(tag_val, tag_ty);
         };
@@ -5458,13 +5461,13 @@ fn airUnionInit(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             break :result result_ptr;
         } else {
             const operand = try func.resolveInst(extra.init);
-            const union_int_type = try pt.intType(.unsigned, @as(u16, @intCast(union_ty.bitSize(pt))));
-            if (field_ty.zigTypeTag(mod) == .Float) {
-                const int_type = try pt.intType(.unsigned, @intCast(field_ty.bitSize(pt)));
+            const union_int_type = try pt.intType(.unsigned, @as(u16, @intCast(union_ty.bitSize(zcu))));
+            if (field_ty.zigTypeTag(zcu) == .Float) {
+                const int_type = try pt.intType(.unsigned, @intCast(field_ty.bitSize(zcu)));
                 const bitcasted = try func.bitcast(field_ty, int_type, operand);
                 break :result try func.trunc(bitcasted, int_type, union_int_type);
-            } else if (field_ty.isPtrAtRuntime(mod)) {
-                const int_type = try pt.intType(.unsigned, @intCast(field_ty.bitSize(pt)));
+            } else if (field_ty.isPtrAtRuntime(zcu)) {
+                const int_type = try pt.intType(.unsigned, @intCast(field_ty.bitSize(zcu)));
                 break :result try func.intcast(operand, int_type, union_int_type);
             }
             break :result try func.intcast(operand, field_ty, union_int_type);
@@ -5497,10 +5500,10 @@ fn airWasmMemoryGrow(func: *CodeGen, inst: Air.Inst.Index) !void {
 
 fn cmpOptionals(func: *CodeGen, lhs: WValue, rhs: WValue, operand_ty: Type, op: std.math.CompareOperator) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    assert(operand_ty.hasRuntimeBitsIgnoreComptime(pt));
+    const zcu = pt.zcu;
+    assert(operand_ty.hasRuntimeBitsIgnoreComptime(zcu));
     assert(op == .eq or op == .neq);
-    const payload_ty = operand_ty.optionalChild(mod);
+    const payload_ty = operand_ty.optionalChild(zcu);
 
     // We store the final result in here that will be validated
     // if the optional is truly equal.
@@ -5534,11 +5537,11 @@ fn cmpOptionals(func: *CodeGen, lhs: WValue, rhs: WValue, operand_ty: Type, op: 
 /// TODO: Lower this to compiler_rt call when bitsize > 128
 fn cmpBigInt(func: *CodeGen, lhs: WValue, rhs: WValue, operand_ty: Type, op: std.math.CompareOperator) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    assert(operand_ty.abiSize(pt) >= 16);
+    const zcu = pt.zcu;
+    assert(operand_ty.abiSize(zcu) >= 16);
     assert(!(lhs != .stack and rhs == .stack));
-    if (operand_ty.bitSize(pt) > 128) {
-        return func.fail("TODO: Support cmpBigInt for integer bitsize: '{d}'", .{operand_ty.bitSize(pt)});
+    if (operand_ty.bitSize(zcu) > 128) {
+        return func.fail("TODO: Support cmpBigInt for integer bitsize: '{d}'", .{operand_ty.bitSize(zcu)});
     }
 
     var lhs_msb = try (try func.load(lhs, Type.u64, 8)).toLocal(func, Type.u64);
@@ -5561,7 +5564,7 @@ fn cmpBigInt(func: *CodeGen, lhs: WValue, rhs: WValue, operand_ty: Type, op: std
             }
         },
         else => {
-            const ty = if (operand_ty.isSignedInt(mod)) Type.i64 else Type.u64;
+            const ty = if (operand_ty.isSignedInt(zcu)) Type.i64 else Type.u64;
             // leave those value on top of the stack for '.select'
             const lhs_lsb = try func.load(lhs, Type.u64, 0);
             const rhs_lsb = try func.load(rhs, Type.u64, 0);
@@ -5577,11 +5580,11 @@ fn cmpBigInt(func: *CodeGen, lhs: WValue, rhs: WValue, operand_ty: Type, op: std
 
 fn airSetUnionTag(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
-    const un_ty = func.typeOf(bin_op.lhs).childType(mod);
+    const un_ty = func.typeOf(bin_op.lhs).childType(zcu);
     const tag_ty = func.typeOf(bin_op.rhs);
-    const layout = un_ty.unionGetLayout(pt);
+    const layout = un_ty.unionGetLayout(zcu);
     if (layout.tag_size == 0) return func.finishAir(inst, .none, &.{ bin_op.lhs, bin_op.rhs });
 
     const union_ptr = try func.resolveInst(bin_op.lhs);
@@ -5601,12 +5604,12 @@ fn airSetUnionTag(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 }
 
 fn airGetUnionTag(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
-    const pt = func.pt;
+    const zcu = func.pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const un_ty = func.typeOf(ty_op.operand);
     const tag_ty = func.typeOfIndex(inst);
-    const layout = un_ty.unionGetLayout(pt);
+    const layout = un_ty.unionGetLayout(zcu);
     if (layout.tag_size == 0) return func.finishAir(inst, .none, &.{ty_op.operand});
 
     const operand = try func.resolveInst(ty_op.operand);
@@ -5705,11 +5708,11 @@ fn fptrunc(func: *CodeGen, operand: WValue, given: Type, wanted: Type) InnerErro
 
 fn airErrUnionPayloadPtrSet(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
-    const err_set_ty = func.typeOf(ty_op.operand).childType(mod);
-    const payload_ty = err_set_ty.errorUnionPayload(mod);
+    const err_set_ty = func.typeOf(ty_op.operand).childType(zcu);
+    const payload_ty = err_set_ty.errorUnionPayload(zcu);
     const operand = try func.resolveInst(ty_op.operand);
 
     // set error-tag to '0' to annotate error union is non-error
@@ -5717,28 +5720,28 @@ fn airErrUnionPayloadPtrSet(func: *CodeGen, inst: Air.Inst.Index) InnerError!voi
         operand,
         .{ .imm32 = 0 },
         Type.anyerror,
-        @intCast(errUnionErrorOffset(payload_ty, pt)),
+        @intCast(errUnionErrorOffset(payload_ty, zcu)),
     );
 
     const result = result: {
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             break :result func.reuseOperand(ty_op.operand, operand);
         }
 
-        break :result try func.buildPointerOffset(operand, @as(u32, @intCast(errUnionPayloadOffset(payload_ty, pt))), .new);
+        break :result try func.buildPointerOffset(operand, @as(u32, @intCast(errUnionPayloadOffset(payload_ty, zcu))), .new);
     };
     return func.finishAir(inst, result, &.{ty_op.operand});
 }
 
 fn airFieldParentPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.FieldParentPtr, ty_pl.payload).data;
 
     const field_ptr = try func.resolveInst(extra.field_ptr);
-    const parent_ty = ty_pl.ty.toType().childType(mod);
-    const field_offset = parent_ty.structFieldOffset(extra.field_index, pt);
+    const parent_ty = ty_pl.ty.toType().childType(zcu);
+    const field_offset = parent_ty.structFieldOffset(extra.field_index, zcu);
 
     const result = if (field_offset != 0) result: {
         const base = try func.buildPointerOffset(field_ptr, 0, .new);
@@ -5754,8 +5757,8 @@ fn airFieldParentPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn sliceOrArrayPtr(func: *CodeGen, ptr: WValue, ptr_ty: Type) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    if (ptr_ty.isSlice(mod)) {
+    const zcu = pt.zcu;
+    if (ptr_ty.isSlice(zcu)) {
         return func.slicePtr(ptr);
     } else {
         return ptr;
@@ -5764,26 +5767,26 @@ fn sliceOrArrayPtr(func: *CodeGen, ptr: WValue, ptr_ty: Type) InnerError!WValue 
 
 fn airMemcpy(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const dst = try func.resolveInst(bin_op.lhs);
     const dst_ty = func.typeOf(bin_op.lhs);
-    const ptr_elem_ty = dst_ty.childType(mod);
+    const ptr_elem_ty = dst_ty.childType(zcu);
     const src = try func.resolveInst(bin_op.rhs);
     const src_ty = func.typeOf(bin_op.rhs);
-    const len = switch (dst_ty.ptrSize(mod)) {
+    const len = switch (dst_ty.ptrSize(zcu)) {
         .Slice => blk: {
             const slice_len = try func.sliceLen(dst);
-            if (ptr_elem_ty.abiSize(pt) != 1) {
+            if (ptr_elem_ty.abiSize(zcu) != 1) {
                 try func.emitWValue(slice_len);
-                try func.emitWValue(.{ .imm32 = @as(u32, @intCast(ptr_elem_ty.abiSize(pt))) });
+                try func.emitWValue(.{ .imm32 = @as(u32, @intCast(ptr_elem_ty.abiSize(zcu))) });
                 try func.addTag(.i32_mul);
                 try func.addLabel(.local_set, slice_len.local.value);
             }
             break :blk slice_len;
         },
         .One => @as(WValue, .{
-            .imm32 = @as(u32, @intCast(ptr_elem_ty.arrayLen(mod) * ptr_elem_ty.childType(mod).abiSize(pt))),
+            .imm32 = @as(u32, @intCast(ptr_elem_ty.arrayLen(zcu) * ptr_elem_ty.childType(zcu).abiSize(zcu))),
         }),
         .C, .Many => unreachable,
     };
@@ -5805,17 +5808,17 @@ fn airRetAddr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airPopcount(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const op_ty = func.typeOf(ty_op.operand);
 
-    if (op_ty.zigTypeTag(mod) == .Vector) {
+    if (op_ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement @popCount for vectors", .{});
     }
 
-    const int_info = op_ty.intInfo(mod);
+    const int_info = op_ty.intInfo(zcu);
     const bits = int_info.bits;
     const wasm_bits = toWasmBits(bits) orelse {
         return func.fail("TODO: Implement @popCount for integers with bitsize '{d}'", .{bits});
@@ -5824,14 +5827,14 @@ fn airPopcount(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     switch (wasm_bits) {
         32 => {
             try func.emitWValue(operand);
-            if (op_ty.isSignedInt(mod) and bits != wasm_bits) {
+            if (op_ty.isSignedInt(zcu) and bits != wasm_bits) {
                 _ = try func.wrapOperand(.stack, try pt.intType(.unsigned, bits));
             }
             try func.addTag(.i32_popcnt);
         },
         64 => {
             try func.emitWValue(operand);
-            if (op_ty.isSignedInt(mod) and bits != wasm_bits) {
+            if (op_ty.isSignedInt(zcu) and bits != wasm_bits) {
                 _ = try func.wrapOperand(.stack, try pt.intType(.unsigned, bits));
             }
             try func.addTag(.i64_popcnt);
@@ -5842,7 +5845,7 @@ fn airPopcount(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             _ = try func.load(operand, Type.u64, 0);
             try func.addTag(.i64_popcnt);
             _ = try func.load(operand, Type.u64, 8);
-            if (op_ty.isSignedInt(mod) and bits != wasm_bits) {
+            if (op_ty.isSignedInt(zcu) and bits != wasm_bits) {
                 _ = try func.wrapOperand(.stack, try pt.intType(.unsigned, bits - 64));
             }
             try func.addTag(.i64_popcnt);
@@ -5857,17 +5860,17 @@ fn airPopcount(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airBitReverse(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const ty = func.typeOf(ty_op.operand);
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement @bitReverse for vectors", .{});
     }
 
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const bits = int_info.bits;
     const wasm_bits = toWasmBits(bits) orelse {
         return func.fail("TODO: Implement @bitReverse for integers with bitsize '{d}'", .{bits});
@@ -5933,7 +5936,7 @@ fn airBitReverse(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 defer tmp.free(func);
                 try func.addLabel(.local_tee, tmp.local.value);
                 try func.emitWValue(.{ .imm64 = 128 - bits });
-                if (ty.isSignedInt(mod)) {
+                if (ty.isSignedInt(zcu)) {
                     try func.addTag(.i64_shr_s);
                 } else {
                     try func.addTag(.i64_shr_u);
@@ -5969,7 +5972,7 @@ fn airErrorName(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
     const error_table_symbol = try func.bin_file.getErrorTableSymbol(pt);
     const name_ty = Type.slice_const_u8_sentinel_0;
-    const abi_size = name_ty.abiSize(pt);
+    const abi_size = name_ty.abiSize(pt.zcu);
 
     const error_name_value: WValue = .{ .memory = error_table_symbol }; // emitting this will create a relocation
     try func.emitWValue(error_name_value);
@@ -6000,8 +6003,8 @@ fn airPtrSliceFieldPtr(func: *CodeGen, inst: Air.Inst.Index, offset: u32) InnerE
 
 /// NOTE: Allocates place for result on virtual stack, when integer size > 64 bits
 fn intZeroValue(func: *CodeGen, ty: Type) InnerError!WValue {
-    const mod = func.bin_file.base.comp.module.?;
-    const int_info = ty.intInfo(mod);
+    const zcu = func.bin_file.base.comp.module.?;
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: Implement intZeroValue for integer bitsize: {d}", .{int_info.bits});
     };
@@ -6027,13 +6030,13 @@ fn airAddSubWithOverflow(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerErro
     const rhs = try func.resolveInst(extra.rhs);
     const ty = func.typeOf(extra.lhs);
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement overflow arithmetic for vectors", .{});
     }
 
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const is_signed = int_info.signedness == .signed;
     if (int_info.bits > 128) {
         return func.fail("TODO: Implement {{add/sub}}_with_overflow for integer bitsize: {d}", .{int_info.bits});
@@ -6058,7 +6061,7 @@ fn airAddSubWithOverflow(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerErro
     defer bit_tmp.free(func);
 
     const result = try func.allocStack(func.typeOfIndex(inst));
-    const offset: u32 = @intCast(ty.abiSize(pt));
+    const offset: u32 = @intCast(ty.abiSize(zcu));
     try func.store(result, op_tmp, ty, 0);
     try func.store(result, bit_tmp, Type.u1, offset);
 
@@ -6067,7 +6070,7 @@ fn airAddSubWithOverflow(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerErro
 
 fn airShlWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.Bin, ty_pl.payload).data;
 
@@ -6076,18 +6079,18 @@ fn airShlWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const ty = func.typeOf(extra.lhs);
     const rhs_ty = func.typeOf(extra.rhs);
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement overflow arithmetic for vectors", .{});
     }
 
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: Implement shl_with_overflow for integer bitsize: {d}", .{int_info.bits});
     };
 
     // Ensure rhs is coerced to lhs as they must have the same WebAssembly types
     // before we can perform any binary operation.
-    const rhs_wasm_bits = toWasmBits(rhs_ty.intInfo(mod).bits).?;
+    const rhs_wasm_bits = toWasmBits(rhs_ty.intInfo(zcu).bits).?;
     // If wasm_bits == 128, compiler-rt expects i32 for shift
     const rhs_final = if (wasm_bits != rhs_wasm_bits and wasm_bits == 64) blk: {
         const rhs_casted = try func.intcast(rhs, rhs_ty, ty);
@@ -6105,7 +6108,7 @@ fn airShlWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     defer overflow_local.free(func);
 
     const result = try func.allocStack(func.typeOfIndex(inst));
-    const offset: u32 = @intCast(ty.abiSize(pt));
+    const offset: u32 = @intCast(ty.abiSize(zcu));
     try func.store(result, shl, ty, 0);
     try func.store(result, overflow_local, Type.u1, offset);
 
@@ -6120,9 +6123,9 @@ fn airMulWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const rhs = try func.resolveInst(extra.rhs);
     const ty = func.typeOf(extra.lhs);
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: Implement overflow arithmetic for vectors", .{});
     }
 
@@ -6131,7 +6134,7 @@ fn airMulWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     var overflow_bit = try func.ensureAllocLocal(Type.u1);
     defer overflow_bit.free(func);
 
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: Implement `@mulWithOverflow` for integer bitsize: {d}", .{int_info.bits});
     };
@@ -6238,7 +6241,7 @@ fn airMulWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     defer bin_op_local.free(func);
 
     const result = try func.allocStack(func.typeOfIndex(inst));
-    const offset: u32 = @intCast(ty.abiSize(pt));
+    const offset: u32 = @intCast(ty.abiSize(zcu));
     try func.store(result, bin_op_local, ty, 0);
     try func.store(result, overflow_bit, Type.u1, offset);
 
@@ -6248,22 +6251,22 @@ fn airMulWithOverflow(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 fn airMaxMin(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     assert(op == .max or op == .min);
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const ty = func.typeOfIndex(inst);
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: `@maximum` and `@minimum` for vectors", .{});
     }
 
-    if (ty.abiSize(pt) > 16) {
+    if (ty.abiSize(zcu) > 16) {
         return func.fail("TODO: `@maximum` and `@minimum` for types larger than 16 bytes", .{});
     }
 
     const lhs = try func.resolveInst(bin_op.lhs);
     const rhs = try func.resolveInst(bin_op.rhs);
 
-    if (ty.zigTypeTag(mod) == .Float) {
+    if (ty.zigTypeTag(zcu) == .Float) {
         var fn_name_buf: [64]u8 = undefined;
         const float_bits = ty.floatBits(func.target.*);
         const fn_name = std.fmt.bufPrint(&fn_name_buf, "{s}f{s}{s}", .{
@@ -6288,12 +6291,12 @@ fn airMaxMin(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
 
 fn airMulAdd(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const pl_op = func.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const bin_op = func.air.extraData(Air.Bin, pl_op.payload).data;
 
     const ty = func.typeOfIndex(inst);
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: `@mulAdd` for vectors", .{});
     }
 
@@ -6323,16 +6326,16 @@ fn airMulAdd(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airClz(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const ty = func.typeOf(ty_op.operand);
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: `@clz` for vectors", .{});
     }
 
     const operand = try func.resolveInst(ty_op.operand);
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: `@clz` for integers with bitsize '{d}'", .{int_info.bits});
     };
@@ -6374,17 +6377,17 @@ fn airClz(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airCtz(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const ty = func.typeOf(ty_op.operand);
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: `@ctz` for vectors", .{});
     }
 
     const operand = try func.resolveInst(ty_op.operand);
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: `@clz` for integers with bitsize '{d}'", .{int_info.bits});
     };
@@ -6497,12 +6500,12 @@ fn airTry(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airTryPtr(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.TryPtr, ty_pl.payload);
     const err_union_ptr = try func.resolveInst(extra.data.ptr);
     const body: []const Air.Inst.Index = @ptrCast(func.air.extra[extra.end..][0..extra.data.body_len]);
-    const err_union_ty = func.typeOf(extra.data.ptr).childType(mod);
+    const err_union_ty = func.typeOf(extra.data.ptr).childType(zcu);
     const result = try lowerTry(func, inst, err_union_ptr, body, err_union_ty, true);
     return func.finishAir(inst, result, &.{extra.data.ptr});
 }
@@ -6516,25 +6519,25 @@ fn lowerTry(
     operand_is_ptr: bool,
 ) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     if (operand_is_ptr) {
         return func.fail("TODO: lowerTry for pointers", .{});
     }
 
-    const pl_ty = err_union_ty.errorUnionPayload(mod);
-    const pl_has_bits = pl_ty.hasRuntimeBitsIgnoreComptime(pt);
+    const pl_ty = err_union_ty.errorUnionPayload(zcu);
+    const pl_has_bits = pl_ty.hasRuntimeBitsIgnoreComptime(zcu);
 
-    if (!err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+    if (!err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
         // Block we can jump out of when error is not set
         try func.startBlock(.block, wasm.block_empty);
 
         // check if the error tag is set for the error union.
         try func.emitWValue(err_union);
         if (pl_has_bits) {
-            const err_offset: u32 = @intCast(errUnionErrorOffset(pl_ty, pt));
+            const err_offset: u32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
             try func.addMemArg(.i32_load16_u, .{
                 .offset = err_union.offset() + err_offset,
-                .alignment = @intCast(Type.anyerror.abiAlignment(pt).toByteUnits().?),
+                .alignment = @intCast(Type.anyerror.abiAlignment(zcu).toByteUnits().?),
             });
         }
         try func.addTag(.i32_eqz);
@@ -6556,7 +6559,7 @@ fn lowerTry(
         return .none;
     }
 
-    const pl_offset: u32 = @intCast(errUnionPayloadOffset(pl_ty, pt));
+    const pl_offset: u32 = @intCast(errUnionPayloadOffset(pl_ty, zcu));
     if (isByRef(pl_ty, pt, func.target.*)) {
         return buildPointerOffset(func, err_union, pl_offset, .new);
     }
@@ -6566,16 +6569,16 @@ fn lowerTry(
 
 fn airByteSwap(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const ty = func.typeOfIndex(inst);
     const operand = try func.resolveInst(ty_op.operand);
 
-    if (ty.zigTypeTag(mod) == .Vector) {
+    if (ty.zigTypeTag(zcu) == .Vector) {
         return func.fail("TODO: @byteSwap for vectors", .{});
     }
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: @byteSwap for integers with bitsize {d}", .{int_info.bits});
     };
@@ -6649,15 +6652,15 @@ fn airDivFloor(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty = func.typeOfIndex(inst);
     const lhs = try func.resolveInst(bin_op.lhs);
     const rhs = try func.resolveInst(bin_op.rhs);
 
-    if (ty.isUnsignedInt(mod)) {
+    if (ty.isUnsignedInt(zcu)) {
         _ = try func.binOp(lhs, rhs, ty, .div);
-    } else if (ty.isSignedInt(mod)) {
-        const int_bits = ty.intInfo(mod).bits;
+    } else if (ty.isSignedInt(zcu)) {
+        const int_bits = ty.intInfo(zcu).bits;
         const wasm_bits = toWasmBits(int_bits) orelse {
             return func.fail("TODO: `@divFloor` for signed integers larger than 64 bits ({d} bits requested)", .{int_bits});
         };
@@ -6767,19 +6770,19 @@ fn airMod(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty = func.typeOfIndex(inst);
     const lhs = try func.resolveInst(bin_op.lhs);
     const rhs = try func.resolveInst(bin_op.rhs);
 
-    if (ty.isUnsignedInt(mod)) {
+    if (ty.isUnsignedInt(zcu)) {
         _ = try func.binOp(lhs, rhs, ty, .rem);
-    } else if (ty.isSignedInt(mod)) {
+    } else if (ty.isSignedInt(zcu)) {
         // The wasm rem instruction gives the remainder after truncating division (rounding towards
         // 0), equivalent to @rem.
         // We make use of the fact that:
         // @mod(a, b) = @rem(@rem(a, b) + b, b)
-        const int_bits = ty.intInfo(mod).bits;
+        const int_bits = ty.intInfo(zcu).bits;
         const wasm_bits = toWasmBits(int_bits) orelse {
             return func.fail("TODO: `@mod` for signed integers larger than 64 bits ({d} bits requested)", .{int_bits});
         };
@@ -6802,9 +6805,9 @@ fn airSatMul(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty = func.typeOfIndex(inst);
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const is_signed = int_info.signedness == .signed;
 
     const lhs = try func.resolveInst(bin_op.lhs);
@@ -6903,12 +6906,12 @@ fn airSatBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty = func.typeOfIndex(inst);
     const lhs = try func.resolveInst(bin_op.lhs);
     const rhs = try func.resolveInst(bin_op.rhs);
 
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const is_signed = int_info.signedness == .signed;
 
     if (int_info.bits > 64) {
@@ -6950,8 +6953,8 @@ fn airSatBinOp(func: *CodeGen, inst: Air.Inst.Index, op: Op) InnerError!void {
 
 fn signedSat(func: *CodeGen, lhs: WValue, rhs: WValue, ty: Type, op: Op) InnerError!WValue {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const int_info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits).?;
     const is_wasm_bits = wasm_bits == int_info.bits;
     const ext_ty = if (!is_wasm_bits) try pt.intType(int_info.signedness, wasm_bits) else ty;
@@ -7009,9 +7012,9 @@ fn airShlSat(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty = func.typeOfIndex(inst);
-    const int_info = ty.intInfo(mod);
+    const int_info = ty.intInfo(zcu);
     const is_signed = int_info.signedness == .signed;
     if (int_info.bits > 64) {
         return func.fail("TODO: Saturating shifting left for integers with bitsize '{d}'", .{int_info.bits});
@@ -7130,7 +7133,7 @@ fn callIntrinsic(
 
     // Always pass over C-ABI
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     var func_type = try genFunctype(func.gpa, .C, param_types, return_type, pt, func.target.*);
     defer func_type.deinit(func.gpa);
     const func_type_index = try func.bin_file.zigObjectPtr().?.putOrGetFuncType(func.gpa, func_type);
@@ -7148,16 +7151,16 @@ fn callIntrinsic(
     // Lower all arguments to the stack before we call our function
     for (args, 0..) |arg, arg_i| {
         assert(!(want_sret_param and arg == .stack));
-        assert(Type.fromInterned(param_types[arg_i]).hasRuntimeBitsIgnoreComptime(pt));
+        assert(Type.fromInterned(param_types[arg_i]).hasRuntimeBitsIgnoreComptime(zcu));
         try func.lowerArg(.C, Type.fromInterned(param_types[arg_i]), arg);
     }
 
     // Actually call our intrinsic
     try func.addLabel(.call, @intFromEnum(symbol_index));
 
-    if (!return_type.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!return_type.hasRuntimeBitsIgnoreComptime(zcu)) {
         return .none;
-    } else if (return_type.isNoReturn(mod)) {
+    } else if (return_type.isNoReturn(zcu)) {
         try func.addTag(.@"unreachable");
         return .none;
     } else if (want_sret_param) {
@@ -7184,8 +7187,8 @@ fn airTagName(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
 
     var arena_allocator = std.heap.ArenaAllocator.init(func.gpa);
     defer arena_allocator.deinit();
@@ -7198,9 +7201,9 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
         return @intFromEnum(loc.index);
     }
 
-    const int_tag_ty = enum_ty.intTagType(mod);
+    const int_tag_ty = enum_ty.intTagType(zcu);
 
-    if (int_tag_ty.bitSize(pt) > 64) {
+    if (int_tag_ty.bitSize(zcu) > 64) {
         return func.fail("TODO: Implement @tagName for enums with tag size larger than 64 bits", .{});
     }
 
@@ -7220,7 +7223,7 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
 
     // TODO: Make switch implementation generic so we can use a jump table for this when the tags are not sparse.
     // generate an if-else chain for each tag value as well as constant.
-    const tag_names = enum_ty.enumFields(mod);
+    const tag_names = enum_ty.enumFields(zcu);
     for (0..tag_names.len) |tag_index| {
         const tag_name = tag_names.get(ip)[tag_index];
         const tag_name_len = tag_name.length(ip);
@@ -7345,15 +7348,15 @@ fn getTagNameFunction(func: *CodeGen, enum_ty: Type) InnerError!u32 {
 
 fn airErrorSetHasValue(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const ty_op = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const operand = try func.resolveInst(ty_op.operand);
     const error_set_ty = ty_op.ty.toType();
     const result = try func.allocLocal(Type.bool);
 
-    const names = error_set_ty.errorSetNames(mod);
+    const names = error_set_ty.errorSetNames(zcu);
     var values = try std.ArrayList(u32).initCapacity(func.gpa, names.len);
     defer values.deinit();
 
@@ -7432,12 +7435,12 @@ inline fn useAtomicFeature(func: *const CodeGen) bool {
 
 fn airCmpxchg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = func.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = func.air.extraData(Air.Cmpxchg, ty_pl.payload).data;
 
     const ptr_ty = func.typeOf(extra.ptr);
-    const ty = ptr_ty.childType(mod);
+    const ty = ptr_ty.childType(zcu);
     const result_ty = func.typeOfIndex(inst);
 
     const ptr_operand = try func.resolveInst(extra.ptr);
@@ -7451,7 +7454,7 @@ fn airCmpxchg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         try func.emitWValue(ptr_operand);
         try func.lowerToStack(expected_val);
         try func.lowerToStack(new_val);
-        try func.addAtomicMemArg(switch (ty.abiSize(pt)) {
+        try func.addAtomicMemArg(switch (ty.abiSize(zcu)) {
             1 => .i32_atomic_rmw8_cmpxchg_u,
             2 => .i32_atomic_rmw16_cmpxchg_u,
             4 => .i32_atomic_rmw_cmpxchg,
@@ -7459,14 +7462,14 @@ fn airCmpxchg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             else => |size| return func.fail("TODO: implement `@cmpxchg` for types with abi size '{d}'", .{size}),
         }, .{
             .offset = ptr_operand.offset(),
-            .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+            .alignment = @intCast(ty.abiAlignment(zcu).toByteUnits().?),
         });
         try func.addLabel(.local_tee, val_local.local.value);
         _ = try func.cmp(.stack, expected_val, ty, .eq);
         try func.addLabel(.local_set, cmp_result.local.value);
         break :val val_local;
     } else val: {
-        if (ty.abiSize(pt) > 8) {
+        if (ty.abiSize(zcu) > 8) {
             return func.fail("TODO: Implement `@cmpxchg` for types larger than abi size of 8 bytes", .{});
         }
         const ptr_val = try WValue.toLocal(try func.load(ptr_operand, ty, 0), func, ty);
@@ -7490,7 +7493,7 @@ fn airCmpxchg(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         try func.addTag(.i32_and);
         const and_result = try WValue.toLocal(.stack, func, Type.bool);
         const result_ptr = try func.allocStack(result_ty);
-        try func.store(result_ptr, and_result, Type.bool, @as(u32, @intCast(ty.abiSize(pt))));
+        try func.store(result_ptr, and_result, Type.bool, @as(u32, @intCast(ty.abiSize(zcu))));
         try func.store(result_ptr, ptr_val, ty, 0);
         break :val result_ptr;
     } else val: {
@@ -7511,7 +7514,7 @@ fn airAtomicLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const ty = func.typeOfIndex(inst);
 
     if (func.useAtomicFeature()) {
-        const tag: wasm.AtomicsOpcode = switch (ty.abiSize(pt)) {
+        const tag: wasm.AtomicsOpcode = switch (ty.abiSize(pt.zcu)) {
             1 => .i32_atomic_load8_u,
             2 => .i32_atomic_load16_u,
             4 => .i32_atomic_load,
@@ -7521,7 +7524,7 @@ fn airAtomicLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         try func.emitWValue(ptr);
         try func.addAtomicMemArg(tag, .{
             .offset = ptr.offset(),
-            .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+            .alignment = @intCast(ty.abiAlignment(pt.zcu).toByteUnits().?),
         });
     } else {
         _ = try func.load(ptr, ty, 0);
@@ -7532,7 +7535,7 @@ fn airAtomicLoad(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const pl_op = func.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const extra = func.air.extraData(Air.AtomicRmw, pl_op.payload).data;
 
@@ -7556,7 +7559,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 try func.emitWValue(ptr);
                 try func.emitWValue(value);
                 if (op == .Nand) {
-                    const wasm_bits = toWasmBits(@intCast(ty.bitSize(pt))).?;
+                    const wasm_bits = toWasmBits(@intCast(ty.bitSize(zcu))).?;
 
                     const and_res = try func.binOp(value, operand, ty, .@"and");
                     if (wasm_bits == 32)
@@ -7573,7 +7576,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     try func.addTag(.select);
                 }
                 try func.addAtomicMemArg(
-                    switch (ty.abiSize(pt)) {
+                    switch (ty.abiSize(zcu)) {
                         1 => .i32_atomic_rmw8_cmpxchg_u,
                         2 => .i32_atomic_rmw16_cmpxchg_u,
                         4 => .i32_atomic_rmw_cmpxchg,
@@ -7582,7 +7585,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     },
                     .{
                         .offset = ptr.offset(),
-                        .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+                        .alignment = @intCast(ty.abiAlignment(zcu).toByteUnits().?),
                     },
                 );
                 const select_res = try func.allocLocal(ty);
@@ -7601,7 +7604,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
             else => {
                 try func.emitWValue(ptr);
                 try func.emitWValue(operand);
-                const tag: wasm.AtomicsOpcode = switch (ty.abiSize(pt)) {
+                const tag: wasm.AtomicsOpcode = switch (ty.abiSize(zcu)) {
                     1 => switch (op) {
                         .Xchg => .i32_atomic_rmw8_xchg_u,
                         .Add => .i32_atomic_rmw8_add_u,
@@ -7642,7 +7645,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 };
                 try func.addAtomicMemArg(tag, .{
                     .offset = ptr.offset(),
-                    .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+                    .alignment = @intCast(ty.abiAlignment(zcu).toByteUnits().?),
                 });
                 return func.finishAir(inst, .stack, &.{ pl_op.operand, extra.operand });
             },
@@ -7670,7 +7673,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                     .Xor => .xor,
                     else => unreachable,
                 });
-                if (ty.isInt(mod) and (op == .Add or op == .Sub)) {
+                if (ty.isInt(zcu) and (op == .Add or op == .Sub)) {
                     _ = try func.wrapOperand(.stack, ty);
                 }
                 try func.store(.stack, .stack, ty, ptr.offset());
@@ -7686,7 +7689,7 @@ fn airAtomicRmw(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
                 try func.store(.stack, .stack, ty, ptr.offset());
             },
             .Nand => {
-                const wasm_bits = toWasmBits(@intCast(ty.bitSize(pt))).?;
+                const wasm_bits = toWasmBits(@intCast(ty.bitSize(zcu))).?;
 
                 try func.emitWValue(ptr);
                 const and_res = try func.binOp(result, operand, ty, .@"and");
@@ -7721,16 +7724,16 @@ fn airFence(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn airAtomicStore(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
     const pt = func.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = func.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const ptr = try func.resolveInst(bin_op.lhs);
     const operand = try func.resolveInst(bin_op.rhs);
     const ptr_ty = func.typeOf(bin_op.lhs);
-    const ty = ptr_ty.childType(mod);
+    const ty = ptr_ty.childType(zcu);
 
     if (func.useAtomicFeature()) {
-        const tag: wasm.AtomicsOpcode = switch (ty.abiSize(pt)) {
+        const tag: wasm.AtomicsOpcode = switch (ty.abiSize(zcu)) {
             1 => .i32_atomic_store8,
             2 => .i32_atomic_store16,
             4 => .i32_atomic_store,
@@ -7741,7 +7744,7 @@ fn airAtomicStore(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
         try func.lowerToStack(operand);
         try func.addAtomicMemArg(tag, .{
             .offset = ptr.offset(),
-            .alignment = @intCast(ty.abiAlignment(pt).toByteUnits().?),
+            .alignment = @intCast(ty.abiAlignment(zcu).toByteUnits().?),
         });
     } else {
         try func.store(ptr, operand, ty, 0);
@@ -7760,12 +7763,12 @@ fn airFrameAddress(func: *CodeGen, inst: Air.Inst.Index) InnerError!void {
 
 fn typeOf(func: *CodeGen, inst: Air.Inst.Ref) Type {
     const pt = func.pt;
-    const mod = pt.zcu;
-    return func.air.typeOf(inst, &mod.intern_pool);
+    const zcu = pt.zcu;
+    return func.air.typeOf(inst, &zcu.intern_pool);
 }
 
 fn typeOfIndex(func: *CodeGen, inst: Air.Inst.Index) Type {
     const pt = func.pt;
-    const mod = pt.zcu;
-    return func.air.typeOfIndex(inst, &mod.intern_pool);
+    const zcu = pt.zcu;
+    return func.air.typeOfIndex(inst, &zcu.intern_pool);
 }

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -6003,7 +6003,7 @@ fn airPtrSliceFieldPtr(func: *CodeGen, inst: Air.Inst.Index, offset: u32) InnerE
 
 /// NOTE: Allocates place for result on virtual stack, when integer size > 64 bits
 fn intZeroValue(func: *CodeGen, ty: Type) InnerError!WValue {
-    const zcu = func.bin_file.base.comp.module.?;
+    const zcu = func.bin_file.base.comp.zcu.?;
     const int_info = ty.intInfo(zcu);
     const wasm_bits = toWasmBits(int_info.bits) orelse {
         return func.fail("TODO: Implement intZeroValue for integer bitsize: {d}", .{int_info.bits});

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -255,7 +255,7 @@ fn fail(emit: *Emit, comptime format: []const u8, args: anytype) InnerError {
     @setCold(true);
     std.debug.assert(emit.error_msg == null);
     const comp = emit.bin_file.base.comp;
-    const zcu = comp.module.?;
+    const zcu = comp.zcu.?;
     const gpa = comp.gpa;
     emit.error_msg = try Zcu.ErrorMsg.create(gpa, zcu.navSrcLoc(emit.owner_nav), format, args);
     return error.EmitFail;

--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -22,16 +22,15 @@ const direct: [2]Class = .{ .direct, .none };
 /// Classifies a given Zig type to determine how they must be passed
 /// or returned as value within a wasm function.
 /// When all elements result in `.none`, no value must be passed in or returned.
-pub fn classifyType(ty: Type, pt: Zcu.PerThread) [2]Class {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    const target = mod.getTarget();
-    if (!ty.hasRuntimeBitsIgnoreComptime(pt)) return none;
-    switch (ty.zigTypeTag(mod)) {
+pub fn classifyType(ty: Type, zcu: *Zcu) [2]Class {
+    const ip = &zcu.intern_pool;
+    const target = zcu.getTarget();
+    if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) return none;
+    switch (ty.zigTypeTag(zcu)) {
         .Struct => {
-            const struct_type = pt.zcu.typeToStruct(ty).?;
+            const struct_type = zcu.typeToStruct(ty).?;
             if (struct_type.layout == .@"packed") {
-                if (ty.bitSize(pt) <= 64) return direct;
+                if (ty.bitSize(zcu) <= 64) return direct;
                 return .{ .direct, .direct };
             }
             if (struct_type.field_types.len > 1) {
@@ -41,13 +40,13 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread) [2]Class {
             const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[0]);
             const explicit_align = struct_type.fieldAlign(ip, 0);
             if (explicit_align != .none) {
-                if (explicit_align.compareStrict(.gt, field_ty.abiAlignment(pt)))
+                if (explicit_align.compareStrict(.gt, field_ty.abiAlignment(zcu)))
                     return memory;
             }
-            return classifyType(field_ty, pt);
+            return classifyType(field_ty, zcu);
         },
         .Int, .Enum, .ErrorSet => {
-            const int_bits = ty.intInfo(pt.zcu).bits;
+            const int_bits = ty.intInfo(zcu).bits;
             if (int_bits <= 64) return direct;
             if (int_bits <= 128) return .{ .direct, .direct };
             return memory;
@@ -62,24 +61,24 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread) [2]Class {
         .Vector => return direct,
         .Array => return memory,
         .Optional => {
-            assert(ty.isPtrLikeOptional(pt.zcu));
+            assert(ty.isPtrLikeOptional(zcu));
             return direct;
         },
         .Pointer => {
-            assert(!ty.isSlice(pt.zcu));
+            assert(!ty.isSlice(zcu));
             return direct;
         },
         .Union => {
-            const union_obj = pt.zcu.typeToUnion(ty).?;
+            const union_obj = zcu.typeToUnion(ty).?;
             if (union_obj.flagsUnordered(ip).layout == .@"packed") {
-                if (ty.bitSize(pt) <= 64) return direct;
+                if (ty.bitSize(zcu) <= 64) return direct;
                 return .{ .direct, .direct };
             }
-            const layout = ty.unionGetLayout(pt);
+            const layout = ty.unionGetLayout(zcu);
             assert(layout.tag_size == 0);
             if (union_obj.field_types.len > 1) return memory;
             const first_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[0]);
-            return classifyType(first_field_ty, pt);
+            return classifyType(first_field_ty, zcu);
         },
         .ErrorUnion,
         .Frame,
@@ -101,29 +100,28 @@ pub fn classifyType(ty: Type, pt: Zcu.PerThread) [2]Class {
 /// Returns the scalar type a given type can represent.
 /// Asserts given type can be represented as scalar, such as
 /// a struct with a single scalar field.
-pub fn scalarType(ty: Type, pt: Zcu.PerThread) Type {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    switch (ty.zigTypeTag(mod)) {
+pub fn scalarType(ty: Type, zcu: *Zcu) Type {
+    const ip = &zcu.intern_pool;
+    switch (ty.zigTypeTag(zcu)) {
         .Struct => {
-            if (mod.typeToPackedStruct(ty)) |packed_struct| {
-                return scalarType(Type.fromInterned(packed_struct.backingIntTypeUnordered(ip)), pt);
+            if (zcu.typeToPackedStruct(ty)) |packed_struct| {
+                return scalarType(Type.fromInterned(packed_struct.backingIntTypeUnordered(ip)), zcu);
             } else {
-                assert(ty.structFieldCount(mod) == 1);
-                return scalarType(ty.structFieldType(0, mod), pt);
+                assert(ty.structFieldCount(zcu) == 1);
+                return scalarType(ty.structFieldType(0, zcu), zcu);
             }
         },
         .Union => {
-            const union_obj = mod.typeToUnion(ty).?;
+            const union_obj = zcu.typeToUnion(ty).?;
             if (union_obj.flagsUnordered(ip).layout != .@"packed") {
-                const layout = pt.getUnionLayout(union_obj);
+                const layout = Type.getUnionLayout(union_obj, zcu);
                 if (layout.payload_size == 0 and layout.tag_size != 0) {
-                    return scalarType(ty.unionTagTypeSafety(mod).?, pt);
+                    return scalarType(ty.unionTagTypeSafety(zcu).?, zcu);
                 }
                 assert(union_obj.field_types.len == 1);
             }
             const first_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[0]);
-            return scalarType(first_field_ty, pt);
+            return scalarType(first_field_ty, zcu);
         },
         else => return ty,
     }

--- a/src/arch/wasm/abi.zig
+++ b/src/arch/wasm/abi.zig
@@ -108,7 +108,7 @@ pub fn scalarType(ty: Type, zcu: *Zcu) Type {
                 return scalarType(Type.fromInterned(packed_struct.backingIntTypeUnordered(ip)), zcu);
             } else {
                 assert(ty.structFieldCount(zcu) == 1);
-                return scalarType(ty.structFieldType(0, zcu), zcu);
+                return scalarType(ty.fieldType(0, zcu), zcu);
             }
         },
         .Union => {

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -12105,7 +12105,7 @@ fn genLocalDebugInfo(
                             self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op.operand,
                         ),
                     };
-                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(ty, self.pt));
+                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(ty, self.pt.zcu));
                     try self.genSetMem(.{ .frame = frame_index }, 0, ty, mcv, .{});
                     try self.asmAirMemory(.dbg_local, inst, .{
                         .base = .{ .frame = frame_index },

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -732,14 +732,14 @@ const FrameAlloc = struct {
             .ref_count = 0,
         };
     }
-    fn initType(ty: Type, pt: Zcu.PerThread) FrameAlloc {
+    fn initType(ty: Type, zcu: *Zcu) FrameAlloc {
         return init(.{
-            .size = ty.abiSize(pt),
-            .alignment = ty.abiAlignment(pt),
+            .size = ty.abiSize(zcu),
+            .alignment = ty.abiAlignment(zcu),
         });
     }
-    fn initSpill(ty: Type, pt: Zcu.PerThread) FrameAlloc {
-        const abi_size = ty.abiSize(pt);
+    fn initSpill(ty: Type, zcu: *Zcu) FrameAlloc {
+        const abi_size = ty.abiSize(zcu);
         const spill_size = if (abi_size < 8)
             math.ceilPowerOfTwoAssert(u64, abi_size)
         else
@@ -747,7 +747,7 @@ const FrameAlloc = struct {
         return init(.{
             .size = spill_size,
             .pad = @intCast(spill_size - abi_size),
-            .alignment = ty.abiAlignment(pt).maxStrict(
+            .alignment = ty.abiAlignment(zcu).maxStrict(
                 Alignment.fromNonzeroByteUnits(@min(spill_size, 8)),
             ),
         });
@@ -756,7 +756,7 @@ const FrameAlloc = struct {
 
 const StackAllocation = struct {
     inst: ?Air.Inst.Index,
-    /// TODO do we need size? should be determined by inst.ty.abiSize(pt)
+    /// TODO do we need size? should be determined by inst.ty.abiSize(zcu)
     size: u32,
 };
 
@@ -859,11 +859,11 @@ pub fn generate(
     function.args = call_info.args;
     function.ret_mcv = call_info.return_value;
     function.frame_allocs.set(@intFromEnum(FrameIndex.ret_addr), FrameAlloc.init(.{
-        .size = Type.usize.abiSize(pt),
-        .alignment = Type.usize.abiAlignment(pt).min(call_info.stack_align),
+        .size = Type.usize.abiSize(zcu),
+        .alignment = Type.usize.abiAlignment(zcu).min(call_info.stack_align),
     }));
     function.frame_allocs.set(@intFromEnum(FrameIndex.base_ptr), FrameAlloc.init(.{
-        .size = Type.usize.abiSize(pt),
+        .size = Type.usize.abiSize(zcu),
         .alignment = Alignment.min(
             call_info.stack_align,
             Alignment.fromNonzeroByteUnits(function.target.stackAlignment()),
@@ -1872,8 +1872,8 @@ fn asmMemoryRegisterImmediate(
 
 fn gen(self: *Self) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const fn_info = mod.typeToFunc(self.fn_type).?;
+    const zcu = pt.zcu;
+    const fn_info = zcu.typeToFunc(self.fn_type).?;
     const cc = abi.resolveCallingConvention(fn_info.cc, self.target.*);
     if (cc != .Naked) {
         try self.asmRegister(.{ ._, .push }, .rbp);
@@ -1890,7 +1890,7 @@ fn gen(self: *Self) InnerError!void {
                 // The address where to store the return value for the caller is in a
                 // register which the callee is free to clobber. Therefore, we purposely
                 // spill it to stack immediately.
-                const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(Type.usize, pt));
+                const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(Type.usize, zcu));
                 try self.genSetMem(
                     .{ .frame = frame_index },
                     0,
@@ -2099,8 +2099,8 @@ fn checkInvariantsAfterAirInst(self: *Self, inst: Air.Inst.Index, old_air_bookke
 
 fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const air_tags = self.air.instructions.items(.tag);
 
     self.arg_index = 0;
@@ -2370,9 +2370,9 @@ fn genBody(self: *Self, body: []const Air.Inst.Index) InnerError!void {
 
 fn genLazy(self: *Self, lazy_sym: link.File.LazySymbol) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
-    switch (Type.fromInterned(lazy_sym.ty).zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+    switch (Type.fromInterned(lazy_sym.ty).zigTypeTag(zcu)) {
         .Enum => {
             const enum_ty = Type.fromInterned(lazy_sym.ty);
             wip_mir_log.debug("{}.@tagName:", .{enum_ty.fmt(pt)});
@@ -2385,7 +2385,7 @@ fn genLazy(self: *Self, lazy_sym: link.File.LazySymbol) InnerError!void {
             const ret_reg = param_regs[0];
             const enum_mcv = MCValue{ .register = param_regs[1] };
 
-            const exitlude_jump_relocs = try self.gpa.alloc(Mir.Inst.Index, enum_ty.enumFieldCount(mod));
+            const exitlude_jump_relocs = try self.gpa.alloc(Mir.Inst.Index, enum_ty.enumFieldCount(zcu));
             defer self.gpa.free(exitlude_jump_relocs);
 
             const data_reg = try self.register_manager.allocReg(null, abi.RegisterClass.gp);
@@ -2394,7 +2394,7 @@ fn genLazy(self: *Self, lazy_sym: link.File.LazySymbol) InnerError!void {
             try self.genLazySymbolRef(.lea, data_reg, .{ .kind = .const_data, .ty = enum_ty.toIntern() });
 
             var data_off: i32 = 0;
-            const tag_names = enum_ty.enumFields(mod);
+            const tag_names = enum_ty.enumFields(zcu);
             for (exitlude_jump_relocs, 0..) |*exitlude_jump_reloc, tag_index| {
                 const tag_name_len = tag_names.get(ip)[tag_index].length(ip);
                 const tag_val = try pt.enumValueFieldIndex(enum_ty, @intCast(tag_index));
@@ -2630,14 +2630,14 @@ fn allocFrameIndex(self: *Self, alloc: FrameAlloc) !FrameIndex {
 /// Use a pointer instruction as the basis for allocating stack memory.
 fn allocMemPtr(self: *Self, inst: Air.Inst.Index) !FrameIndex {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ptr_ty = self.typeOfIndex(inst);
-    const val_ty = ptr_ty.childType(mod);
+    const val_ty = ptr_ty.childType(zcu);
     return self.allocFrameIndex(FrameAlloc.init(.{
-        .size = math.cast(u32, val_ty.abiSize(pt)) orelse {
+        .size = math.cast(u32, val_ty.abiSize(zcu)) orelse {
             return self.fail("type '{}' too big to fit into stack frame", .{val_ty.fmt(pt)});
         },
-        .alignment = ptr_ty.ptrAlignment(pt).max(.@"1"),
+        .alignment = ptr_ty.ptrAlignment(zcu).max(.@"1"),
     }));
 }
 
@@ -2651,20 +2651,20 @@ fn allocTempRegOrMem(self: *Self, elem_ty: Type, reg_ok: bool) !MCValue {
 
 fn allocRegOrMemAdvanced(self: *Self, ty: Type, inst: ?Air.Inst.Index, reg_ok: bool) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size = math.cast(u32, ty.abiSize(pt)) orelse {
+    const zcu = pt.zcu;
+    const abi_size = math.cast(u32, ty.abiSize(zcu)) orelse {
         return self.fail("type '{}' too big to fit into stack frame", .{ty.fmt(pt)});
     };
 
     if (reg_ok) need_mem: {
-        if (abi_size <= @as(u32, switch (ty.zigTypeTag(mod)) {
+        if (abi_size <= @as(u32, switch (ty.zigTypeTag(zcu)) {
             .Float => switch (ty.floatBits(self.target.*)) {
                 16, 32, 64, 128 => 16,
                 80 => break :need_mem,
                 else => unreachable,
             },
-            .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-                .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
+            .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+                .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
                     16, 32, 64, 128 => if (self.hasFeature(.avx)) 32 else 16,
                     80 => break :need_mem,
                     else => unreachable,
@@ -2679,21 +2679,21 @@ fn allocRegOrMemAdvanced(self: *Self, ty: Type, inst: ?Air.Inst.Index, reg_ok: b
         }
     }
 
-    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(ty, pt));
+    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(ty, zcu));
     return .{ .load_frame = .{ .index = frame_index } };
 }
 
 fn regClassForType(self: *Self, ty: Type) RegisterManager.RegisterBitSet {
     const pt = self.pt;
-    const mod = pt.zcu;
-    return switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    return switch (ty.zigTypeTag(zcu)) {
         .Float => switch (ty.floatBits(self.target.*)) {
             80 => abi.RegisterClass.x87,
             else => abi.RegisterClass.sse,
         },
-        .Vector => switch (ty.childType(mod).toIntern()) {
+        .Vector => switch (ty.childType(zcu).toIntern()) {
             .bool_type, .u1_type => abi.RegisterClass.gp,
-            else => if (ty.isAbiInt(mod) and ty.intInfo(mod).bits == 1)
+            else => if (ty.isAbiInt(zcu) and ty.intInfo(zcu).bits == 1)
                 abi.RegisterClass.gp
             else
                 abi.RegisterClass.sse,
@@ -3001,13 +3001,13 @@ fn airFptrunc(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airFpext(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const dst_ty = self.typeOfIndex(inst);
-    const dst_scalar_ty = dst_ty.scalarType(mod);
+    const dst_scalar_ty = dst_ty.scalarType(zcu);
     const dst_bits = dst_scalar_ty.floatBits(self.target.*);
     const src_ty = self.typeOf(ty_op.operand);
-    const src_scalar_ty = src_ty.scalarType(mod);
+    const src_scalar_ty = src_ty.scalarType(zcu);
     const src_bits = src_scalar_ty.floatBits(self.target.*);
 
     const result = result: {
@@ -3032,7 +3032,7 @@ fn airFpext(self: *Self, inst: Air.Inst.Index) !void {
             },
             else => unreachable,
         }) {
-            if (dst_ty.isVector(mod)) break :result null;
+            if (dst_ty.isVector(zcu)) break :result null;
             var callee_buf: ["__extend?f?f2".len]u8 = undefined;
             break :result try self.genCall(.{ .lib = .{
                 .return_type = self.floatCompilerRtAbiType(dst_scalar_ty, src_scalar_ty).toIntern(),
@@ -3044,18 +3044,18 @@ fn airFpext(self: *Self, inst: Air.Inst.Index) !void {
             } }, &.{src_scalar_ty}, &.{.{ .air_ref = ty_op.operand }});
         }
 
-        const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
+        const src_abi_size: u32 = @intCast(src_ty.abiSize(zcu));
         const src_mcv = try self.resolveInst(ty_op.operand);
         const dst_mcv = if (src_mcv.isRegister() and self.reuseOperand(inst, ty_op.operand, 0, src_mcv))
             src_mcv
         else
             try self.copyToRegisterWithInstTracking(inst, dst_ty, src_mcv);
         const dst_reg = dst_mcv.getReg().?;
-        const dst_alias = registerAlias(dst_reg, @intCast(@max(dst_ty.abiSize(pt), 16)));
+        const dst_alias = registerAlias(dst_reg, @intCast(@max(dst_ty.abiSize(zcu), 16)));
         const dst_lock = self.register_manager.lockReg(dst_reg);
         defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const vec_len = if (dst_ty.isVector(mod)) dst_ty.vectorLen(mod) else 1;
+        const vec_len = if (dst_ty.isVector(zcu)) dst_ty.vectorLen(zcu) else 1;
         if (src_bits == 16) {
             assert(self.hasFeature(.f16c));
             const mat_src_reg = if (src_mcv.isRegister())
@@ -3137,30 +3137,30 @@ fn airFpext(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIntCast(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const src_ty = self.typeOf(ty_op.operand);
     const dst_ty = self.typeOfIndex(inst);
 
     const result = @as(?MCValue, result: {
-        const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+        const dst_abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
 
-        const src_int_info = src_ty.intInfo(mod);
-        const dst_int_info = dst_ty.intInfo(mod);
+        const src_int_info = src_ty.intInfo(zcu);
+        const dst_int_info = dst_ty.intInfo(zcu);
         const extend = switch (src_int_info.signedness) {
             .signed => dst_int_info,
             .unsigned => src_int_info,
         }.signedness;
 
         const src_mcv = try self.resolveInst(ty_op.operand);
-        if (dst_ty.isVector(mod)) {
-            const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
+        if (dst_ty.isVector(zcu)) {
+            const src_abi_size: u32 = @intCast(src_ty.abiSize(zcu));
             const max_abi_size = @max(dst_abi_size, src_abi_size);
             if (max_abi_size > @as(u32, if (self.hasFeature(.avx2)) 32 else 16)) break :result null;
             const has_avx = self.hasFeature(.avx);
 
-            const dst_elem_abi_size = dst_ty.childType(mod).abiSize(pt);
-            const src_elem_abi_size = src_ty.childType(mod).abiSize(pt);
+            const dst_elem_abi_size = dst_ty.childType(zcu).abiSize(zcu);
+            const src_elem_abi_size = src_ty.childType(zcu).abiSize(zcu);
             switch (math.order(dst_elem_abi_size, src_elem_abi_size)) {
                 .lt => {
                     const mir_tag: Mir.Inst.FixedTag = switch (dst_elem_abi_size) {
@@ -3396,13 +3396,13 @@ fn airIntCast(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const dst_ty = self.typeOfIndex(inst);
-    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
     const src_ty = self.typeOf(ty_op.operand);
-    const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
+    const src_abi_size: u32 = @intCast(src_ty.abiSize(zcu));
 
     const result = result: {
         const src_mcv = try self.resolveInst(ty_op.operand);
@@ -3414,7 +3414,7 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
             src_mcv
         else if (dst_abi_size <= 8)
             try self.copyToRegisterWithInstTracking(inst, dst_ty, src_mcv)
-        else if (dst_abi_size <= 16 and !dst_ty.isVector(mod)) dst: {
+        else if (dst_abi_size <= 16 and !dst_ty.isVector(zcu)) dst: {
             const dst_regs =
                 try self.register_manager.allocRegs(2, .{ inst, inst }, abi.RegisterClass.gp);
             const dst_mcv: MCValue = .{ .register_pair = dst_regs };
@@ -3429,16 +3429,16 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
             break :dst dst_mcv;
         };
 
-        if (dst_ty.zigTypeTag(mod) == .Vector) {
-            assert(src_ty.zigTypeTag(mod) == .Vector and dst_ty.vectorLen(mod) == src_ty.vectorLen(mod));
-            const dst_elem_ty = dst_ty.childType(mod);
-            const dst_elem_abi_size: u32 = @intCast(dst_elem_ty.abiSize(pt));
-            const src_elem_ty = src_ty.childType(mod);
-            const src_elem_abi_size: u32 = @intCast(src_elem_ty.abiSize(pt));
+        if (dst_ty.zigTypeTag(zcu) == .Vector) {
+            assert(src_ty.zigTypeTag(zcu) == .Vector and dst_ty.vectorLen(zcu) == src_ty.vectorLen(zcu));
+            const dst_elem_ty = dst_ty.childType(zcu);
+            const dst_elem_abi_size: u32 = @intCast(dst_elem_ty.abiSize(zcu));
+            const src_elem_ty = src_ty.childType(zcu);
+            const src_elem_abi_size: u32 = @intCast(src_elem_ty.abiSize(zcu));
 
             const mir_tag = @as(?Mir.Inst.FixedTag, switch (dst_elem_abi_size) {
                 1 => switch (src_elem_abi_size) {
-                    2 => switch (dst_ty.vectorLen(mod)) {
+                    2 => switch (dst_ty.vectorLen(zcu)) {
                         1...8 => if (self.hasFeature(.avx)) .{ .vp_b, .ackusw } else .{ .p_b, .ackusw },
                         9...16 => if (self.hasFeature(.avx2)) .{ .vp_b, .ackusw } else null,
                         else => null,
@@ -3446,7 +3446,7 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
                     else => null,
                 },
                 2 => switch (src_elem_abi_size) {
-                    4 => switch (dst_ty.vectorLen(mod)) {
+                    4 => switch (dst_ty.vectorLen(zcu)) {
                         1...4 => if (self.hasFeature(.avx))
                             .{ .vp_w, .ackusd }
                         else if (self.hasFeature(.sse4_1))
@@ -3461,8 +3461,8 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
                 else => null,
             }) orelse return self.fail("TODO implement airTrunc for {}", .{dst_ty.fmt(pt)});
 
-            const dst_info = dst_elem_ty.intInfo(mod);
-            const src_info = src_elem_ty.intInfo(mod);
+            const dst_info = dst_elem_ty.intInfo(zcu);
+            const src_info = src_elem_ty.intInfo(zcu);
 
             const mask_val = try pt.intValue(src_elem_ty, @as(u64, math.maxInt(u64)) >> @intCast(64 - dst_info.bits));
 
@@ -3470,7 +3470,7 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
                 .len = @intCast(@divExact(@as(u64, if (src_abi_size > 16) 256 else 128), src_info.bits)),
                 .child = src_elem_ty.ip_index,
             });
-            const splat_abi_size: u32 = @intCast(splat_ty.abiSize(pt));
+            const splat_abi_size: u32 = @intCast(splat_ty.abiSize(zcu));
 
             const splat_val = try pt.intern(.{ .aggregate = .{
                 .ty = splat_ty.ip_index,
@@ -3528,7 +3528,7 @@ fn airTrunc(self: *Self, inst: Air.Inst.Index) !void {
                 try self.truncateRegister(dst_ty, dst_mcv.register.to64());
             }
         } else if (dst_abi_size <= 16) {
-            const dst_info = dst_ty.intInfo(mod);
+            const dst_info = dst_ty.intInfo(zcu);
             const high_ty = try pt.intType(dst_info.signedness, dst_info.bits - 64);
             if (self.regExtraBits(high_ty) > 0) {
                 try self.truncateRegister(high_ty, dst_mcv.register_pair[1].to64());
@@ -3554,12 +3554,12 @@ fn airIntFromBool(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airSlice(self: *Self, inst: Air.Inst.Index) !void {
-    const pt = self.pt;
+    const zcu = self.pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
 
     const slice_ty = self.typeOfIndex(inst);
-    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(slice_ty, pt));
+    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(slice_ty, zcu));
 
     const ptr_ty = self.typeOf(bin_op.lhs);
     try self.genSetMem(.{ .frame = frame_index }, 0, ptr_ty, .{ .air_ref = bin_op.lhs }, .{});
@@ -3567,7 +3567,7 @@ fn airSlice(self: *Self, inst: Air.Inst.Index) !void {
     const len_ty = self.typeOf(bin_op.rhs);
     try self.genSetMem(
         .{ .frame = frame_index },
-        @intCast(ptr_ty.abiSize(pt)),
+        @intCast(ptr_ty.abiSize(zcu)),
         len_ty,
         .{ .air_ref = bin_op.rhs },
         .{},
@@ -3585,14 +3585,14 @@ fn airUnOp(self: *Self, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
 
 fn airBinOp(self: *Self, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const dst_mcv = try self.genBinOp(inst, tag, bin_op.lhs, bin_op.rhs);
 
     const dst_ty = self.typeOfIndex(inst);
-    if (dst_ty.isAbiInt(mod)) {
-        const abi_size: u32 = @intCast(dst_ty.abiSize(pt));
-        const bit_size: u32 = @intCast(dst_ty.bitSize(pt));
+    if (dst_ty.isAbiInt(zcu)) {
+        const abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
+        const bit_size: u32 = @intCast(dst_ty.bitSize(zcu));
         if (abi_size * 8 > bit_size) {
             const dst_lock = switch (dst_mcv) {
                 .register => |dst_reg| self.register_manager.lockRegAssumeUnused(dst_reg),
@@ -3607,7 +3607,7 @@ fn airBinOp(self: *Self, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void {
                 const tmp_lock = self.register_manager.lockRegAssumeUnused(tmp_reg);
                 defer self.register_manager.unlockReg(tmp_lock);
 
-                const hi_ty = try pt.intType(.unsigned, @intCast((dst_ty.bitSize(pt) - 1) % 64 + 1));
+                const hi_ty = try pt.intType(.unsigned, @intCast((dst_ty.bitSize(zcu) - 1) % 64 + 1));
                 const hi_mcv = dst_mcv.address().offset(@intCast(bit_size / 64 * 8)).deref();
                 try self.genSetReg(tmp_reg, hi_ty, hi_mcv, .{});
                 try self.truncateRegister(dst_ty, tmp_reg);
@@ -3627,17 +3627,17 @@ fn airPtrArithmetic(self: *Self, inst: Air.Inst.Index, tag: Air.Inst.Tag) !void 
 
 fn activeIntBits(self: *Self, dst_air: Air.Inst.Ref) u16 {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const air_tag = self.air.instructions.items(.tag);
     const air_data = self.air.instructions.items(.data);
 
     const dst_ty = self.typeOf(dst_air);
-    const dst_info = dst_ty.intInfo(mod);
+    const dst_info = dst_ty.intInfo(zcu);
     if (dst_air.toIndex()) |inst| {
         switch (air_tag[@intFromEnum(inst)]) {
             .intcast => {
                 const src_ty = self.typeOf(air_data[@intFromEnum(inst)].ty_op.operand);
-                const src_info = src_ty.intInfo(mod);
+                const src_info = src_ty.intInfo(zcu);
                 return @min(switch (src_info.signedness) {
                     .signed => switch (dst_info.signedness) {
                         .signed => src_info.bits,
@@ -3653,7 +3653,7 @@ fn activeIntBits(self: *Self, dst_air: Air.Inst.Ref) u16 {
         }
     } else if (dst_air.toInterned()) |ip_index| {
         var space: Value.BigIntSpace = undefined;
-        const src_int = Value.fromInterned(ip_index).toBigInt(&space, pt);
+        const src_int = Value.fromInterned(ip_index).toBigInt(&space, zcu);
         return @as(u16, @intCast(src_int.bitCountTwosComp())) +
             @intFromBool(src_int.positive and dst_info.signedness == .signed);
     }
@@ -3662,18 +3662,18 @@ fn activeIntBits(self: *Self, dst_air: Air.Inst.Ref) u16 {
 
 fn airMulDivBinOp(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const result = result: {
         const tag = self.air.instructions.items(.tag)[@intFromEnum(inst)];
         const dst_ty = self.typeOfIndex(inst);
-        switch (dst_ty.zigTypeTag(mod)) {
+        switch (dst_ty.zigTypeTag(zcu)) {
             .Float, .Vector => break :result try self.genBinOp(inst, tag, bin_op.lhs, bin_op.rhs),
             else => {},
         }
-        const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+        const dst_abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
 
-        const dst_info = dst_ty.intInfo(mod);
+        const dst_info = dst_ty.intInfo(zcu);
         const src_ty = try pt.intType(dst_info.signedness, switch (tag) {
             else => unreachable,
             .mul, .mul_wrap => @max(
@@ -3683,20 +3683,20 @@ fn airMulDivBinOp(self: *Self, inst: Air.Inst.Index) !void {
             ),
             .div_trunc, .div_floor, .div_exact, .rem, .mod => dst_info.bits,
         });
-        const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
+        const src_abi_size: u32 = @intCast(src_ty.abiSize(zcu));
 
         if (dst_abi_size == 16 and src_abi_size == 16) switch (tag) {
             else => unreachable,
             .mul, .mul_wrap => {},
             .div_trunc, .div_floor, .div_exact, .rem, .mod => {
-                const signed = dst_ty.isSignedInt(mod);
+                const signed = dst_ty.isSignedInt(zcu);
                 var callee_buf: ["__udiv?i3".len]u8 = undefined;
                 const signed_div_floor_state: struct {
                     frame_index: FrameIndex,
                     state: State,
                     reloc: Mir.Inst.Index,
                 } = if (signed and tag == .div_floor) state: {
-                    const frame_index = try self.allocFrameIndex(FrameAlloc.initType(Type.usize, pt));
+                    const frame_index = try self.allocFrameIndex(FrameAlloc.initType(Type.usize, zcu));
                     try self.asmMemoryImmediate(
                         .{ ._, .mov },
                         .{ .base = .{ .frame = frame_index }, .mod = .{ .rm = .{ .size = .qword } } },
@@ -3771,7 +3771,7 @@ fn airMulDivBinOp(self: *Self, inst: Air.Inst.Index) !void {
                                 .rem, .mod => "mod",
                                 else => unreachable,
                             },
-                            intCompilerRtAbiName(@intCast(dst_ty.bitSize(pt))),
+                            intCompilerRtAbiName(@intCast(dst_ty.bitSize(zcu))),
                         }) catch unreachable,
                     } },
                     &.{ src_ty, src_ty },
@@ -3800,7 +3800,7 @@ fn airMulDivBinOp(self: *Self, inst: Air.Inst.Index) !void {
                                 .return_type = dst_ty.toIntern(),
                                 .param_types = &.{ src_ty.toIntern(), src_ty.toIntern() },
                                 .callee = std.fmt.bufPrint(&callee_buf, "__div{c}i3", .{
-                                    intCompilerRtAbiName(@intCast(dst_ty.bitSize(pt))),
+                                    intCompilerRtAbiName(@intCast(dst_ty.bitSize(zcu))),
                                 }) catch unreachable,
                             } },
                             &.{ src_ty, src_ty },
@@ -3892,10 +3892,10 @@ fn airMulDivBinOp(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAddSat(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const ty = self.typeOf(bin_op.lhs);
-    if (ty.zigTypeTag(mod) == .Vector or ty.abiSize(pt) > 8) return self.fail(
+    if (ty.zigTypeTag(zcu) == .Vector or ty.abiSize(zcu) > 8) return self.fail(
         "TODO implement airAddSat for {}",
         .{ty.fmt(pt)},
     );
@@ -3923,7 +3923,7 @@ fn airAddSat(self: *Self, inst: Air.Inst.Index) !void {
 
     const reg_bits = self.regBitSize(ty);
     const reg_extra_bits = self.regExtraBits(ty);
-    const cc: Condition = if (ty.isSignedInt(mod)) cc: {
+    const cc: Condition = if (ty.isSignedInt(zcu)) cc: {
         if (reg_extra_bits > 0) {
             try self.genShiftBinOpMir(
                 .{ ._l, .sa },
@@ -3962,7 +3962,7 @@ fn airAddSat(self: *Self, inst: Air.Inst.Index) !void {
         break :cc .o;
     } else cc: {
         try self.genSetReg(limit_reg, ty, .{
-            .immediate = @as(u64, math.maxInt(u64)) >> @intCast(64 - ty.bitSize(pt)),
+            .immediate = @as(u64, math.maxInt(u64)) >> @intCast(64 - ty.bitSize(zcu)),
         }, .{});
 
         try self.genBinOpMir(.{ ._, .add }, ty, dst_mcv, rhs_mcv);
@@ -3973,14 +3973,14 @@ fn airAddSat(self: *Self, inst: Air.Inst.Index) !void {
         break :cc .c;
     };
 
-    const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(pt))), 2);
+    const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(zcu))), 2);
     try self.asmCmovccRegisterRegister(
         cc,
         registerAlias(dst_reg, cmov_abi_size),
         registerAlias(limit_reg, cmov_abi_size),
     );
 
-    if (reg_extra_bits > 0 and ty.isSignedInt(mod)) try self.genShiftBinOpMir(
+    if (reg_extra_bits > 0 and ty.isSignedInt(zcu)) try self.genShiftBinOpMir(
         .{ ._r, .sa },
         ty,
         dst_mcv,
@@ -3993,10 +3993,10 @@ fn airAddSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airSubSat(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const ty = self.typeOf(bin_op.lhs);
-    if (ty.zigTypeTag(mod) == .Vector or ty.abiSize(pt) > 8) return self.fail(
+    if (ty.zigTypeTag(zcu) == .Vector or ty.abiSize(zcu) > 8) return self.fail(
         "TODO implement airSubSat for {}",
         .{ty.fmt(pt)},
     );
@@ -4024,7 +4024,7 @@ fn airSubSat(self: *Self, inst: Air.Inst.Index) !void {
 
     const reg_bits = self.regBitSize(ty);
     const reg_extra_bits = self.regExtraBits(ty);
-    const cc: Condition = if (ty.isSignedInt(mod)) cc: {
+    const cc: Condition = if (ty.isSignedInt(zcu)) cc: {
         if (reg_extra_bits > 0) {
             try self.genShiftBinOpMir(
                 .{ ._l, .sa },
@@ -4067,14 +4067,14 @@ fn airSubSat(self: *Self, inst: Air.Inst.Index) !void {
         break :cc .c;
     };
 
-    const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(pt))), 2);
+    const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(zcu))), 2);
     try self.asmCmovccRegisterRegister(
         cc,
         registerAlias(dst_reg, cmov_abi_size),
         registerAlias(limit_reg, cmov_abi_size),
     );
 
-    if (reg_extra_bits > 0 and ty.isSignedInt(mod)) try self.genShiftBinOpMir(
+    if (reg_extra_bits > 0 and ty.isSignedInt(zcu)) try self.genShiftBinOpMir(
         .{ ._r, .sa },
         ty,
         dst_mcv,
@@ -4087,7 +4087,7 @@ fn airSubSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const ty = self.typeOf(bin_op.lhs);
 
@@ -4170,7 +4170,7 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
             break :result dst_mcv;
         }
 
-        if (ty.zigTypeTag(mod) == .Vector or ty.abiSize(pt) > 8) return self.fail(
+        if (ty.zigTypeTag(zcu) == .Vector or ty.abiSize(zcu) > 8) return self.fail(
             "TODO implement airMulSat for {}",
             .{ty.fmt(pt)},
         );
@@ -4199,7 +4199,7 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
         defer self.register_manager.unlockReg(limit_lock);
 
         const reg_bits = self.regBitSize(ty);
-        const cc: Condition = if (ty.isSignedInt(mod)) cc: {
+        const cc: Condition = if (ty.isSignedInt(zcu)) cc: {
             try self.genSetReg(limit_reg, ty, lhs_mcv, .{});
             try self.genBinOpMir(.{ ._, .xor }, ty, limit_mcv, rhs_mcv);
             try self.genShiftBinOpMir(
@@ -4221,7 +4221,7 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
         };
 
         const dst_mcv = try self.genMulDivBinOp(.mul, inst, ty, ty, lhs_mcv, rhs_mcv);
-        const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(pt))), 2);
+        const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(zcu))), 2);
         try self.asmCmovccRegisterRegister(
             cc,
             registerAlias(dst_mcv.register, cmov_abi_size),
@@ -4234,13 +4234,13 @@ fn airMulSat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
     const result: MCValue = result: {
         const tag = self.air.instructions.items(.tag)[@intFromEnum(inst)];
         const ty = self.typeOf(bin_op.lhs);
-        switch (ty.zigTypeTag(mod)) {
+        switch (ty.zigTypeTag(zcu)) {
             .Vector => return self.fail("TODO implement add/sub with overflow for Vector type", .{}),
             .Int => {
                 try self.spillEflagsIfOccupied();
@@ -4253,7 +4253,7 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     .sub_with_overflow => .sub,
                     else => unreachable,
                 }, bin_op.lhs, bin_op.rhs);
-                const int_info = ty.intInfo(mod);
+                const int_info = ty.intInfo(zcu);
                 const cc: Condition = switch (int_info.signedness) {
                     .unsigned => .c,
                     .signed => .o,
@@ -4270,17 +4270,17 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     }
 
                     const frame_index =
-                        try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, pt));
+                        try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, zcu));
                     try self.genSetMem(
                         .{ .frame = frame_index },
-                        @intCast(tuple_ty.structFieldOffset(1, pt)),
+                        @intCast(tuple_ty.structFieldOffset(1, zcu)),
                         Type.u1,
                         .{ .eflags = cc },
                         .{},
                     );
                     try self.genSetMem(
                         .{ .frame = frame_index },
-                        @intCast(tuple_ty.structFieldOffset(0, pt)),
+                        @intCast(tuple_ty.structFieldOffset(0, zcu)),
                         ty,
                         partial_mcv,
                         .{},
@@ -4289,7 +4289,7 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                 }
 
                 const frame_index =
-                    try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, pt));
+                    try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, zcu));
                 try self.genSetFrameTruncatedOverflowCompare(tuple_ty, frame_index, partial_mcv, cc);
                 break :result .{ .load_frame = .{ .index = frame_index } };
             },
@@ -4301,13 +4301,13 @@ fn airAddSubWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
     const result: MCValue = result: {
         const lhs_ty = self.typeOf(bin_op.lhs);
         const rhs_ty = self.typeOf(bin_op.rhs);
-        switch (lhs_ty.zigTypeTag(mod)) {
+        switch (lhs_ty.zigTypeTag(zcu)) {
             .Vector => return self.fail("TODO implement shl with overflow for Vector type", .{}),
             .Int => {
                 try self.spillEflagsIfOccupied();
@@ -4318,7 +4318,7 @@ fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                 const lhs = try self.resolveInst(bin_op.lhs);
                 const rhs = try self.resolveInst(bin_op.rhs);
 
-                const int_info = lhs_ty.intInfo(mod);
+                const int_info = lhs_ty.intInfo(zcu);
 
                 const partial_mcv = try self.genShiftBinOp(.shl, null, lhs, rhs, lhs_ty, rhs_ty);
                 const partial_lock = switch (partial_mcv) {
@@ -4348,18 +4348,18 @@ fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     }
 
                     const frame_index =
-                        try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, pt));
+                        try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, zcu));
                     try self.genSetMem(
                         .{ .frame = frame_index },
-                        @intCast(tuple_ty.structFieldOffset(1, pt)),
-                        tuple_ty.structFieldType(1, mod),
+                        @intCast(tuple_ty.structFieldOffset(1, zcu)),
+                        tuple_ty.structFieldType(1, zcu),
                         .{ .eflags = cc },
                         .{},
                     );
                     try self.genSetMem(
                         .{ .frame = frame_index },
-                        @intCast(tuple_ty.structFieldOffset(0, pt)),
-                        tuple_ty.structFieldType(0, mod),
+                        @intCast(tuple_ty.structFieldOffset(0, zcu)),
+                        tuple_ty.structFieldType(0, zcu),
                         partial_mcv,
                         .{},
                     );
@@ -4367,7 +4367,7 @@ fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                 }
 
                 const frame_index =
-                    try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, pt));
+                    try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, zcu));
                 try self.genSetFrameTruncatedOverflowCompare(tuple_ty, frame_index, partial_mcv, cc);
                 break :result .{ .load_frame = .{ .index = frame_index } };
             },
@@ -4385,15 +4385,15 @@ fn genSetFrameTruncatedOverflowCompare(
     overflow_cc: ?Condition,
 ) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const src_lock = switch (src_mcv) {
         .register => |reg| self.register_manager.lockReg(reg),
         else => null,
     };
     defer if (src_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const ty = tuple_ty.structFieldType(0, mod);
-    const int_info = ty.intInfo(mod);
+    const ty = tuple_ty.structFieldType(0, zcu);
+    const int_info = ty.intInfo(zcu);
 
     const hi_bits = (int_info.bits - 1) % 64 + 1;
     const hi_ty = try pt.intType(int_info.signedness, hi_bits);
@@ -4432,7 +4432,7 @@ fn genSetFrameTruncatedOverflowCompare(
         );
     }
 
-    const payload_off: i32 = @intCast(tuple_ty.structFieldOffset(0, pt));
+    const payload_off: i32 = @intCast(tuple_ty.structFieldOffset(0, zcu));
     if (hi_limb_off > 0) try self.genSetMem(
         .{ .frame = frame_index },
         payload_off,
@@ -4449,8 +4449,8 @@ fn genSetFrameTruncatedOverflowCompare(
     );
     try self.genSetMem(
         .{ .frame = frame_index },
-        @intCast(tuple_ty.structFieldOffset(1, pt)),
-        tuple_ty.structFieldType(1, mod),
+        @intCast(tuple_ty.structFieldOffset(1, zcu)),
+        tuple_ty.structFieldType(1, zcu),
         if (overflow_cc) |_| .{ .register = overflow_reg.to8() } else .{ .eflags = .ne },
         .{},
     );
@@ -4458,18 +4458,18 @@ fn genSetFrameTruncatedOverflowCompare(
 
 fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
     const tuple_ty = self.typeOfIndex(inst);
     const dst_ty = self.typeOf(bin_op.lhs);
-    const result: MCValue = switch (dst_ty.zigTypeTag(mod)) {
+    const result: MCValue = switch (dst_ty.zigTypeTag(zcu)) {
         .Vector => return self.fail("TODO implement airMulWithOverflow for {}", .{dst_ty.fmt(pt)}),
         .Int => result: {
-            const dst_info = dst_ty.intInfo(mod);
+            const dst_info = dst_ty.intInfo(zcu);
             if (dst_info.bits > 128 and dst_info.signedness == .unsigned) {
                 const slow_inc = self.hasFeature(.slow_incdec);
-                const abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+                const abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
                 const limb_len = math.divCeil(u32, abi_size, 8) catch unreachable;
 
                 try self.spillRegisters(&.{ .rax, .rcx, .rdx });
@@ -4480,7 +4480,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                 try self.genInlineMemset(
                     dst_mcv.address(),
                     .{ .immediate = 0 },
-                    .{ .immediate = tuple_ty.abiSize(pt) },
+                    .{ .immediate = tuple_ty.abiSize(zcu) },
                     .{},
                 );
                 const lhs_mcv = try self.resolveInst(bin_op.lhs);
@@ -4520,7 +4520,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                         .index = temp_regs[3].to64(),
                         .scale = .@"8",
                         .disp = dst_mcv.load_frame.off +
-                            @as(i32, @intCast(tuple_ty.structFieldOffset(0, pt))),
+                            @as(i32, @intCast(tuple_ty.structFieldOffset(0, zcu))),
                     } },
                 }, .rdx);
                 try self.asmSetccRegister(.c, .cl);
@@ -4544,7 +4544,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                         .index = temp_regs[3].to64(),
                         .scale = .@"8",
                         .disp = dst_mcv.load_frame.off +
-                            @as(i32, @intCast(tuple_ty.structFieldOffset(0, pt))),
+                            @as(i32, @intCast(tuple_ty.structFieldOffset(0, zcu))),
                     } },
                 }, .rax);
                 try self.asmSetccRegister(.c, .ch);
@@ -4593,7 +4593,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     .mod = .{ .rm = .{
                         .size = .byte,
                         .disp = dst_mcv.load_frame.off +
-                            @as(i32, @intCast(tuple_ty.structFieldOffset(1, pt))),
+                            @as(i32, @intCast(tuple_ty.structFieldOffset(1, zcu))),
                     } },
                 }, Immediate.u(1));
                 self.performReloc(no_overflow);
@@ -4636,8 +4636,8 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     const dst_mcv = try self.allocRegOrMem(inst, false);
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
-                        @intCast(tuple_ty.structFieldOffset(0, pt)),
-                        tuple_ty.structFieldType(0, mod),
+                        @intCast(tuple_ty.structFieldOffset(0, zcu)),
+                        tuple_ty.structFieldType(0, zcu),
                         result,
                         .{},
                     );
@@ -4648,8 +4648,8 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     );
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
-                        @intCast(tuple_ty.structFieldOffset(1, pt)),
-                        tuple_ty.structFieldType(1, mod),
+                        @intCast(tuple_ty.structFieldOffset(1, zcu)),
+                        tuple_ty.structFieldType(1, zcu),
                         .{ .eflags = .ne },
                         .{},
                     );
@@ -4760,15 +4760,15 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     const dst_mcv = try self.allocRegOrMem(inst, false);
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
-                        @intCast(tuple_ty.structFieldOffset(0, pt)),
-                        tuple_ty.structFieldType(0, mod),
+                        @intCast(tuple_ty.structFieldOffset(0, zcu)),
+                        tuple_ty.structFieldType(0, zcu),
                         .{ .register_pair = .{ .rax, .rdx } },
                         .{},
                     );
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
-                        @intCast(tuple_ty.structFieldOffset(1, pt)),
-                        tuple_ty.structFieldType(1, mod),
+                        @intCast(tuple_ty.structFieldOffset(1, zcu)),
+                        tuple_ty.structFieldType(1, zcu),
                         .{ .register = tmp_regs[1] },
                         .{},
                     );
@@ -4800,7 +4800,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     self.eflags_inst = inst;
                     break :result .{ .register_overflow = .{ .reg = reg, .eflags = cc } };
                 } else {
-                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, pt));
+                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, zcu));
                     try self.genSetFrameTruncatedOverflowCompare(tuple_ty, frame_index, partial_mcv, cc);
                     break :result .{ .load_frame = .{ .index = frame_index } };
                 },
@@ -4811,19 +4811,19 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                             src_ty.fmt(pt), dst_ty.fmt(pt),
                         });
 
-                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, pt));
+                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(tuple_ty, zcu));
                     if (dst_info.bits >= lhs_active_bits + rhs_active_bits) {
                         try self.genSetMem(
                             .{ .frame = frame_index },
-                            @intCast(tuple_ty.structFieldOffset(0, pt)),
-                            tuple_ty.structFieldType(0, mod),
+                            @intCast(tuple_ty.structFieldOffset(0, zcu)),
+                            tuple_ty.structFieldType(0, zcu),
                             partial_mcv,
                             .{},
                         );
                         try self.genSetMem(
                             .{ .frame = frame_index },
-                            @intCast(tuple_ty.structFieldOffset(1, pt)),
-                            tuple_ty.structFieldType(1, mod),
+                            @intCast(tuple_ty.structFieldOffset(1, zcu)),
+                            tuple_ty.structFieldType(1, zcu),
                             .{ .immediate = 0 }, // cc being set is impossible
                             .{},
                         );
@@ -4847,7 +4847,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
 /// Quotient is saved in .rax and remainder in .rdx.
 fn genIntMulDivOpMir(self: *Self, tag: Mir.Inst.FixedTag, ty: Type, lhs: MCValue, rhs: MCValue) !void {
     const pt = self.pt;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const abi_size: u32 = @intCast(ty.abiSize(pt.zcu));
     const bit_size: u32 = @intCast(self.regBitSize(ty));
     if (abi_size > 8) {
         return self.fail("TODO implement genIntMulDivOpMir for ABI size larger than 8", .{});
@@ -4897,9 +4897,9 @@ fn genIntMulDivOpMir(self: *Self, tag: Mir.Inst.FixedTag, ty: Type, lhs: MCValue
 /// Clobbers .rax and .rdx registers.
 fn genInlineIntDivFloor(self: *Self, ty: Type, lhs: MCValue, rhs: MCValue) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
-    const int_info = ty.intInfo(mod);
+    const zcu = pt.zcu;
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
+    const int_info = ty.intInfo(zcu);
     const dividend = switch (lhs) {
         .register => |reg| reg,
         else => try self.copyToTmpRegister(ty, lhs),
@@ -4950,7 +4950,7 @@ fn genInlineIntDivFloor(self: *Self, ty: Type, lhs: MCValue, rhs: MCValue) !MCVa
 
 fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const air_tags = self.air.instructions.items(.tag);
@@ -4958,7 +4958,7 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
     const lhs_ty = self.typeOf(bin_op.lhs);
     const rhs_ty = self.typeOf(bin_op.rhs);
     const result: MCValue = result: {
-        switch (lhs_ty.zigTypeTag(mod)) {
+        switch (lhs_ty.zigTypeTag(zcu)) {
             .Int => {
                 try self.spillRegisters(&.{.rcx});
                 try self.register_manager.getKnownReg(.rcx, null);
@@ -4977,7 +4977,7 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                             const tmp_lock = self.register_manager.lockRegAssumeUnused(tmp_reg);
                             defer self.register_manager.unlockReg(tmp_lock);
 
-                            const lhs_bits: u31 = @intCast(lhs_ty.bitSize(pt));
+                            const lhs_bits: u31 = @intCast(lhs_ty.bitSize(zcu));
                             const tmp_ty = if (lhs_bits > 64) Type.usize else lhs_ty;
                             const off = frame_addr.off + (lhs_bits - 1) / 64 * 8;
                             try self.genSetReg(
@@ -5001,14 +5001,14 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                 }
                 break :result dst_mcv;
             },
-            .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
-                .Int => if (@as(?Mir.Inst.FixedTag, switch (lhs_ty.childType(mod).intInfo(mod).bits) {
+            .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
+                .Int => if (@as(?Mir.Inst.FixedTag, switch (lhs_ty.childType(zcu).intInfo(zcu).bits) {
                     else => null,
-                    16 => switch (lhs_ty.vectorLen(mod)) {
+                    16 => switch (lhs_ty.vectorLen(zcu)) {
                         else => null,
                         1...8 => switch (tag) {
                             else => unreachable,
-                            .shr, .shr_exact => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                            .shr, .shr_exact => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                                 .signed => if (self.hasFeature(.avx))
                                     .{ .vp_w, .sra }
                                 else
@@ -5025,18 +5025,18 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                         },
                         9...16 => switch (tag) {
                             else => unreachable,
-                            .shr, .shr_exact => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                            .shr, .shr_exact => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                                 .signed => if (self.hasFeature(.avx2)) .{ .vp_w, .sra } else null,
                                 .unsigned => if (self.hasFeature(.avx2)) .{ .vp_w, .srl } else null,
                             },
                             .shl, .shl_exact => if (self.hasFeature(.avx2)) .{ .vp_w, .sll } else null,
                         },
                     },
-                    32 => switch (lhs_ty.vectorLen(mod)) {
+                    32 => switch (lhs_ty.vectorLen(zcu)) {
                         else => null,
                         1...4 => switch (tag) {
                             else => unreachable,
-                            .shr, .shr_exact => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                            .shr, .shr_exact => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                                 .signed => if (self.hasFeature(.avx))
                                     .{ .vp_d, .sra }
                                 else
@@ -5053,18 +5053,18 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                         },
                         5...8 => switch (tag) {
                             else => unreachable,
-                            .shr, .shr_exact => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                            .shr, .shr_exact => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                                 .signed => if (self.hasFeature(.avx2)) .{ .vp_d, .sra } else null,
                                 .unsigned => if (self.hasFeature(.avx2)) .{ .vp_d, .srl } else null,
                             },
                             .shl, .shl_exact => if (self.hasFeature(.avx2)) .{ .vp_d, .sll } else null,
                         },
                     },
-                    64 => switch (lhs_ty.vectorLen(mod)) {
+                    64 => switch (lhs_ty.vectorLen(zcu)) {
                         else => null,
                         1...2 => switch (tag) {
                             else => unreachable,
-                            .shr, .shr_exact => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                            .shr, .shr_exact => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                                 .signed => if (self.hasFeature(.avx))
                                     .{ .vp_q, .sra }
                                 else
@@ -5081,7 +5081,7 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                         },
                         3...4 => switch (tag) {
                             else => unreachable,
-                            .shr, .shr_exact => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                            .shr, .shr_exact => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                                 .signed => if (self.hasFeature(.avx2)) .{ .vp_q, .sra } else null,
                                 .unsigned => if (self.hasFeature(.avx2)) .{ .vp_q, .srl } else null,
                             },
@@ -5089,10 +5089,10 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                         },
                     },
                 })) |mir_tag| if (try self.air.value(bin_op.rhs, pt)) |rhs_val| {
-                    switch (mod.intern_pool.indexToKey(rhs_val.toIntern())) {
+                    switch (zcu.intern_pool.indexToKey(rhs_val.toIntern())) {
                         .aggregate => |rhs_aggregate| switch (rhs_aggregate.storage) {
                             .repeated_elem => |rhs_elem| {
-                                const abi_size: u32 = @intCast(lhs_ty.abiSize(pt));
+                                const abi_size: u32 = @intCast(lhs_ty.abiSize(zcu));
 
                                 const lhs_mcv = try self.resolveInst(bin_op.lhs);
                                 const dst_reg, const lhs_reg = if (lhs_mcv.isRegister() and
@@ -5112,7 +5112,7 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                                     self.register_manager.unlockReg(lock);
 
                                 const shift_imm =
-                                    Immediate.u(@intCast(Value.fromInterned(rhs_elem).toUnsignedInt(pt)));
+                                    Immediate.u(@intCast(Value.fromInterned(rhs_elem).toUnsignedInt(zcu)));
                                 if (self.hasFeature(.avx)) try self.asmRegisterRegisterImmediate(
                                     mir_tag,
                                     registerAlias(dst_reg, abi_size),
@@ -5134,7 +5134,7 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                     }
                 } else if (bin_op.rhs.toIndex()) |rhs_inst| switch (air_tags[@intFromEnum(rhs_inst)]) {
                     .splat => {
-                        const abi_size: u32 = @intCast(lhs_ty.abiSize(pt));
+                        const abi_size: u32 = @intCast(lhs_ty.abiSize(zcu));
 
                         const lhs_mcv = try self.resolveInst(bin_op.lhs);
                         const dst_reg, const lhs_reg = if (lhs_mcv.isRegister() and
@@ -5161,7 +5161,7 @@ fn airShlShrBinOp(self: *Self, inst: Air.Inst.Index) !void {
                         const mask_mcv = try self.genTypedValue(Value.fromInterned(try pt.intern(.{ .aggregate = .{
                             .ty = mask_ty.toIntern(),
                             .storage = .{ .elems = &([1]InternPool.Index{
-                                (try rhs_ty.childType(mod).maxIntScalar(pt, Type.u8)).toIntern(),
+                                (try rhs_ty.childType(zcu).maxIntScalar(pt, Type.u8)).toIntern(),
                             } ++ [1]InternPool.Index{
                                 (try pt.intValue(Type.u8, 0)).toIntern(),
                             } ** 15) },
@@ -5224,11 +5224,11 @@ fn airShlSat(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airOptionalPayload(self: *Self, inst: Air.Inst.Index) !void {
-    const pt = self.pt;
+    const zcu = self.pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = result: {
         const pl_ty = self.typeOfIndex(inst);
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const opt_mcv = try self.resolveInst(ty_op.operand);
         if (self.reuseOperand(inst, ty_op.operand, 0, opt_mcv)) {
@@ -5271,15 +5271,15 @@ fn airOptionalPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airOptionalPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result = result: {
         const dst_ty = self.typeOfIndex(inst);
         const src_ty = self.typeOf(ty_op.operand);
-        const opt_ty = src_ty.childType(mod);
+        const opt_ty = src_ty.childType(zcu);
         const src_mcv = try self.resolveInst(ty_op.operand);
 
-        if (opt_ty.optionalReprIsPayload(mod)) {
+        if (opt_ty.optionalReprIsPayload(zcu)) {
             break :result if (self.liveness.isUnused(inst))
                 .unreach
             else if (self.reuseOperand(inst, ty_op.operand, 0, src_mcv))
@@ -5296,8 +5296,8 @@ fn airOptionalPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
         else
             try self.copyToRegisterWithInstTracking(inst, dst_ty, src_mcv);
 
-        const pl_ty = dst_ty.childType(mod);
-        const pl_abi_size: i32 = @intCast(pl_ty.abiSize(pt));
+        const pl_ty = dst_ty.childType(zcu);
+        const pl_abi_size: i32 = @intCast(pl_ty.abiSize(zcu));
         try self.genSetMem(
             .{ .reg = dst_mcv.getReg().? },
             pl_abi_size,
@@ -5312,23 +5312,23 @@ fn airOptionalPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airUnwrapErrUnionErr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const err_union_ty = self.typeOf(ty_op.operand);
-    const err_ty = err_union_ty.errorUnionSet(mod);
-    const payload_ty = err_union_ty.errorUnionPayload(mod);
+    const err_ty = err_union_ty.errorUnionSet(zcu);
+    const payload_ty = err_union_ty.errorUnionPayload(zcu);
     const operand = try self.resolveInst(ty_op.operand);
 
     const result: MCValue = result: {
-        if (err_ty.errorSetIsEmpty(mod)) {
+        if (err_ty.errorSetIsEmpty(zcu)) {
             break :result MCValue{ .immediate = 0 };
         }
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             break :result operand;
         }
 
-        const err_off = errUnionErrorOffset(payload_ty, pt);
+        const err_off = errUnionErrorOffset(payload_ty, zcu);
         switch (operand) {
             .register => |reg| {
                 // TODO reuse operand
@@ -5366,7 +5366,7 @@ fn airUnwrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) !void {
 // *(E!T) -> E
 fn airUnwrapErrUnionErrPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const src_ty = self.typeOf(ty_op.operand);
@@ -5383,11 +5383,11 @@ fn airUnwrapErrUnionErrPtr(self: *Self, inst: Air.Inst.Index) !void {
     const dst_lock = self.register_manager.lockRegAssumeUnused(dst_reg);
     defer self.register_manager.unlockReg(dst_lock);
 
-    const eu_ty = src_ty.childType(mod);
-    const pl_ty = eu_ty.errorUnionPayload(mod);
-    const err_ty = eu_ty.errorUnionSet(mod);
-    const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, pt));
-    const err_abi_size: u32 = @intCast(err_ty.abiSize(pt));
+    const eu_ty = src_ty.childType(zcu);
+    const pl_ty = eu_ty.errorUnionPayload(zcu);
+    const err_ty = eu_ty.errorUnionSet(zcu);
+    const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
+    const err_abi_size: u32 = @intCast(err_ty.abiSize(zcu));
     try self.asmRegisterMemory(
         .{ ._, .mov },
         registerAlias(dst_reg, err_abi_size),
@@ -5414,7 +5414,7 @@ fn airUnwrapErrUnionPayloadPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = result: {
         const src_ty = self.typeOf(ty_op.operand);
@@ -5426,11 +5426,11 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
         const src_lock = self.register_manager.lockRegAssumeUnused(src_reg);
         defer self.register_manager.unlockReg(src_lock);
 
-        const eu_ty = src_ty.childType(mod);
-        const pl_ty = eu_ty.errorUnionPayload(mod);
-        const err_ty = eu_ty.errorUnionSet(mod);
-        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, pt));
-        const err_abi_size: u32 = @intCast(err_ty.abiSize(pt));
+        const eu_ty = src_ty.childType(zcu);
+        const pl_ty = eu_ty.errorUnionPayload(zcu);
+        const err_ty = eu_ty.errorUnionSet(zcu);
+        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
+        const err_abi_size: u32 = @intCast(err_ty.abiSize(zcu));
         try self.asmMemoryImmediate(
             .{ ._, .mov },
             .{
@@ -5453,8 +5453,8 @@ fn airErrUnionPayloadPtrSet(self: *Self, inst: Air.Inst.Index) !void {
         const dst_lock = self.register_manager.lockReg(dst_reg);
         defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, pt));
-        const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, zcu));
+        const dst_abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
         try self.asmRegisterMemory(
             .{ ._, .lea },
             registerAlias(dst_reg, dst_abi_size),
@@ -5475,13 +5475,13 @@ fn genUnwrapErrUnionPayloadMir(
     err_union: MCValue,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const payload_ty = err_union_ty.errorUnionPayload(mod);
+    const zcu = pt.zcu;
+    const payload_ty = err_union_ty.errorUnionPayload(zcu);
 
     const result: MCValue = result: {
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
-        const payload_off: u31 = @intCast(errUnionPayloadOffset(payload_ty, pt));
+        const payload_off: u31 = @intCast(errUnionPayloadOffset(payload_ty, zcu));
         switch (err_union) {
             .load_frame => |frame_addr| break :result .{ .load_frame = .{
                 .index = frame_addr.index,
@@ -5525,12 +5525,12 @@ fn genUnwrapErrUnionPayloadPtrMir(
     ptr_mcv: MCValue,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const err_union_ty = ptr_ty.childType(mod);
-    const payload_ty = err_union_ty.errorUnionPayload(mod);
+    const zcu = pt.zcu;
+    const err_union_ty = ptr_ty.childType(zcu);
+    const payload_ty = err_union_ty.errorUnionPayload(zcu);
 
     const result: MCValue = result: {
-        const payload_off = errUnionPayloadOffset(payload_ty, pt);
+        const payload_off = errUnionPayloadOffset(payload_ty, zcu);
         const result_mcv: MCValue = if (maybe_inst) |inst|
             try self.copyToRegisterWithInstTracking(inst, ptr_ty, ptr_mcv)
         else
@@ -5560,15 +5560,15 @@ fn airSaveErrReturnTraceIndex(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = result: {
         const pl_ty = self.typeOf(ty_op.operand);
-        if (!pl_ty.hasRuntimeBits(pt)) break :result .{ .immediate = 1 };
+        if (!pl_ty.hasRuntimeBits(zcu)) break :result .{ .immediate = 1 };
 
         const opt_ty = self.typeOfIndex(inst);
         const pl_mcv = try self.resolveInst(ty_op.operand);
-        const same_repr = opt_ty.optionalReprIsPayload(mod);
+        const same_repr = opt_ty.optionalReprIsPayload(zcu);
         if (same_repr and self.reuseOperand(inst, ty_op.operand, 0, pl_mcv)) break :result pl_mcv;
 
         const pl_lock: ?RegisterLock = switch (pl_mcv) {
@@ -5581,7 +5581,7 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
         try self.genCopy(pl_ty, opt_mcv, pl_mcv, .{});
 
         if (!same_repr) {
-            const pl_abi_size: i32 = @intCast(pl_ty.abiSize(pt));
+            const pl_abi_size: i32 = @intCast(pl_ty.abiSize(zcu));
             switch (opt_mcv) {
                 else => unreachable,
 
@@ -5615,20 +5615,20 @@ fn airWrapOptional(self: *Self, inst: Air.Inst.Index) !void {
 /// T to E!T
 fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const eu_ty = ty_op.ty.toType();
-    const pl_ty = eu_ty.errorUnionPayload(mod);
-    const err_ty = eu_ty.errorUnionSet(mod);
+    const pl_ty = eu_ty.errorUnionPayload(zcu);
+    const err_ty = eu_ty.errorUnionSet(zcu);
     const operand = try self.resolveInst(ty_op.operand);
 
     const result: MCValue = result: {
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .{ .immediate = 0 };
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .{ .immediate = 0 };
 
-        const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(eu_ty, pt));
-        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, pt));
-        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, pt));
+        const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(eu_ty, zcu));
+        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, zcu));
+        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
         try self.genSetMem(.{ .frame = frame_index }, pl_off, pl_ty, operand, .{});
         try self.genSetMem(.{ .frame = frame_index }, err_off, err_ty, .{ .immediate = 0 }, .{});
         break :result .{ .load_frame = .{ .index = frame_index } };
@@ -5639,19 +5639,19 @@ fn airWrapErrUnionPayload(self: *Self, inst: Air.Inst.Index) !void {
 /// E to E!T
 fn airWrapErrUnionErr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const eu_ty = ty_op.ty.toType();
-    const pl_ty = eu_ty.errorUnionPayload(mod);
-    const err_ty = eu_ty.errorUnionSet(mod);
+    const pl_ty = eu_ty.errorUnionPayload(zcu);
+    const err_ty = eu_ty.errorUnionSet(zcu);
 
     const result: MCValue = result: {
-        if (!pl_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result try self.resolveInst(ty_op.operand);
+        if (!pl_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result try self.resolveInst(ty_op.operand);
 
-        const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(eu_ty, pt));
-        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, pt));
-        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, pt));
+        const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(eu_ty, zcu));
+        const pl_off: i32 = @intCast(errUnionPayloadOffset(pl_ty, zcu));
+        const err_off: i32 = @intCast(errUnionErrorOffset(pl_ty, zcu));
         try self.genSetMem(.{ .frame = frame_index }, pl_off, pl_ty, .undef, .{});
         const operand = try self.resolveInst(ty_op.operand);
         try self.genSetMem(.{ .frame = frame_index }, err_off, err_ty, operand, .{});
@@ -5719,7 +5719,7 @@ fn airPtrSliceLenPtr(self: *Self, inst: Air.Inst.Index) !void {
     const dst_lock = self.register_manager.lockReg(dst_reg);
     defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt.zcu));
     try self.asmRegisterMemory(
         .{ ._, .lea },
         registerAlias(dst_reg, dst_abi_size),
@@ -5767,7 +5767,7 @@ fn elemOffset(self: *Self, index_ty: Type, index: MCValue, elem_size: u64) !Regi
 
 fn genSliceElemPtr(self: *Self, lhs: Air.Inst.Ref, rhs: Air.Inst.Ref) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const slice_ty = self.typeOf(lhs);
     const slice_mcv = try self.resolveInst(lhs);
     const slice_mcv_lock: ?RegisterLock = switch (slice_mcv) {
@@ -5776,9 +5776,9 @@ fn genSliceElemPtr(self: *Self, lhs: Air.Inst.Ref, rhs: Air.Inst.Ref) !MCValue {
     };
     defer if (slice_mcv_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const elem_ty = slice_ty.childType(mod);
-    const elem_size = elem_ty.abiSize(pt);
-    const slice_ptr_field_type = slice_ty.slicePtrFieldType(mod);
+    const elem_ty = slice_ty.childType(zcu);
+    const elem_size = elem_ty.abiSize(zcu);
+    const slice_ptr_field_type = slice_ty.slicePtrFieldType(zcu);
 
     const index_ty = self.typeOf(rhs);
     const index_mcv = try self.resolveInst(rhs);
@@ -5804,15 +5804,15 @@ fn genSliceElemPtr(self: *Self, lhs: Air.Inst.Ref, rhs: Air.Inst.Ref) !MCValue {
 
 fn airSliceElemVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const result: MCValue = result: {
         const elem_ty = self.typeOfIndex(inst);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         const slice_ty = self.typeOf(bin_op.lhs);
-        const slice_ptr_field_type = slice_ty.slicePtrFieldType(mod);
+        const slice_ptr_field_type = slice_ty.slicePtrFieldType(zcu);
         const elem_ptr = try self.genSliceElemPtr(bin_op.lhs, bin_op.rhs);
         const dst_mcv = try self.allocRegOrMem(inst, false);
         try self.load(dst_mcv, slice_ptr_field_type, elem_ptr);
@@ -5830,12 +5830,12 @@ fn airSliceElemPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     const result: MCValue = result: {
         const array_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = array_ty.childType(mod);
+        const elem_ty = array_ty.childType(zcu);
 
         const array_mcv = try self.resolveInst(bin_op.lhs);
         const array_lock: ?RegisterLock = switch (array_mcv) {
@@ -5853,7 +5853,7 @@ fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
         defer if (index_lock) |lock| self.register_manager.unlockReg(lock);
 
         try self.spillEflagsIfOccupied();
-        if (array_ty.isVector(mod) and elem_ty.bitSize(pt) == 1) {
+        if (array_ty.isVector(zcu) and elem_ty.bitSize(zcu) == 1) {
             const index_reg = switch (index_mcv) {
                 .register => |reg| reg,
                 else => try self.copyToTmpRegister(index_ty, index_mcv),
@@ -5866,7 +5866,7 @@ fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
                         index_reg.to64(),
                     ),
                     .sse => {
-                        const frame_index = try self.allocFrameIndex(FrameAlloc.initType(array_ty, pt));
+                        const frame_index = try self.allocFrameIndex(FrameAlloc.initType(array_ty, zcu));
                         try self.genSetMem(.{ .frame = frame_index }, 0, array_ty, array_mcv, .{});
                         try self.asmMemoryRegister(
                             .{ ._, .bt },
@@ -5904,14 +5904,14 @@ fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
             break :result .{ .register = dst_reg };
         }
 
-        const elem_abi_size = elem_ty.abiSize(pt);
+        const elem_abi_size = elem_ty.abiSize(zcu);
         const addr_reg = try self.register_manager.allocReg(null, abi.RegisterClass.gp);
         const addr_lock = self.register_manager.lockRegAssumeUnused(addr_reg);
         defer self.register_manager.unlockReg(addr_lock);
 
         switch (array_mcv) {
             .register => {
-                const frame_index = try self.allocFrameIndex(FrameAlloc.initType(array_ty, pt));
+                const frame_index = try self.allocFrameIndex(FrameAlloc.initType(array_ty, zcu));
                 try self.genSetMem(.{ .frame = frame_index }, 0, array_ty, array_mcv, .{});
                 try self.asmRegisterMemory(
                     .{ ._, .lea },
@@ -5960,7 +5960,7 @@ fn airArrayElemVal(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airPtrElemVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const ptr_ty = self.typeOf(bin_op.lhs);
 
@@ -5968,10 +5968,10 @@ fn airPtrElemVal(self: *Self, inst: Air.Inst.Index) !void {
     // additional `mov` is needed at the end to get the actual value
 
     const result = result: {
-        const elem_ty = ptr_ty.elemType2(mod);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        const elem_ty = ptr_ty.elemType2(zcu);
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
-        const elem_abi_size: u32 = @intCast(elem_ty.abiSize(pt));
+        const elem_abi_size: u32 = @intCast(elem_ty.abiSize(zcu));
         const index_ty = self.typeOf(bin_op.rhs);
         const index_mcv = try self.resolveInst(bin_op.rhs);
         const index_lock = switch (index_mcv) {
@@ -6011,7 +6011,7 @@ fn airPtrElemVal(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airPtrElemPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
 
@@ -6026,15 +6026,15 @@ fn airPtrElemPtr(self: *Self, inst: Air.Inst.Index) !void {
         };
         defer if (base_ptr_lock) |lock| self.register_manager.unlockReg(lock);
 
-        if (elem_ptr_ty.ptrInfo(mod).flags.vector_index != .none) {
+        if (elem_ptr_ty.ptrInfo(zcu).flags.vector_index != .none) {
             break :result if (self.reuseOperand(inst, extra.lhs, 0, base_ptr_mcv))
                 base_ptr_mcv
             else
                 try self.copyToRegisterWithInstTracking(inst, elem_ptr_ty, base_ptr_mcv);
         }
 
-        const elem_ty = base_ptr_ty.elemType2(mod);
-        const elem_abi_size = elem_ty.abiSize(pt);
+        const elem_ty = base_ptr_ty.elemType2(zcu);
+        const elem_abi_size = elem_ty.abiSize(zcu);
         const index_ty = self.typeOf(extra.rhs);
         const index_mcv = try self.resolveInst(extra.rhs);
         const index_lock: ?RegisterLock = switch (index_mcv) {
@@ -6057,12 +6057,12 @@ fn airPtrElemPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airSetUnionTag(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     const ptr_union_ty = self.typeOf(bin_op.lhs);
-    const union_ty = ptr_union_ty.childType(mod);
+    const union_ty = ptr_union_ty.childType(zcu);
     const tag_ty = self.typeOf(bin_op.rhs);
-    const layout = union_ty.unionGetLayout(pt);
+    const layout = union_ty.unionGetLayout(zcu);
 
     if (layout.tag_size == 0) {
         return self.finishAir(inst, .none, .{ bin_op.lhs, bin_op.rhs, .none });
@@ -6101,12 +6101,12 @@ fn airSetUnionTag(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn airGetUnionTag(self: *Self, inst: Air.Inst.Index) !void {
-    const pt = self.pt;
+    const zcu = self.pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const tag_ty = self.typeOfIndex(inst);
     const union_ty = self.typeOf(ty_op.operand);
-    const layout = union_ty.unionGetLayout(pt);
+    const layout = union_ty.unionGetLayout(zcu);
 
     if (layout.tag_size == 0) {
         return self.finishAir(inst, .none, .{ ty_op.operand, .none, .none });
@@ -6120,7 +6120,7 @@ fn airGetUnionTag(self: *Self, inst: Air.Inst.Index) !void {
     };
     defer if (operand_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const tag_abi_size = tag_ty.abiSize(pt);
+    const tag_abi_size = tag_ty.abiSize(zcu);
     const dst_mcv: MCValue = blk: {
         switch (operand) {
             .load_frame => |frame_addr| {
@@ -6159,14 +6159,14 @@ fn airGetUnionTag(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airClz(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result = result: {
         try self.spillEflagsIfOccupied();
 
         const dst_ty = self.typeOfIndex(inst);
         const src_ty = self.typeOf(ty_op.operand);
-        if (src_ty.zigTypeTag(mod) == .Vector) return self.fail("TODO implement airClz for {}", .{
+        if (src_ty.zigTypeTag(zcu) == .Vector) return self.fail("TODO implement airClz for {}", .{
             src_ty.fmt(pt),
         });
 
@@ -6186,8 +6186,8 @@ fn airClz(self: *Self, inst: Air.Inst.Index) !void {
         const dst_lock = self.register_manager.lockRegAssumeUnused(dst_reg);
         defer self.register_manager.unlockReg(dst_lock);
 
-        const abi_size: u31 = @intCast(src_ty.abiSize(pt));
-        const src_bits: u31 = @intCast(src_ty.bitSize(pt));
+        const abi_size: u31 = @intCast(src_ty.abiSize(zcu));
+        const src_bits: u31 = @intCast(src_ty.bitSize(zcu));
         const has_lzcnt = self.hasFeature(.lzcnt);
         if (src_bits > @as(u32, if (has_lzcnt) 128 else 64)) {
             const limbs_len = math.divCeil(u32, abi_size, 8) catch unreachable;
@@ -6297,7 +6297,7 @@ fn airClz(self: *Self, inst: Air.Inst.Index) !void {
         }
 
         assert(src_bits <= 64);
-        const cmov_abi_size = @max(@as(u32, @intCast(dst_ty.abiSize(pt))), 2);
+        const cmov_abi_size = @max(@as(u32, @intCast(dst_ty.abiSize(zcu))), 2);
         if (math.isPowerOfTwo(src_bits)) {
             const imm_reg = try self.copyToTmpRegister(dst_ty, .{
                 .immediate = src_bits ^ (src_bits - 1),
@@ -6356,14 +6356,14 @@ fn airClz(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airCtz(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result = result: {
         try self.spillEflagsIfOccupied();
 
         const dst_ty = self.typeOfIndex(inst);
         const src_ty = self.typeOf(ty_op.operand);
-        if (src_ty.zigTypeTag(mod) == .Vector) return self.fail("TODO implement airCtz for {}", .{
+        if (src_ty.zigTypeTag(zcu) == .Vector) return self.fail("TODO implement airCtz for {}", .{
             src_ty.fmt(pt),
         });
 
@@ -6383,8 +6383,8 @@ fn airCtz(self: *Self, inst: Air.Inst.Index) !void {
         const dst_lock = self.register_manager.lockReg(dst_reg);
         defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const abi_size: u31 = @intCast(src_ty.abiSize(pt));
-        const src_bits: u31 = @intCast(src_ty.bitSize(pt));
+        const abi_size: u31 = @intCast(src_ty.abiSize(zcu));
+        const src_bits: u31 = @intCast(src_ty.bitSize(zcu));
         const has_bmi = self.hasFeature(.bmi);
         if (src_bits > @as(u32, if (has_bmi) 128 else 64)) {
             const limbs_len = math.divCeil(u32, abi_size, 8) catch unreachable;
@@ -6505,7 +6505,7 @@ fn airCtz(self: *Self, inst: Air.Inst.Index) !void {
             try self.genBinOpMir(.{ ._, .bsf }, wide_ty, dst_mcv, .{ .register = wide_reg });
         } else try self.genBinOpMir(.{ ._, .bsf }, src_ty, dst_mcv, mat_src_mcv);
 
-        const cmov_abi_size = @max(@as(u32, @intCast(dst_ty.abiSize(pt))), 2);
+        const cmov_abi_size = @max(@as(u32, @intCast(dst_ty.abiSize(zcu))), 2);
         try self.asmCmovccRegisterRegister(
             .z,
             registerAlias(dst_reg, cmov_abi_size),
@@ -6518,14 +6518,14 @@ fn airCtz(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airPopCount(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const result: MCValue = result: {
         try self.spillEflagsIfOccupied();
 
         const src_ty = self.typeOf(ty_op.operand);
-        const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
-        if (src_ty.zigTypeTag(mod) == .Vector or src_abi_size > 16)
+        const src_abi_size: u32 = @intCast(src_ty.abiSize(zcu));
+        if (src_ty.zigTypeTag(zcu) == .Vector or src_abi_size > 16)
             return self.fail("TODO implement airPopCount for {}", .{src_ty.fmt(pt)});
         const src_mcv = try self.resolveInst(ty_op.operand);
 
@@ -6562,7 +6562,7 @@ fn airPopCount(self: *Self, inst: Air.Inst.Index) !void {
             mat_src_mcv
         else
             .{ .register = mat_src_mcv.register_pair[0] }, false);
-        const src_info = src_ty.intInfo(mod);
+        const src_info = src_ty.intInfo(zcu);
         const hi_ty = try pt.intType(src_info.signedness, (src_info.bits - 1) % 64 + 1);
         try self.genPopCount(tmp_regs[1], hi_ty, if (mat_src_mcv.isMemory())
             mat_src_mcv.address().offset(8).deref()
@@ -6583,7 +6583,7 @@ fn genPopCount(
 ) !void {
     const pt = self.pt;
 
-    const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
+    const src_abi_size: u32 = @intCast(src_ty.abiSize(pt.zcu));
     if (self.hasFeature(.popcnt)) return self.genBinOpMir(
         .{ ._, .popcnt },
         if (src_abi_size > 1) src_ty else Type.u32,
@@ -6674,11 +6674,11 @@ fn genByteSwap(
     mem_ok: bool,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const has_movbe = self.hasFeature(.movbe);
 
-    if (src_ty.zigTypeTag(mod) == .Vector) return self.fail(
+    if (src_ty.zigTypeTag(zcu) == .Vector) return self.fail(
         "TODO implement genByteSwap for {}",
         .{src_ty.fmt(pt)},
     );
@@ -6689,7 +6689,7 @@ fn genByteSwap(
     };
     defer if (src_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const abi_size: u32 = @intCast(src_ty.abiSize(pt));
+    const abi_size: u32 = @intCast(src_ty.abiSize(zcu));
     switch (abi_size) {
         0 => unreachable,
         1 => return if ((mem_ok or src_mcv.isRegister()) and
@@ -6838,35 +6838,35 @@ fn genByteSwap(
 
 fn airByteSwap(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const src_ty = self.typeOf(ty_op.operand);
-    const src_bits: u32 = @intCast(src_ty.bitSize(pt));
+    const src_bits: u32 = @intCast(src_ty.bitSize(zcu));
     const src_mcv = try self.resolveInst(ty_op.operand);
 
     const dst_mcv = try self.genByteSwap(inst, src_ty, src_mcv, true);
     try self.genShiftBinOpMir(
-        .{ ._r, switch (if (src_ty.isAbiInt(mod)) src_ty.intInfo(mod).signedness else .unsigned) {
+        .{ ._r, switch (if (src_ty.isAbiInt(zcu)) src_ty.intInfo(zcu).signedness else .unsigned) {
             .signed => .sa,
             .unsigned => .sh,
         } },
         src_ty,
         dst_mcv,
         if (src_bits > 256) Type.u16 else Type.u8,
-        .{ .immediate = src_ty.abiSize(pt) * 8 - src_bits },
+        .{ .immediate = src_ty.abiSize(zcu) * 8 - src_bits },
     );
     return self.finishAir(inst, dst_mcv, .{ ty_op.operand, .none, .none });
 }
 
 fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const src_ty = self.typeOf(ty_op.operand);
-    const abi_size: u32 = @intCast(src_ty.abiSize(pt));
-    const bit_size: u32 = @intCast(src_ty.bitSize(pt));
+    const abi_size: u32 = @intCast(src_ty.abiSize(zcu));
+    const bit_size: u32 = @intCast(src_ty.bitSize(zcu));
     const src_mcv = try self.resolveInst(ty_op.operand);
 
     const dst_mcv = try self.genByteSwap(inst, src_ty, src_mcv, false);
@@ -6973,7 +6973,7 @@ fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
 
     const extra_bits = abi_size * 8 - bit_size;
     const signedness: std.builtin.Signedness =
-        if (src_ty.isAbiInt(mod)) src_ty.intInfo(mod).signedness else .unsigned;
+        if (src_ty.isAbiInt(zcu)) src_ty.intInfo(zcu).signedness else .unsigned;
     if (extra_bits > 0) try self.genShiftBinOpMir(switch (signedness) {
         .signed => .{ ._r, .sa },
         .unsigned => .{ ._r, .sh },
@@ -6984,13 +6984,13 @@ fn airBitReverse(self: *Self, inst: Air.Inst.Index) !void {
 
 fn floatSign(self: *Self, inst: Air.Inst.Index, operand: Air.Inst.Ref, ty: Type) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const tag = self.air.instructions.items(.tag)[@intFromEnum(inst)];
 
     const result = result: {
-        const scalar_bits = ty.scalarType(mod).floatBits(self.target.*);
+        const scalar_bits = ty.scalarType(zcu).floatBits(self.target.*);
         if (scalar_bits == 80) {
-            if (ty.zigTypeTag(mod) != .Float) return self.fail("TODO implement floatSign for {}", .{
+            if (ty.zigTypeTag(zcu) != .Float) return self.fail("TODO implement floatSign for {}", .{
                 ty.fmt(pt),
             });
 
@@ -7011,7 +7011,7 @@ fn floatSign(self: *Self, inst: Air.Inst.Index, operand: Air.Inst.Ref, ty: Type)
             break :result dst_mcv;
         }
 
-        const abi_size: u32 = switch (ty.abiSize(pt)) {
+        const abi_size: u32 = switch (ty.abiSize(zcu)) {
             1...16 => 16,
             17...32 => 32,
             else => return self.fail("TODO implement floatSign for {}", .{
@@ -7161,23 +7161,23 @@ fn airRound(self: *Self, inst: Air.Inst.Index, mode: RoundMode) !void {
 
 fn getRoundTag(self: *Self, ty: Type) ?Mir.Inst.FixedTag {
     const pt = self.pt;
-    const mod = pt.zcu;
-    return if (self.hasFeature(.sse4_1)) switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    return if (self.hasFeature(.sse4_1)) switch (ty.zigTypeTag(zcu)) {
         .Float => switch (ty.floatBits(self.target.*)) {
             32 => if (self.hasFeature(.avx)) .{ .v_ss, .round } else .{ ._ss, .round },
             64 => if (self.hasFeature(.avx)) .{ .v_sd, .round } else .{ ._sd, .round },
             16, 80, 128 => null,
             else => unreachable,
         },
-        .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-            .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
-                32 => switch (ty.vectorLen(mod)) {
+        .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+            .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
+                32 => switch (ty.vectorLen(zcu)) {
                     1 => if (self.hasFeature(.avx)) .{ .v_ss, .round } else .{ ._ss, .round },
                     2...4 => if (self.hasFeature(.avx)) .{ .v_ps, .round } else .{ ._ps, .round },
                     5...8 => if (self.hasFeature(.avx)) .{ .v_ps, .round } else null,
                     else => null,
                 },
-                64 => switch (ty.vectorLen(mod)) {
+                64 => switch (ty.vectorLen(zcu)) {
                     1 => if (self.hasFeature(.avx)) .{ .v_sd, .round } else .{ ._sd, .round },
                     2 => if (self.hasFeature(.avx)) .{ .v_pd, .round } else .{ ._pd, .round },
                     3...4 => if (self.hasFeature(.avx)) .{ .v_pd, .round } else null,
@@ -7194,10 +7194,10 @@ fn getRoundTag(self: *Self, ty: Type) ?Mir.Inst.FixedTag {
 
 fn genRoundLibcall(self: *Self, ty: Type, src_mcv: MCValue, mode: RoundMode) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     if (self.getRoundTag(ty)) |_| return .none;
 
-    if (ty.zigTypeTag(mod) != .Float)
+    if (ty.zigTypeTag(zcu) != .Float)
         return self.fail("TODO implement genRound for {}", .{ty.fmt(pt)});
 
     var callee_buf: ["__trunc?".len]u8 = undefined;
@@ -7223,7 +7223,7 @@ fn genRound(self: *Self, ty: Type, dst_reg: Register, src_mcv: MCValue, mode: Ro
         const result = try self.genRoundLibcall(ty, src_mcv, mode);
         return self.genSetReg(dst_reg, ty, result, .{});
     };
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const abi_size: u32 = @intCast(ty.abiSize(pt.zcu));
     const dst_alias = registerAlias(dst_reg, abi_size);
     switch (mir_tag[0]) {
         .v_ss, .v_sd => if (src_mcv.isMemory()) try self.asmRegisterRegisterMemoryImmediate(
@@ -7261,14 +7261,14 @@ fn genRound(self: *Self, ty: Type, dst_reg: Register, src_mcv: MCValue, mode: Ro
 
 fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const ty = self.typeOf(ty_op.operand);
 
     const result: MCValue = result: {
-        const mir_tag = @as(?Mir.Inst.FixedTag, switch (ty.zigTypeTag(mod)) {
+        const mir_tag = @as(?Mir.Inst.FixedTag, switch (ty.zigTypeTag(zcu)) {
             else => null,
-            .Int => switch (ty.abiSize(pt)) {
+            .Int => switch (ty.abiSize(zcu)) {
                 0 => unreachable,
                 1...8 => {
                     try self.spillEflagsIfOccupied();
@@ -7277,7 +7277,7 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
 
                     try self.genUnOpMir(.{ ._, .neg }, ty, dst_mcv);
 
-                    const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(pt))), 2);
+                    const cmov_abi_size = @max(@as(u32, @intCast(ty.abiSize(zcu))), 2);
                     switch (src_mcv) {
                         .register => |val_reg| try self.asmCmovccRegisterRegister(
                             .l,
@@ -7336,7 +7336,7 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
                     break :result dst_mcv;
                 },
                 else => {
-                    const abi_size: u31 = @intCast(ty.abiSize(pt));
+                    const abi_size: u31 = @intCast(ty.abiSize(zcu));
                     const limb_len = math.divCeil(u31, abi_size, 8) catch unreachable;
 
                     const tmp_regs =
@@ -7397,11 +7397,11 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
                 },
             },
             .Float => return self.floatSign(inst, ty_op.operand, ty),
-            .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
+            .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
                 else => null,
-                .Int => switch (ty.childType(mod).intInfo(mod).bits) {
+                .Int => switch (ty.childType(zcu).intInfo(zcu).bits) {
                     else => null,
-                    8 => switch (ty.vectorLen(mod)) {
+                    8 => switch (ty.vectorLen(zcu)) {
                         else => null,
                         1...16 => if (self.hasFeature(.avx))
                             .{ .vp_b, .abs }
@@ -7411,7 +7411,7 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
                             null,
                         17...32 => if (self.hasFeature(.avx2)) .{ .vp_b, .abs } else null,
                     },
-                    16 => switch (ty.vectorLen(mod)) {
+                    16 => switch (ty.vectorLen(zcu)) {
                         else => null,
                         1...8 => if (self.hasFeature(.avx))
                             .{ .vp_w, .abs }
@@ -7421,7 +7421,7 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
                             null,
                         9...16 => if (self.hasFeature(.avx2)) .{ .vp_w, .abs } else null,
                     },
-                    32 => switch (ty.vectorLen(mod)) {
+                    32 => switch (ty.vectorLen(zcu)) {
                         else => null,
                         1...4 => if (self.hasFeature(.avx))
                             .{ .vp_d, .abs }
@@ -7436,7 +7436,7 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
             },
         }) orelse return self.fail("TODO implement airAbs for {}", .{ty.fmt(pt)});
 
-        const abi_size: u32 = @intCast(ty.abiSize(pt));
+        const abi_size: u32 = @intCast(ty.abiSize(zcu));
         const src_mcv = try self.resolveInst(ty_op.operand);
         const dst_reg = if (src_mcv.isRegister() and self.reuseOperand(inst, ty_op.operand, 0, src_mcv))
             src_mcv.getReg().?
@@ -7462,13 +7462,13 @@ fn airAbs(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airSqrt(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const ty = self.typeOf(un_op);
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
 
     const result: MCValue = result: {
-        switch (ty.zigTypeTag(mod)) {
+        switch (ty.zigTypeTag(zcu)) {
             .Float => {
                 const float_bits = ty.floatBits(self.target.*);
                 if (switch (float_bits) {
@@ -7500,7 +7500,7 @@ fn airSqrt(self: *Self, inst: Air.Inst.Index) !void {
         const dst_lock = self.register_manager.lockReg(dst_reg);
         defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const mir_tag = @as(?Mir.Inst.FixedTag, switch (ty.zigTypeTag(mod)) {
+        const mir_tag = @as(?Mir.Inst.FixedTag, switch (ty.zigTypeTag(zcu)) {
             .Float => switch (ty.floatBits(self.target.*)) {
                 16 => {
                     assert(self.hasFeature(.f16c));
@@ -7522,9 +7522,9 @@ fn airSqrt(self: *Self, inst: Air.Inst.Index) !void {
                 64 => if (self.hasFeature(.avx)) .{ .v_sd, .sqrt } else .{ ._sd, .sqrt },
                 else => unreachable,
             },
-            .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-                .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
-                    16 => if (self.hasFeature(.f16c)) switch (ty.vectorLen(mod)) {
+            .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+                .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
+                    16 => if (self.hasFeature(.f16c)) switch (ty.vectorLen(zcu)) {
                         1 => {
                             try self.asmRegisterRegister(
                                 .{ .v_ps, .cvtph2 },
@@ -7575,13 +7575,13 @@ fn airSqrt(self: *Self, inst: Air.Inst.Index) !void {
                         },
                         else => null,
                     } else null,
-                    32 => switch (ty.vectorLen(mod)) {
+                    32 => switch (ty.vectorLen(zcu)) {
                         1 => if (self.hasFeature(.avx)) .{ .v_ss, .sqrt } else .{ ._ss, .sqrt },
                         2...4 => if (self.hasFeature(.avx)) .{ .v_ps, .sqrt } else .{ ._ps, .sqrt },
                         5...8 => if (self.hasFeature(.avx)) .{ .v_ps, .sqrt } else null,
                         else => null,
                     },
-                    64 => switch (ty.vectorLen(mod)) {
+                    64 => switch (ty.vectorLen(zcu)) {
                         1 => if (self.hasFeature(.avx)) .{ .v_sd, .sqrt } else .{ ._sd, .sqrt },
                         2 => if (self.hasFeature(.avx)) .{ .v_pd, .sqrt } else .{ ._pd, .sqrt },
                         3...4 => if (self.hasFeature(.avx)) .{ .v_pd, .sqrt } else null,
@@ -7708,14 +7708,14 @@ fn reuseOperandAdvanced(
 
 fn packedLoad(self: *Self, dst_mcv: MCValue, ptr_ty: Type, ptr_mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
 
-    const ptr_info = ptr_ty.ptrInfo(mod);
+    const ptr_info = ptr_ty.ptrInfo(zcu);
     const val_ty = Type.fromInterned(ptr_info.child);
-    if (!val_ty.hasRuntimeBitsIgnoreComptime(pt)) return;
-    const val_abi_size: u32 = @intCast(val_ty.abiSize(pt));
+    if (!val_ty.hasRuntimeBitsIgnoreComptime(zcu)) return;
+    const val_abi_size: u32 = @intCast(val_ty.abiSize(zcu));
 
-    const val_bit_size: u32 = @intCast(val_ty.bitSize(pt));
+    const val_bit_size: u32 = @intCast(val_ty.bitSize(zcu));
     const ptr_bit_off = ptr_info.packed_offset.bit_offset + switch (ptr_info.flags.vector_index) {
         .none => 0,
         .runtime => unreachable,
@@ -7821,9 +7821,9 @@ fn packedLoad(self: *Self, dst_mcv: MCValue, ptr_ty: Type, ptr_mcv: MCValue) Inn
 
 fn load(self: *Self, dst_mcv: MCValue, ptr_ty: Type, ptr_mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const dst_ty = ptr_ty.childType(mod);
-    if (!dst_ty.hasRuntimeBitsIgnoreComptime(pt)) return;
+    const zcu = pt.zcu;
+    const dst_ty = ptr_ty.childType(zcu);
+    if (!dst_ty.hasRuntimeBitsIgnoreComptime(zcu)) return;
     switch (ptr_mcv) {
         .none,
         .unreach,
@@ -7864,18 +7864,18 @@ fn load(self: *Self, dst_mcv: MCValue, ptr_ty: Type, ptr_mcv: MCValue) InnerErro
 
 fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const elem_ty = self.typeOfIndex(inst);
     const result: MCValue = result: {
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
 
         try self.spillRegisters(&.{ .rdi, .rsi, .rcx });
         const reg_locks = self.register_manager.lockRegsAssumeUnused(3, .{ .rdi, .rsi, .rcx });
         defer for (reg_locks) |lock| self.register_manager.unlockReg(lock);
 
         const ptr_ty = self.typeOf(ty_op.operand);
-        const elem_size = elem_ty.abiSize(pt);
+        const elem_size = elem_ty.abiSize(zcu);
 
         const elem_rc = self.regClassForType(elem_ty);
         const ptr_rc = self.regClassForType(ptr_ty);
@@ -7888,14 +7888,14 @@ fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
         else
             try self.allocRegOrMem(inst, true);
 
-        const ptr_info = ptr_ty.ptrInfo(mod);
+        const ptr_info = ptr_ty.ptrInfo(zcu);
         if (ptr_info.flags.vector_index != .none or ptr_info.packed_offset.host_size > 0) {
             try self.packedLoad(dst_mcv, ptr_ty, ptr_mcv);
         } else {
             try self.load(dst_mcv, ptr_ty, ptr_mcv);
         }
 
-        if (elem_ty.isAbiInt(mod) and elem_size * 8 > elem_ty.bitSize(pt)) {
+        if (elem_ty.isAbiInt(zcu) and elem_size * 8 > elem_ty.bitSize(zcu)) {
             const high_mcv: MCValue = switch (dst_mcv) {
                 .register => |dst_reg| .{ .register = dst_reg },
                 .register_pair => |dst_regs| .{ .register = dst_regs[1] },
@@ -7923,16 +7923,16 @@ fn airLoad(self: *Self, inst: Air.Inst.Index) !void {
 
 fn packedStore(self: *Self, ptr_ty: Type, ptr_mcv: MCValue, src_mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ptr_info = ptr_ty.ptrInfo(mod);
+    const zcu = pt.zcu;
+    const ptr_info = ptr_ty.ptrInfo(zcu);
     const src_ty = Type.fromInterned(ptr_info.child);
-    if (!src_ty.hasRuntimeBitsIgnoreComptime(pt)) return;
+    if (!src_ty.hasRuntimeBitsIgnoreComptime(zcu)) return;
 
     const limb_abi_size: u16 = @min(ptr_info.packed_offset.host_size, 8);
     const limb_abi_bits = limb_abi_size * 8;
     const limb_ty = try pt.intType(.unsigned, limb_abi_bits);
 
-    const src_bit_size = src_ty.bitSize(pt);
+    const src_bit_size = src_ty.bitSize(zcu);
     const ptr_bit_off = ptr_info.packed_offset.bit_offset + switch (ptr_info.flags.vector_index) {
         .none => 0,
         .runtime => unreachable,
@@ -8029,9 +8029,9 @@ fn store(
     opts: CopyOptions,
 ) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const src_ty = ptr_ty.childType(mod);
-    if (!src_ty.hasRuntimeBitsIgnoreComptime(pt)) return;
+    const zcu = pt.zcu;
+    const src_ty = ptr_ty.childType(zcu);
+    if (!src_ty.hasRuntimeBitsIgnoreComptime(zcu)) return;
     switch (ptr_mcv) {
         .none,
         .unreach,
@@ -8072,7 +8072,7 @@ fn store(
 
 fn airStore(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     result: {
@@ -8086,7 +8086,7 @@ fn airStore(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
         const ptr_mcv = try self.resolveInst(bin_op.lhs);
         const ptr_ty = self.typeOf(bin_op.lhs);
 
-        const ptr_info = ptr_ty.ptrInfo(mod);
+        const ptr_info = ptr_ty.ptrInfo(zcu);
         if (ptr_info.flags.vector_index != .none or ptr_info.packed_offset.host_size > 0) {
             try self.packedStore(ptr_ty, ptr_mcv, src_mcv);
         } else {
@@ -8111,16 +8111,16 @@ fn airStructFieldPtrIndex(self: *Self, inst: Air.Inst.Index, index: u8) !void {
 
 fn fieldPtr(self: *Self, inst: Air.Inst.Index, operand: Air.Inst.Ref, index: u32) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ptr_field_ty = self.typeOfIndex(inst);
     const ptr_container_ty = self.typeOf(operand);
-    const container_ty = ptr_container_ty.childType(mod);
+    const container_ty = ptr_container_ty.childType(zcu);
 
-    const field_off: i32 = switch (container_ty.containerLayout(mod)) {
-        .auto, .@"extern" => @intCast(container_ty.structFieldOffset(index, pt)),
-        .@"packed" => @divExact(@as(i32, ptr_container_ty.ptrInfo(mod).packed_offset.bit_offset) +
-            (if (mod.typeToStruct(container_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, index) else 0) -
-            ptr_field_ty.ptrInfo(mod).packed_offset.bit_offset, 8),
+    const field_off: i32 = switch (container_ty.containerLayout(zcu)) {
+        .auto, .@"extern" => @intCast(container_ty.structFieldOffset(index, zcu)),
+        .@"packed" => @divExact(@as(i32, ptr_container_ty.ptrInfo(zcu).packed_offset.bit_offset) +
+            (if (zcu.typeToStruct(container_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, index) else 0) -
+            ptr_field_ty.ptrInfo(zcu).packed_offset.bit_offset, 8),
     };
 
     const src_mcv = try self.resolveInst(operand);
@@ -8134,7 +8134,7 @@ fn fieldPtr(self: *Self, inst: Air.Inst.Index, operand: Air.Inst.Ref, index: u32
 
 fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.StructField, ty_pl.payload).data;
     const result: MCValue = result: {
@@ -8143,15 +8143,15 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
 
         const container_ty = self.typeOf(operand);
         const container_rc = self.regClassForType(container_ty);
-        const field_ty = container_ty.structFieldType(index, mod);
-        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) break :result .none;
+        const field_ty = container_ty.structFieldType(index, zcu);
+        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
         const field_rc = self.regClassForType(field_ty);
         const field_is_gp = field_rc.supersetOf(abi.RegisterClass.gp);
 
         const src_mcv = try self.resolveInst(operand);
-        const field_off: u32 = switch (container_ty.containerLayout(mod)) {
-            .auto, .@"extern" => @intCast(container_ty.structFieldOffset(extra.field_index, pt) * 8),
-            .@"packed" => if (mod.typeToStruct(container_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, extra.field_index) else 0,
+        const field_off: u32 = switch (container_ty.containerLayout(zcu)) {
+            .auto, .@"extern" => @intCast(container_ty.structFieldOffset(extra.field_index, zcu) * 8),
+            .@"packed" => if (zcu.typeToStruct(container_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, extra.field_index) else 0,
         };
 
         switch (src_mcv) {
@@ -8182,7 +8182,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
                     );
                 }
                 if (abi.RegisterClass.gp.isSet(RegisterManager.indexOfRegIntoTracked(dst_reg).?) and
-                    container_ty.abiSize(pt) * 8 > field_ty.bitSize(pt))
+                    container_ty.abiSize(zcu) * 8 > field_ty.bitSize(zcu))
                     try self.truncateRegister(field_ty, dst_reg);
 
                 break :result if (field_off == 0 or field_rc.supersetOf(abi.RegisterClass.gp))
@@ -8194,7 +8194,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
                 const src_regs_lock = self.register_manager.lockRegsAssumeUnused(2, src_regs);
                 defer for (src_regs_lock) |lock| self.register_manager.unlockReg(lock);
 
-                const field_bit_size: u32 = @intCast(field_ty.bitSize(pt));
+                const field_bit_size: u32 = @intCast(field_ty.bitSize(zcu));
                 const src_reg = if (field_off + field_bit_size <= 64)
                     src_regs[0]
                 else if (field_off >= 64)
@@ -8293,15 +8293,15 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
                 }
             },
             .load_frame => |frame_addr| {
-                const field_abi_size: u32 = @intCast(field_ty.abiSize(pt));
+                const field_abi_size: u32 = @intCast(field_ty.abiSize(zcu));
                 if (field_off % 8 == 0) {
                     const field_byte_off = @divExact(field_off, 8);
                     const off_mcv = src_mcv.address().offset(@intCast(field_byte_off)).deref();
-                    const field_bit_size = field_ty.bitSize(pt);
+                    const field_bit_size = field_ty.bitSize(zcu);
 
                     if (field_abi_size <= 8) {
                         const int_ty = try pt.intType(
-                            if (field_ty.isAbiInt(mod)) field_ty.intInfo(mod).signedness else .unsigned,
+                            if (field_ty.isAbiInt(zcu)) field_ty.intInfo(zcu).signedness else .unsigned,
                             @intCast(field_bit_size),
                         );
 
@@ -8321,7 +8321,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
                             try self.copyToRegisterWithInstTracking(inst, field_ty, dst_mcv);
                     }
 
-                    const container_abi_size: u32 = @intCast(container_ty.abiSize(pt));
+                    const container_abi_size: u32 = @intCast(container_ty.abiSize(zcu));
                     const dst_mcv = if (field_byte_off + field_abi_size <= container_abi_size and
                         self.reuseOperand(inst, operand, 0, src_mcv))
                         off_mcv
@@ -8423,17 +8423,17 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.FieldParentPtr, ty_pl.payload).data;
 
     const inst_ty = self.typeOfIndex(inst);
-    const parent_ty = inst_ty.childType(mod);
-    const field_off: i32 = switch (parent_ty.containerLayout(mod)) {
-        .auto, .@"extern" => @intCast(parent_ty.structFieldOffset(extra.field_index, pt)),
-        .@"packed" => @divExact(@as(i32, inst_ty.ptrInfo(mod).packed_offset.bit_offset) +
-            (if (mod.typeToStruct(parent_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, extra.field_index) else 0) -
-            self.typeOf(extra.field_ptr).ptrInfo(mod).packed_offset.bit_offset, 8),
+    const parent_ty = inst_ty.childType(zcu);
+    const field_off: i32 = switch (parent_ty.containerLayout(zcu)) {
+        .auto, .@"extern" => @intCast(parent_ty.structFieldOffset(extra.field_index, zcu)),
+        .@"packed" => @divExact(@as(i32, inst_ty.ptrInfo(zcu).packed_offset.bit_offset) +
+            (if (zcu.typeToStruct(parent_ty)) |struct_obj| pt.structPackedFieldBitOffset(struct_obj, extra.field_index) else 0) -
+            self.typeOf(extra.field_ptr).ptrInfo(zcu).packed_offset.bit_offset, 8),
     };
 
     const src_mcv = try self.resolveInst(extra.field_ptr);
@@ -8448,9 +8448,9 @@ fn airFieldParentPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn genUnOp(self: *Self, maybe_inst: ?Air.Inst.Index, tag: Air.Inst.Tag, src_air: Air.Inst.Ref) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const src_ty = self.typeOf(src_air);
-    if (src_ty.zigTypeTag(mod) == .Vector)
+    if (src_ty.zigTypeTag(zcu) == .Vector)
         return self.fail("TODO implement genUnOp for {}", .{src_ty.fmt(pt)});
 
     var src_mcv = try self.resolveInst(src_air);
@@ -8486,14 +8486,14 @@ fn genUnOp(self: *Self, maybe_inst: ?Air.Inst.Index, tag: Air.Inst.Tag, src_air:
     };
     defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const abi_size: u16 = @intCast(src_ty.abiSize(pt));
+    const abi_size: u16 = @intCast(src_ty.abiSize(zcu));
     switch (tag) {
         .not => {
             const limb_abi_size: u16 = @min(abi_size, 8);
             const int_info = if (src_ty.ip_index == .bool_type)
                 std.builtin.Type.Int{ .signedness = .unsigned, .bits = 1 }
             else
-                src_ty.intInfo(mod);
+                src_ty.intInfo(zcu);
             var byte_off: i32 = 0;
             while (byte_off * 8 < int_info.bits) : (byte_off += limb_abi_size) {
                 const limb_bits: u16 = @intCast(@min(switch (int_info.signedness) {
@@ -8514,7 +8514,7 @@ fn genUnOp(self: *Self, maybe_inst: ?Air.Inst.Index, tag: Air.Inst.Tag, src_air:
         },
         .neg => {
             try self.genUnOpMir(.{ ._, .neg }, src_ty, dst_mcv);
-            const bit_size = src_ty.intInfo(mod).bits;
+            const bit_size = src_ty.intInfo(zcu).bits;
             if (abi_size * 8 > bit_size) {
                 if (dst_mcv.isRegister()) {
                     try self.truncateRegister(src_ty, dst_mcv.getReg().?);
@@ -8537,7 +8537,7 @@ fn genUnOp(self: *Self, maybe_inst: ?Air.Inst.Index, tag: Air.Inst.Tag, src_air:
 
 fn genUnOpMir(self: *Self, mir_tag: Mir.Inst.FixedTag, dst_ty: Type, dst_mcv: MCValue) !void {
     const pt = self.pt;
-    const abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+    const abi_size: u32 = @intCast(dst_ty.abiSize(pt.zcu));
     if (abi_size > 8) return self.fail("TODO implement {} for {}", .{ mir_tag, dst_ty.fmt(pt) });
     switch (dst_mcv) {
         .none,
@@ -8586,8 +8586,9 @@ fn genShiftBinOpMir(
     rhs_mcv: MCValue,
 ) !void {
     const pt = self.pt;
-    const abi_size: u32 = @intCast(lhs_ty.abiSize(pt));
-    const shift_abi_size: u32 = @intCast(rhs_ty.abiSize(pt));
+    const zcu = pt.zcu;
+    const abi_size: u32 = @intCast(lhs_ty.abiSize(zcu));
+    const shift_abi_size: u32 = @intCast(rhs_ty.abiSize(zcu));
     try self.spillEflagsIfOccupied();
 
     if (abi_size > 16) {
@@ -9243,8 +9244,8 @@ fn genShiftBinOp(
     rhs_ty: Type,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    if (lhs_ty.zigTypeTag(mod) == .Vector) return self.fail("TODO implement genShiftBinOp for {}", .{
+    const zcu = pt.zcu;
+    if (lhs_ty.zigTypeTag(zcu) == .Vector) return self.fail("TODO implement genShiftBinOp for {}", .{
         lhs_ty.fmt(pt),
     });
 
@@ -9274,7 +9275,7 @@ fn genShiftBinOp(
         break :dst dst_mcv;
     };
 
-    const signedness = lhs_ty.intInfo(mod).signedness;
+    const signedness = lhs_ty.intInfo(zcu).signedness;
     try self.genShiftBinOpMir(switch (air_tag) {
         .shl, .shl_exact => switch (signedness) {
             .signed => .{ ._l, .sa },
@@ -9302,13 +9303,13 @@ fn genMulDivBinOp(
     rhs_mcv: MCValue,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    if (dst_ty.zigTypeTag(mod) == .Vector or dst_ty.zigTypeTag(mod) == .Float) return self.fail(
+    const zcu = pt.zcu;
+    if (dst_ty.zigTypeTag(zcu) == .Vector or dst_ty.zigTypeTag(zcu) == .Float) return self.fail(
         "TODO implement genMulDivBinOp for {s} from {} to {}",
         .{ @tagName(tag), src_ty.fmt(pt), dst_ty.fmt(pt) },
     );
-    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
-    const src_abi_size: u32 = @intCast(src_ty.abiSize(pt));
+    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
+    const src_abi_size: u32 = @intCast(src_ty.abiSize(zcu));
 
     assert(self.register_manager.isRegFree(.rax));
     assert(self.register_manager.isRegFree(.rcx));
@@ -9384,7 +9385,7 @@ fn genMulDivBinOp(
         .mul, .mul_wrap => dst_abi_size != src_abi_size and dst_abi_size != src_abi_size * 2,
         .div_trunc, .div_floor, .div_exact, .rem, .mod => dst_abi_size != src_abi_size,
     } or src_abi_size > 8) {
-        const src_info = src_ty.intInfo(mod);
+        const src_info = src_ty.intInfo(zcu);
         switch (tag) {
             .mul, .mul_wrap => {
                 const slow_inc = self.hasFeature(.slow_incdec);
@@ -9555,7 +9556,7 @@ fn genMulDivBinOp(
     const reg_locks = self.register_manager.lockRegs(2, .{ .rax, .rdx });
     defer for (reg_locks) |reg_lock| if (reg_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const signedness = ty.intInfo(mod).signedness;
+    const signedness = ty.intInfo(zcu).signedness;
     switch (tag) {
         .mul,
         .mul_wrap,
@@ -9714,10 +9715,10 @@ fn genBinOp(
     rhs_air: Air.Inst.Ref,
 ) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const lhs_ty = self.typeOf(lhs_air);
     const rhs_ty = self.typeOf(rhs_air);
-    const abi_size: u32 = @intCast(lhs_ty.abiSize(pt));
+    const abi_size: u32 = @intCast(lhs_ty.abiSize(zcu));
 
     if (lhs_ty.isRuntimeFloat()) libcall: {
         const float_bits = lhs_ty.floatBits(self.target.*);
@@ -9889,23 +9890,23 @@ fn genBinOp(
         };
     }
 
-    const sse_op = switch (lhs_ty.zigTypeTag(mod)) {
+    const sse_op = switch (lhs_ty.zigTypeTag(zcu)) {
         else => false,
         .Float => true,
-        .Vector => switch (lhs_ty.childType(mod).toIntern()) {
+        .Vector => switch (lhs_ty.childType(zcu).toIntern()) {
             .bool_type, .u1_type => false,
             else => true,
         },
     };
-    if (sse_op and ((lhs_ty.scalarType(mod).isRuntimeFloat() and
-        lhs_ty.scalarType(mod).floatBits(self.target.*) == 80) or
-        lhs_ty.abiSize(pt) > @as(u6, if (self.hasFeature(.avx)) 32 else 16)))
+    if (sse_op and ((lhs_ty.scalarType(zcu).isRuntimeFloat() and
+        lhs_ty.scalarType(zcu).floatBits(self.target.*) == 80) or
+        lhs_ty.abiSize(zcu) > @as(u6, if (self.hasFeature(.avx)) 32 else 16)))
         return self.fail("TODO implement genBinOp for {s} {}", .{ @tagName(air_tag), lhs_ty.fmt(pt) });
 
     const maybe_mask_reg = switch (air_tag) {
         else => null,
         .rem, .mod => unreachable,
-        .max, .min => if (lhs_ty.scalarType(mod).isRuntimeFloat()) registerAlias(
+        .max, .min => if (lhs_ty.scalarType(zcu).isRuntimeFloat()) registerAlias(
             if (!self.hasFeature(.avx) and self.hasFeature(.sse4_1)) mask: {
                 try self.register_manager.getKnownReg(.xmm0, null);
                 break :mask .xmm0;
@@ -9917,8 +9918,8 @@ fn genBinOp(
         if (maybe_mask_reg) |mask_reg| self.register_manager.lockRegAssumeUnused(mask_reg) else null;
     defer if (mask_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const ordered_air: [2]Air.Inst.Ref = if (lhs_ty.isVector(mod) and
-        switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
+    const ordered_air: [2]Air.Inst.Ref = if (lhs_ty.isVector(zcu) and
+        switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
         .Bool => false,
         .Int => switch (air_tag) {
             .cmp_lt, .cmp_gte => true,
@@ -9931,7 +9932,7 @@ fn genBinOp(
         else => unreachable,
     }) .{ rhs_air, lhs_air } else .{ lhs_air, rhs_air };
 
-    if (lhs_ty.isAbiInt(mod)) for (ordered_air) |op_air| {
+    if (lhs_ty.isAbiInt(zcu)) for (ordered_air) |op_air| {
         switch (try self.resolveInst(op_air)) {
             .register => |op_reg| switch (op_reg.class()) {
                 .sse => try self.register_manager.getReg(op_reg, null),
@@ -10056,7 +10057,7 @@ fn genBinOp(
                 const tmp_lock = self.register_manager.lockRegAssumeUnused(tmp_reg);
                 defer self.register_manager.unlockReg(tmp_lock);
 
-                const elem_size = lhs_ty.elemType2(mod).abiSize(pt);
+                const elem_size = lhs_ty.elemType2(zcu).abiSize(zcu);
                 try self.genIntMulComplexOpMir(rhs_ty, tmp_mcv, .{ .immediate = elem_size });
                 try self.genBinOpMir(
                     switch (air_tag) {
@@ -10112,7 +10113,7 @@ fn genBinOp(
                     const tmp_lock = self.register_manager.lockRegAssumeUnused(tmp_reg);
                     defer self.register_manager.unlockReg(tmp_lock);
 
-                    const signed = lhs_ty.isSignedInt(mod);
+                    const signed = lhs_ty.isSignedInt(zcu);
                     const cc: Condition = switch (air_tag) {
                         .min => if (signed) .nl else .nb,
                         .max => if (signed) .nge else .nae,
@@ -10188,7 +10189,7 @@ fn genBinOp(
 
                     try self.genBinOpMir(.{ ._, .cmp }, lhs_ty, dst_mcv, mat_src_mcv);
 
-                    const int_info = lhs_ty.intInfo(mod);
+                    const int_info = lhs_ty.intInfo(zcu);
                     const cc: Condition = switch (int_info.signedness) {
                         .unsigned => switch (air_tag) {
                             .min => .a,
@@ -10202,7 +10203,7 @@ fn genBinOp(
                         },
                     };
 
-                    const cmov_abi_size = @max(@as(u32, @intCast(lhs_ty.abiSize(pt))), 2);
+                    const cmov_abi_size = @max(@as(u32, @intCast(lhs_ty.abiSize(zcu))), 2);
                     const tmp_reg = switch (dst_mcv) {
                         .register => |reg| reg,
                         else => try self.copyToTmpRegister(lhs_ty, dst_mcv),
@@ -10271,7 +10272,7 @@ fn genBinOp(
             },
 
             .cmp_eq, .cmp_neq => {
-                assert(lhs_ty.isVector(mod) and lhs_ty.childType(mod).toIntern() == .bool_type);
+                assert(lhs_ty.isVector(zcu) and lhs_ty.childType(zcu).toIntern() == .bool_type);
                 try self.genBinOpMir(.{ ._, .xor }, lhs_ty, dst_mcv, src_mcv);
                 switch (air_tag) {
                     .cmp_eq => try self.genUnOpMir(.{ ._, .not }, lhs_ty, dst_mcv),
@@ -10288,7 +10289,7 @@ fn genBinOp(
     }
 
     const dst_reg = registerAlias(dst_mcv.getReg().?, abi_size);
-    const mir_tag = @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(mod)) {
+    const mir_tag = @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(zcu)) {
         else => unreachable,
         .Float => switch (lhs_ty.floatBits(self.target.*)) {
             16 => {
@@ -10383,10 +10384,10 @@ fn genBinOp(
             80, 128 => null,
             else => unreachable,
         },
-        .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
+        .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
             else => null,
-            .Int => switch (lhs_ty.childType(mod).intInfo(mod).bits) {
-                8 => switch (lhs_ty.vectorLen(mod)) {
+            .Int => switch (lhs_ty.childType(zcu).intInfo(zcu).bits) {
+                8 => switch (lhs_ty.vectorLen(zcu)) {
                     1...16 => switch (air_tag) {
                         .add,
                         .add_wrap,
@@ -10400,7 +10401,7 @@ fn genBinOp(
                             .{ .p_, .@"and" },
                         .bit_or => if (self.hasFeature(.avx)) .{ .vp_, .@"or" } else .{ .p_, .@"or" },
                         .xor => if (self.hasFeature(.avx)) .{ .vp_, .xor } else .{ .p_, .xor },
-                        .min => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .min => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_b, .mins }
                             else if (self.hasFeature(.sse4_1))
@@ -10414,7 +10415,7 @@ fn genBinOp(
                             else
                                 null,
                         },
-                        .max => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .max => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_b, .maxs }
                             else if (self.hasFeature(.sse4_1))
@@ -10432,7 +10433,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_b, .cmpgt }
                             else
@@ -10454,11 +10455,11 @@ fn genBinOp(
                         .bit_and => if (self.hasFeature(.avx2)) .{ .vp_, .@"and" } else null,
                         .bit_or => if (self.hasFeature(.avx2)) .{ .vp_, .@"or" } else null,
                         .xor => if (self.hasFeature(.avx2)) .{ .vp_, .xor } else null,
-                        .min => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .min => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx2)) .{ .vp_b, .mins } else null,
                             .unsigned => if (self.hasFeature(.avx)) .{ .vp_b, .minu } else null,
                         },
-                        .max => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .max => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx2)) .{ .vp_b, .maxs } else null,
                             .unsigned => if (self.hasFeature(.avx2)) .{ .vp_b, .maxu } else null,
                         },
@@ -10466,7 +10467,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx)) .{ .vp_b, .cmpgt } else null,
                             .unsigned => null,
                         },
@@ -10477,7 +10478,7 @@ fn genBinOp(
                     },
                     else => null,
                 },
-                16 => switch (lhs_ty.vectorLen(mod)) {
+                16 => switch (lhs_ty.vectorLen(zcu)) {
                     1...8 => switch (air_tag) {
                         .add,
                         .add_wrap,
@@ -10494,7 +10495,7 @@ fn genBinOp(
                             .{ .p_, .@"and" },
                         .bit_or => if (self.hasFeature(.avx)) .{ .vp_, .@"or" } else .{ .p_, .@"or" },
                         .xor => if (self.hasFeature(.avx)) .{ .vp_, .xor } else .{ .p_, .xor },
-                        .min => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .min => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_w, .mins }
                             else
@@ -10504,7 +10505,7 @@ fn genBinOp(
                             else
                                 .{ .p_w, .minu },
                         },
-                        .max => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .max => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_w, .maxs }
                             else
@@ -10518,7 +10519,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_w, .cmpgt }
                             else
@@ -10543,11 +10544,11 @@ fn genBinOp(
                         .bit_and => if (self.hasFeature(.avx2)) .{ .vp_, .@"and" } else null,
                         .bit_or => if (self.hasFeature(.avx2)) .{ .vp_, .@"or" } else null,
                         .xor => if (self.hasFeature(.avx2)) .{ .vp_, .xor } else null,
-                        .min => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .min => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx2)) .{ .vp_w, .mins } else null,
                             .unsigned => if (self.hasFeature(.avx)) .{ .vp_w, .minu } else null,
                         },
-                        .max => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .max => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx2)) .{ .vp_w, .maxs } else null,
                             .unsigned => if (self.hasFeature(.avx2)) .{ .vp_w, .maxu } else null,
                         },
@@ -10555,7 +10556,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx)) .{ .vp_w, .cmpgt } else null,
                             .unsigned => null,
                         },
@@ -10566,7 +10567,7 @@ fn genBinOp(
                     },
                     else => null,
                 },
-                32 => switch (lhs_ty.vectorLen(mod)) {
+                32 => switch (lhs_ty.vectorLen(zcu)) {
                     1...4 => switch (air_tag) {
                         .add,
                         .add_wrap,
@@ -10588,7 +10589,7 @@ fn genBinOp(
                             .{ .p_, .@"and" },
                         .bit_or => if (self.hasFeature(.avx)) .{ .vp_, .@"or" } else .{ .p_, .@"or" },
                         .xor => if (self.hasFeature(.avx)) .{ .vp_, .xor } else .{ .p_, .xor },
-                        .min => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .min => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_d, .mins }
                             else if (self.hasFeature(.sse4_1))
@@ -10602,7 +10603,7 @@ fn genBinOp(
                             else
                                 null,
                         },
-                        .max => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .max => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_d, .maxs }
                             else if (self.hasFeature(.sse4_1))
@@ -10620,7 +10621,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_d, .cmpgt }
                             else
@@ -10645,11 +10646,11 @@ fn genBinOp(
                         .bit_and => if (self.hasFeature(.avx2)) .{ .vp_, .@"and" } else null,
                         .bit_or => if (self.hasFeature(.avx2)) .{ .vp_, .@"or" } else null,
                         .xor => if (self.hasFeature(.avx2)) .{ .vp_, .xor } else null,
-                        .min => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .min => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx2)) .{ .vp_d, .mins } else null,
                             .unsigned => if (self.hasFeature(.avx)) .{ .vp_d, .minu } else null,
                         },
-                        .max => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        .max => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx2)) .{ .vp_d, .maxs } else null,
                             .unsigned => if (self.hasFeature(.avx2)) .{ .vp_d, .maxu } else null,
                         },
@@ -10657,7 +10658,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx)) .{ .vp_d, .cmpgt } else null,
                             .unsigned => null,
                         },
@@ -10668,7 +10669,7 @@ fn genBinOp(
                     },
                     else => null,
                 },
-                64 => switch (lhs_ty.vectorLen(mod)) {
+                64 => switch (lhs_ty.vectorLen(zcu)) {
                     1...2 => switch (air_tag) {
                         .add,
                         .add_wrap,
@@ -10686,7 +10687,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gte,
                         .cmp_gt,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx))
                                 .{ .vp_q, .cmpgt }
                             else if (self.hasFeature(.sse4_2))
@@ -10722,7 +10723,7 @@ fn genBinOp(
                         .cmp_lte,
                         .cmp_gt,
                         .cmp_gte,
-                        => switch (lhs_ty.childType(mod).intInfo(mod).signedness) {
+                        => switch (lhs_ty.childType(zcu).intInfo(zcu).signedness) {
                             .signed => if (self.hasFeature(.avx)) .{ .vp_d, .cmpgt } else null,
                             .unsigned => null,
                         },
@@ -10732,10 +10733,10 @@ fn genBinOp(
                 },
                 else => null,
             },
-            .Float => switch (lhs_ty.childType(mod).floatBits(self.target.*)) {
+            .Float => switch (lhs_ty.childType(zcu).floatBits(self.target.*)) {
                 16 => tag: {
                     assert(self.hasFeature(.f16c));
-                    switch (lhs_ty.vectorLen(mod)) {
+                    switch (lhs_ty.vectorLen(zcu)) {
                         1 => {
                             const tmp_reg = (try self.register_manager.allocReg(
                                 null,
@@ -10923,7 +10924,7 @@ fn genBinOp(
                         else => break :tag null,
                     }
                 },
-                32 => switch (lhs_ty.vectorLen(mod)) {
+                32 => switch (lhs_ty.vectorLen(zcu)) {
                     1 => switch (air_tag) {
                         .add => if (self.hasFeature(.avx)) .{ .v_ss, .add } else .{ ._ss, .add },
                         .sub => if (self.hasFeature(.avx)) .{ .v_ss, .sub } else .{ ._ss, .sub },
@@ -10976,7 +10977,7 @@ fn genBinOp(
                     } else null,
                     else => null,
                 },
-                64 => switch (lhs_ty.vectorLen(mod)) {
+                64 => switch (lhs_ty.vectorLen(zcu)) {
                     1 => switch (air_tag) {
                         .add => if (self.hasFeature(.avx)) .{ .v_sd, .add } else .{ ._sd, .add },
                         .sub => if (self.hasFeature(.avx)) .{ .v_sd, .sub } else .{ ._sd, .sub },
@@ -11052,7 +11053,7 @@ fn genBinOp(
                 mir_tag,
                 dst_reg,
                 lhs_reg,
-                try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(mod)) {
+                try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(zcu)) {
                     else => Memory.Size.fromSize(abi_size),
                     .Vector => Memory.Size.fromBitSize(dst_reg.bitSize()),
                 }),
@@ -11070,7 +11071,7 @@ fn genBinOp(
             if (src_mcv.isMemory()) try self.asmRegisterMemory(
                 mir_tag,
                 dst_reg,
-                try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(mod)) {
+                try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(zcu)) {
                     else => Memory.Size.fromSize(abi_size),
                     .Vector => Memory.Size.fromBitSize(dst_reg.bitSize()),
                 }),
@@ -11098,7 +11099,7 @@ fn genBinOp(
                     mir_tag,
                     dst_reg,
                     lhs_reg,
-                    try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(mod)) {
+                    try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(zcu)) {
                         else => Memory.Size.fromSize(abi_size),
                         .Vector => Memory.Size.fromBitSize(dst_reg.bitSize()),
                     }),
@@ -11118,7 +11119,7 @@ fn genBinOp(
                 if (src_mcv.isMemory()) try self.asmRegisterMemoryImmediate(
                     mir_tag,
                     dst_reg,
-                    try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(mod)) {
+                    try src_mcv.mem(self, switch (lhs_ty.zigTypeTag(zcu)) {
                         else => Memory.Size.fromSize(abi_size),
                         .Vector => Memory.Size.fromBitSize(dst_reg.bitSize()),
                     }),
@@ -11151,21 +11152,21 @@ fn genBinOp(
             const rhs_copy_reg = registerAlias(src_mcv.getReg().?, abi_size);
 
             try self.asmRegisterRegisterRegisterImmediate(
-                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(mod)) {
+                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(zcu)) {
                     .Float => switch (lhs_ty.floatBits(self.target.*)) {
                         32 => .{ .v_ss, .cmp },
                         64 => .{ .v_sd, .cmp },
                         16, 80, 128 => null,
                         else => unreachable,
                     },
-                    .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
-                        .Float => switch (lhs_ty.childType(mod).floatBits(self.target.*)) {
-                            32 => switch (lhs_ty.vectorLen(mod)) {
+                    .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
+                        .Float => switch (lhs_ty.childType(zcu).floatBits(self.target.*)) {
+                            32 => switch (lhs_ty.vectorLen(zcu)) {
                                 1 => .{ .v_ss, .cmp },
                                 2...8 => .{ .v_ps, .cmp },
                                 else => null,
                             },
-                            64 => switch (lhs_ty.vectorLen(mod)) {
+                            64 => switch (lhs_ty.vectorLen(zcu)) {
                                 1 => .{ .v_sd, .cmp },
                                 2...4 => .{ .v_pd, .cmp },
                                 else => null,
@@ -11185,20 +11186,20 @@ fn genBinOp(
                 Immediate.u(3), // unord
             );
             try self.asmRegisterRegisterRegisterRegister(
-                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(mod)) {
+                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(zcu)) {
                     .Float => switch (lhs_ty.floatBits(self.target.*)) {
                         32 => .{ .v_ps, .blendv },
                         64 => .{ .v_pd, .blendv },
                         16, 80, 128 => null,
                         else => unreachable,
                     },
-                    .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
-                        .Float => switch (lhs_ty.childType(mod).floatBits(self.target.*)) {
-                            32 => switch (lhs_ty.vectorLen(mod)) {
+                    .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
+                        .Float => switch (lhs_ty.childType(zcu).floatBits(self.target.*)) {
+                            32 => switch (lhs_ty.vectorLen(zcu)) {
                                 1...8 => .{ .v_ps, .blendv },
                                 else => null,
                             },
-                            64 => switch (lhs_ty.vectorLen(mod)) {
+                            64 => switch (lhs_ty.vectorLen(zcu)) {
                                 1...4 => .{ .v_pd, .blendv },
                                 else => null,
                             },
@@ -11219,21 +11220,21 @@ fn genBinOp(
         } else {
             const has_blend = self.hasFeature(.sse4_1);
             try self.asmRegisterRegisterImmediate(
-                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(mod)) {
+                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(zcu)) {
                     .Float => switch (lhs_ty.floatBits(self.target.*)) {
                         32 => .{ ._ss, .cmp },
                         64 => .{ ._sd, .cmp },
                         16, 80, 128 => null,
                         else => unreachable,
                     },
-                    .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
-                        .Float => switch (lhs_ty.childType(mod).floatBits(self.target.*)) {
-                            32 => switch (lhs_ty.vectorLen(mod)) {
+                    .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
+                        .Float => switch (lhs_ty.childType(zcu).floatBits(self.target.*)) {
+                            32 => switch (lhs_ty.vectorLen(zcu)) {
                                 1 => .{ ._ss, .cmp },
                                 2...4 => .{ ._ps, .cmp },
                                 else => null,
                             },
-                            64 => switch (lhs_ty.vectorLen(mod)) {
+                            64 => switch (lhs_ty.vectorLen(zcu)) {
                                 1 => .{ ._sd, .cmp },
                                 2 => .{ ._pd, .cmp },
                                 else => null,
@@ -11252,20 +11253,20 @@ fn genBinOp(
                 Immediate.u(if (has_blend) 3 else 7), // unord, ord
             );
             if (has_blend) try self.asmRegisterRegisterRegister(
-                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(mod)) {
+                @as(?Mir.Inst.FixedTag, switch (lhs_ty.zigTypeTag(zcu)) {
                     .Float => switch (lhs_ty.floatBits(self.target.*)) {
                         32 => .{ ._ps, .blendv },
                         64 => .{ ._pd, .blendv },
                         16, 80, 128 => null,
                         else => unreachable,
                     },
-                    .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
-                        .Float => switch (lhs_ty.childType(mod).floatBits(self.target.*)) {
-                            32 => switch (lhs_ty.vectorLen(mod)) {
+                    .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
+                        .Float => switch (lhs_ty.childType(zcu).floatBits(self.target.*)) {
+                            32 => switch (lhs_ty.vectorLen(zcu)) {
                                 1...4 => .{ ._ps, .blendv },
                                 else => null,
                             },
-                            64 => switch (lhs_ty.vectorLen(mod)) {
+                            64 => switch (lhs_ty.vectorLen(zcu)) {
                                 1...2 => .{ ._pd, .blendv },
                                 else => null,
                             },
@@ -11282,20 +11283,20 @@ fn genBinOp(
                 lhs_copy_reg.?,
                 mask_reg,
             ) else {
-                const mir_fixes = @as(?Mir.Inst.Fixes, switch (lhs_ty.zigTypeTag(mod)) {
+                const mir_fixes = @as(?Mir.Inst.Fixes, switch (lhs_ty.zigTypeTag(zcu)) {
                     .Float => switch (lhs_ty.floatBits(self.target.*)) {
                         32 => ._ps,
                         64 => ._pd,
                         16, 80, 128 => null,
                         else => unreachable,
                     },
-                    .Vector => switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
-                        .Float => switch (lhs_ty.childType(mod).floatBits(self.target.*)) {
-                            32 => switch (lhs_ty.vectorLen(mod)) {
+                    .Vector => switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
+                        .Float => switch (lhs_ty.childType(zcu).floatBits(self.target.*)) {
+                            32 => switch (lhs_ty.vectorLen(zcu)) {
                                 1...4 => ._ps,
                                 else => null,
                             },
-                            64 => switch (lhs_ty.vectorLen(mod)) {
+                            64 => switch (lhs_ty.vectorLen(zcu)) {
                                 1...2 => ._pd,
                                 else => null,
                             },
@@ -11314,7 +11315,7 @@ fn genBinOp(
             }
         },
         .cmp_lt, .cmp_lte, .cmp_eq, .cmp_gte, .cmp_gt, .cmp_neq => {
-            switch (lhs_ty.childType(mod).zigTypeTag(mod)) {
+            switch (lhs_ty.childType(zcu).zigTypeTag(zcu)) {
                 .Int => switch (air_tag) {
                     .cmp_lt,
                     .cmp_eq,
@@ -11395,8 +11396,8 @@ fn genBinOpMir(
     src_mcv: MCValue,
 ) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const zcu = pt.zcu;
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
     try self.spillEflagsIfOccupied();
     switch (dst_mcv) {
         .none,
@@ -11643,7 +11644,7 @@ fn genBinOpMir(
             defer if (src_info) |info| self.register_manager.unlockReg(info.addr_lock);
 
             const ty_signedness =
-                if (ty.isAbiInt(mod)) ty.intInfo(mod).signedness else .unsigned;
+                if (ty.isAbiInt(zcu)) ty.intInfo(zcu).signedness else .unsigned;
             const limb_ty = if (abi_size <= 8) ty else switch (ty_signedness) {
                 .signed => Type.usize,
                 .unsigned => Type.isize,
@@ -11820,7 +11821,7 @@ fn genBinOpMir(
 /// Does not support byte-size operands.
 fn genIntMulComplexOpMir(self: *Self, dst_ty: Type, dst_mcv: MCValue, src_mcv: MCValue) InnerError!void {
     const pt = self.pt;
-    const abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+    const abi_size: u32 = @intCast(dst_ty.abiSize(pt.zcu));
     try self.spillEflagsIfOccupied();
     switch (dst_mcv) {
         .none,
@@ -12009,7 +12010,7 @@ fn airArg(self: *Self, inst: Air.Inst.Index) !void {
                 try self.genInlineMemset(
                     dst_mcv.address().offset(@intFromBool(regs_frame_addr.regs > 0)),
                     .{ .immediate = 0 },
-                    .{ .immediate = arg_ty.abiSize(pt) - @intFromBool(regs_frame_addr.regs > 0) },
+                    .{ .immediate = arg_ty.abiSize(zcu) - @intFromBool(regs_frame_addr.regs > 0) },
                     .{},
                 );
 
@@ -12296,7 +12297,7 @@ fn genCall(self: *Self, info: union(enum) {
                 try reg_locks.appendSlice(&self.register_manager.lockRegs(2, regs));
             },
             .indirect => |reg_off| {
-                frame_index.* = try self.allocFrameIndex(FrameAlloc.initType(arg_ty, pt));
+                frame_index.* = try self.allocFrameIndex(FrameAlloc.initType(arg_ty, zcu));
                 try self.genSetMem(.{ .frame = frame_index.* }, 0, arg_ty, src_arg, .{});
                 try self.register_manager.getReg(reg_off.reg, null);
                 try reg_locks.append(self.register_manager.lockReg(reg_off.reg));
@@ -12368,7 +12369,7 @@ fn genCall(self: *Self, info: union(enum) {
         .none, .unreach => {},
         .indirect => |reg_off| {
             const ret_ty = Type.fromInterned(fn_info.return_type);
-            const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(ret_ty, pt));
+            const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(ret_ty, zcu));
             try self.genSetReg(reg_off.reg, Type.usize, .{
                 .lea_frame = .{ .index = frame_index, .off = -reg_off.off },
             }, .{});
@@ -12383,14 +12384,14 @@ fn genCall(self: *Self, info: union(enum) {
             .none, .load_frame => {},
             .register => |dst_reg| switch (fn_info.cc) {
                 else => try self.genSetReg(
-                    registerAlias(dst_reg, @intCast(arg_ty.abiSize(pt))),
+                    registerAlias(dst_reg, @intCast(arg_ty.abiSize(zcu))),
                     arg_ty,
                     src_arg,
                     .{},
                 ),
                 .C, .SysV, .Win64 => {
                     const promoted_ty = self.promoteInt(arg_ty);
-                    const promoted_abi_size: u32 = @intCast(promoted_ty.abiSize(pt));
+                    const promoted_abi_size: u32 = @intCast(promoted_ty.abiSize(zcu));
                     const dst_alias = registerAlias(dst_reg, promoted_abi_size);
                     try self.genSetReg(dst_alias, promoted_ty, src_arg, .{});
                     if (promoted_ty.toIntern() != arg_ty.toIntern())
@@ -12514,10 +12515,10 @@ fn genCall(self: *Self, info: union(enum) {
 
 fn airRet(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
 
-    const ret_ty = self.fn_type.fnReturnType(mod);
+    const ret_ty = self.fn_type.fnReturnType(zcu);
     switch (self.ret_mcv.short) {
         .none => {},
         .register,
@@ -12570,7 +12571,7 @@ fn airRetLoad(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
     var ty = self.typeOf(bin_op.lhs);
     var null_compare: ?Mir.Inst.Index = null;
@@ -12602,7 +12603,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
         };
         defer for (rhs_locks) |rhs_lock| if (rhs_lock) |lock| self.register_manager.unlockReg(lock);
 
-        switch (ty.zigTypeTag(mod)) {
+        switch (ty.zigTypeTag(zcu)) {
             .Float => {
                 const float_bits = ty.floatBits(self.target.*);
                 if (switch (float_bits) {
@@ -12638,11 +12639,11 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
                     };
                 }
             },
-            .Optional => if (!ty.optionalReprIsPayload(mod)) {
+            .Optional => if (!ty.optionalReprIsPayload(zcu)) {
                 const opt_ty = ty;
-                const opt_abi_size: u31 = @intCast(opt_ty.abiSize(pt));
-                ty = opt_ty.optionalChild(mod);
-                const payload_abi_size: u31 = @intCast(ty.abiSize(pt));
+                const opt_abi_size: u31 = @intCast(opt_ty.abiSize(zcu));
+                ty = opt_ty.optionalChild(zcu);
+                const payload_abi_size: u31 = @intCast(ty.abiSize(zcu));
 
                 const temp_lhs_reg = try self.register_manager.allocReg(null, abi.RegisterClass.gp);
                 const temp_lhs_lock = self.register_manager.lockRegAssumeUnused(temp_lhs_reg);
@@ -12699,9 +12700,9 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
             else => {},
         }
 
-        switch (ty.zigTypeTag(mod)) {
+        switch (ty.zigTypeTag(zcu)) {
             else => {
-                const abi_size: u16 = @intCast(ty.abiSize(pt));
+                const abi_size: u16 = @intCast(ty.abiSize(zcu));
                 const may_flip: enum {
                     may_flip,
                     must_flip,
@@ -12734,7 +12735,7 @@ fn airCmp(self: *Self, inst: Air.Inst.Index, op: math.CompareOperator) !void {
                 defer if (src_lock) |lock| self.register_manager.unlockReg(lock);
 
                 break :result Condition.fromCompareOperator(
-                    if (ty.isAbiInt(mod)) ty.intInfo(mod).signedness else .unsigned,
+                    if (ty.isAbiInt(zcu)) ty.intInfo(zcu).signedness else .unsigned,
                     result_op: {
                         const flipped_op = if (flipped) op.reverse() else op;
                         if (abi_size > 8) switch (flipped_op) {
@@ -13029,6 +13030,7 @@ fn airCmpVector(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airCmpLtErrorsLen(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
 
     const addr_reg = try self.register_manager.allocReg(null, abi.RegisterClass.gp);
@@ -13040,7 +13042,7 @@ fn airCmpLtErrorsLen(self: *Self, inst: Air.Inst.Index) !void {
     try self.spillEflagsIfOccupied();
 
     const op_ty = self.typeOf(un_op);
-    const op_abi_size: u32 = @intCast(op_ty.abiSize(pt));
+    const op_abi_size: u32 = @intCast(op_ty.abiSize(zcu));
     const op_mcv = try self.resolveInst(un_op);
     const dst_reg = switch (op_mcv) {
         .register => |reg| reg,
@@ -13164,7 +13166,7 @@ fn airDbgVar(self: *Self, inst: Air.Inst.Index) !void {
 
 fn genCondBrMir(self: *Self, ty: Type, mcv: MCValue) !Mir.Inst.Index {
     const pt = self.pt;
-    const abi_size = ty.abiSize(pt);
+    const abi_size = ty.abiSize(pt.zcu);
     switch (mcv) {
         .eflags => |cc| {
             // Here we map the opposites since the jump is to the false branch.
@@ -13237,7 +13239,7 @@ fn airCondBr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn isNull(self: *Self, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     switch (opt_mcv) {
         .register_overflow => |ro| return .{ .eflags = ro.eflags.negate() },
         else => {},
@@ -13245,12 +13247,12 @@ fn isNull(self: *Self, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MC
 
     try self.spillEflagsIfOccupied();
 
-    const pl_ty = opt_ty.optionalChild(mod);
+    const pl_ty = opt_ty.optionalChild(zcu);
 
-    const some_info: struct { off: i32, ty: Type } = if (opt_ty.optionalReprIsPayload(mod))
-        .{ .off = 0, .ty = if (pl_ty.isSlice(mod)) pl_ty.slicePtrFieldType(mod) else pl_ty }
+    const some_info: struct { off: i32, ty: Type } = if (opt_ty.optionalReprIsPayload(zcu))
+        .{ .off = 0, .ty = if (pl_ty.isSlice(zcu)) pl_ty.slicePtrFieldType(zcu) else pl_ty }
     else
-        .{ .off = @intCast(pl_ty.abiSize(pt)), .ty = Type.bool };
+        .{ .off = @intCast(pl_ty.abiSize(zcu)), .ty = Type.bool };
 
     self.eflags_inst = inst;
     switch (opt_mcv) {
@@ -13279,14 +13281,14 @@ fn isNull(self: *Self, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MC
 
         .register => |opt_reg| {
             if (some_info.off == 0) {
-                const some_abi_size: u32 = @intCast(some_info.ty.abiSize(pt));
+                const some_abi_size: u32 = @intCast(some_info.ty.abiSize(zcu));
                 const alias_reg = registerAlias(opt_reg, some_abi_size);
                 assert(some_abi_size * 8 == alias_reg.bitSize());
                 try self.asmRegisterRegister(.{ ._, .@"test" }, alias_reg, alias_reg);
                 return .{ .eflags = .z };
             }
             assert(some_info.ty.ip_index == .bool_type);
-            const opt_abi_size: u32 = @intCast(opt_ty.abiSize(pt));
+            const opt_abi_size: u32 = @intCast(opt_ty.abiSize(zcu));
             try self.asmRegisterImmediate(
                 .{ ._, .bt },
                 registerAlias(opt_reg, opt_abi_size),
@@ -13306,7 +13308,7 @@ fn isNull(self: *Self, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MC
             defer self.register_manager.unlockReg(addr_reg_lock);
 
             try self.genSetReg(addr_reg, Type.usize, opt_mcv.address(), .{});
-            const some_abi_size: u32 = @intCast(some_info.ty.abiSize(pt));
+            const some_abi_size: u32 = @intCast(some_info.ty.abiSize(zcu));
             try self.asmMemoryImmediate(
                 .{ ._, .cmp },
                 .{
@@ -13322,7 +13324,7 @@ fn isNull(self: *Self, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MC
         },
 
         .indirect, .load_frame => {
-            const some_abi_size: u32 = @intCast(some_info.ty.abiSize(pt));
+            const some_abi_size: u32 = @intCast(some_info.ty.abiSize(zcu));
             try self.asmMemoryImmediate(
                 .{ ._, .cmp },
                 switch (opt_mcv) {
@@ -13351,16 +13353,16 @@ fn isNull(self: *Self, inst: Air.Inst.Index, opt_ty: Type, opt_mcv: MCValue) !MC
 
 fn isNullPtr(self: *Self, inst: Air.Inst.Index, ptr_ty: Type, ptr_mcv: MCValue) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const opt_ty = ptr_ty.childType(mod);
-    const pl_ty = opt_ty.optionalChild(mod);
+    const zcu = pt.zcu;
+    const opt_ty = ptr_ty.childType(zcu);
+    const pl_ty = opt_ty.optionalChild(zcu);
 
     try self.spillEflagsIfOccupied();
 
-    const some_info: struct { off: i32, ty: Type } = if (opt_ty.optionalReprIsPayload(mod))
-        .{ .off = 0, .ty = if (pl_ty.isSlice(mod)) pl_ty.slicePtrFieldType(mod) else pl_ty }
+    const some_info: struct { off: i32, ty: Type } = if (opt_ty.optionalReprIsPayload(zcu))
+        .{ .off = 0, .ty = if (pl_ty.isSlice(zcu)) pl_ty.slicePtrFieldType(zcu) else pl_ty }
     else
-        .{ .off = @intCast(pl_ty.abiSize(pt)), .ty = Type.bool };
+        .{ .off = @intCast(pl_ty.abiSize(zcu)), .ty = Type.bool };
 
     const ptr_reg = switch (ptr_mcv) {
         .register => |reg| reg,
@@ -13369,7 +13371,7 @@ fn isNullPtr(self: *Self, inst: Air.Inst.Index, ptr_ty: Type, ptr_mcv: MCValue) 
     const ptr_lock = self.register_manager.lockReg(ptr_reg);
     defer if (ptr_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const some_abi_size: u32 = @intCast(some_info.ty.abiSize(pt));
+    const some_abi_size: u32 = @intCast(some_info.ty.abiSize(zcu));
     try self.asmMemoryImmediate(
         .{ ._, .cmp },
         .{
@@ -13388,13 +13390,13 @@ fn isNullPtr(self: *Self, inst: Air.Inst.Index, ptr_ty: Type, ptr_mcv: MCValue) 
 
 fn isErr(self: *Self, maybe_inst: ?Air.Inst.Index, eu_ty: Type, eu_mcv: MCValue) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const err_ty = eu_ty.errorUnionSet(mod);
-    if (err_ty.errorSetIsEmpty(mod)) return MCValue{ .immediate = 0 }; // always false
+    const zcu = pt.zcu;
+    const err_ty = eu_ty.errorUnionSet(zcu);
+    if (err_ty.errorSetIsEmpty(zcu)) return MCValue{ .immediate = 0 }; // always false
 
     try self.spillEflagsIfOccupied();
 
-    const err_off: u31 = @intCast(errUnionErrorOffset(eu_ty.errorUnionPayload(mod), pt));
+    const err_off: u31 = @intCast(errUnionErrorOffset(eu_ty.errorUnionPayload(zcu), zcu));
     switch (eu_mcv) {
         .register => |reg| {
             const eu_lock = self.register_manager.lockReg(reg);
@@ -13437,10 +13439,10 @@ fn isErr(self: *Self, maybe_inst: ?Air.Inst.Index, eu_ty: Type, eu_mcv: MCValue)
 
 fn isErrPtr(self: *Self, maybe_inst: ?Air.Inst.Index, ptr_ty: Type, ptr_mcv: MCValue) !MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const eu_ty = ptr_ty.childType(mod);
-    const err_ty = eu_ty.errorUnionSet(mod);
-    if (err_ty.errorSetIsEmpty(mod)) return MCValue{ .immediate = 0 }; // always false
+    const zcu = pt.zcu;
+    const eu_ty = ptr_ty.childType(zcu);
+    const err_ty = eu_ty.errorUnionSet(zcu);
+    if (err_ty.errorSetIsEmpty(zcu)) return MCValue{ .immediate = 0 }; // always false
 
     try self.spillEflagsIfOccupied();
 
@@ -13451,7 +13453,7 @@ fn isErrPtr(self: *Self, maybe_inst: ?Air.Inst.Index, ptr_ty: Type, ptr_mcv: MCV
     const ptr_lock = self.register_manager.lockReg(ptr_reg);
     defer if (ptr_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const err_off: u31 = @intCast(errUnionErrorOffset(eu_ty.errorUnionPayload(mod), pt));
+    const err_off: u31 = @intCast(errUnionErrorOffset(eu_ty.errorUnionPayload(zcu), zcu));
     try self.asmMemoryImmediate(
         .{ ._, .cmp },
         .{
@@ -13724,12 +13726,12 @@ fn performReloc(self: *Self, reloc: Mir.Inst.Index) void {
 }
 
 fn airBr(self: *Self, inst: Air.Inst.Index) !void {
-    const pt = self.pt;
+    const zcu = self.pt.zcu;
     const br = self.air.instructions.items(.data)[@intFromEnum(inst)].br;
 
     const block_ty = self.typeOfIndex(br.block_inst);
     const block_unused =
-        !block_ty.hasRuntimeBitsIgnoreComptime(pt) or self.liveness.isUnused(br.block_inst);
+        !block_ty.hasRuntimeBitsIgnoreComptime(zcu) or self.liveness.isUnused(br.block_inst);
     const block_tracking = self.inst_tracking.getPtr(br.block_inst).?;
     const block_data = self.blocks.getPtr(br.block_inst).?;
     const first_br = block_data.relocs.items.len == 0;
@@ -13786,7 +13788,7 @@ fn airBr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.Asm, ty_pl.payload);
     const clobbers_len: u31 = @truncate(extra.data.flags);
@@ -13825,7 +13827,7 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
         };
         const ty = switch (output) {
             .none => self.typeOfIndex(inst),
-            else => self.typeOf(output).childType(mod),
+            else => self.typeOf(output).childType(zcu),
         };
         const is_read = switch (constraint[0]) {
             '=' => false,
@@ -13850,7 +13852,7 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
                         'x' => abi.RegisterClass.sse,
                         else => unreachable,
                     }) orelse return self.fail("ran out of registers lowering inline asm", .{}),
-                    @intCast(ty.abiSize(pt)),
+                    @intCast(ty.abiSize(zcu)),
                 )
             else if (mem.eql(u8, rest, "m"))
                 if (output != .none) null else return self.fail(
@@ -13920,7 +13922,7 @@ fn airAsm(self: *Self, inst: Air.Inst.Index) !void {
                 break :arg input_mcv;
             const reg = try self.register_manager.allocReg(null, rc);
             try self.genSetReg(reg, ty, input_mcv, .{});
-            break :arg .{ .register = registerAlias(reg, @intCast(ty.abiSize(pt))) };
+            break :arg .{ .register = registerAlias(reg, @intCast(ty.abiSize(zcu))) };
         } else if (mem.eql(u8, constraint, "i") or mem.eql(u8, constraint, "n"))
             switch (input_mcv) {
                 .immediate => |imm| .{ .immediate = imm },
@@ -14497,18 +14499,18 @@ const MoveStrategy = union(enum) {
 };
 fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !MoveStrategy {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     switch (class) {
         .general_purpose, .segment => return .{ .move = .{ ._, .mov } },
         .x87 => return .x87_load_store,
         .mmx => {},
-        .sse => switch (ty.zigTypeTag(mod)) {
+        .sse => switch (ty.zigTypeTag(zcu)) {
             else => {
-                const classes = mem.sliceTo(&abi.classifySystemV(ty, pt, self.target.*, .other), .none);
+                const classes = mem.sliceTo(&abi.classifySystemV(ty, zcu, self.target.*, .other), .none);
                 assert(std.mem.indexOfNone(abi.Class, classes, &.{
                     .integer, .sse, .sseup, .memory, .float, .float_combine,
                 }) == null);
-                const abi_size = ty.abiSize(pt);
+                const abi_size = ty.abiSize(zcu);
                 if (abi_size < 4 or
                     std.mem.indexOfScalar(abi.Class, classes, .integer) != null) switch (abi_size) {
                     1 => if (self.hasFeature(.avx)) return .{ .vex_insert_extract = .{
@@ -14579,16 +14581,16 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                 else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
                 else => {},
             },
-            .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-                .Bool => switch (ty.vectorLen(mod)) {
+            .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+                .Bool => switch (ty.vectorLen(zcu)) {
                     33...64 => return .{ .move = if (self.hasFeature(.avx))
                         .{ .v_q, .mov }
                     else
                         .{ ._q, .mov } },
                     else => {},
                 },
-                .Int => switch (ty.childType(mod).intInfo(mod).bits) {
-                    1...8 => switch (ty.vectorLen(mod)) {
+                .Int => switch (ty.childType(zcu).intInfo(zcu).bits) {
+                    1...8 => switch (ty.vectorLen(zcu)) {
                         1...16 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14599,7 +14601,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_, .movdqu } },
                         else => {},
                     },
-                    9...16 => switch (ty.vectorLen(mod)) {
+                    9...16 => switch (ty.vectorLen(zcu)) {
                         1...8 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14610,7 +14612,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_, .movdqu } },
                         else => {},
                     },
-                    17...32 => switch (ty.vectorLen(mod)) {
+                    17...32 => switch (ty.vectorLen(zcu)) {
                         1...4 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14621,7 +14623,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_, .movdqu } },
                         else => {},
                     },
-                    33...64 => switch (ty.vectorLen(mod)) {
+                    33...64 => switch (ty.vectorLen(zcu)) {
                         1...2 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14632,7 +14634,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_, .movdqu } },
                         else => {},
                     },
-                    65...128 => switch (ty.vectorLen(mod)) {
+                    65...128 => switch (ty.vectorLen(zcu)) {
                         1 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14643,7 +14645,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_, .movdqu } },
                         else => {},
                     },
-                    129...256 => switch (ty.vectorLen(mod)) {
+                    129...256 => switch (ty.vectorLen(zcu)) {
                         1 => if (self.hasFeature(.avx))
                             return .{ .move = if (aligned)
                                 .{ .v_, .movdqa }
@@ -14653,8 +14655,8 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                     },
                     else => {},
                 },
-                .Pointer, .Optional => if (ty.childType(mod).isPtrAtRuntime(mod))
-                    switch (ty.vectorLen(mod)) {
+                .Pointer, .Optional => if (ty.childType(zcu).isPtrAtRuntime(zcu))
+                    switch (ty.vectorLen(zcu)) {
                         1...2 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14667,8 +14669,8 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                     }
                 else
                     unreachable,
-                .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
-                    16 => switch (ty.vectorLen(mod)) {
+                .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
+                    16 => switch (ty.vectorLen(zcu)) {
                         1...8 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14679,7 +14681,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_, .movdqu } },
                         else => {},
                     },
-                    32 => switch (ty.vectorLen(mod)) {
+                    32 => switch (ty.vectorLen(zcu)) {
                         1...4 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_ps, .mova } else .{ .v_ps, .movu }
                         else if (aligned) .{ ._ps, .mova } else .{ ._ps, .movu } },
@@ -14690,7 +14692,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_ps, .movu } },
                         else => {},
                     },
-                    64 => switch (ty.vectorLen(mod)) {
+                    64 => switch (ty.vectorLen(zcu)) {
                         1...2 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_pd, .mova } else .{ .v_pd, .movu }
                         else if (aligned) .{ ._pd, .mova } else .{ ._pd, .movu } },
@@ -14701,7 +14703,7 @@ fn moveStrategy(self: *Self, ty: Type, class: Register.Class, aligned: bool) !Mo
                                 .{ .v_pd, .movu } },
                         else => {},
                     },
-                    128 => switch (ty.vectorLen(mod)) {
+                    128 => switch (ty.vectorLen(zcu)) {
                         1 => return .{ .move = if (self.hasFeature(.avx))
                             if (aligned) .{ .v_, .movdqa } else .{ .v_, .movdqu }
                         else if (aligned) .{ ._, .movdqa } else .{ ._, .movdqu } },
@@ -14804,7 +14806,7 @@ fn genCopy(self: *Self, ty: Type, dst_mcv: MCValue, src_mcv: MCValue, opts: Copy
                     } },
                     else => unreachable,
                 }, opts);
-                part_disp += @intCast(dst_ty.abiSize(pt));
+                part_disp += @intCast(dst_ty.abiSize(pt.zcu));
             }
         },
         .indirect => |reg_off| try self.genSetMem(
@@ -14846,9 +14848,9 @@ fn genSetReg(
     opts: CopyOptions,
 ) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
-    if (ty.bitSize(pt) > dst_reg.bitSize())
+    const zcu = pt.zcu;
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
+    if (ty.bitSize(zcu) > dst_reg.bitSize())
         return self.fail("genSetReg called with a value larger than dst_reg", .{});
     switch (src_mcv) {
         .none,
@@ -14965,13 +14967,13 @@ fn genSetReg(
                 ),
                 .x87, .mmx, .ip => unreachable,
                 .sse => try self.asmRegisterRegister(
-                    @as(?Mir.Inst.FixedTag, switch (ty.scalarType(mod).zigTypeTag(mod)) {
+                    @as(?Mir.Inst.FixedTag, switch (ty.scalarType(zcu).zigTypeTag(zcu)) {
                         else => switch (abi_size) {
                             1...16 => if (self.hasFeature(.avx)) .{ .v_, .movdqa } else .{ ._, .movdqa },
                             17...32 => if (self.hasFeature(.avx)) .{ .v_, .movdqa } else null,
                             else => null,
                         },
-                        .Float => switch (ty.scalarType(mod).floatBits(self.target.*)) {
+                        .Float => switch (ty.scalarType(zcu).floatBits(self.target.*)) {
                             16, 128 => switch (abi_size) {
                                 2...16 => if (self.hasFeature(.avx))
                                     .{ .v_, .movdqa }
@@ -15035,7 +15037,7 @@ fn genSetReg(
                     return (try self.moveStrategy(
                         ty,
                         dst_reg.class(),
-                        ty.abiAlignment(pt).check(@as(u32, @bitCast(small_addr))),
+                        ty.abiAlignment(zcu).check(@as(u32, @bitCast(small_addr))),
                     )).read(self, registerAlias(dst_reg, abi_size), .{
                         .base = .{ .reg = .ds },
                         .mod = .{ .rm = .{
@@ -15136,8 +15138,8 @@ fn genSetMem(
     opts: CopyOptions,
 ) InnerError!void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const zcu = pt.zcu;
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
     const dst_ptr_mcv: MCValue = switch (base) {
         .none => .{ .immediate = @bitCast(@as(i64, disp)) },
         .reg => |base_reg| .{ .register_offset = .{ .reg = base_reg, .off = disp } },
@@ -15159,8 +15161,8 @@ fn genSetMem(
         ),
         .immediate => |imm| switch (abi_size) {
             1, 2, 4 => {
-                const immediate = switch (if (ty.isAbiInt(mod))
-                    ty.intInfo(mod).signedness
+                const immediate = switch (if (ty.isAbiInt(zcu))
+                    ty.intInfo(zcu).signedness
                 else
                     .unsigned) {
                     .signed => Immediate.s(@truncate(@as(i64, @bitCast(imm)))),
@@ -15193,7 +15195,7 @@ fn genSetMem(
                         .size = .dword,
                         .disp = disp + offset,
                     } } },
-                    if (ty.isSignedInt(mod)) Immediate.s(
+                    if (ty.isSignedInt(zcu)) Immediate.s(
                         @truncate(@as(i64, @bitCast(imm)) >> (math.cast(u6, offset * 8) orelse 63)),
                     ) else Immediate.u(
                         @as(u32, @truncate(if (math.cast(u6, offset * 8)) |shift| imm >> shift else 0)),
@@ -15263,33 +15265,33 @@ fn genSetMem(
             var part_disp: i32 = disp;
             for (try self.splitType(ty), src_regs) |src_ty, src_reg| {
                 try self.genSetMem(base, part_disp, src_ty, .{ .register = src_reg }, opts);
-                part_disp += @intCast(src_ty.abiSize(pt));
+                part_disp += @intCast(src_ty.abiSize(zcu));
             }
         },
-        .register_overflow => |ro| switch (ty.zigTypeTag(mod)) {
+        .register_overflow => |ro| switch (ty.zigTypeTag(zcu)) {
             .Struct => {
                 try self.genSetMem(
                     base,
-                    disp + @as(i32, @intCast(ty.structFieldOffset(0, pt))),
-                    ty.structFieldType(0, mod),
+                    disp + @as(i32, @intCast(ty.structFieldOffset(0, zcu))),
+                    ty.structFieldType(0, zcu),
                     .{ .register = ro.reg },
                     opts,
                 );
                 try self.genSetMem(
                     base,
-                    disp + @as(i32, @intCast(ty.structFieldOffset(1, pt))),
-                    ty.structFieldType(1, mod),
+                    disp + @as(i32, @intCast(ty.structFieldOffset(1, zcu))),
+                    ty.structFieldType(1, zcu),
                     .{ .eflags = ro.eflags },
                     opts,
                 );
             },
             .Optional => {
-                assert(!ty.optionalReprIsPayload(mod));
-                const child_ty = ty.optionalChild(mod);
+                assert(!ty.optionalReprIsPayload(zcu));
+                const child_ty = ty.optionalChild(zcu);
                 try self.genSetMem(base, disp, child_ty, .{ .register = ro.reg }, opts);
                 try self.genSetMem(
                     base,
-                    disp + @as(i32, @intCast(child_ty.abiSize(pt))),
+                    disp + @as(i32, @intCast(child_ty.abiSize(zcu))),
                     Type.bool,
                     .{ .eflags = ro.eflags },
                     opts,
@@ -15521,14 +15523,14 @@ fn airIntFromPtr(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airBitCast(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const dst_ty = self.typeOfIndex(inst);
     const src_ty = self.typeOf(ty_op.operand);
 
     const result = result: {
         const src_mcv = try self.resolveInst(ty_op.operand);
-        if (dst_ty.isPtrAtRuntime(mod) and src_ty.isPtrAtRuntime(mod)) switch (src_mcv) {
+        if (dst_ty.isPtrAtRuntime(zcu) and src_ty.isPtrAtRuntime(zcu)) switch (src_mcv) {
             .lea_frame => break :result src_mcv,
             else => if (self.reuseOperand(inst, ty_op.operand, 0, src_mcv)) break :result src_mcv,
         };
@@ -15539,10 +15541,10 @@ fn airBitCast(self: *Self, inst: Air.Inst.Index) !void {
         const src_lock = if (src_mcv.getReg()) |reg| self.register_manager.lockReg(reg) else null;
         defer if (src_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const dst_mcv = if (dst_rc.supersetOf(src_rc) and dst_ty.abiSize(pt) <= src_ty.abiSize(pt) and
+        const dst_mcv = if (dst_rc.supersetOf(src_rc) and dst_ty.abiSize(zcu) <= src_ty.abiSize(zcu) and
             self.reuseOperand(inst, ty_op.operand, 0, src_mcv)) src_mcv else dst: {
             const dst_mcv = try self.allocRegOrMem(inst, true);
-            try self.genCopy(switch (math.order(dst_ty.abiSize(pt), src_ty.abiSize(pt))) {
+            try self.genCopy(switch (math.order(dst_ty.abiSize(zcu), src_ty.abiSize(zcu))) {
                 .lt => dst_ty,
                 .eq => if (!dst_mcv.isMemory() or src_mcv.isMemory()) dst_ty else src_ty,
                 .gt => src_ty,
@@ -15552,12 +15554,12 @@ fn airBitCast(self: *Self, inst: Air.Inst.Index) !void {
 
         if (dst_ty.isRuntimeFloat()) break :result dst_mcv;
 
-        if (dst_ty.isAbiInt(mod) and src_ty.isAbiInt(mod) and
-            dst_ty.intInfo(mod).signedness == src_ty.intInfo(mod).signedness) break :result dst_mcv;
+        if (dst_ty.isAbiInt(zcu) and src_ty.isAbiInt(zcu) and
+            dst_ty.intInfo(zcu).signedness == src_ty.intInfo(zcu).signedness) break :result dst_mcv;
 
-        const abi_size = dst_ty.abiSize(pt);
-        const bit_size = dst_ty.bitSize(pt);
-        if (abi_size * 8 <= bit_size or dst_ty.isVector(mod)) break :result dst_mcv;
+        const abi_size = dst_ty.abiSize(zcu);
+        const bit_size = dst_ty.bitSize(zcu);
+        if (abi_size * 8 <= bit_size or dst_ty.isVector(zcu)) break :result dst_mcv;
 
         const dst_limbs_len = math.divCeil(i32, @intCast(bit_size), 64) catch unreachable;
         const high_mcv: MCValue = switch (dst_mcv) {
@@ -15586,20 +15588,20 @@ fn airBitCast(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airArrayToSlice(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const slice_ty = self.typeOfIndex(inst);
     const ptr_ty = self.typeOf(ty_op.operand);
     const ptr = try self.resolveInst(ty_op.operand);
-    const array_ty = ptr_ty.childType(mod);
-    const array_len = array_ty.arrayLen(mod);
+    const array_ty = ptr_ty.childType(zcu);
+    const array_len = array_ty.arrayLen(zcu);
 
-    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(slice_ty, pt));
+    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(slice_ty, zcu));
     try self.genSetMem(.{ .frame = frame_index }, 0, ptr_ty, ptr, .{});
     try self.genSetMem(
         .{ .frame = frame_index },
-        @intCast(ptr_ty.abiSize(pt)),
+        @intCast(ptr_ty.abiSize(zcu)),
         Type.usize,
         .{ .immediate = array_len },
         .{},
@@ -15611,16 +15613,16 @@ fn airArrayToSlice(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airFloatFromInt(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const dst_ty = self.typeOfIndex(inst);
     const dst_bits = dst_ty.floatBits(self.target.*);
 
     const src_ty = self.typeOf(ty_op.operand);
-    const src_bits: u32 = @intCast(src_ty.bitSize(pt));
+    const src_bits: u32 = @intCast(src_ty.bitSize(zcu));
     const src_signedness =
-        if (src_ty.isAbiInt(mod)) src_ty.intInfo(mod).signedness else .unsigned;
+        if (src_ty.isAbiInt(zcu)) src_ty.intInfo(zcu).signedness else .unsigned;
     const src_size = math.divCeil(u32, @max(switch (src_signedness) {
         .signed => src_bits,
         .unsigned => src_bits + 1,
@@ -15666,7 +15668,7 @@ fn airFloatFromInt(self: *Self, inst: Air.Inst.Index) !void {
         const dst_lock = self.register_manager.lockRegAssumeUnused(dst_reg);
         defer self.register_manager.unlockReg(dst_lock);
 
-        const mir_tag = @as(?Mir.Inst.FixedTag, switch (dst_ty.zigTypeTag(mod)) {
+        const mir_tag = @as(?Mir.Inst.FixedTag, switch (dst_ty.zigTypeTag(zcu)) {
             .Float => switch (dst_ty.floatBits(self.target.*)) {
                 32 => if (self.hasFeature(.avx)) .{ .v_ss, .cvtsi2 } else .{ ._ss, .cvtsi2 },
                 64 => if (self.hasFeature(.avx)) .{ .v_sd, .cvtsi2 } else .{ ._sd, .cvtsi2 },
@@ -15691,13 +15693,13 @@ fn airFloatFromInt(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airIntFromFloat(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
     const dst_ty = self.typeOfIndex(inst);
-    const dst_bits: u32 = @intCast(dst_ty.bitSize(pt));
+    const dst_bits: u32 = @intCast(dst_ty.bitSize(zcu));
     const dst_signedness =
-        if (dst_ty.isAbiInt(mod)) dst_ty.intInfo(mod).signedness else .unsigned;
+        if (dst_ty.isAbiInt(zcu)) dst_ty.intInfo(zcu).signedness else .unsigned;
     const dst_size = math.divCeil(u32, @max(switch (dst_signedness) {
         .signed => dst_bits,
         .unsigned => dst_bits + 1,
@@ -15768,7 +15770,7 @@ fn airCmpxchg(self: *Self, inst: Air.Inst.Index) !void {
 
     const ptr_ty = self.typeOf(extra.ptr);
     const val_ty = self.typeOf(extra.expected_value);
-    const val_abi_size: u32 = @intCast(val_ty.abiSize(pt));
+    const val_abi_size: u32 = @intCast(val_ty.abiSize(pt.zcu));
 
     try self.spillRegisters(&.{ .rax, .rdx, .rbx, .rcx });
     const regs_lock = self.register_manager.lockRegsAssumeUnused(4, .{ .rax, .rdx, .rbx, .rcx });
@@ -15859,7 +15861,7 @@ fn atomicOp(
     order: std.builtin.AtomicOrder,
 ) InnerError!MCValue {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ptr_lock = switch (ptr_mcv) {
         .register => |reg| self.register_manager.lockReg(reg),
         else => null,
@@ -15872,7 +15874,7 @@ fn atomicOp(
     };
     defer if (val_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const val_abi_size: u32 = @intCast(val_ty.abiSize(pt));
+    const val_abi_size: u32 = @intCast(val_ty.abiSize(zcu));
     const mem_size = Memory.Size.fromSize(val_abi_size);
     const ptr_mem: Memory = switch (ptr_mcv) {
         .immediate, .register, .register_offset, .lea_frame => try ptr_mcv.deref().mem(self, mem_size),
@@ -16031,8 +16033,8 @@ fn atomicOp(
                 .Or => try self.genBinOpMir(.{ ._, .@"or" }, val_ty, tmp_mcv, val_mcv),
                 .Xor => try self.genBinOpMir(.{ ._, .xor }, val_ty, tmp_mcv, val_mcv),
                 .Min, .Max => {
-                    const cc: Condition = switch (if (val_ty.isAbiInt(mod))
-                        val_ty.intInfo(mod).signedness
+                    const cc: Condition = switch (if (val_ty.isAbiInt(zcu))
+                        val_ty.intInfo(zcu).signedness
                     else
                         .unsigned) {
                         .unsigned => switch (op) {
@@ -16156,8 +16158,8 @@ fn atomicOp(
                     try self.asmRegisterMemory(.{ ._, .xor }, .rcx, val_hi_mem);
                 },
                 .Min, .Max => {
-                    const cc: Condition = switch (if (val_ty.isAbiInt(mod))
-                        val_ty.intInfo(mod).signedness
+                    const cc: Condition = switch (if (val_ty.isAbiInt(zcu))
+                        val_ty.intInfo(zcu).signedness
                     else
                         .unsigned) {
                         .unsigned => switch (op) {
@@ -16264,7 +16266,7 @@ fn airAtomicStore(self: *Self, inst: Air.Inst.Index, order: std.builtin.AtomicOr
 
 fn airMemset(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     result: {
@@ -16290,19 +16292,19 @@ fn airMemset(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
         };
         defer if (src_val_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const elem_abi_size: u31 = @intCast(elem_ty.abiSize(pt));
+        const elem_abi_size: u31 = @intCast(elem_ty.abiSize(zcu));
 
         if (elem_abi_size == 1) {
-            const ptr: MCValue = switch (dst_ptr_ty.ptrSize(mod)) {
+            const ptr: MCValue = switch (dst_ptr_ty.ptrSize(zcu)) {
                 // TODO: this only handles slices stored in the stack
                 .Slice => dst_ptr,
                 .One => dst_ptr,
                 .C, .Many => unreachable,
             };
-            const len: MCValue = switch (dst_ptr_ty.ptrSize(mod)) {
+            const len: MCValue = switch (dst_ptr_ty.ptrSize(zcu)) {
                 // TODO: this only handles slices stored in the stack
                 .Slice => dst_ptr.address().offset(8).deref(),
-                .One => .{ .immediate = dst_ptr_ty.childType(mod).arrayLen(mod) },
+                .One => .{ .immediate = dst_ptr_ty.childType(zcu).arrayLen(zcu) },
                 .C, .Many => unreachable,
             };
             const len_lock: ?RegisterLock = switch (len) {
@@ -16318,9 +16320,9 @@ fn airMemset(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
         // Store the first element, and then rely on memcpy copying forwards.
         // Length zero requires a runtime check - so we handle arrays specially
         // here to elide it.
-        switch (dst_ptr_ty.ptrSize(mod)) {
+        switch (dst_ptr_ty.ptrSize(zcu)) {
             .Slice => {
-                const slice_ptr_ty = dst_ptr_ty.slicePtrFieldType(mod);
+                const slice_ptr_ty = dst_ptr_ty.slicePtrFieldType(zcu);
 
                 // TODO: this only handles slices stored in the stack
                 const ptr = dst_ptr;
@@ -16365,7 +16367,7 @@ fn airMemset(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
             .One => {
                 const elem_ptr_ty = try pt.singleMutPtrType(elem_ty);
 
-                const len = dst_ptr_ty.childType(mod).arrayLen(mod);
+                const len = dst_ptr_ty.childType(zcu).arrayLen(zcu);
 
                 assert(len != 0); // prevented by Sema
                 try self.store(elem_ptr_ty, dst_ptr, src_val, .{ .safety = safety });
@@ -16393,7 +16395,7 @@ fn airMemset(self: *Self, inst: Air.Inst.Index, safety: bool) !void {
 
 fn airMemcpy(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
     try self.spillRegisters(&.{ .rdi, .rsi, .rcx });
@@ -16415,7 +16417,7 @@ fn airMemcpy(self: *Self, inst: Air.Inst.Index) !void {
     };
     defer if (src_ptr_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const len: MCValue = switch (dst_ptr_ty.ptrSize(mod)) {
+    const len: MCValue = switch (dst_ptr_ty.ptrSize(zcu)) {
         .Slice => len: {
             const len_reg = try self.register_manager.allocReg(null, abi.RegisterClass.gp);
             const len_lock = self.register_manager.lockRegAssumeUnused(len_reg);
@@ -16425,13 +16427,13 @@ fn airMemcpy(self: *Self, inst: Air.Inst.Index) !void {
                 .{ .i_, .mul },
                 len_reg,
                 try dst_ptr.address().offset(8).deref().mem(self, .qword),
-                Immediate.s(@intCast(dst_ptr_ty.childType(mod).abiSize(pt))),
+                Immediate.s(@intCast(dst_ptr_ty.childType(zcu).abiSize(zcu))),
             );
             break :len .{ .register = len_reg };
         },
         .One => len: {
-            const array_ty = dst_ptr_ty.childType(mod);
-            break :len .{ .immediate = array_ty.arrayLen(mod) * array_ty.childType(mod).abiSize(pt) };
+            const array_ty = dst_ptr_ty.childType(zcu);
+            break :len .{ .immediate = array_ty.arrayLen(zcu) * array_ty.childType(zcu).abiSize(zcu) };
         },
         .C, .Many => unreachable,
     };
@@ -16449,6 +16451,7 @@ fn airMemcpy(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airTagName(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
+    const zcu = pt.zcu;
     const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
     const inst_ty = self.typeOfIndex(inst);
     const enum_ty = self.typeOf(un_op);
@@ -16457,8 +16460,8 @@ fn airTagName(self: *Self, inst: Air.Inst.Index) !void {
     // We need a properly aligned and sized call frame to be able to call this function.
     {
         const needed_call_frame = FrameAlloc.init(.{
-            .size = inst_ty.abiSize(pt),
-            .alignment = inst_ty.abiAlignment(pt),
+            .size = inst_ty.abiSize(zcu),
+            .alignment = inst_ty.abiAlignment(zcu),
         });
         const frame_allocs_slice = self.frame_allocs.slice();
         const stack_frame_size =
@@ -16590,15 +16593,15 @@ fn airErrorName(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airSplat(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const vector_ty = self.typeOfIndex(inst);
-    const vector_len = vector_ty.vectorLen(mod);
+    const vector_len = vector_ty.vectorLen(zcu);
     const dst_rc = self.regClassForType(vector_ty);
     const scalar_ty = self.typeOf(ty_op.operand);
 
     const result: MCValue = result: {
-        switch (scalar_ty.zigTypeTag(mod)) {
+        switch (scalar_ty.zigTypeTag(zcu)) {
             else => {},
             .Bool => {
                 const regs =
@@ -16641,7 +16644,7 @@ fn airSplat(self: *Self, inst: Air.Inst.Index) !void {
                 break :result .{ .register = regs[0] };
             },
             .Int => if (self.hasFeature(.avx2)) avx2: {
-                const mir_tag = @as(?Mir.Inst.FixedTag, switch (scalar_ty.intInfo(mod).bits) {
+                const mir_tag = @as(?Mir.Inst.FixedTag, switch (scalar_ty.intInfo(zcu).bits) {
                     else => null,
                     1...8 => switch (vector_len) {
                         else => null,
@@ -16672,15 +16675,15 @@ fn airSplat(self: *Self, inst: Air.Inst.Index) !void {
                 const src_mcv = try self.resolveInst(ty_op.operand);
                 if (src_mcv.isMemory()) try self.asmRegisterMemory(
                     mir_tag,
-                    registerAlias(dst_reg, @intCast(vector_ty.abiSize(pt))),
+                    registerAlias(dst_reg, @intCast(vector_ty.abiSize(zcu))),
                     try src_mcv.mem(self, self.memSize(scalar_ty)),
                 ) else {
                     if (mir_tag[0] == .v_i128) break :avx2;
                     try self.genSetReg(dst_reg, scalar_ty, src_mcv, .{});
                     try self.asmRegisterRegister(
                         mir_tag,
-                        registerAlias(dst_reg, @intCast(vector_ty.abiSize(pt))),
-                        registerAlias(dst_reg, @intCast(scalar_ty.abiSize(pt))),
+                        registerAlias(dst_reg, @intCast(vector_ty.abiSize(zcu))),
+                        registerAlias(dst_reg, @intCast(scalar_ty.abiSize(zcu))),
                     );
                 }
                 break :result .{ .register = dst_reg };
@@ -16692,8 +16695,8 @@ fn airSplat(self: *Self, inst: Air.Inst.Index) !void {
                 try self.genSetReg(dst_reg, scalar_ty, .{ .air_ref = ty_op.operand }, .{});
                 if (vector_len == 1) break :result .{ .register = dst_reg };
 
-                const dst_alias = registerAlias(dst_reg, @intCast(vector_ty.abiSize(pt)));
-                const scalar_bits = scalar_ty.intInfo(mod).bits;
+                const dst_alias = registerAlias(dst_reg, @intCast(vector_ty.abiSize(zcu)));
+                const scalar_bits = scalar_ty.intInfo(zcu).bits;
                 if (switch (scalar_bits) {
                     1...8 => true,
                     9...128 => false,
@@ -16929,14 +16932,14 @@ fn airSplat(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airSelect(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const extra = self.air.extraData(Air.Bin, pl_op.payload).data;
     const ty = self.typeOfIndex(inst);
-    const vec_len = ty.vectorLen(mod);
-    const elem_ty = ty.childType(mod);
-    const elem_abi_size: u32 = @intCast(elem_ty.abiSize(pt));
-    const abi_size: u32 = @intCast(ty.abiSize(pt));
+    const vec_len = ty.vectorLen(zcu);
+    const elem_ty = ty.childType(zcu);
+    const elem_abi_size: u32 = @intCast(elem_ty.abiSize(zcu));
+    const abi_size: u32 = @intCast(ty.abiSize(zcu));
     const pred_ty = self.typeOf(pl_op.operand);
 
     const result = result: {
@@ -17160,7 +17163,7 @@ fn airSelect(self: *Self, inst: Air.Inst.Index) !void {
         const dst_lock = self.register_manager.lockReg(dst_reg);
         defer if (dst_lock) |lock| self.register_manager.unlockReg(lock);
 
-        const mir_tag = @as(?Mir.Inst.FixedTag, switch (ty.childType(mod).zigTypeTag(mod)) {
+        const mir_tag = @as(?Mir.Inst.FixedTag, switch (ty.childType(zcu).zigTypeTag(zcu)) {
             else => null,
             .Int => switch (abi_size) {
                 0 => unreachable,
@@ -17176,7 +17179,7 @@ fn airSelect(self: *Self, inst: Air.Inst.Index) !void {
                     null,
                 else => null,
             },
-            .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
+            .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
                 else => unreachable,
                 16, 80, 128 => null,
                 32 => switch (vec_len) {
@@ -17230,7 +17233,7 @@ fn airSelect(self: *Self, inst: Air.Inst.Index) !void {
                 try self.copyToTmpRegister(ty, lhs_mcv), abi_size),
             mask_alias,
         ) else {
-            const mir_fixes = @as(?Mir.Inst.Fixes, switch (elem_ty.zigTypeTag(mod)) {
+            const mir_fixes = @as(?Mir.Inst.Fixes, switch (elem_ty.zigTypeTag(zcu)) {
                 else => null,
                 .Int => .p_,
                 .Float => switch (elem_ty.floatBits(self.target.*)) {
@@ -17262,18 +17265,18 @@ fn airSelect(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airShuffle(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.Shuffle, ty_pl.payload).data;
 
     const dst_ty = self.typeOfIndex(inst);
-    const elem_ty = dst_ty.childType(mod);
-    const elem_abi_size: u16 = @intCast(elem_ty.abiSize(pt));
-    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(pt));
+    const elem_ty = dst_ty.childType(zcu);
+    const elem_abi_size: u16 = @intCast(elem_ty.abiSize(zcu));
+    const dst_abi_size: u32 = @intCast(dst_ty.abiSize(zcu));
     const lhs_ty = self.typeOf(extra.a);
-    const lhs_abi_size: u32 = @intCast(lhs_ty.abiSize(pt));
+    const lhs_abi_size: u32 = @intCast(lhs_ty.abiSize(zcu));
     const rhs_ty = self.typeOf(extra.b);
-    const rhs_abi_size: u32 = @intCast(rhs_ty.abiSize(pt));
+    const rhs_abi_size: u32 = @intCast(rhs_ty.abiSize(zcu));
     const max_abi_size = @max(dst_abi_size, lhs_abi_size, rhs_abi_size);
 
     const ExpectedContents = [32]?i32;
@@ -17286,10 +17289,10 @@ fn airShuffle(self: *Self, inst: Air.Inst.Index) !void {
     for (mask_elems, 0..) |*mask_elem, elem_index| {
         const mask_elem_val =
             Value.fromInterned(extra.mask).elemValue(pt, elem_index) catch unreachable;
-        mask_elem.* = if (mask_elem_val.isUndef(mod))
+        mask_elem.* = if (mask_elem_val.isUndef(zcu))
             null
         else
-            @intCast(mask_elem_val.toSignedInt(pt));
+            @intCast(mask_elem_val.toSignedInt(zcu));
     }
 
     const has_avx = self.hasFeature(.avx);
@@ -18028,7 +18031,7 @@ fn airShuffle(self: *Self, inst: Air.Inst.Index) !void {
             );
 
             if (has_avx) try self.asmRegisterRegisterRegister(
-                .{ switch (elem_ty.zigTypeTag(mod)) {
+                .{ switch (elem_ty.zigTypeTag(zcu)) {
                     else => break :result null,
                     .Int => .vp_,
                     .Float => switch (elem_ty.floatBits(self.target.*)) {
@@ -18042,7 +18045,7 @@ fn airShuffle(self: *Self, inst: Air.Inst.Index) !void {
                 lhs_temp_alias,
                 rhs_temp_alias,
             ) else try self.asmRegisterRegister(
-                .{ switch (elem_ty.zigTypeTag(mod)) {
+                .{ switch (elem_ty.zigTypeTag(zcu)) {
                     else => break :result null,
                     .Int => .p_,
                     .Float => switch (elem_ty.floatBits(self.target.*)) {
@@ -18068,19 +18071,19 @@ fn airShuffle(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airReduce(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const reduce = self.air.instructions.items(.data)[@intFromEnum(inst)].reduce;
 
     const result: MCValue = result: {
         const operand_ty = self.typeOf(reduce.operand);
-        if (operand_ty.isVector(mod) and operand_ty.childType(mod).toIntern() == .bool_type) {
+        if (operand_ty.isVector(zcu) and operand_ty.childType(zcu).toIntern() == .bool_type) {
             try self.spillEflagsIfOccupied();
 
             const operand_mcv = try self.resolveInst(reduce.operand);
-            const mask_len = (math.cast(u6, operand_ty.vectorLen(mod)) orelse
+            const mask_len = (math.cast(u6, operand_ty.vectorLen(zcu)) orelse
                 return self.fail("TODO implement airReduce for {}", .{operand_ty.fmt(pt)}));
             const mask = (@as(u64, 1) << mask_len) - 1;
-            const abi_size: u32 = @intCast(operand_ty.abiSize(pt));
+            const abi_size: u32 = @intCast(operand_ty.abiSize(zcu));
             switch (reduce.operation) {
                 .Or => {
                     if (operand_mcv.isMemory()) try self.asmMemoryImmediate(
@@ -18126,36 +18129,36 @@ fn airReduce(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const result_ty = self.typeOfIndex(inst);
-    const len: usize = @intCast(result_ty.arrayLen(mod));
+    const len: usize = @intCast(result_ty.arrayLen(zcu));
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const elements: []const Air.Inst.Ref = @ptrCast(self.air.extra[ty_pl.payload..][0..len]);
     const result: MCValue = result: {
-        switch (result_ty.zigTypeTag(mod)) {
+        switch (result_ty.zigTypeTag(zcu)) {
             .Struct => {
-                const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(result_ty, pt));
-                if (result_ty.containerLayout(mod) == .@"packed") {
-                    const struct_obj = mod.typeToStruct(result_ty).?;
+                const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(result_ty, zcu));
+                if (result_ty.containerLayout(zcu) == .@"packed") {
+                    const struct_obj = zcu.typeToStruct(result_ty).?;
                     try self.genInlineMemset(
                         .{ .lea_frame = .{ .index = frame_index } },
                         .{ .immediate = 0 },
-                        .{ .immediate = result_ty.abiSize(pt) },
+                        .{ .immediate = result_ty.abiSize(zcu) },
                         .{},
                     );
                     for (elements, 0..) |elem, elem_i_usize| {
                         const elem_i: u32 = @intCast(elem_i_usize);
                         if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
-                        const elem_ty = result_ty.structFieldType(elem_i, mod);
-                        const elem_bit_size: u32 = @intCast(elem_ty.bitSize(pt));
+                        const elem_ty = result_ty.structFieldType(elem_i, zcu);
+                        const elem_bit_size: u32 = @intCast(elem_ty.bitSize(zcu));
                         if (elem_bit_size > 64) {
                             return self.fail(
                                 "TODO airAggregateInit implement packed structs with large fields",
                                 .{},
                             );
                         }
-                        const elem_abi_size: u32 = @intCast(elem_ty.abiSize(pt));
+                        const elem_abi_size: u32 = @intCast(elem_ty.abiSize(zcu));
                         const elem_abi_bits = elem_abi_size * 8;
                         const elem_off = pt.structPackedFieldBitOffset(struct_obj, elem_i);
                         const elem_byte_off: i32 = @intCast(elem_off / elem_abi_bits * elem_abi_size);
@@ -18229,8 +18232,8 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
                 } else for (elements, 0..) |elem, elem_i| {
                     if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
-                    const elem_ty = result_ty.structFieldType(elem_i, mod);
-                    const elem_off: i32 = @intCast(result_ty.structFieldOffset(elem_i, pt));
+                    const elem_ty = result_ty.structFieldType(elem_i, zcu);
+                    const elem_off: i32 = @intCast(result_ty.structFieldOffset(elem_i, zcu));
                     const elem_mcv = try self.resolveInst(elem);
                     const mat_elem_mcv = switch (elem_mcv) {
                         .load_tlv => |sym_index| MCValue{ .lea_tlv = sym_index },
@@ -18241,9 +18244,9 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
                 break :result .{ .load_frame = .{ .index = frame_index } };
             },
             .Array, .Vector => {
-                const elem_ty = result_ty.childType(mod);
-                if (result_ty.isVector(mod) and elem_ty.toIntern() == .bool_type) {
-                    const result_size: u32 = @intCast(result_ty.abiSize(pt));
+                const elem_ty = result_ty.childType(zcu);
+                if (result_ty.isVector(zcu) and elem_ty.toIntern() == .bool_type) {
+                    const result_size: u32 = @intCast(result_ty.abiSize(zcu));
                     const dst_reg = try self.register_manager.allocReg(inst, abi.RegisterClass.gp);
                     try self.asmRegisterRegister(
                         .{ ._, .xor },
@@ -18274,8 +18277,8 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
                     }
                     break :result .{ .register = dst_reg };
                 } else {
-                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(result_ty, pt));
-                    const elem_size: u32 = @intCast(elem_ty.abiSize(pt));
+                    const frame_index = try self.allocFrameIndex(FrameAlloc.initSpill(result_ty, zcu));
+                    const elem_size: u32 = @intCast(elem_ty.abiSize(zcu));
 
                     for (elements, 0..) |elem, elem_i| {
                         const elem_mcv = try self.resolveInst(elem);
@@ -18292,7 +18295,7 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
                             .{},
                         );
                     }
-                    if (result_ty.sentinel(mod)) |sentinel| try self.genSetMem(
+                    if (result_ty.sentinel(zcu)) |sentinel| try self.genSetMem(
                         .{ .frame = frame_index },
                         @intCast(elem_size * elements.len),
                         elem_ty,
@@ -18318,18 +18321,18 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airUnionInit(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
     const extra = self.air.extraData(Air.UnionInit, ty_pl.payload).data;
     const result: MCValue = result: {
         const union_ty = self.typeOfIndex(inst);
-        const layout = union_ty.unionGetLayout(pt);
+        const layout = union_ty.unionGetLayout(zcu);
 
         const src_ty = self.typeOf(extra.init);
         const src_mcv = try self.resolveInst(extra.init);
         if (layout.tag_size == 0) {
-            if (layout.abi_size <= src_ty.abiSize(pt) and
+            if (layout.abi_size <= src_ty.abiSize(zcu) and
                 self.reuseOperand(inst, extra.init, 0, src_mcv)) break :result src_mcv;
 
             const dst_mcv = try self.allocRegOrMem(inst, true);
@@ -18339,13 +18342,13 @@ fn airUnionInit(self: *Self, inst: Air.Inst.Index) !void {
 
         const dst_mcv = try self.allocRegOrMem(inst, false);
 
-        const union_obj = mod.typeToUnion(union_ty).?;
+        const union_obj = zcu.typeToUnion(union_ty).?;
         const field_name = union_obj.loadTagType(ip).names.get(ip)[extra.field_index];
         const tag_ty = Type.fromInterned(union_obj.enum_tag_ty);
-        const field_index = tag_ty.enumFieldIndex(field_name, mod).?;
+        const field_index = tag_ty.enumFieldIndex(field_name, zcu).?;
         const tag_val = try pt.enumValueFieldIndex(tag_ty, field_index);
         const tag_int_val = try tag_val.intFromEnum(tag_ty, pt);
-        const tag_int = tag_int_val.toUnsignedInt(pt);
+        const tag_int = tag_int_val.toUnsignedInt(zcu);
         const tag_off: i32 = @intCast(layout.tagOffset());
         try self.genCopy(
             tag_ty,
@@ -18369,19 +18372,19 @@ fn airPrefetch(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
     const extra = self.air.extraData(Air.Bin, pl_op.payload).data;
     const ty = self.typeOfIndex(inst);
 
     const ops = [3]Air.Inst.Ref{ extra.lhs, extra.rhs, pl_op.operand };
     const result = result: {
-        if (switch (ty.scalarType(mod).floatBits(self.target.*)) {
+        if (switch (ty.scalarType(zcu).floatBits(self.target.*)) {
             16, 80, 128 => true,
             32, 64 => !self.hasFeature(.fma),
             else => unreachable,
         }) {
-            if (ty.zigTypeTag(mod) != .Float) return self.fail("TODO implement airMulAdd for {}", .{
+            if (ty.zigTypeTag(zcu) != .Float) return self.fail("TODO implement airMulAdd for {}", .{
                 ty.fmt(pt),
             });
 
@@ -18430,21 +18433,21 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
 
         const mir_tag = @as(?Mir.Inst.FixedTag, if (mem.eql(u2, &order, &.{ 1, 3, 2 }) or
             mem.eql(u2, &order, &.{ 3, 1, 2 }))
-            switch (ty.zigTypeTag(mod)) {
+            switch (ty.zigTypeTag(zcu)) {
                 .Float => switch (ty.floatBits(self.target.*)) {
                     32 => .{ .v_ss, .fmadd132 },
                     64 => .{ .v_sd, .fmadd132 },
                     16, 80, 128 => null,
                     else => unreachable,
                 },
-                .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-                    .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
-                        32 => switch (ty.vectorLen(mod)) {
+                .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+                    .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
+                        32 => switch (ty.vectorLen(zcu)) {
                             1 => .{ .v_ss, .fmadd132 },
                             2...8 => .{ .v_ps, .fmadd132 },
                             else => null,
                         },
-                        64 => switch (ty.vectorLen(mod)) {
+                        64 => switch (ty.vectorLen(zcu)) {
                             1 => .{ .v_sd, .fmadd132 },
                             2...4 => .{ .v_pd, .fmadd132 },
                             else => null,
@@ -18457,21 +18460,21 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
                 else => unreachable,
             }
         else if (mem.eql(u2, &order, &.{ 2, 1, 3 }) or mem.eql(u2, &order, &.{ 1, 2, 3 }))
-            switch (ty.zigTypeTag(mod)) {
+            switch (ty.zigTypeTag(zcu)) {
                 .Float => switch (ty.floatBits(self.target.*)) {
                     32 => .{ .v_ss, .fmadd213 },
                     64 => .{ .v_sd, .fmadd213 },
                     16, 80, 128 => null,
                     else => unreachable,
                 },
-                .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-                    .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
-                        32 => switch (ty.vectorLen(mod)) {
+                .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+                    .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
+                        32 => switch (ty.vectorLen(zcu)) {
                             1 => .{ .v_ss, .fmadd213 },
                             2...8 => .{ .v_ps, .fmadd213 },
                             else => null,
                         },
-                        64 => switch (ty.vectorLen(mod)) {
+                        64 => switch (ty.vectorLen(zcu)) {
                             1 => .{ .v_sd, .fmadd213 },
                             2...4 => .{ .v_pd, .fmadd213 },
                             else => null,
@@ -18484,21 +18487,21 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
                 else => unreachable,
             }
         else if (mem.eql(u2, &order, &.{ 2, 3, 1 }) or mem.eql(u2, &order, &.{ 3, 2, 1 }))
-            switch (ty.zigTypeTag(mod)) {
+            switch (ty.zigTypeTag(zcu)) {
                 .Float => switch (ty.floatBits(self.target.*)) {
                     32 => .{ .v_ss, .fmadd231 },
                     64 => .{ .v_sd, .fmadd231 },
                     16, 80, 128 => null,
                     else => unreachable,
                 },
-                .Vector => switch (ty.childType(mod).zigTypeTag(mod)) {
-                    .Float => switch (ty.childType(mod).floatBits(self.target.*)) {
-                        32 => switch (ty.vectorLen(mod)) {
+                .Vector => switch (ty.childType(zcu).zigTypeTag(zcu)) {
+                    .Float => switch (ty.childType(zcu).floatBits(self.target.*)) {
+                        32 => switch (ty.vectorLen(zcu)) {
                             1 => .{ .v_ss, .fmadd231 },
                             2...8 => .{ .v_ps, .fmadd231 },
                             else => null,
                         },
-                        64 => switch (ty.vectorLen(mod)) {
+                        64 => switch (ty.vectorLen(zcu)) {
                             1 => .{ .v_sd, .fmadd231 },
                             2...4 => .{ .v_pd, .fmadd231 },
                             else => null,
@@ -18516,7 +18519,7 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
         var mops: [3]MCValue = undefined;
         for (order, mcvs) |mop_index, mcv| mops[mop_index - 1] = mcv;
 
-        const abi_size: u32 = @intCast(ty.abiSize(pt));
+        const abi_size: u32 = @intCast(ty.abiSize(zcu));
         const mop1_reg = registerAlias(mops[0].getReg().?, abi_size);
         const mop2_reg = registerAlias(mops[1].getReg().?, abi_size);
         if (mops[2].isRegister()) try self.asmRegisterRegisterRegister(
@@ -18537,17 +18540,17 @@ fn airMulAdd(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airVaStart(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const va_list_ty = self.air.instructions.items(.data)[@intFromEnum(inst)].ty;
     const ptr_anyopaque_ty = try pt.singleMutPtrType(Type.anyopaque);
 
     const result: MCValue = switch (abi.resolveCallingConvention(
-        self.fn_type.fnCallingConvention(mod),
+        self.fn_type.fnCallingConvention(zcu),
         self.target.*,
     )) {
         .SysV => result: {
             const info = self.va_info.sysv;
-            const dst_fi = try self.allocFrameIndex(FrameAlloc.initSpill(va_list_ty, pt));
+            const dst_fi = try self.allocFrameIndex(FrameAlloc.initSpill(va_list_ty, zcu));
             var field_off: u31 = 0;
             // gp_offset: c_uint,
             try self.genSetMem(
@@ -18557,7 +18560,7 @@ fn airVaStart(self: *Self, inst: Air.Inst.Index) !void {
                 .{ .immediate = info.gp_count * 8 },
                 .{},
             );
-            field_off += @intCast(Type.c_uint.abiSize(pt));
+            field_off += @intCast(Type.c_uint.abiSize(zcu));
             // fp_offset: c_uint,
             try self.genSetMem(
                 .{ .frame = dst_fi },
@@ -18566,7 +18569,7 @@ fn airVaStart(self: *Self, inst: Air.Inst.Index) !void {
                 .{ .immediate = abi.SysV.c_abi_int_param_regs.len * 8 + info.fp_count * 16 },
                 .{},
             );
-            field_off += @intCast(Type.c_uint.abiSize(pt));
+            field_off += @intCast(Type.c_uint.abiSize(zcu));
             // overflow_arg_area: *anyopaque,
             try self.genSetMem(
                 .{ .frame = dst_fi },
@@ -18575,7 +18578,7 @@ fn airVaStart(self: *Self, inst: Air.Inst.Index) !void {
                 .{ .lea_frame = info.overflow_arg_area },
                 .{},
             );
-            field_off += @intCast(ptr_anyopaque_ty.abiSize(pt));
+            field_off += @intCast(ptr_anyopaque_ty.abiSize(zcu));
             // reg_save_area: *anyopaque,
             try self.genSetMem(
                 .{ .frame = dst_fi },
@@ -18584,7 +18587,7 @@ fn airVaStart(self: *Self, inst: Air.Inst.Index) !void {
                 .{ .lea_frame = info.reg_save_area },
                 .{},
             );
-            field_off += @intCast(ptr_anyopaque_ty.abiSize(pt));
+            field_off += @intCast(ptr_anyopaque_ty.abiSize(zcu));
             break :result .{ .load_frame = .{ .index = dst_fi } };
         },
         .Win64 => return self.fail("TODO implement c_va_start for Win64", .{}),
@@ -18595,7 +18598,7 @@ fn airVaStart(self: *Self, inst: Air.Inst.Index) !void {
 
 fn airVaArg(self: *Self, inst: Air.Inst.Index) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
     const ty = self.typeOfIndex(inst);
     const promote_ty = self.promoteVarArg(ty);
@@ -18603,7 +18606,7 @@ fn airVaArg(self: *Self, inst: Air.Inst.Index) !void {
     const unused = self.liveness.isUnused(inst);
 
     const result: MCValue = switch (abi.resolveCallingConvention(
-        self.fn_type.fnCallingConvention(mod),
+        self.fn_type.fnCallingConvention(zcu),
         self.target.*,
     )) {
         .SysV => result: {
@@ -18633,7 +18636,7 @@ fn airVaArg(self: *Self, inst: Air.Inst.Index) !void {
             const overflow_arg_area: MCValue = .{ .indirect = .{ .reg = ptr_arg_list_reg, .off = 8 } };
             const reg_save_area: MCValue = .{ .indirect = .{ .reg = ptr_arg_list_reg, .off = 16 } };
 
-            const classes = mem.sliceTo(&abi.classifySystemV(promote_ty, pt, self.target.*, .arg), .none);
+            const classes = mem.sliceTo(&abi.classifySystemV(promote_ty, zcu, self.target.*, .arg), .none);
             switch (classes[0]) {
                 .integer => {
                     assert(classes.len == 1);
@@ -18668,7 +18671,7 @@ fn airVaArg(self: *Self, inst: Air.Inst.Index) !void {
                         .base = .{ .reg = addr_reg },
                         .mod = .{ .rm = .{
                             .size = .qword,
-                            .disp = @intCast(@max(promote_ty.abiSize(pt), 8)),
+                            .disp = @intCast(@max(promote_ty.abiSize(zcu), 8)),
                         } },
                     });
                     try self.genCopy(
@@ -18716,7 +18719,7 @@ fn airVaArg(self: *Self, inst: Air.Inst.Index) !void {
                         .base = .{ .reg = addr_reg },
                         .mod = .{ .rm = .{
                             .size = .qword,
-                            .disp = @intCast(@max(promote_ty.abiSize(pt), 8)),
+                            .disp = @intCast(@max(promote_ty.abiSize(zcu), 8)),
                         } },
                     });
                     try self.genCopy(
@@ -18806,11 +18809,11 @@ fn airVaEnd(self: *Self, inst: Air.Inst.Index) !void {
 }
 
 fn resolveInst(self: *Self, ref: Air.Inst.Ref) InnerError!MCValue {
-    const pt = self.pt;
+    const zcu = self.pt.zcu;
     const ty = self.typeOf(ref);
 
     // If the type has no codegen bits, no need to store it.
-    if (!ty.hasRuntimeBitsIgnoreComptime(pt)) return .none;
+    if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) return .none;
 
     const mcv = if (ref.toIndex()) |inst| mcv: {
         break :mcv self.inst_tracking.getPtr(inst).?.short;
@@ -18927,8 +18930,8 @@ fn resolveCallingConventionValues(
     stack_frame_base: FrameIndex,
 ) !CallMCValues {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const cc = fn_info.cc;
     const param_types = try self.gpa.alloc(Type, fn_info.param_types.len + var_args.len);
     defer self.gpa.free(param_types);
@@ -18970,15 +18973,15 @@ fn resolveCallingConventionValues(
                 .SysV => {},
                 .Win64 => {
                     // Align the stack to 16bytes before allocating shadow stack space (if any).
-                    result.stack_byte_count += @intCast(4 * Type.usize.abiSize(pt));
+                    result.stack_byte_count += @intCast(4 * Type.usize.abiSize(zcu));
                 },
                 else => unreachable,
             }
 
             // Return values
-            if (ret_ty.zigTypeTag(mod) == .NoReturn) {
+            if (ret_ty.zigTypeTag(zcu) == .NoReturn) {
                 result.return_value = InstTracking.init(.unreach);
-            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 // TODO: is this even possible for C calling convention?
                 result.return_value = InstTracking.init(.none);
             } else {
@@ -18986,15 +18989,15 @@ fn resolveCallingConventionValues(
                 var ret_tracking_i: usize = 0;
 
                 const classes = switch (resolved_cc) {
-                    .SysV => mem.sliceTo(&abi.classifySystemV(ret_ty, pt, self.target.*, .ret), .none),
-                    .Win64 => &.{abi.classifyWindows(ret_ty, pt)},
+                    .SysV => mem.sliceTo(&abi.classifySystemV(ret_ty, zcu, self.target.*, .ret), .none),
+                    .Win64 => &.{abi.classifyWindows(ret_ty, zcu)},
                     else => unreachable,
                 };
                 for (classes) |class| switch (class) {
                     .integer => {
                         const ret_int_reg = registerAlias(
                             abi.getCAbiIntReturnRegs(resolved_cc)[ret_int_reg_i],
-                            @intCast(@min(ret_ty.abiSize(pt), 8)),
+                            @intCast(@min(ret_ty.abiSize(zcu), 8)),
                         );
                         ret_int_reg_i += 1;
 
@@ -19004,7 +19007,7 @@ fn resolveCallingConventionValues(
                     .sse, .float, .float_combine, .win_i128 => {
                         const ret_sse_reg = registerAlias(
                             abi.getCAbiSseReturnRegs(resolved_cc)[ret_sse_reg_i],
-                            @intCast(ret_ty.abiSize(pt)),
+                            @intCast(ret_ty.abiSize(zcu)),
                         );
                         ret_sse_reg_i += 1;
 
@@ -19047,7 +19050,7 @@ fn resolveCallingConventionValues(
 
             // Input params
             for (param_types, result.args) |ty, *arg| {
-                assert(ty.hasRuntimeBitsIgnoreComptime(pt));
+                assert(ty.hasRuntimeBitsIgnoreComptime(zcu));
                 switch (resolved_cc) {
                     .SysV => {},
                     .Win64 => {
@@ -19061,8 +19064,8 @@ fn resolveCallingConventionValues(
                 var arg_mcv_i: usize = 0;
 
                 const classes = switch (resolved_cc) {
-                    .SysV => mem.sliceTo(&abi.classifySystemV(ty, pt, self.target.*, .arg), .none),
-                    .Win64 => &.{abi.classifyWindows(ty, pt)},
+                    .SysV => mem.sliceTo(&abi.classifySystemV(ty, zcu, self.target.*, .arg), .none),
+                    .Win64 => &.{abi.classifyWindows(ty, zcu)},
                     else => unreachable,
                 };
                 for (classes) |class| switch (class) {
@@ -19072,7 +19075,7 @@ fn resolveCallingConventionValues(
 
                         const param_int_reg = registerAlias(
                             abi.getCAbiIntParamRegs(resolved_cc)[param_int_reg_i],
-                            @intCast(@min(ty.abiSize(pt), 8)),
+                            @intCast(@min(ty.abiSize(zcu), 8)),
                         );
                         param_int_reg_i += 1;
 
@@ -19085,7 +19088,7 @@ fn resolveCallingConventionValues(
 
                         const param_sse_reg = registerAlias(
                             abi.getCAbiSseParamRegs(resolved_cc)[param_sse_reg_i],
-                            @intCast(ty.abiSize(pt)),
+                            @intCast(ty.abiSize(zcu)),
                         );
                         param_sse_reg_i += 1;
 
@@ -19098,7 +19101,7 @@ fn resolveCallingConventionValues(
                             .x87, .x87up, .complex_x87, .memory => break,
                             else => unreachable,
                         },
-                        .Win64 => if (ty.abiSize(pt) > 8) {
+                        .Win64 => if (ty.abiSize(zcu) > 8) {
                             const param_int_reg =
                                 abi.getCAbiIntParamRegs(resolved_cc)[param_int_reg_i].to64();
                             param_int_reg_i += 1;
@@ -19117,10 +19120,10 @@ fn resolveCallingConventionValues(
                         param_int_reg_i = param_int_regs_len;
 
                         const frame_elem_align = 8;
-                        const frame_elems_len = ty.vectorLen(mod) - remaining_param_int_regs;
+                        const frame_elems_len = ty.vectorLen(zcu) - remaining_param_int_regs;
                         const frame_elem_size = mem.alignForward(
                             u64,
-                            ty.childType(mod).abiSize(pt),
+                            ty.childType(zcu).abiSize(zcu),
                             frame_elem_align,
                         );
                         const frame_size: u31 = @intCast(frame_elems_len * frame_elem_size);
@@ -19144,9 +19147,9 @@ fn resolveCallingConventionValues(
                     continue;
                 }
 
-                const param_size: u31 = @intCast(ty.abiSize(pt));
+                const param_size: u31 = @intCast(ty.abiSize(zcu));
                 const param_align: u31 =
-                    @intCast(@max(ty.abiAlignment(pt).toByteUnits().?, 8));
+                    @intCast(@max(ty.abiAlignment(zcu).toByteUnits().?, 8));
                 result.stack_byte_count =
                     mem.alignForward(u31, result.stack_byte_count, param_align);
                 arg.* = .{ .load_frame = .{
@@ -19164,13 +19167,13 @@ fn resolveCallingConventionValues(
             result.stack_align = .@"16";
 
             // Return values
-            if (ret_ty.zigTypeTag(mod) == .NoReturn) {
+            if (ret_ty.zigTypeTag(zcu) == .NoReturn) {
                 result.return_value = InstTracking.init(.unreach);
-            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            } else if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 result.return_value = InstTracking.init(.none);
             } else {
                 const ret_reg = abi.getCAbiIntReturnRegs(resolved_cc)[0];
-                const ret_ty_size: u31 = @intCast(ret_ty.abiSize(pt));
+                const ret_ty_size: u31 = @intCast(ret_ty.abiSize(zcu));
                 if (ret_ty_size <= 8 and !ret_ty.isRuntimeFloat()) {
                     const aliased_reg = registerAlias(ret_reg, ret_ty_size);
                     result.return_value = .{ .short = .{ .register = aliased_reg }, .long = .none };
@@ -19185,12 +19188,12 @@ fn resolveCallingConventionValues(
 
             // Input params
             for (param_types, result.args) |ty, *arg| {
-                if (!ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     arg.* = .none;
                     continue;
                 }
-                const param_size: u31 = @intCast(ty.abiSize(pt));
-                const param_align: u31 = @intCast(ty.abiAlignment(pt).toByteUnits().?);
+                const param_size: u31 = @intCast(ty.abiSize(zcu));
+                const param_align: u31 = @intCast(ty.abiAlignment(zcu).toByteUnits().?);
                 result.stack_byte_count =
                     mem.alignForward(u31, result.stack_byte_count, param_align);
                 arg.* = .{ .load_frame = .{
@@ -19276,25 +19279,26 @@ fn registerAlias(reg: Register, size_bytes: u32) Register {
 
 fn memSize(self: *Self, ty: Type) Memory.Size {
     const pt = self.pt;
-    const mod = pt.zcu;
-    return switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    return switch (ty.zigTypeTag(zcu)) {
         .Float => Memory.Size.fromBitSize(ty.floatBits(self.target.*)),
-        else => Memory.Size.fromSize(@intCast(ty.abiSize(pt))),
+        else => Memory.Size.fromSize(@intCast(ty.abiSize(zcu))),
     };
 }
 
 fn splitType(self: *Self, ty: Type) ![2]Type {
     const pt = self.pt;
-    const classes = mem.sliceTo(&abi.classifySystemV(ty, pt, self.target.*, .other), .none);
+    const zcu = pt.zcu;
+    const classes = mem.sliceTo(&abi.classifySystemV(ty, zcu, self.target.*, .other), .none);
     var parts: [2]Type = undefined;
     if (classes.len == 2) for (&parts, classes, 0..) |*part, class, part_i| {
         part.* = switch (class) {
             .integer => switch (part_i) {
                 0 => Type.u64,
                 1 => part: {
-                    const elem_size = ty.abiAlignment(pt).minStrict(.@"8").toByteUnits().?;
+                    const elem_size = ty.abiAlignment(zcu).minStrict(.@"8").toByteUnits().?;
                     const elem_ty = try pt.intType(.unsigned, @intCast(elem_size * 8));
-                    break :part switch (@divExact(ty.abiSize(pt) - 8, elem_size)) {
+                    break :part switch (@divExact(ty.abiSize(zcu) - 8, elem_size)) {
                         1 => elem_ty,
                         else => |len| try pt.arrayType(.{ .len = len, .child = elem_ty.toIntern() }),
                     };
@@ -19306,7 +19310,7 @@ fn splitType(self: *Self, ty: Type) ![2]Type {
             .sse => Type.f64,
             else => break,
         };
-    } else if (parts[0].abiSize(pt) + parts[1].abiSize(pt) == ty.abiSize(pt)) return parts;
+    } else if (parts[0].abiSize(zcu) + parts[1].abiSize(zcu) == ty.abiSize(zcu)) return parts;
     return self.fail("TODO implement splitType for {}", .{ty.fmt(pt)});
 }
 
@@ -19314,10 +19318,10 @@ fn splitType(self: *Self, ty: Type) ![2]Type {
 /// Clobbers any remaining bits.
 fn truncateRegister(self: *Self, ty: Type, reg: Register) !void {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const int_info = if (ty.isAbiInt(mod)) ty.intInfo(mod) else std.builtin.Type.Int{
+    const zcu = pt.zcu;
+    const int_info = if (ty.isAbiInt(zcu)) ty.intInfo(zcu) else std.builtin.Type.Int{
         .signedness = .unsigned,
-        .bits = @intCast(ty.bitSize(pt)),
+        .bits = @intCast(ty.bitSize(zcu)),
     };
     const shift = math.cast(u6, 64 - int_info.bits % 64) orelse return;
     try self.spillEflagsIfOccupied();
@@ -19362,9 +19366,9 @@ fn truncateRegister(self: *Self, ty: Type, reg: Register) !void {
 
 fn regBitSize(self: *Self, ty: Type) u64 {
     const pt = self.pt;
-    const mod = pt.zcu;
-    const abi_size = ty.abiSize(pt);
-    return switch (ty.zigTypeTag(mod)) {
+    const zcu = pt.zcu;
+    const abi_size = ty.abiSize(zcu);
+    return switch (ty.zigTypeTag(zcu)) {
         else => switch (abi_size) {
             1 => 8,
             2 => 16,
@@ -19381,7 +19385,7 @@ fn regBitSize(self: *Self, ty: Type) u64 {
 }
 
 fn regExtraBits(self: *Self, ty: Type) u64 {
-    return self.regBitSize(ty) - ty.bitSize(self.pt);
+    return self.regBitSize(ty) - ty.bitSize(self.pt.zcu);
 }
 
 fn hasFeature(self: *Self, feature: Target.x86.Feature) bool {
@@ -19396,14 +19400,14 @@ fn hasAllFeatures(self: *Self, features: anytype) bool {
 
 fn typeOf(self: *Self, inst: Air.Inst.Ref) Type {
     const pt = self.pt;
-    const mod = pt.zcu;
-    return self.air.typeOf(inst, &mod.intern_pool);
+    const zcu = pt.zcu;
+    return self.air.typeOf(inst, &zcu.intern_pool);
 }
 
 fn typeOfIndex(self: *Self, inst: Air.Inst.Index) Type {
     const pt = self.pt;
-    const mod = pt.zcu;
-    return self.air.typeOfIndex(inst, &mod.intern_pool);
+    const zcu = pt.zcu;
+    return self.air.typeOfIndex(inst, &zcu.intern_pool);
 }
 
 fn intCompilerRtAbiName(int_bits: u32) u8 {
@@ -19455,17 +19459,17 @@ fn floatLibcAbiSuffix(ty: Type) []const u8 {
 
 fn promoteInt(self: *Self, ty: Type) Type {
     const pt = self.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const int_info: InternPool.Key.IntType = switch (ty.toIntern()) {
         .bool_type => .{ .signedness = .unsigned, .bits = 1 },
-        else => if (ty.isAbiInt(mod)) ty.intInfo(mod) else return ty,
+        else => if (ty.isAbiInt(zcu)) ty.intInfo(zcu) else return ty,
     };
     for ([_]Type{
         Type.c_int,      Type.c_uint,
         Type.c_long,     Type.c_ulong,
         Type.c_longlong, Type.c_ulonglong,
     }) |promote_ty| {
-        const promote_info = promote_ty.intInfo(mod);
+        const promote_info = promote_ty.intInfo(zcu);
         if (int_info.signedness == .signed and promote_info.signedness == .unsigned) continue;
         if (int_info.bits + @intFromBool(int_info.signedness == .unsigned and
             promote_info.signedness == .signed) <= promote_info.bits) return promote_ty;

--- a/src/arch/x86_64/CodeGen.zig
+++ b/src/arch/x86_64/CodeGen.zig
@@ -4352,14 +4352,14 @@ fn airShlWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     try self.genSetMem(
                         .{ .frame = frame_index },
                         @intCast(tuple_ty.structFieldOffset(1, zcu)),
-                        tuple_ty.structFieldType(1, zcu),
+                        tuple_ty.fieldType(1, zcu),
                         .{ .eflags = cc },
                         .{},
                     );
                     try self.genSetMem(
                         .{ .frame = frame_index },
                         @intCast(tuple_ty.structFieldOffset(0, zcu)),
-                        tuple_ty.structFieldType(0, zcu),
+                        tuple_ty.fieldType(0, zcu),
                         partial_mcv,
                         .{},
                     );
@@ -4392,7 +4392,7 @@ fn genSetFrameTruncatedOverflowCompare(
     };
     defer if (src_lock) |lock| self.register_manager.unlockReg(lock);
 
-    const ty = tuple_ty.structFieldType(0, zcu);
+    const ty = tuple_ty.fieldType(0, zcu);
     const int_info = ty.intInfo(zcu);
 
     const hi_bits = (int_info.bits - 1) % 64 + 1;
@@ -4450,7 +4450,7 @@ fn genSetFrameTruncatedOverflowCompare(
     try self.genSetMem(
         .{ .frame = frame_index },
         @intCast(tuple_ty.structFieldOffset(1, zcu)),
-        tuple_ty.structFieldType(1, zcu),
+        tuple_ty.fieldType(1, zcu),
         if (overflow_cc) |_| .{ .register = overflow_reg.to8() } else .{ .eflags = .ne },
         .{},
     );
@@ -4637,7 +4637,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
                         @intCast(tuple_ty.structFieldOffset(0, zcu)),
-                        tuple_ty.structFieldType(0, zcu),
+                        tuple_ty.fieldType(0, zcu),
                         result,
                         .{},
                     );
@@ -4649,7 +4649,7 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
                         @intCast(tuple_ty.structFieldOffset(1, zcu)),
-                        tuple_ty.structFieldType(1, zcu),
+                        tuple_ty.fieldType(1, zcu),
                         .{ .eflags = .ne },
                         .{},
                     );
@@ -4761,14 +4761,14 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
                         @intCast(tuple_ty.structFieldOffset(0, zcu)),
-                        tuple_ty.structFieldType(0, zcu),
+                        tuple_ty.fieldType(0, zcu),
                         .{ .register_pair = .{ .rax, .rdx } },
                         .{},
                     );
                     try self.genSetMem(
                         .{ .frame = dst_mcv.load_frame.index },
                         @intCast(tuple_ty.structFieldOffset(1, zcu)),
-                        tuple_ty.structFieldType(1, zcu),
+                        tuple_ty.fieldType(1, zcu),
                         .{ .register = tmp_regs[1] },
                         .{},
                     );
@@ -4816,14 +4816,14 @@ fn airMulWithOverflow(self: *Self, inst: Air.Inst.Index) !void {
                         try self.genSetMem(
                             .{ .frame = frame_index },
                             @intCast(tuple_ty.structFieldOffset(0, zcu)),
-                            tuple_ty.structFieldType(0, zcu),
+                            tuple_ty.fieldType(0, zcu),
                             partial_mcv,
                             .{},
                         );
                         try self.genSetMem(
                             .{ .frame = frame_index },
                             @intCast(tuple_ty.structFieldOffset(1, zcu)),
-                            tuple_ty.structFieldType(1, zcu),
+                            tuple_ty.fieldType(1, zcu),
                             .{ .immediate = 0 }, // cc being set is impossible
                             .{},
                         );
@@ -8143,7 +8143,7 @@ fn airStructFieldVal(self: *Self, inst: Air.Inst.Index) !void {
 
         const container_ty = self.typeOf(operand);
         const container_rc = self.regClassForType(container_ty);
-        const field_ty = container_ty.structFieldType(index, zcu);
+        const field_ty = container_ty.fieldType(index, zcu);
         if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) break :result .none;
         const field_rc = self.regClassForType(field_ty);
         const field_is_gp = field_rc.supersetOf(abi.RegisterClass.gp);
@@ -15273,14 +15273,14 @@ fn genSetMem(
                 try self.genSetMem(
                     base,
                     disp + @as(i32, @intCast(ty.structFieldOffset(0, zcu))),
-                    ty.structFieldType(0, zcu),
+                    ty.fieldType(0, zcu),
                     .{ .register = ro.reg },
                     opts,
                 );
                 try self.genSetMem(
                     base,
                     disp + @as(i32, @intCast(ty.structFieldOffset(1, zcu))),
-                    ty.structFieldType(1, zcu),
+                    ty.fieldType(1, zcu),
                     .{ .eflags = ro.eflags },
                     opts,
                 );
@@ -18150,7 +18150,7 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
                         const elem_i: u32 = @intCast(elem_i_usize);
                         if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
-                        const elem_ty = result_ty.structFieldType(elem_i, zcu);
+                        const elem_ty = result_ty.fieldType(elem_i, zcu);
                         const elem_bit_size: u32 = @intCast(elem_ty.bitSize(zcu));
                         if (elem_bit_size > 64) {
                             return self.fail(
@@ -18232,7 +18232,7 @@ fn airAggregateInit(self: *Self, inst: Air.Inst.Index) !void {
                 } else for (elements, 0..) |elem, elem_i| {
                     if ((try result_ty.structFieldValueComptime(pt, elem_i)) != null) continue;
 
-                    const elem_ty = result_ty.structFieldType(elem_i, zcu);
+                    const elem_ty = result_ty.fieldType(elem_i, zcu);
                     const elem_off: i32 = @intCast(result_ty.structFieldOffset(elem_i, zcu));
                     const elem_mcv = try self.resolveInst(elem);
                     const mat_elem_mcv = switch (elem_mcv) {

--- a/src/arch/x86_64/Emit.zig
+++ b/src/arch/x86_64/Emit.zig
@@ -357,7 +357,7 @@ pub fn emitMir(emit: *Emit) Error!void {
                                         } } };
                                     },
                                 };
-                                const ip = &emit.lower.bin_file.comp.module.?.intern_pool;
+                                const ip = &emit.lower.bin_file.comp.zcu.?.intern_pool;
                                 const air_inst = emit.air.instructions.get(@intFromEnum(air_inst_index));
                                 const name: Air.NullTerminatedString = switch (air_inst.tag) {
                                     else => unreachable,

--- a/src/arch/x86_64/abi.zig
+++ b/src/arch/x86_64/abi.zig
@@ -44,7 +44,7 @@ pub const Class = enum {
     }
 };
 
-pub fn classifyWindows(ty: Type, pt: Zcu.PerThread) Class {
+pub fn classifyWindows(ty: Type, zcu: *Zcu) Class {
     // https://docs.microsoft.com/en-gb/cpp/build/x64-calling-convention?view=vs-2017
     // "There's a strict one-to-one correspondence between a function call's arguments
     // and the registers used for those arguments. Any argument that doesn't fit in 8
@@ -53,7 +53,7 @@ pub fn classifyWindows(ty: Type, pt: Zcu.PerThread) Class {
     // "All floating point operations are done using the 16 XMM registers."
     // "Structs and unions of size 8, 16, 32, or 64 bits, and __m64 types, are passed
     // as if they were integers of the same size."
-    switch (ty.zigTypeTag(pt.zcu)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Pointer,
         .Int,
         .Bool,
@@ -68,12 +68,12 @@ pub fn classifyWindows(ty: Type, pt: Zcu.PerThread) Class {
         .ErrorUnion,
         .AnyFrame,
         .Frame,
-        => switch (ty.abiSize(pt)) {
+        => switch (ty.abiSize(zcu)) {
             0 => unreachable,
             1, 2, 4, 8 => return .integer,
-            else => switch (ty.zigTypeTag(pt.zcu)) {
+            else => switch (ty.zigTypeTag(zcu)) {
                 .Int => return .win_i128,
-                .Struct, .Union => if (ty.containerLayout(pt.zcu) == .@"packed") {
+                .Struct, .Union => if (ty.containerLayout(zcu) == .@"packed") {
                     return .win_i128;
                 } else {
                     return .memory;
@@ -100,14 +100,14 @@ pub const Context = enum { ret, arg, field, other };
 
 /// There are a maximum of 8 possible return slots. Returned values are in
 /// the beginning of the array; unused slots are filled with .none.
-pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Context) [8]Class {
+pub fn classifySystemV(ty: Type, zcu: *Zcu, target: std.Target, ctx: Context) [8]Class {
     const memory_class = [_]Class{
         .memory, .none, .none, .none,
         .none,   .none, .none, .none,
     };
     var result = [1]Class{.none} ** 8;
-    switch (ty.zigTypeTag(pt.zcu)) {
-        .Pointer => switch (ty.ptrSize(pt.zcu)) {
+    switch (ty.zigTypeTag(zcu)) {
+        .Pointer => switch (ty.ptrSize(zcu)) {
             .Slice => {
                 result[0] = .integer;
                 result[1] = .integer;
@@ -119,7 +119,7 @@ pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Con
             },
         },
         .Int, .Enum, .ErrorSet => {
-            const bits = ty.intInfo(pt.zcu).bits;
+            const bits = ty.intInfo(zcu).bits;
             if (bits <= 64) {
                 result[0] = .integer;
                 return result;
@@ -185,8 +185,8 @@ pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Con
             else => unreachable,
         },
         .Vector => {
-            const elem_ty = ty.childType(pt.zcu);
-            const bits = elem_ty.bitSize(pt) * ty.arrayLen(pt.zcu);
+            const elem_ty = ty.childType(zcu);
+            const bits = elem_ty.bitSize(zcu) * ty.arrayLen(zcu);
             if (elem_ty.toIntern() == .bool_type) {
                 if (bits <= 32) return .{
                     .integer, .none, .none, .none,
@@ -250,7 +250,7 @@ pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Con
             return memory_class;
         },
         .Optional => {
-            if (ty.isPtrLikeOptional(pt.zcu)) {
+            if (ty.isPtrLikeOptional(zcu)) {
                 result[0] = .integer;
                 return result;
             }
@@ -261,8 +261,8 @@ pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Con
             // it contains unaligned fields, it has class MEMORY"
             // "If the size of the aggregate exceeds a single eightbyte, each is classified
             // separately.".
-            const ty_size = ty.abiSize(pt);
-            switch (ty.containerLayout(pt.zcu)) {
+            const ty_size = ty.abiSize(zcu);
+            switch (ty.containerLayout(zcu)) {
                 .auto, .@"extern" => {},
                 .@"packed" => {
                     assert(ty_size <= 16);
@@ -274,10 +274,10 @@ pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Con
             if (ty_size > 64)
                 return memory_class;
 
-            _ = if (pt.zcu.typeToStruct(ty)) |loaded_struct|
-                classifySystemVStruct(&result, 0, loaded_struct, pt, target)
-            else if (pt.zcu.typeToUnion(ty)) |loaded_union|
-                classifySystemVUnion(&result, 0, loaded_union, pt, target)
+            _ = if (zcu.typeToStruct(ty)) |loaded_struct|
+                classifySystemVStruct(&result, 0, loaded_struct, zcu, target)
+            else if (zcu.typeToUnion(ty)) |loaded_union|
+                classifySystemVUnion(&result, 0, loaded_union, zcu, target)
             else
                 unreachable;
 
@@ -306,7 +306,7 @@ pub fn classifySystemV(ty: Type, pt: Zcu.PerThread, target: std.Target, ctx: Con
             return result;
         },
         .Array => {
-            const ty_size = ty.abiSize(pt);
+            const ty_size = ty.abiSize(zcu);
             if (ty_size <= 8) {
                 result[0] = .integer;
                 return result;
@@ -326,10 +326,10 @@ fn classifySystemVStruct(
     result: *[8]Class,
     starting_byte_offset: u64,
     loaded_struct: InternPool.LoadedStructType,
-    pt: Zcu.PerThread,
+    zcu: *Zcu,
     target: std.Target,
 ) u64 {
-    const ip = &pt.zcu.intern_pool;
+    const ip = &zcu.intern_pool;
     var byte_offset = starting_byte_offset;
     var field_it = loaded_struct.iterateRuntimeOrder(ip);
     while (field_it.next()) |field_index| {
@@ -338,29 +338,29 @@ fn classifySystemVStruct(
         byte_offset = std.mem.alignForward(
             u64,
             byte_offset,
-            field_align.toByteUnits() orelse field_ty.abiAlignment(pt).toByteUnits().?,
+            field_align.toByteUnits() orelse field_ty.abiAlignment(zcu).toByteUnits().?,
         );
-        if (pt.zcu.typeToStruct(field_ty)) |field_loaded_struct| {
+        if (zcu.typeToStruct(field_ty)) |field_loaded_struct| {
             switch (field_loaded_struct.layout) {
                 .auto, .@"extern" => {
-                    byte_offset = classifySystemVStruct(result, byte_offset, field_loaded_struct, pt, target);
+                    byte_offset = classifySystemVStruct(result, byte_offset, field_loaded_struct, zcu, target);
                     continue;
                 },
                 .@"packed" => {},
             }
-        } else if (pt.zcu.typeToUnion(field_ty)) |field_loaded_union| {
+        } else if (zcu.typeToUnion(field_ty)) |field_loaded_union| {
             switch (field_loaded_union.flagsUnordered(ip).layout) {
                 .auto, .@"extern" => {
-                    byte_offset = classifySystemVUnion(result, byte_offset, field_loaded_union, pt, target);
+                    byte_offset = classifySystemVUnion(result, byte_offset, field_loaded_union, zcu, target);
                     continue;
                 },
                 .@"packed" => {},
             }
         }
-        const field_classes = std.mem.sliceTo(&classifySystemV(field_ty, pt, target, .field), .none);
+        const field_classes = std.mem.sliceTo(&classifySystemV(field_ty, zcu, target, .field), .none);
         for (result[@intCast(byte_offset / 8)..][0..field_classes.len], field_classes) |*result_class, field_class|
             result_class.* = result_class.combineSystemV(field_class);
-        byte_offset += field_ty.abiSize(pt);
+        byte_offset += field_ty.abiSize(zcu);
     }
     const final_byte_offset = starting_byte_offset + loaded_struct.sizeUnordered(ip);
     std.debug.assert(final_byte_offset == std.mem.alignForward(
@@ -375,30 +375,30 @@ fn classifySystemVUnion(
     result: *[8]Class,
     starting_byte_offset: u64,
     loaded_union: InternPool.LoadedUnionType,
-    pt: Zcu.PerThread,
+    zcu: *Zcu,
     target: std.Target,
 ) u64 {
-    const ip = &pt.zcu.intern_pool;
+    const ip = &zcu.intern_pool;
     for (0..loaded_union.field_types.len) |field_index| {
         const field_ty = Type.fromInterned(loaded_union.field_types.get(ip)[field_index]);
-        if (pt.zcu.typeToStruct(field_ty)) |field_loaded_struct| {
+        if (zcu.typeToStruct(field_ty)) |field_loaded_struct| {
             switch (field_loaded_struct.layout) {
                 .auto, .@"extern" => {
-                    _ = classifySystemVStruct(result, starting_byte_offset, field_loaded_struct, pt, target);
+                    _ = classifySystemVStruct(result, starting_byte_offset, field_loaded_struct, zcu, target);
                     continue;
                 },
                 .@"packed" => {},
             }
-        } else if (pt.zcu.typeToUnion(field_ty)) |field_loaded_union| {
+        } else if (zcu.typeToUnion(field_ty)) |field_loaded_union| {
             switch (field_loaded_union.flagsUnordered(ip).layout) {
                 .auto, .@"extern" => {
-                    _ = classifySystemVUnion(result, starting_byte_offset, field_loaded_union, pt, target);
+                    _ = classifySystemVUnion(result, starting_byte_offset, field_loaded_union, zcu, target);
                     continue;
                 },
                 .@"packed" => {},
             }
         }
-        const field_classes = std.mem.sliceTo(&classifySystemV(field_ty, pt, target, .field), .none);
+        const field_classes = std.mem.sliceTo(&classifySystemV(field_ty, zcu, target, .field), .none);
         for (result[@intCast(starting_byte_offset / 8)..][0..field_classes.len], field_classes) |*result_class, field_class|
             result_class.* = result_class.combineSystemV(field_class);
     }

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -7206,7 +7206,7 @@ fn airAggregateInit(f: *Function, inst: Air.Inst.Index) !CValue {
                     var empty = true;
                     for (0..elements.len) |field_index| {
                         if (inst_ty.structFieldIsComptime(field_index, zcu)) continue;
-                        const field_ty = inst_ty.structFieldType(field_index, zcu);
+                        const field_ty = inst_ty.fieldType(field_index, zcu);
                         if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
                         if (!empty) {
@@ -7219,7 +7219,7 @@ fn airAggregateInit(f: *Function, inst: Air.Inst.Index) !CValue {
                     empty = true;
                     for (resolved_elements, 0..) |element, field_index| {
                         if (inst_ty.structFieldIsComptime(field_index, zcu)) continue;
-                        const field_ty = inst_ty.structFieldType(field_index, zcu);
+                        const field_ty = inst_ty.fieldType(field_index, zcu);
                         if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
                         if (!empty) try writer.writeAll(", ");

--- a/src/codegen/c/Type.zig
+++ b/src/codegen/c/Type.zig
@@ -1344,6 +1344,7 @@ pub const Pool = struct {
         kind: Kind,
     ) !CType {
         const ip = &pt.zcu.intern_pool;
+        const zcu = pt.zcu;
         switch (ty.toIntern()) {
             .u0_type,
             .i0_type,
@@ -1476,7 +1477,7 @@ pub const Pool = struct {
                                 ),
                                 .alignas = AlignAs.fromAlignment(.{
                                     .@"align" = ptr_info.flags.alignment,
-                                    .abi = Type.fromInterned(ptr_info.child).abiAlignment(pt),
+                                    .abi = Type.fromInterned(ptr_info.child).abiAlignment(zcu),
                                 }),
                             };
                             break :elem_ctype if (elem.alignas.abiOrder().compare(.gte))
@@ -1552,7 +1553,7 @@ pub const Pool = struct {
                         .{
                             .name = .{ .index = .array },
                             .ctype = array_ctype,
-                            .alignas = AlignAs.fromAbiAlignment(elem_type.abiAlignment(pt)),
+                            .alignas = AlignAs.fromAbiAlignment(elem_type.abiAlignment(zcu)),
                         },
                     };
                     return pool.fromFields(allocator, .@"struct", &fields, kind);
@@ -1578,7 +1579,7 @@ pub const Pool = struct {
                         .{
                             .name = .{ .index = .array },
                             .ctype = vector_ctype,
-                            .alignas = AlignAs.fromAbiAlignment(elem_type.abiAlignment(pt)),
+                            .alignas = AlignAs.fromAbiAlignment(elem_type.abiAlignment(zcu)),
                         },
                     };
                     return pool.fromFields(allocator, .@"struct", &fields, kind);
@@ -1613,7 +1614,7 @@ pub const Pool = struct {
                             .name = .{ .index = .payload },
                             .ctype = payload_ctype,
                             .alignas = AlignAs.fromAbiAlignment(
-                                Type.fromInterned(payload_type).abiAlignment(pt),
+                                Type.fromInterned(payload_type).abiAlignment(zcu),
                             ),
                         },
                     };
@@ -1649,7 +1650,7 @@ pub const Pool = struct {
                         .{
                             .name = .{ .index = .payload },
                             .ctype = payload_ctype,
-                            .alignas = AlignAs.fromAbiAlignment(payload_type.abiAlignment(pt)),
+                            .alignas = AlignAs.fromAbiAlignment(payload_type.abiAlignment(zcu)),
                         },
                     };
                     return pool.fromFields(allocator, .@"struct", &fields, kind);
@@ -1663,7 +1664,7 @@ pub const Pool = struct {
                                 .tag = .@"struct",
                                 .name = .{ .index = ip_index },
                             });
-                            if (kind.isForward()) return if (ty.hasRuntimeBitsIgnoreComptime(pt))
+                            if (kind.isForward()) return if (ty.hasRuntimeBitsIgnoreComptime(zcu))
                                 fwd_decl
                             else
                                 CType.void;
@@ -1696,7 +1697,7 @@ pub const Pool = struct {
                                     String.fromUnnamed(@intCast(field_index));
                                 const field_alignas = AlignAs.fromAlignment(.{
                                     .@"align" = loaded_struct.fieldAlign(ip, field_index),
-                                    .abi = field_type.abiAlignment(pt),
+                                    .abi = field_type.abiAlignment(zcu),
                                 });
                                 pool.addHashedExtraAssumeCapacityTo(scratch, &hasher, Field, .{
                                     .name = field_name.index,
@@ -1758,7 +1759,7 @@ pub const Pool = struct {
                             .name = field_name.index,
                             .ctype = field_ctype.index,
                             .flags = .{ .alignas = AlignAs.fromAbiAlignment(
-                                field_type.abiAlignment(pt),
+                                field_type.abiAlignment(zcu),
                             ) },
                         });
                     }
@@ -1802,7 +1803,7 @@ pub const Pool = struct {
                                 .tag = if (has_tag) .@"struct" else .@"union",
                                 .name = .{ .index = ip_index },
                             });
-                            if (kind.isForward()) return if (ty.hasRuntimeBitsIgnoreComptime(pt))
+                            if (kind.isForward()) return if (ty.hasRuntimeBitsIgnoreComptime(zcu))
                                 fwd_decl
                             else
                                 CType.void;
@@ -1836,7 +1837,7 @@ pub const Pool = struct {
                                 );
                                 const field_alignas = AlignAs.fromAlignment(.{
                                     .@"align" = loaded_union.fieldAlign(ip, field_index),
-                                    .abi = field_type.abiAlignment(pt),
+                                    .abi = field_type.abiAlignment(zcu),
                                 });
                                 pool.addHashedExtraAssumeCapacityTo(scratch, &hasher, Field, .{
                                     .name = field_name.index,
@@ -1881,7 +1882,7 @@ pub const Pool = struct {
                                     struct_fields[struct_fields_len] = .{
                                         .name = .{ .index = .tag },
                                         .ctype = tag_ctype,
-                                        .alignas = AlignAs.fromAbiAlignment(tag_type.abiAlignment(pt)),
+                                        .alignas = AlignAs.fromAbiAlignment(tag_type.abiAlignment(zcu)),
                                     };
                                     struct_fields_len += 1;
                                 }
@@ -1929,7 +1930,7 @@ pub const Pool = struct {
                         },
                         .@"packed" => return pool.fromIntInfo(allocator, .{
                             .signedness = .unsigned,
-                            .bits = @intCast(ty.bitSize(pt)),
+                            .bits = @intCast(ty.bitSize(zcu)),
                         }, mod, kind),
                     }
                 },

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1001,12 +1001,12 @@ pub const Object = struct {
         if (o.error_name_table == .none) return;
 
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
 
         const error_name_list = ip.global_error_set.getNamesFromMainThread();
-        const llvm_errors = try mod.gpa.alloc(Builder.Constant, 1 + error_name_list.len);
-        defer mod.gpa.free(llvm_errors);
+        const llvm_errors = try zcu.gpa.alloc(Builder.Constant, 1 + error_name_list.len);
+        defer zcu.gpa.free(llvm_errors);
 
         // TODO: Address space
         const slice_ty = Type.slice_const_u8_sentinel_0;
@@ -1041,7 +1041,7 @@ pub const Object = struct {
         table_variable_index.setMutability(.constant, &o.builder);
         table_variable_index.setUnnamedAddr(.unnamed_addr, &o.builder);
         table_variable_index.setAlignment(
-            slice_ty.abiAlignment(pt).toLlvm(),
+            slice_ty.abiAlignment(zcu).toLlvm(),
             &o.builder,
         );
 
@@ -1428,7 +1428,7 @@ pub const Object = struct {
         var llvm_arg_i: u32 = 0;
 
         // This gets the LLVM values from the function and stores them in `ng.args`.
-        const sret = firstParamSRet(fn_info, pt, target);
+        const sret = firstParamSRet(fn_info, zcu, target);
         const ret_ptr: Builder.Value = if (sret) param: {
             const param = wip.arg(llvm_arg_i);
             llvm_arg_i += 1;
@@ -1469,8 +1469,8 @@ pub const Object = struct {
                         const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[param_index]);
                         const param = wip.arg(llvm_arg_i);
 
-                        if (isByRef(param_ty, pt)) {
-                            const alignment = param_ty.abiAlignment(pt).toLlvm();
+                        if (isByRef(param_ty, zcu)) {
+                            const alignment = param_ty.abiAlignment(zcu).toLlvm();
                             const param_llvm_ty = param.typeOfWip(&wip);
                             const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, alignment, target);
                             _ = try wip.store(.normal, param, arg_ptr, alignment);
@@ -1486,12 +1486,12 @@ pub const Object = struct {
                         const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                         const param_llvm_ty = try o.lowerType(param_ty);
                         const param = wip.arg(llvm_arg_i);
-                        const alignment = param_ty.abiAlignment(pt).toLlvm();
+                        const alignment = param_ty.abiAlignment(zcu).toLlvm();
 
                         try o.addByRefParamAttrs(&attributes, llvm_arg_i, alignment, it.byval_attr, param_llvm_ty);
                         llvm_arg_i += 1;
 
-                        if (isByRef(param_ty, pt)) {
+                        if (isByRef(param_ty, zcu)) {
                             args.appendAssumeCapacity(param);
                         } else {
                             args.appendAssumeCapacity(try wip.load(.normal, param_llvm_ty, param, alignment, ""));
@@ -1501,12 +1501,12 @@ pub const Object = struct {
                         const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                         const param_llvm_ty = try o.lowerType(param_ty);
                         const param = wip.arg(llvm_arg_i);
-                        const alignment = param_ty.abiAlignment(pt).toLlvm();
+                        const alignment = param_ty.abiAlignment(zcu).toLlvm();
 
                         try attributes.addParamAttr(llvm_arg_i, .noundef, &o.builder);
                         llvm_arg_i += 1;
 
-                        if (isByRef(param_ty, pt)) {
+                        if (isByRef(param_ty, zcu)) {
                             args.appendAssumeCapacity(param);
                         } else {
                             args.appendAssumeCapacity(try wip.load(.normal, param_llvm_ty, param, alignment, ""));
@@ -1519,11 +1519,11 @@ pub const Object = struct {
                         llvm_arg_i += 1;
 
                         const param_llvm_ty = try o.lowerType(param_ty);
-                        const alignment = param_ty.abiAlignment(pt).toLlvm();
+                        const alignment = param_ty.abiAlignment(zcu).toLlvm();
                         const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, alignment, target);
                         _ = try wip.store(.normal, param, arg_ptr, alignment);
 
-                        args.appendAssumeCapacity(if (isByRef(param_ty, pt))
+                        args.appendAssumeCapacity(if (isByRef(param_ty, zcu))
                             arg_ptr
                         else
                             try wip.load(.normal, param_llvm_ty, arg_ptr, alignment, ""));
@@ -1547,7 +1547,7 @@ pub const Object = struct {
                         const elem_align = (if (ptr_info.flags.alignment != .none)
                             @as(InternPool.Alignment, ptr_info.flags.alignment)
                         else
-                            Type.fromInterned(ptr_info.child).abiAlignment(pt).max(.@"1")).toLlvm();
+                            Type.fromInterned(ptr_info.child).abiAlignment(zcu).max(.@"1")).toLlvm();
                         try attributes.addParamAttr(llvm_arg_i, .{ .@"align" = elem_align }, &o.builder);
                         const ptr_param = wip.arg(llvm_arg_i);
                         llvm_arg_i += 1;
@@ -1564,7 +1564,7 @@ pub const Object = struct {
                         const field_types = it.types_buffer[0..it.types_len];
                         const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                         const param_llvm_ty = try o.lowerType(param_ty);
-                        const param_alignment = param_ty.abiAlignment(pt).toLlvm();
+                        const param_alignment = param_ty.abiAlignment(zcu).toLlvm();
                         const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, param_alignment, target);
                         const llvm_ty = try o.builder.structType(.normal, field_types);
                         for (0..field_types.len) |field_i| {
@@ -1576,7 +1576,7 @@ pub const Object = struct {
                             _ = try wip.store(.normal, param, field_ptr, alignment);
                         }
 
-                        const is_by_ref = isByRef(param_ty, pt);
+                        const is_by_ref = isByRef(param_ty, zcu);
                         args.appendAssumeCapacity(if (is_by_ref)
                             arg_ptr
                         else
@@ -1594,11 +1594,11 @@ pub const Object = struct {
                         const param = wip.arg(llvm_arg_i);
                         llvm_arg_i += 1;
 
-                        const alignment = param_ty.abiAlignment(pt).toLlvm();
+                        const alignment = param_ty.abiAlignment(zcu).toLlvm();
                         const arg_ptr = try buildAllocaInner(&wip, param_llvm_ty, alignment, target);
                         _ = try wip.store(.normal, param, arg_ptr, alignment);
 
-                        args.appendAssumeCapacity(if (isByRef(param_ty, pt))
+                        args.appendAssumeCapacity(if (isByRef(param_ty, zcu))
                             arg_ptr
                         else
                             try wip.load(.normal, param_llvm_ty, arg_ptr, alignment, ""));
@@ -1609,11 +1609,11 @@ pub const Object = struct {
                         const param = wip.arg(llvm_arg_i);
                         llvm_arg_i += 1;
 
-                        const alignment = param_ty.abiAlignment(pt).toLlvm();
+                        const alignment = param_ty.abiAlignment(zcu).toLlvm();
                         const arg_ptr = try buildAllocaInner(&wip, param.typeOfWip(&wip), alignment, target);
                         _ = try wip.store(.normal, param, arg_ptr, alignment);
 
-                        args.appendAssumeCapacity(if (isByRef(param_ty, pt))
+                        args.appendAssumeCapacity(if (isByRef(param_ty, zcu))
                             arg_ptr
                         else
                             try wip.load(.normal, param_llvm_ty, arg_ptr, alignment, ""));
@@ -1738,13 +1738,13 @@ pub const Object = struct {
 
     fn updateExportedValue(
         o: *Object,
-        mod: *Zcu,
+        zcu: *Zcu,
         exported_value: InternPool.Index,
         export_indices: []const u32,
     ) link.File.UpdateExportsError!void {
-        const gpa = mod.gpa;
-        const ip = &mod.intern_pool;
-        const main_exp_name = try o.builder.strtabString(mod.all_exports.items[export_indices[0]].opts.name.toSlice(ip));
+        const gpa = zcu.gpa;
+        const ip = &zcu.intern_pool;
+        const main_exp_name = try o.builder.strtabString(zcu.all_exports.items[export_indices[0]].opts.name.toSlice(ip));
         const global_index = i: {
             const gop = try o.uav_map.getOrPut(gpa, exported_value);
             if (gop.found_existing) {
@@ -1768,18 +1768,18 @@ pub const Object = struct {
             try variable_index.setInitializer(init_val, &o.builder);
             break :i global_index;
         };
-        return updateExportedGlobal(o, mod, global_index, export_indices);
+        return updateExportedGlobal(o, zcu, global_index, export_indices);
     }
 
     fn updateExportedGlobal(
         o: *Object,
-        mod: *Zcu,
+        zcu: *Zcu,
         global_index: Builder.Global.Index,
         export_indices: []const u32,
     ) link.File.UpdateExportsError!void {
-        const comp = mod.comp;
-        const ip = &mod.intern_pool;
-        const first_export = mod.all_exports.items[export_indices[0]];
+        const comp = zcu.comp;
+        const ip = &zcu.intern_pool;
+        const first_export = zcu.all_exports.items[export_indices[0]];
 
         // We will rename this global to have a name matching `first_export`.
         // Successive exports become aliases.
@@ -1836,7 +1836,7 @@ pub const Object = struct {
         // Until then we iterate over existing aliases and make them point
         // to the correct decl, or otherwise add a new alias. Old aliases are leaked.
         for (export_indices[1..]) |export_idx| {
-            const exp = mod.all_exports.items[export_idx];
+            const exp = zcu.all_exports.items[export_idx];
             const exp_name = try o.builder.strtabString(exp.opts.name.toSlice(ip));
             if (o.builder.getGlobal(exp_name)) |global| {
                 switch (global.ptrConst(&o.builder).kind) {
@@ -1923,7 +1923,7 @@ pub const Object = struct {
                 const name = try o.allocTypeName(ty);
                 defer gpa.free(name);
                 const builder_name = try o.builder.metadataString(name);
-                const debug_bits = ty.abiSize(pt) * 8; // lldb cannot handle non-byte sized types
+                const debug_bits = ty.abiSize(zcu) * 8; // lldb cannot handle non-byte sized types
                 const debug_int_type = switch (info.signedness) {
                     .signed => try o.builder.debugSignedType(builder_name, debug_bits),
                     .unsigned => try o.builder.debugUnsignedType(builder_name, debug_bits),
@@ -1932,7 +1932,7 @@ pub const Object = struct {
                 return debug_int_type;
             },
             .Enum => {
-                if (!ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     const debug_enum_type = try o.makeEmptyNamespaceDebugType(ty);
                     try o.debug_type_map.put(gpa, ty, debug_enum_type);
                     return debug_enum_type;
@@ -1949,7 +1949,7 @@ pub const Object = struct {
                 for (enum_type.names.get(ip), 0..) |field_name_ip, i| {
                     var bigint_space: Value.BigIntSpace = undefined;
                     const bigint = if (enum_type.values.len != 0)
-                        Value.fromInterned(enum_type.values.get(ip)[i]).toBigInt(&bigint_space, pt)
+                        Value.fromInterned(enum_type.values.get(ip)[i]).toBigInt(&bigint_space, zcu)
                     else
                         std.math.big.int.Mutable.init(&bigint_space.limbs, i).toConst();
 
@@ -1976,8 +1976,8 @@ pub const Object = struct {
                     scope,
                     ty.typeDeclSrcLine(zcu).? + 1, // Line
                     try o.lowerDebugType(int_ty),
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(enumerators),
                 );
 
@@ -2017,10 +2017,10 @@ pub const Object = struct {
                     ptr_info.flags.is_const or
                     ptr_info.flags.is_volatile or
                     ptr_info.flags.size == .Many or ptr_info.flags.size == .C or
-                    !Type.fromInterned(ptr_info.child).hasRuntimeBitsIgnoreComptime(pt))
+                    !Type.fromInterned(ptr_info.child).hasRuntimeBitsIgnoreComptime(zcu))
                 {
                     const bland_ptr_ty = try pt.ptrType(.{
-                        .child = if (!Type.fromInterned(ptr_info.child).hasRuntimeBitsIgnoreComptime(pt))
+                        .child = if (!Type.fromInterned(ptr_info.child).hasRuntimeBitsIgnoreComptime(zcu))
                             .anyopaque_type
                         else
                             ptr_info.child,
@@ -2050,10 +2050,10 @@ pub const Object = struct {
                     defer gpa.free(name);
                     const line = 0;
 
-                    const ptr_size = ptr_ty.abiSize(pt);
-                    const ptr_align = ptr_ty.abiAlignment(pt);
-                    const len_size = len_ty.abiSize(pt);
-                    const len_align = len_ty.abiAlignment(pt);
+                    const ptr_size = ptr_ty.abiSize(zcu);
+                    const ptr_align = ptr_ty.abiAlignment(zcu);
+                    const len_size = len_ty.abiSize(zcu);
+                    const len_align = len_ty.abiAlignment(zcu);
 
                     const len_offset = len_align.forward(ptr_size);
 
@@ -2085,8 +2085,8 @@ pub const Object = struct {
                         o.debug_compile_unit, // Scope
                         line,
                         .none, // Underlying type
-                        ty.abiSize(pt) * 8,
-                        (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                        ty.abiSize(zcu) * 8,
+                        (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                         try o.builder.debugTuple(&.{
                             debug_ptr_type,
                             debug_len_type,
@@ -2114,7 +2114,7 @@ pub const Object = struct {
                     0, // Line
                     debug_elem_ty,
                     target.ptrBitWidth(),
-                    (ty.ptrAlignment(pt).toByteUnits() orelse 0) * 8,
+                    (ty.ptrAlignment(zcu).toByteUnits() orelse 0) * 8,
                     0, // Offset
                 );
 
@@ -2165,8 +2165,8 @@ pub const Object = struct {
                     .none, // Scope
                     0, // Line
                     try o.lowerDebugType(ty.childType(zcu)),
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(&.{
                         try o.builder.debugSubrange(
                             try o.builder.debugConstant(try o.builder.intConst(.i64, 0)),
@@ -2208,8 +2208,8 @@ pub const Object = struct {
                     .none, // Scope
                     0, // Line
                     debug_elem_type,
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(&.{
                         try o.builder.debugSubrange(
                             try o.builder.debugConstant(try o.builder.intConst(.i64, 0)),
@@ -2225,7 +2225,7 @@ pub const Object = struct {
                 const name = try o.allocTypeName(ty);
                 defer gpa.free(name);
                 const child_ty = ty.optionalChild(zcu);
-                if (!child_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!child_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     const debug_bool_type = try o.builder.debugBoolType(
                         try o.builder.metadataString(name),
                         8,
@@ -2252,10 +2252,10 @@ pub const Object = struct {
                 }
 
                 const non_null_ty = Type.u8;
-                const payload_size = child_ty.abiSize(pt);
-                const payload_align = child_ty.abiAlignment(pt);
-                const non_null_size = non_null_ty.abiSize(pt);
-                const non_null_align = non_null_ty.abiAlignment(pt);
+                const payload_size = child_ty.abiSize(zcu);
+                const payload_align = child_ty.abiAlignment(zcu);
+                const non_null_size = non_null_ty.abiSize(zcu);
+                const non_null_align = non_null_ty.abiAlignment(zcu);
                 const non_null_offset = non_null_align.forward(payload_size);
 
                 const debug_data_type = try o.builder.debugMemberType(
@@ -2286,8 +2286,8 @@ pub const Object = struct {
                     o.debug_compile_unit, // Scope
                     0, // Line
                     .none, // Underlying type
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(&.{
                         debug_data_type,
                         debug_some_type,
@@ -2304,7 +2304,7 @@ pub const Object = struct {
             },
             .ErrorUnion => {
                 const payload_ty = ty.errorUnionPayload(zcu);
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     // TODO: Maybe remove?
                     const debug_error_union_type = try o.lowerDebugType(Type.anyerror);
                     try o.debug_type_map.put(gpa, ty, debug_error_union_type);
@@ -2314,10 +2314,10 @@ pub const Object = struct {
                 const name = try o.allocTypeName(ty);
                 defer gpa.free(name);
 
-                const error_size = Type.anyerror.abiSize(pt);
-                const error_align = Type.anyerror.abiAlignment(pt);
-                const payload_size = payload_ty.abiSize(pt);
-                const payload_align = payload_ty.abiAlignment(pt);
+                const error_size = Type.anyerror.abiSize(zcu);
+                const error_align = Type.anyerror.abiAlignment(zcu);
+                const payload_size = payload_ty.abiSize(zcu);
+                const payload_align = payload_ty.abiAlignment(zcu);
 
                 var error_index: u32 = undefined;
                 var payload_index: u32 = undefined;
@@ -2365,8 +2365,8 @@ pub const Object = struct {
                     o.debug_compile_unit, // Sope
                     0, // Line
                     .none, // Underlying type
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(&fields),
                 );
 
@@ -2393,8 +2393,8 @@ pub const Object = struct {
                         const info = Type.fromInterned(backing_int_ty).intInfo(zcu);
                         const builder_name = try o.builder.metadataString(name);
                         const debug_int_type = switch (info.signedness) {
-                            .signed => try o.builder.debugSignedType(builder_name, ty.abiSize(pt) * 8),
-                            .unsigned => try o.builder.debugUnsignedType(builder_name, ty.abiSize(pt) * 8),
+                            .signed => try o.builder.debugSignedType(builder_name, ty.abiSize(zcu) * 8),
+                            .unsigned => try o.builder.debugUnsignedType(builder_name, ty.abiSize(zcu) * 8),
                         };
                         try o.debug_type_map.put(gpa, ty, debug_int_type);
                         return debug_int_type;
@@ -2414,10 +2414,10 @@ pub const Object = struct {
                         const debug_fwd_ref = try o.builder.debugForwardReference();
 
                         for (tuple.types.get(ip), tuple.values.get(ip), 0..) |field_ty, field_val, i| {
-                            if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(pt)) continue;
+                            if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(zcu)) continue;
 
-                            const field_size = Type.fromInterned(field_ty).abiSize(pt);
-                            const field_align = Type.fromInterned(field_ty).abiAlignment(pt);
+                            const field_size = Type.fromInterned(field_ty).abiSize(zcu);
+                            const field_align = Type.fromInterned(field_ty).abiAlignment(zcu);
                             const field_offset = field_align.forward(offset);
                             offset = field_offset + field_size;
 
@@ -2445,8 +2445,8 @@ pub const Object = struct {
                             o.debug_compile_unit, // Scope
                             0, // Line
                             .none, // Underlying type
-                            ty.abiSize(pt) * 8,
-                            (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                            ty.abiSize(zcu) * 8,
+                            (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                             try o.builder.debugTuple(fields.items),
                         );
 
@@ -2472,7 +2472,7 @@ pub const Object = struct {
                     else => {},
                 }
 
-                if (!ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     const debug_struct_type = try o.makeEmptyNamespaceDebugType(ty);
                     try o.debug_type_map.put(gpa, ty, debug_struct_type);
                     return debug_struct_type;
@@ -2494,14 +2494,14 @@ pub const Object = struct {
                 var it = struct_type.iterateRuntimeOrder(ip);
                 while (it.next()) |field_index| {
                     const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
-                    if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
-                    const field_size = field_ty.abiSize(pt);
+                    if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
+                    const field_size = field_ty.abiSize(zcu);
                     const field_align = pt.structFieldAlignment(
                         struct_type.fieldAlign(ip, field_index),
                         field_ty,
                         struct_type.layout,
                     );
-                    const field_offset = ty.structFieldOffset(field_index, pt);
+                    const field_offset = ty.structFieldOffset(field_index, zcu);
 
                     const field_name = struct_type.fieldName(ip, field_index).unwrap() orelse
                         try ip.getOrPutStringFmt(gpa, pt.tid, "{d}", .{field_index}, .no_embedded_nulls);
@@ -2524,8 +2524,8 @@ pub const Object = struct {
                     o.debug_compile_unit, // Scope
                     0, // Line
                     .none, // Underlying type
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(fields.items),
                 );
 
@@ -2543,7 +2543,7 @@ pub const Object = struct {
 
                 const union_type = ip.loadUnionType(ty.toIntern());
                 if (!union_type.haveFieldTypes(ip) or
-                    !ty.hasRuntimeBitsIgnoreComptime(pt) or
+                    !ty.hasRuntimeBitsIgnoreComptime(zcu) or
                     !union_type.haveLayout(ip))
                 {
                     const debug_union_type = try o.makeEmptyNamespaceDebugType(ty);
@@ -2551,7 +2551,7 @@ pub const Object = struct {
                     return debug_union_type;
                 }
 
-                const layout = pt.getUnionLayout(union_type);
+                const layout = Type.getUnionLayout(union_type, zcu);
 
                 const debug_fwd_ref = try o.builder.debugForwardReference();
 
@@ -2565,8 +2565,8 @@ pub const Object = struct {
                         o.debug_compile_unit, // Scope
                         0, // Line
                         .none, // Underlying type
-                        ty.abiSize(pt) * 8,
-                        (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                        ty.abiSize(zcu) * 8,
+                        (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                         try o.builder.debugTuple(
                             &.{try o.lowerDebugType(Type.fromInterned(union_type.enum_tag_ty))},
                         ),
@@ -2593,12 +2593,12 @@ pub const Object = struct {
 
                 for (0..tag_type.names.len) |field_index| {
                     const field_ty = union_type.field_types.get(ip)[field_index];
-                    if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(pt)) continue;
+                    if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
-                    const field_size = Type.fromInterned(field_ty).abiSize(pt);
+                    const field_size = Type.fromInterned(field_ty).abiSize(zcu);
                     const field_align: InternPool.Alignment = switch (union_type.flagsUnordered(ip).layout) {
                         .@"packed" => .none,
-                        .auto, .@"extern" => pt.unionFieldNormalAlignment(union_type, @intCast(field_index)),
+                        .auto, .@"extern" => Type.unionFieldNormalAlignment(union_type, @intCast(field_index), zcu),
                     };
 
                     const field_name = tag_type.names.get(ip)[field_index];
@@ -2627,8 +2627,8 @@ pub const Object = struct {
                     o.debug_compile_unit, // Scope
                     0, // Line
                     .none, // Underlying type
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(fields.items),
                 );
 
@@ -2686,8 +2686,8 @@ pub const Object = struct {
                     o.debug_compile_unit, // Scope
                     0, // Line
                     .none, // Underlying type
-                    ty.abiSize(pt) * 8,
-                    (ty.abiAlignment(pt).toByteUnits() orelse 0) * 8,
+                    ty.abiSize(zcu) * 8,
+                    (ty.abiAlignment(zcu).toByteUnits() orelse 0) * 8,
                     try o.builder.debugTuple(&full_fields),
                 );
 
@@ -2708,8 +2708,8 @@ pub const Object = struct {
                 try debug_param_types.ensureUnusedCapacity(3 + fn_info.param_types.len);
 
                 // Return type goes first.
-                if (Type.fromInterned(fn_info.return_type).hasRuntimeBitsIgnoreComptime(pt)) {
-                    const sret = firstParamSRet(fn_info, pt, target);
+                if (Type.fromInterned(fn_info.return_type).hasRuntimeBitsIgnoreComptime(zcu)) {
+                    const sret = firstParamSRet(fn_info, zcu, target);
                     const ret_ty = if (sret) Type.void else Type.fromInterned(fn_info.return_type);
                     debug_param_types.appendAssumeCapacity(try o.lowerDebugType(ret_ty));
 
@@ -2730,9 +2730,9 @@ pub const Object = struct {
 
                 for (0..fn_info.param_types.len) |i| {
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[i]);
-                    if (!param_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                    if (!param_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
-                    if (isByRef(param_ty, pt)) {
+                    if (isByRef(param_ty, zcu)) {
                         const ptr_ty = try pt.singleMutPtrType(param_ty);
                         debug_param_types.appendAssumeCapacity(try o.lowerDebugType(ptr_ty));
                     } else {
@@ -2842,7 +2842,7 @@ pub const Object = struct {
 
         const fn_info = zcu.typeToFunc(ty).?;
         const target = owner_mod.resolved_target.result;
-        const sret = firstParamSRet(fn_info, pt, target);
+        const sret = firstParamSRet(fn_info, zcu, target);
 
         const is_extern, const lib_name = switch (ip.indexToKey(val.toIntern())) {
             .variable => |variable| .{ false, variable.lib_name },
@@ -2934,14 +2934,14 @@ pub const Object = struct {
                 .byval => {
                     const param_index = it.zig_index - 1;
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[param_index]);
-                    if (!isByRef(param_ty, pt)) {
+                    if (!isByRef(param_ty, zcu)) {
                         try o.addByValParamAttrs(&attributes, param_ty, param_index, fn_info, it.llvm_index - 1);
                     }
                 },
                 .byref => {
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                     const param_llvm_ty = try o.lowerType(param_ty);
-                    const alignment = param_ty.abiAlignment(pt);
+                    const alignment = param_ty.abiAlignment(zcu);
                     try o.addByRefParamAttrs(&attributes, it.llvm_index - 1, alignment.toLlvm(), it.byval_attr, param_llvm_ty);
                 },
                 .byref_mut => try attributes.addParamAttr(it.llvm_index - 1, .noundef, &o.builder),
@@ -3042,8 +3042,8 @@ pub const Object = struct {
         }
         errdefer assert(o.uav_map.remove(uav));
 
-        const mod = o.pt.zcu;
-        const decl_ty = mod.intern_pool.typeOf(uav);
+        const zcu = o.pt.zcu;
+        const decl_ty = zcu.intern_pool.typeOf(uav);
 
         const variable_index = try o.builder.addVariable(
             try o.builder.strtabStringFmt("__anon_{d}", .{@intFromEnum(uav)}),
@@ -3106,9 +3106,9 @@ pub const Object = struct {
 
     fn lowerType(o: *Object, t: Type) Allocator.Error!Builder.Type {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const target = mod.getTarget();
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const target = zcu.getTarget();
+        const ip = &zcu.intern_pool;
         return switch (t.toIntern()) {
             .u0_type, .i0_type => unreachable,
             inline .u1_type,
@@ -3230,16 +3230,16 @@ pub const Object = struct {
                 ),
                 .opt_type => |child_ty| {
                     // Must stay in sync with `opt_payload` logic in `lowerPtr`.
-                    if (!Type.fromInterned(child_ty).hasRuntimeBitsIgnoreComptime(pt)) return .i8;
+                    if (!Type.fromInterned(child_ty).hasRuntimeBitsIgnoreComptime(zcu)) return .i8;
 
                     const payload_ty = try o.lowerType(Type.fromInterned(child_ty));
-                    if (t.optionalReprIsPayload(mod)) return payload_ty;
+                    if (t.optionalReprIsPayload(zcu)) return payload_ty;
 
                     comptime assert(optional_layout_version == 3);
                     var fields: [3]Builder.Type = .{ payload_ty, .i8, undefined };
                     var fields_len: usize = 2;
-                    const offset = Type.fromInterned(child_ty).abiSize(pt) + 1;
-                    const abi_size = t.abiSize(pt);
+                    const offset = Type.fromInterned(child_ty).abiSize(zcu) + 1;
+                    const abi_size = t.abiSize(zcu);
                     const padding_len = abi_size - offset;
                     if (padding_len > 0) {
                         fields[2] = try o.builder.arrayType(padding_len, .i8);
@@ -3252,16 +3252,16 @@ pub const Object = struct {
                     // Must stay in sync with `codegen.errUnionPayloadOffset`.
                     // See logic in `lowerPtr`.
                     const error_type = try o.errorIntType();
-                    if (!Type.fromInterned(error_union_type.payload_type).hasRuntimeBitsIgnoreComptime(pt))
+                    if (!Type.fromInterned(error_union_type.payload_type).hasRuntimeBitsIgnoreComptime(zcu))
                         return error_type;
                     const payload_type = try o.lowerType(Type.fromInterned(error_union_type.payload_type));
                     const err_int_ty = try o.pt.errorIntType();
 
-                    const payload_align = Type.fromInterned(error_union_type.payload_type).abiAlignment(pt);
-                    const error_align = err_int_ty.abiAlignment(pt);
+                    const payload_align = Type.fromInterned(error_union_type.payload_type).abiAlignment(zcu);
+                    const error_align = err_int_ty.abiAlignment(zcu);
 
-                    const payload_size = Type.fromInterned(error_union_type.payload_type).abiSize(pt);
-                    const error_size = err_int_ty.abiSize(pt);
+                    const payload_size = Type.fromInterned(error_union_type.payload_type).abiSize(zcu);
+                    const error_size = err_int_ty.abiSize(zcu);
 
                     var fields: [3]Builder.Type = undefined;
                     var fields_len: usize = 2;
@@ -3320,7 +3320,7 @@ pub const Object = struct {
                             field_ty,
                             struct_type.layout,
                         );
-                        const field_ty_align = field_ty.abiAlignment(pt);
+                        const field_ty_align = field_ty.abiAlignment(zcu);
                         if (field_align.compare(.lt, field_ty_align)) struct_kind = .@"packed";
                         big_align = big_align.max(field_align);
                         const prev_offset = offset;
@@ -3332,7 +3332,7 @@ pub const Object = struct {
                             try o.builder.arrayType(padding_len, .i8),
                         );
 
-                        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                             // This is a zero-bit field. If there are runtime bits after this field,
                             // map to the next LLVM field (which we know exists): otherwise, don't
                             // map the field, indicating it's at the end of the struct.
@@ -3351,7 +3351,7 @@ pub const Object = struct {
                         }, @intCast(llvm_field_types.items.len));
                         try llvm_field_types.append(o.gpa, try o.lowerType(field_ty));
 
-                        offset += field_ty.abiSize(pt);
+                        offset += field_ty.abiSize(zcu);
                     }
                     {
                         const prev_offset = offset;
@@ -3384,7 +3384,7 @@ pub const Object = struct {
                     var offset: u64 = 0;
                     var big_align: InternPool.Alignment = .none;
 
-                    const struct_size = t.abiSize(pt);
+                    const struct_size = t.abiSize(zcu);
 
                     for (
                         anon_struct_type.types.get(ip),
@@ -3393,7 +3393,7 @@ pub const Object = struct {
                     ) |field_ty, field_val, field_index| {
                         if (field_val != .none) continue;
 
-                        const field_align = Type.fromInterned(field_ty).abiAlignment(pt);
+                        const field_align = Type.fromInterned(field_ty).abiAlignment(zcu);
                         big_align = big_align.max(field_align);
                         const prev_offset = offset;
                         offset = field_align.forward(offset);
@@ -3403,7 +3403,7 @@ pub const Object = struct {
                             o.gpa,
                             try o.builder.arrayType(padding_len, .i8),
                         );
-                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(pt)) {
+                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(zcu)) {
                             // This is a zero-bit field. If there are runtime bits after this field,
                             // map to the next LLVM field (which we know exists): otherwise, don't
                             // map the field, indicating it's at the end of the struct.
@@ -3421,7 +3421,7 @@ pub const Object = struct {
                         }, @intCast(llvm_field_types.items.len));
                         try llvm_field_types.append(o.gpa, try o.lowerType(Type.fromInterned(field_ty)));
 
-                        offset += Type.fromInterned(field_ty).abiSize(pt);
+                        offset += Type.fromInterned(field_ty).abiSize(zcu);
                     }
                     {
                         const prev_offset = offset;
@@ -3438,10 +3438,10 @@ pub const Object = struct {
                     if (o.type_map.get(t.toIntern())) |value| return value;
 
                     const union_obj = ip.loadUnionType(t.toIntern());
-                    const layout = pt.getUnionLayout(union_obj);
+                    const layout = Type.getUnionLayout(union_obj, zcu);
 
                     if (union_obj.flagsUnordered(ip).layout == .@"packed") {
-                        const int_ty = try o.builder.intType(@intCast(t.bitSize(pt)));
+                        const int_ty = try o.builder.intType(@intCast(t.bitSize(zcu)));
                         try o.type_map.put(o.gpa, t.toIntern(), int_ty);
                         return int_ty;
                     }
@@ -3547,32 +3547,32 @@ pub const Object = struct {
     /// There are other similar cases handled here as well.
     fn lowerPtrElemTy(o: *Object, elem_ty: Type) Allocator.Error!Builder.Type {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const lower_elem_ty = switch (elem_ty.zigTypeTag(mod)) {
+        const zcu = pt.zcu;
+        const lower_elem_ty = switch (elem_ty.zigTypeTag(zcu)) {
             .Opaque => true,
-            .Fn => !mod.typeToFunc(elem_ty).?.is_generic,
-            .Array => elem_ty.childType(mod).hasRuntimeBitsIgnoreComptime(pt),
-            else => elem_ty.hasRuntimeBitsIgnoreComptime(pt),
+            .Fn => !zcu.typeToFunc(elem_ty).?.is_generic,
+            .Array => elem_ty.childType(zcu).hasRuntimeBitsIgnoreComptime(zcu),
+            else => elem_ty.hasRuntimeBitsIgnoreComptime(zcu),
         };
         return if (lower_elem_ty) try o.lowerType(elem_ty) else .i8;
     }
 
     fn lowerTypeFn(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Builder.Type {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
-        const target = mod.getTarget();
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
+        const target = zcu.getTarget();
         const ret_ty = try lowerFnRetTy(o, fn_info);
 
         var llvm_params = std.ArrayListUnmanaged(Builder.Type){};
         defer llvm_params.deinit(o.gpa);
 
-        if (firstParamSRet(fn_info, pt, target)) {
+        if (firstParamSRet(fn_info, zcu, target)) {
             try llvm_params.append(o.gpa, .ptr);
         }
 
-        if (Type.fromInterned(fn_info.return_type).isError(mod) and
-            mod.comp.config.any_error_tracing)
+        if (Type.fromInterned(fn_info.return_type).isError(zcu) and
+            zcu.comp.config.any_error_tracing)
         {
             const ptr_ty = try pt.singleMutPtrType(try o.getStackTraceType());
             try llvm_params.append(o.gpa, try o.lowerType(ptr_ty));
@@ -3591,13 +3591,13 @@ pub const Object = struct {
             .abi_sized_int => {
                 const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                 try llvm_params.append(o.gpa, try o.builder.intType(
-                    @intCast(param_ty.abiSize(pt) * 8),
+                    @intCast(param_ty.abiSize(zcu) * 8),
                 ));
             },
             .slice => {
                 const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
                 try llvm_params.appendSlice(o.gpa, &.{
-                    try o.builder.ptrType(toLlvmAddressSpace(param_ty.ptrAddressSpace(mod), target)),
+                    try o.builder.ptrType(toLlvmAddressSpace(param_ty.ptrAddressSpace(zcu), target)),
                     try o.lowerType(Type.usize),
                 });
             },
@@ -3609,7 +3609,7 @@ pub const Object = struct {
             },
             .float_array => |count| {
                 const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
-                const float_ty = try o.lowerType(aarch64_c_abi.getFloatArrayType(param_ty, mod).?);
+                const float_ty = try o.lowerType(aarch64_c_abi.getFloatArrayType(param_ty, zcu).?);
                 try llvm_params.append(o.gpa, try o.builder.arrayType(count, float_ty));
             },
             .i32_array, .i64_array => |arr_len| {
@@ -3630,14 +3630,14 @@ pub const Object = struct {
 
     fn lowerValueToInt(o: *Object, llvm_int_ty: Builder.Type, arg_val: InternPool.Index) Error!Builder.Constant {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
-        const target = mod.getTarget();
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
+        const target = zcu.getTarget();
 
         const val = Value.fromInterned(arg_val);
         const val_key = ip.indexToKey(val.toIntern());
 
-        if (val.isUndefDeep(mod)) return o.builder.undefConst(llvm_int_ty);
+        if (val.isUndefDeep(zcu)) return o.builder.undefConst(llvm_int_ty);
 
         const ty = Type.fromInterned(val_key.typeOf());
         switch (val_key) {
@@ -3661,7 +3661,7 @@ pub const Object = struct {
                     var running_int = try o.builder.intConst(llvm_int_ty, 0);
                     var running_bits: u16 = 0;
                     for (struct_type.field_types.get(ip), 0..) |field_ty, field_index| {
-                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(pt)) continue;
+                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
                         const shift_rhs = try o.builder.intConst(llvm_int_ty, running_bits);
                         const field_val = try o.lowerValueToInt(llvm_int_ty, (try val.fieldValue(pt, field_index)).toIntern());
@@ -3669,7 +3669,7 @@ pub const Object = struct {
 
                         running_int = try o.builder.binConst(.xor, running_int, shifted);
 
-                        const ty_bit_size: u16 = @intCast(Type.fromInterned(field_ty).bitSize(pt));
+                        const ty_bit_size: u16 = @intCast(Type.fromInterned(field_ty).bitSize(zcu));
                         running_bits += ty_bit_size;
                     }
                     return running_int;
@@ -3678,10 +3678,10 @@ pub const Object = struct {
                 else => unreachable,
             },
             .un => |un| {
-                const layout = ty.unionGetLayout(pt);
+                const layout = ty.unionGetLayout(zcu);
                 if (layout.payload_size == 0) return o.lowerValue(un.tag);
 
-                const union_obj = mod.typeToUnion(ty).?;
+                const union_obj = zcu.typeToUnion(ty).?;
                 const container_layout = union_obj.flagsUnordered(ip).layout;
 
                 assert(container_layout == .@"packed");
@@ -3694,9 +3694,9 @@ pub const Object = struct {
                     need_unnamed = true;
                     return union_val;
                 }
-                const field_index = mod.unionTagFieldIndex(union_obj, Value.fromInterned(un.tag)).?;
+                const field_index = zcu.unionTagFieldIndex(union_obj, Value.fromInterned(un.tag)).?;
                 const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
-                if (!field_ty.hasRuntimeBits(pt)) return o.builder.intConst(llvm_int_ty, 0);
+                if (!field_ty.hasRuntimeBits(zcu)) return o.builder.intConst(llvm_int_ty, 0);
                 return o.lowerValueToInt(llvm_int_ty, un.val);
             },
             .simple_value => |simple_value| switch (simple_value) {
@@ -3710,7 +3710,7 @@ pub const Object = struct {
             .opt => {}, // pointer like optional expected
             else => unreachable,
         }
-        const bits = ty.bitSize(pt);
+        const bits = ty.bitSize(zcu);
         const bytes: usize = @intCast(std.mem.alignForward(u64, bits, 8) / 8);
 
         var stack = std.heap.stackFallback(32, o.gpa);
@@ -3743,14 +3743,14 @@ pub const Object = struct {
 
     fn lowerValue(o: *Object, arg_val: InternPool.Index) Error!Builder.Constant {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
-        const target = mod.getTarget();
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
+        const target = zcu.getTarget();
 
         const val = Value.fromInterned(arg_val);
         const val_key = ip.indexToKey(val.toIntern());
 
-        if (val.isUndefDeep(mod)) {
+        if (val.isUndefDeep(zcu)) {
             return o.builder.undefConst(try o.lowerType(Type.fromInterned(val_key.typeOf())));
         }
 
@@ -3800,7 +3800,7 @@ pub const Object = struct {
             },
             .int => {
                 var bigint_space: Value.BigIntSpace = undefined;
-                const bigint = val.toBigInt(&bigint_space, pt);
+                const bigint = val.toBigInt(&bigint_space, zcu);
                 return lowerBigInt(o, ty, bigint);
             },
             .err => |err| {
@@ -3811,20 +3811,20 @@ pub const Object = struct {
             .error_union => |error_union| {
                 const err_val = switch (error_union.val) {
                     .err_name => |err_name| try pt.intern(.{ .err = .{
-                        .ty = ty.errorUnionSet(mod).toIntern(),
+                        .ty = ty.errorUnionSet(zcu).toIntern(),
                         .name = err_name,
                     } }),
                     .payload => (try pt.intValue(try pt.errorIntType(), 0)).toIntern(),
                 };
                 const err_int_ty = try pt.errorIntType();
-                const payload_type = ty.errorUnionPayload(mod);
-                if (!payload_type.hasRuntimeBitsIgnoreComptime(pt)) {
+                const payload_type = ty.errorUnionPayload(zcu);
+                if (!payload_type.hasRuntimeBitsIgnoreComptime(zcu)) {
                     // We use the error type directly as the type.
                     return o.lowerValue(err_val);
                 }
 
-                const payload_align = payload_type.abiAlignment(pt);
-                const error_align = err_int_ty.abiAlignment(pt);
+                const payload_align = payload_type.abiAlignment(zcu);
+                const error_align = err_int_ty.abiAlignment(zcu);
                 const llvm_error_value = try o.lowerValue(err_val);
                 const llvm_payload_value = try o.lowerValue(switch (error_union.val) {
                     .err_name => try pt.intern(.{ .undef = payload_type.toIntern() }),
@@ -3858,16 +3858,16 @@ pub const Object = struct {
             .enum_tag => |enum_tag| o.lowerValue(enum_tag.int),
             .float => switch (ty.floatBits(target)) {
                 16 => if (backendSupportsF16(target))
-                    try o.builder.halfConst(val.toFloat(f16, pt))
+                    try o.builder.halfConst(val.toFloat(f16, zcu))
                 else
-                    try o.builder.intConst(.i16, @as(i16, @bitCast(val.toFloat(f16, pt)))),
-                32 => try o.builder.floatConst(val.toFloat(f32, pt)),
-                64 => try o.builder.doubleConst(val.toFloat(f64, pt)),
+                    try o.builder.intConst(.i16, @as(i16, @bitCast(val.toFloat(f16, zcu)))),
+                32 => try o.builder.floatConst(val.toFloat(f32, zcu)),
+                64 => try o.builder.doubleConst(val.toFloat(f64, zcu)),
                 80 => if (backendSupportsF80(target))
-                    try o.builder.x86_fp80Const(val.toFloat(f80, pt))
+                    try o.builder.x86_fp80Const(val.toFloat(f80, zcu))
                 else
-                    try o.builder.intConst(.i80, @as(i80, @bitCast(val.toFloat(f80, pt)))),
-                128 => try o.builder.fp128Const(val.toFloat(f128, pt)),
+                    try o.builder.intConst(.i80, @as(i80, @bitCast(val.toFloat(f80, zcu)))),
+                128 => try o.builder.fp128Const(val.toFloat(f128, zcu)),
                 else => unreachable,
             },
             .ptr => try o.lowerPtr(arg_val, 0),
@@ -3877,14 +3877,14 @@ pub const Object = struct {
             }),
             .opt => |opt| {
                 comptime assert(optional_layout_version == 3);
-                const payload_ty = ty.optionalChild(mod);
+                const payload_ty = ty.optionalChild(zcu);
 
                 const non_null_bit = try o.builder.intConst(.i8, @intFromBool(opt.val != .none));
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     return non_null_bit;
                 }
                 const llvm_ty = try o.lowerType(ty);
-                if (ty.optionalReprIsPayload(mod)) return switch (opt.val) {
+                if (ty.optionalReprIsPayload(zcu)) return switch (opt.val) {
                     .none => switch (llvm_ty.tag(&o.builder)) {
                         .integer => try o.builder.intConst(llvm_ty, 0),
                         .pointer => try o.builder.nullConst(llvm_ty),
@@ -3893,7 +3893,7 @@ pub const Object = struct {
                     },
                     else => |payload| try o.lowerValue(payload),
                 };
-                assert(payload_ty.zigTypeTag(mod) != .Fn);
+                assert(payload_ty.zigTypeTag(zcu) != .Fn);
 
                 var fields: [3]Builder.Type = undefined;
                 var vals: [3]Builder.Constant = undefined;
@@ -4047,9 +4047,9 @@ pub const Object = struct {
                         0..,
                     ) |field_ty, field_val, field_index| {
                         if (field_val != .none) continue;
-                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(pt)) continue;
+                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
-                        const field_align = Type.fromInterned(field_ty).abiAlignment(pt);
+                        const field_align = Type.fromInterned(field_ty).abiAlignment(zcu);
                         big_align = big_align.max(field_align);
                         const prev_offset = offset;
                         offset = field_align.forward(offset);
@@ -4071,7 +4071,7 @@ pub const Object = struct {
                             need_unnamed = true;
                         llvm_index += 1;
 
-                        offset += Type.fromInterned(field_ty).abiSize(pt);
+                        offset += Type.fromInterned(field_ty).abiSize(zcu);
                     }
                     {
                         const prev_offset = offset;
@@ -4098,7 +4098,7 @@ pub const Object = struct {
                     if (struct_type.layout == .@"packed") {
                         comptime assert(Type.packed_struct_layout_version == 2);
 
-                        const bits = ty.bitSize(pt);
+                        const bits = ty.bitSize(zcu);
                         const llvm_int_ty = try o.builder.intType(@intCast(bits));
 
                         return o.lowerValueToInt(llvm_int_ty, arg_val);
@@ -4147,7 +4147,7 @@ pub const Object = struct {
                             llvm_index += 1;
                         }
 
-                        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                             // This is a zero-bit field - we only needed it for the alignment.
                             continue;
                         }
@@ -4160,7 +4160,7 @@ pub const Object = struct {
                             need_unnamed = true;
                         llvm_index += 1;
 
-                        offset += field_ty.abiSize(pt);
+                        offset += field_ty.abiSize(zcu);
                     }
                     {
                         const prev_offset = offset;
@@ -4184,19 +4184,19 @@ pub const Object = struct {
             },
             .un => |un| {
                 const union_ty = try o.lowerType(ty);
-                const layout = ty.unionGetLayout(pt);
+                const layout = ty.unionGetLayout(zcu);
                 if (layout.payload_size == 0) return o.lowerValue(un.tag);
 
-                const union_obj = mod.typeToUnion(ty).?;
+                const union_obj = zcu.typeToUnion(ty).?;
                 const container_layout = union_obj.flagsUnordered(ip).layout;
 
                 var need_unnamed = false;
                 const payload = if (un.tag != .none) p: {
-                    const field_index = mod.unionTagFieldIndex(union_obj, Value.fromInterned(un.tag)).?;
+                    const field_index = zcu.unionTagFieldIndex(union_obj, Value.fromInterned(un.tag)).?;
                     const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[field_index]);
                     if (container_layout == .@"packed") {
-                        if (!field_ty.hasRuntimeBits(pt)) return o.builder.intConst(union_ty, 0);
-                        const bits = ty.bitSize(pt);
+                        if (!field_ty.hasRuntimeBits(zcu)) return o.builder.intConst(union_ty, 0);
+                        const bits = ty.bitSize(zcu);
                         const llvm_int_ty = try o.builder.intType(@intCast(bits));
 
                         return o.lowerValueToInt(llvm_int_ty, arg_val);
@@ -4208,7 +4208,7 @@ pub const Object = struct {
                     // must pointer cast to the expected type before accessing the union.
                     need_unnamed = layout.most_aligned_field != field_index;
 
-                    if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                    if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                         const padding_len = layout.payload_size;
                         break :p try o.builder.undefConst(try o.builder.arrayType(padding_len, .i8));
                     }
@@ -4217,7 +4217,7 @@ pub const Object = struct {
                     if (payload_ty != union_ty.structFields(&o.builder)[
                         @intFromBool(layout.tag_align.compare(.gte, layout.payload_align))
                     ]) need_unnamed = true;
-                    const field_size = field_ty.abiSize(pt);
+                    const field_size = field_ty.abiSize(zcu);
                     if (field_size == layout.payload_size) break :p payload;
                     const padding_len = layout.payload_size - field_size;
                     const padding_ty = try o.builder.arrayType(padding_len, .i8);
@@ -4228,7 +4228,7 @@ pub const Object = struct {
                 } else p: {
                     assert(layout.tag_size == 0);
                     if (container_layout == .@"packed") {
-                        const bits = ty.bitSize(pt);
+                        const bits = ty.bitSize(zcu);
                         const llvm_int_ty = try o.builder.intType(@intCast(bits));
 
                         return o.lowerValueToInt(llvm_int_ty, arg_val);
@@ -4275,8 +4275,8 @@ pub const Object = struct {
         ty: Type,
         bigint: std.math.big.int.Const,
     ) Allocator.Error!Builder.Constant {
-        const mod = o.pt.zcu;
-        return o.builder.bigIntConst(try o.builder.intType(ty.intInfo(mod).bits), bigint);
+        const zcu = o.pt.zcu;
+        return o.builder.bigIntConst(try o.builder.intType(ty.intInfo(zcu).bits), bigint);
     }
 
     fn lowerPtr(
@@ -4310,7 +4310,7 @@ pub const Object = struct {
                 eu_ptr,
                 offset + @import("../codegen.zig").errUnionPayloadOffset(
                     Value.fromInterned(eu_ptr).typeOf(zcu).childType(zcu),
-                    pt,
+                    zcu,
                 ),
             ),
             .opt_payload => |opt_ptr| try o.lowerPtr(opt_ptr, offset),
@@ -4326,7 +4326,7 @@ pub const Object = struct {
                         };
                     },
                     .Struct, .Union => switch (agg_ty.containerLayout(zcu)) {
-                        .auto => agg_ty.structFieldOffset(@intCast(field.index), pt),
+                        .auto => agg_ty.structFieldOffset(@intCast(field.index), zcu),
                         .@"extern", .@"packed" => unreachable,
                     },
                     else => unreachable,
@@ -4344,11 +4344,11 @@ pub const Object = struct {
         uav: InternPool.Key.Ptr.BaseAddr.Uav,
     ) Error!Builder.Constant {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const uav_val = uav.val;
         const uav_ty = Type.fromInterned(ip.typeOf(uav_val));
-        const target = mod.getTarget();
+        const target = zcu.getTarget();
 
         switch (ip.indexToKey(uav_val)) {
             .func => @panic("TODO"),
@@ -4358,15 +4358,15 @@ pub const Object = struct {
 
         const ptr_ty = Type.fromInterned(uav.orig_ty);
 
-        const is_fn_body = uav_ty.zigTypeTag(mod) == .Fn;
-        if ((!is_fn_body and !uav_ty.hasRuntimeBits(pt)) or
-            (is_fn_body and mod.typeToFunc(uav_ty).?.is_generic)) return o.lowerPtrToVoid(ptr_ty);
+        const is_fn_body = uav_ty.zigTypeTag(zcu) == .Fn;
+        if ((!is_fn_body and !uav_ty.hasRuntimeBits(zcu)) or
+            (is_fn_body and zcu.typeToFunc(uav_ty).?.is_generic)) return o.lowerPtrToVoid(ptr_ty);
 
         if (is_fn_body)
             @panic("TODO");
 
-        const llvm_addr_space = toLlvmAddressSpace(ptr_ty.ptrAddressSpace(mod), target);
-        const alignment = ptr_ty.ptrAlignment(pt);
+        const llvm_addr_space = toLlvmAddressSpace(ptr_ty.ptrAddressSpace(zcu), target);
+        const alignment = ptr_ty.ptrAlignment(zcu);
         const llvm_global = (try o.resolveGlobalUav(uav.val, llvm_addr_space, alignment)).ptrConst(&o.builder).global;
 
         const llvm_val = try o.builder.convConst(
@@ -4398,7 +4398,7 @@ pub const Object = struct {
         const ptr_ty = try pt.navPtrType(owner_nav_index);
 
         const is_fn_body = nav_ty.zigTypeTag(zcu) == .Fn;
-        if ((!is_fn_body and !nav_ty.hasRuntimeBits(pt)) or
+        if ((!is_fn_body and !nav_ty.hasRuntimeBits(zcu)) or
             (is_fn_body and zcu.typeToFunc(nav_ty).?.is_generic))
         {
             return o.lowerPtrToVoid(ptr_ty);
@@ -4418,19 +4418,19 @@ pub const Object = struct {
     }
 
     fn lowerPtrToVoid(o: *Object, ptr_ty: Type) Allocator.Error!Builder.Constant {
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         // Even though we are pointing at something which has zero bits (e.g. `void`),
         // Pointers are defined to have bits. So we must return something here.
         // The value cannot be undefined, because we use the `nonnull` annotation
         // for non-optional pointers. We also need to respect the alignment, even though
         // the address will never be dereferenced.
-        const int: u64 = ptr_ty.ptrInfo(mod).flags.alignment.toByteUnits() orelse
+        const int: u64 = ptr_ty.ptrInfo(zcu).flags.alignment.toByteUnits() orelse
             // Note that these 0xaa values are appropriate even in release-optimized builds
             // because we need a well-defined value that is not null, and LLVM does not
             // have an "undef_but_not_null" attribute. As an example, if this `alloc` AIR
             // instruction is followed by a `wrap_optional`, it will return this value
             // verbatim, and the result should test as non-null.
-            switch (mod.getTarget().ptrBitWidth()) {
+            switch (zcu.getTarget().ptrBitWidth()) {
             16 => 0xaaaa,
             32 => 0xaaaaaaaa,
             64 => 0xaaaaaaaa_aaaaaaaa,
@@ -4447,20 +4447,20 @@ pub const Object = struct {
     /// types to work around a LLVM deficiency when targeting ARM/AArch64.
     fn getAtomicAbiType(o: *Object, ty: Type, is_rmw_xchg: bool) Allocator.Error!Builder.Type {
         const pt = o.pt;
-        const mod = pt.zcu;
-        const int_ty = switch (ty.zigTypeTag(mod)) {
+        const zcu = pt.zcu;
+        const int_ty = switch (ty.zigTypeTag(zcu)) {
             .Int => ty,
-            .Enum => ty.intTagType(mod),
+            .Enum => ty.intTagType(zcu),
             .Float => {
                 if (!is_rmw_xchg) return .none;
-                return o.builder.intType(@intCast(ty.abiSize(pt) * 8));
+                return o.builder.intType(@intCast(ty.abiSize(zcu) * 8));
             },
             .Bool => return .i8,
             else => return .none,
         };
-        const bit_count = int_ty.intInfo(mod).bits;
+        const bit_count = int_ty.intInfo(zcu).bits;
         if (!std.math.isPowerOfTwo(bit_count) or (bit_count % 8) != 0) {
-            return o.builder.intType(@intCast(int_ty.abiSize(pt) * 8));
+            return o.builder.intType(@intCast(int_ty.abiSize(zcu) * 8));
         } else {
             return .none;
         }
@@ -4475,15 +4475,15 @@ pub const Object = struct {
         llvm_arg_i: u32,
     ) Allocator.Error!void {
         const pt = o.pt;
-        const mod = pt.zcu;
-        if (param_ty.isPtrAtRuntime(mod)) {
-            const ptr_info = param_ty.ptrInfo(mod);
+        const zcu = pt.zcu;
+        if (param_ty.isPtrAtRuntime(zcu)) {
+            const ptr_info = param_ty.ptrInfo(zcu);
             if (math.cast(u5, param_index)) |i| {
                 if (@as(u1, @truncate(fn_info.noalias_bits >> i)) != 0) {
                     try attributes.addParamAttr(llvm_arg_i, .@"noalias", &o.builder);
                 }
             }
-            if (!param_ty.isPtrLikeOptional(mod) and !ptr_info.flags.is_allowzero) {
+            if (!param_ty.isPtrLikeOptional(zcu) and !ptr_info.flags.is_allowzero) {
                 try attributes.addParamAttr(llvm_arg_i, .nonnull, &o.builder);
             }
             if (fn_info.cc == .Interrupt) {
@@ -4496,9 +4496,9 @@ pub const Object = struct {
             const elem_align = if (ptr_info.flags.alignment != .none)
                 ptr_info.flags.alignment
             else
-                Type.fromInterned(ptr_info.child).abiAlignment(pt).max(.@"1");
+                Type.fromInterned(ptr_info.child).abiAlignment(zcu).max(.@"1");
             try attributes.addParamAttr(llvm_arg_i, .{ .@"align" = elem_align.toLlvm() }, &o.builder);
-        } else if (ccAbiPromoteInt(fn_info.cc, mod, param_ty)) |s| switch (s) {
+        } else if (ccAbiPromoteInt(fn_info.cc, zcu, param_ty)) |s| switch (s) {
             .signed => try attributes.addParamAttr(llvm_arg_i, .signext, &o.builder),
             .unsigned => try attributes.addParamAttr(llvm_arg_i, .zeroext, &o.builder),
         };
@@ -4814,14 +4814,14 @@ pub const FuncGen = struct {
 
     fn resolveValue(self: *FuncGen, val: Value) Error!Builder.Constant {
         const o = self.ng.object;
-        const pt = o.pt;
-        const ty = val.typeOf(pt.zcu);
+        const zcu = o.pt.zcu;
+        const ty = val.typeOf(zcu);
         const llvm_val = try o.lowerValue(val.toIntern());
-        if (!isByRef(ty, pt)) return llvm_val;
+        if (!isByRef(ty, zcu)) return llvm_val;
 
         // We have an LLVM value but we need to create a global constant and
         // set the value as its initializer, and then return a pointer to the global.
-        const target = pt.zcu.getTarget();
+        const target = zcu.getTarget();
         const variable_index = try o.builder.addVariable(
             .empty,
             llvm_val.typeOf(&o.builder),
@@ -4831,7 +4831,7 @@ pub const FuncGen = struct {
         variable_index.setLinkage(.private, &o.builder);
         variable_index.setMutability(.constant, &o.builder);
         variable_index.setUnnamedAddr(.unnamed_addr, &o.builder);
-        variable_index.setAlignment(ty.abiAlignment(pt).toLlvm(), &o.builder);
+        variable_index.setAlignment(ty.abiAlignment(zcu).toLlvm(), &o.builder);
         return o.builder.convConst(
             variable_index.toConst(&o.builder),
             try o.builder.ptrType(toLlvmAddressSpace(.generic, target)),
@@ -4852,8 +4852,8 @@ pub const FuncGen = struct {
 
     fn genBody(self: *FuncGen, body: []const Air.Inst.Index) Error!void {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = o.pt.zcu;
+        const ip = &zcu.intern_pool;
         const air_tags = self.air.instructions.items(.tag);
         for (body, 0..) |inst, i| {
             if (self.liveness.isUnused(inst) and !self.air.mustLower(inst, ip)) continue;
@@ -5200,19 +5200,19 @@ pub const FuncGen = struct {
         const args: []const Air.Inst.Ref = @ptrCast(self.air.extra[extra.end..][0..extra.data.args_len]);
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const callee_ty = self.typeOf(pl_op.operand);
-        const zig_fn_ty = switch (callee_ty.zigTypeTag(mod)) {
+        const zig_fn_ty = switch (callee_ty.zigTypeTag(zcu)) {
             .Fn => callee_ty,
-            .Pointer => callee_ty.childType(mod),
+            .Pointer => callee_ty.childType(zcu),
             else => unreachable,
         };
-        const fn_info = mod.typeToFunc(zig_fn_ty).?;
+        const fn_info = zcu.typeToFunc(zig_fn_ty).?;
         const return_type = Type.fromInterned(fn_info.return_type);
         const llvm_fn = try self.resolveInst(pl_op.operand);
-        const target = mod.getTarget();
-        const sret = firstParamSRet(fn_info, pt, target);
+        const target = zcu.getTarget();
+        const sret = firstParamSRet(fn_info, zcu, target);
 
         var llvm_args = std.ArrayList(Builder.Value).init(self.gpa);
         defer llvm_args.deinit();
@@ -5230,13 +5230,13 @@ pub const FuncGen = struct {
             const llvm_ret_ty = try o.lowerType(return_type);
             try attributes.addParamAttr(0, .{ .sret = llvm_ret_ty }, &o.builder);
 
-            const alignment = return_type.abiAlignment(pt).toLlvm();
+            const alignment = return_type.abiAlignment(zcu).toLlvm();
             const ret_ptr = try self.buildAllocaWorkaround(return_type, alignment);
             try llvm_args.append(ret_ptr);
             break :blk ret_ptr;
         };
 
-        const err_return_tracing = return_type.isError(mod) and mod.comp.config.any_error_tracing;
+        const err_return_tracing = return_type.isError(zcu) and zcu.comp.config.any_error_tracing;
         if (err_return_tracing) {
             assert(self.err_ret_trace != .none);
             try llvm_args.append(self.err_ret_trace);
@@ -5250,8 +5250,8 @@ pub const FuncGen = struct {
                 const param_ty = self.typeOf(arg);
                 const llvm_arg = try self.resolveInst(arg);
                 const llvm_param_ty = try o.lowerType(param_ty);
-                if (isByRef(param_ty, pt)) {
-                    const alignment = param_ty.abiAlignment(pt).toLlvm();
+                if (isByRef(param_ty, zcu)) {
+                    const alignment = param_ty.abiAlignment(zcu).toLlvm();
                     const loaded = try self.wip.load(.normal, llvm_param_ty, llvm_arg, alignment, "");
                     try llvm_args.append(loaded);
                 } else {
@@ -5262,10 +5262,10 @@ pub const FuncGen = struct {
                 const arg = args[it.zig_index - 1];
                 const param_ty = self.typeOf(arg);
                 const llvm_arg = try self.resolveInst(arg);
-                if (isByRef(param_ty, pt)) {
+                if (isByRef(param_ty, zcu)) {
                     try llvm_args.append(llvm_arg);
                 } else {
-                    const alignment = param_ty.abiAlignment(pt).toLlvm();
+                    const alignment = param_ty.abiAlignment(zcu).toLlvm();
                     const param_llvm_ty = llvm_arg.typeOfWip(&self.wip);
                     const arg_ptr = try self.buildAlloca(param_llvm_ty, alignment);
                     _ = try self.wip.store(.normal, llvm_arg, arg_ptr, alignment);
@@ -5277,10 +5277,10 @@ pub const FuncGen = struct {
                 const param_ty = self.typeOf(arg);
                 const llvm_arg = try self.resolveInst(arg);
 
-                const alignment = param_ty.abiAlignment(pt).toLlvm();
+                const alignment = param_ty.abiAlignment(zcu).toLlvm();
                 const param_llvm_ty = try o.lowerType(param_ty);
                 const arg_ptr = try self.buildAllocaWorkaround(param_ty, alignment);
-                if (isByRef(param_ty, pt)) {
+                if (isByRef(param_ty, zcu)) {
                     const loaded = try self.wip.load(.normal, param_llvm_ty, llvm_arg, alignment, "");
                     _ = try self.wip.store(.normal, loaded, arg_ptr, alignment);
                 } else {
@@ -5292,16 +5292,16 @@ pub const FuncGen = struct {
                 const arg = args[it.zig_index - 1];
                 const param_ty = self.typeOf(arg);
                 const llvm_arg = try self.resolveInst(arg);
-                const int_llvm_ty = try o.builder.intType(@intCast(param_ty.abiSize(pt) * 8));
+                const int_llvm_ty = try o.builder.intType(@intCast(param_ty.abiSize(zcu) * 8));
 
-                if (isByRef(param_ty, pt)) {
-                    const alignment = param_ty.abiAlignment(pt).toLlvm();
+                if (isByRef(param_ty, zcu)) {
+                    const alignment = param_ty.abiAlignment(zcu).toLlvm();
                     const loaded = try self.wip.load(.normal, int_llvm_ty, llvm_arg, alignment, "");
                     try llvm_args.append(loaded);
                 } else {
                     // LLVM does not allow bitcasting structs so we must allocate
                     // a local, store as one type, and then load as another type.
-                    const alignment = param_ty.abiAlignment(pt).toLlvm();
+                    const alignment = param_ty.abiAlignment(zcu).toLlvm();
                     const int_ptr = try self.buildAllocaWorkaround(param_ty, alignment);
                     _ = try self.wip.store(.normal, llvm_arg, int_ptr, alignment);
                     const loaded = try self.wip.load(.normal, int_llvm_ty, int_ptr, alignment, "");
@@ -5320,9 +5320,9 @@ pub const FuncGen = struct {
                 const param_ty = self.typeOf(arg);
                 const llvm_types = it.types_buffer[0..it.types_len];
                 const llvm_arg = try self.resolveInst(arg);
-                const is_by_ref = isByRef(param_ty, pt);
+                const is_by_ref = isByRef(param_ty, zcu);
                 const arg_ptr = if (is_by_ref) llvm_arg else ptr: {
-                    const alignment = param_ty.abiAlignment(pt).toLlvm();
+                    const alignment = param_ty.abiAlignment(zcu).toLlvm();
                     const ptr = try self.buildAlloca(llvm_arg.typeOfWip(&self.wip), alignment);
                     _ = try self.wip.store(.normal, llvm_arg, ptr, alignment);
                     break :ptr ptr;
@@ -5348,14 +5348,14 @@ pub const FuncGen = struct {
                 const arg = args[it.zig_index - 1];
                 const arg_ty = self.typeOf(arg);
                 var llvm_arg = try self.resolveInst(arg);
-                const alignment = arg_ty.abiAlignment(pt).toLlvm();
-                if (!isByRef(arg_ty, pt)) {
+                const alignment = arg_ty.abiAlignment(zcu).toLlvm();
+                if (!isByRef(arg_ty, zcu)) {
                     const ptr = try self.buildAlloca(llvm_arg.typeOfWip(&self.wip), alignment);
                     _ = try self.wip.store(.normal, llvm_arg, ptr, alignment);
                     llvm_arg = ptr;
                 }
 
-                const float_ty = try o.lowerType(aarch64_c_abi.getFloatArrayType(arg_ty, mod).?);
+                const float_ty = try o.lowerType(aarch64_c_abi.getFloatArrayType(arg_ty, zcu).?);
                 const array_ty = try o.builder.arrayType(count, float_ty);
 
                 const loaded = try self.wip.load(.normal, array_ty, llvm_arg, alignment, "");
@@ -5366,8 +5366,8 @@ pub const FuncGen = struct {
                 const arg = args[it.zig_index - 1];
                 const arg_ty = self.typeOf(arg);
                 var llvm_arg = try self.resolveInst(arg);
-                const alignment = arg_ty.abiAlignment(pt).toLlvm();
-                if (!isByRef(arg_ty, pt)) {
+                const alignment = arg_ty.abiAlignment(zcu).toLlvm();
+                if (!isByRef(arg_ty, zcu)) {
                     const ptr = try self.buildAlloca(llvm_arg.typeOfWip(&self.wip), alignment);
                     _ = try self.wip.store(.normal, llvm_arg, ptr, alignment);
                     llvm_arg = ptr;
@@ -5389,7 +5389,7 @@ pub const FuncGen = struct {
                 .byval => {
                     const param_index = it.zig_index - 1;
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[param_index]);
-                    if (!isByRef(param_ty, pt)) {
+                    if (!isByRef(param_ty, zcu)) {
                         try o.addByValParamAttrs(&attributes, param_ty, param_index, fn_info, it.llvm_index - 1);
                     }
                 },
@@ -5397,7 +5397,7 @@ pub const FuncGen = struct {
                     const param_index = it.zig_index - 1;
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[param_index]);
                     const param_llvm_ty = try o.lowerType(param_ty);
-                    const alignment = param_ty.abiAlignment(pt).toLlvm();
+                    const alignment = param_ty.abiAlignment(zcu).toLlvm();
                     try o.addByRefParamAttrs(&attributes, it.llvm_index - 1, alignment, it.byval_attr, param_llvm_ty);
                 },
                 .byref_mut => try attributes.addParamAttr(it.llvm_index - 1, .noundef, &o.builder),
@@ -5414,7 +5414,7 @@ pub const FuncGen = struct {
                 .slice => {
                     assert(!it.byval_attr);
                     const param_ty = Type.fromInterned(fn_info.param_types.get(ip)[it.zig_index - 1]);
-                    const ptr_info = param_ty.ptrInfo(mod);
+                    const ptr_info = param_ty.ptrInfo(zcu);
                     const llvm_arg_i = it.llvm_index - 2;
 
                     if (math.cast(u5, it.zig_index - 1)) |i| {
@@ -5422,7 +5422,7 @@ pub const FuncGen = struct {
                             try attributes.addParamAttr(llvm_arg_i, .@"noalias", &o.builder);
                         }
                     }
-                    if (param_ty.zigTypeTag(mod) != .Optional) {
+                    if (param_ty.zigTypeTag(zcu) != .Optional) {
                         try attributes.addParamAttr(llvm_arg_i, .nonnull, &o.builder);
                     }
                     if (ptr_info.flags.is_const) {
@@ -5431,7 +5431,7 @@ pub const FuncGen = struct {
                     const elem_align = (if (ptr_info.flags.alignment != .none)
                         @as(InternPool.Alignment, ptr_info.flags.alignment)
                     else
-                        Type.fromInterned(ptr_info.child).abiAlignment(pt).max(.@"1")).toLlvm();
+                        Type.fromInterned(ptr_info.child).abiAlignment(zcu).max(.@"1")).toLlvm();
                     try attributes.addParamAttr(llvm_arg_i, .{ .@"align" = elem_align }, &o.builder);
                 },
             };
@@ -5456,17 +5456,17 @@ pub const FuncGen = struct {
             return .none;
         }
 
-        if (self.liveness.isUnused(inst) or !return_type.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (self.liveness.isUnused(inst) or !return_type.hasRuntimeBitsIgnoreComptime(zcu)) {
             return .none;
         }
 
         const llvm_ret_ty = try o.lowerType(return_type);
         if (ret_ptr) |rp| {
-            if (isByRef(return_type, pt)) {
+            if (isByRef(return_type, zcu)) {
                 return rp;
             } else {
                 // our by-ref status disagrees with sret so we must load.
-                const return_alignment = return_type.abiAlignment(pt).toLlvm();
+                const return_alignment = return_type.abiAlignment(zcu).toLlvm();
                 return self.wip.load(.normal, llvm_ret_ty, rp, return_alignment, "");
             }
         }
@@ -5477,19 +5477,19 @@ pub const FuncGen = struct {
             // In this case the function return type is honoring the calling convention by having
             // a different LLVM type than the usual one. We solve this here at the callsite
             // by using our canonical type, then loading it if necessary.
-            const alignment = return_type.abiAlignment(pt).toLlvm();
+            const alignment = return_type.abiAlignment(zcu).toLlvm();
             const rp = try self.buildAlloca(abi_ret_ty, alignment);
             _ = try self.wip.store(.normal, call, rp, alignment);
-            return if (isByRef(return_type, pt))
+            return if (isByRef(return_type, zcu))
                 rp
             else
                 try self.wip.load(.normal, llvm_ret_ty, rp, alignment, "");
         }
 
-        if (isByRef(return_type, pt)) {
+        if (isByRef(return_type, zcu)) {
             // our by-ref status disagrees with sret so we must allocate, store,
             // and return the allocation pointer.
-            const alignment = return_type.abiAlignment(pt).toLlvm();
+            const alignment = return_type.abiAlignment(zcu).toLlvm();
             const rp = try self.buildAlloca(llvm_ret_ty, alignment);
             _ = try self.wip.store(.normal, call, rp, alignment);
             return rp;
@@ -5540,8 +5540,8 @@ pub const FuncGen = struct {
     fn airRet(self: *FuncGen, inst: Air.Inst.Index, safety: bool) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const ret_ty = self.typeOf(un_op);
 
@@ -5549,9 +5549,9 @@ pub const FuncGen = struct {
             const ptr_ty = try pt.singleMutPtrType(ret_ty);
 
             const operand = try self.resolveInst(un_op);
-            const val_is_undef = if (try self.air.value(un_op, pt)) |val| val.isUndefDeep(mod) else false;
+            const val_is_undef = if (try self.air.value(un_op, pt)) |val| val.isUndefDeep(zcu) else false;
             if (val_is_undef and safety) undef: {
-                const ptr_info = ptr_ty.ptrInfo(mod);
+                const ptr_info = ptr_ty.ptrInfo(zcu);
                 const needs_bitmask = (ptr_info.packed_offset.host_size != 0);
                 if (needs_bitmask) {
                     // TODO: only some bits are to be undef, we cannot write with a simple memset.
@@ -5559,13 +5559,13 @@ pub const FuncGen = struct {
                     // https://github.com/ziglang/zig/issues/15337
                     break :undef;
                 }
-                const len = try o.builder.intValue(try o.lowerType(Type.usize), ret_ty.abiSize(pt));
+                const len = try o.builder.intValue(try o.lowerType(Type.usize), ret_ty.abiSize(zcu));
                 _ = try self.wip.callMemSet(
                     self.ret_ptr,
-                    ptr_ty.ptrAlignment(pt).toLlvm(),
+                    ptr_ty.ptrAlignment(zcu).toLlvm(),
                     try o.builder.intValue(.i8, 0xaa),
                     len,
-                    if (ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal,
+                    if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal,
                 );
                 const owner_mod = self.ng.ownerModule();
                 if (owner_mod.valgrind) {
@@ -5588,9 +5588,9 @@ pub const FuncGen = struct {
             _ = try self.wip.retVoid();
             return .none;
         }
-        const fn_info = mod.typeToFunc(Type.fromInterned(ip.getNav(self.ng.nav_index).typeOf(ip))).?;
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-            if (Type.fromInterned(fn_info.return_type).isError(mod)) {
+        const fn_info = zcu.typeToFunc(Type.fromInterned(ip.getNav(self.ng.nav_index).typeOf(ip))).?;
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+            if (Type.fromInterned(fn_info.return_type).isError(zcu)) {
                 // Functions with an empty error set are emitted with an error code
                 // return type and return zero so they can be function pointers coerced
                 // to functions that return anyerror.
@@ -5603,13 +5603,13 @@ pub const FuncGen = struct {
 
         const abi_ret_ty = try lowerFnRetTy(o, fn_info);
         const operand = try self.resolveInst(un_op);
-        const val_is_undef = if (try self.air.value(un_op, pt)) |val| val.isUndefDeep(mod) else false;
-        const alignment = ret_ty.abiAlignment(pt).toLlvm();
+        const val_is_undef = if (try self.air.value(un_op, pt)) |val| val.isUndefDeep(zcu) else false;
+        const alignment = ret_ty.abiAlignment(zcu).toLlvm();
 
         if (val_is_undef and safety) {
             const llvm_ret_ty = operand.typeOfWip(&self.wip);
             const rp = try self.buildAlloca(llvm_ret_ty, alignment);
-            const len = try o.builder.intValue(try o.lowerType(Type.usize), ret_ty.abiSize(pt));
+            const len = try o.builder.intValue(try o.lowerType(Type.usize), ret_ty.abiSize(zcu));
             _ = try self.wip.callMemSet(
                 rp,
                 alignment,
@@ -5625,7 +5625,7 @@ pub const FuncGen = struct {
             return .none;
         }
 
-        if (isByRef(ret_ty, pt)) {
+        if (isByRef(ret_ty, zcu)) {
             // operand is a pointer however self.ret_ptr is null so that means
             // we need to return a value.
             _ = try self.wip.ret(try self.wip.load(.normal, abi_ret_ty, operand, alignment, ""));
@@ -5647,14 +5647,14 @@ pub const FuncGen = struct {
     fn airRetLoad(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const ptr_ty = self.typeOf(un_op);
-        const ret_ty = ptr_ty.childType(mod);
-        const fn_info = mod.typeToFunc(Type.fromInterned(ip.getNav(self.ng.nav_index).typeOf(ip))).?;
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-            if (Type.fromInterned(fn_info.return_type).isError(mod)) {
+        const ret_ty = ptr_ty.childType(zcu);
+        const fn_info = zcu.typeToFunc(Type.fromInterned(ip.getNav(self.ng.nav_index).typeOf(ip))).?;
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+            if (Type.fromInterned(fn_info.return_type).isError(zcu)) {
                 // Functions with an empty error set are emitted with an error code
                 // return type and return zero so they can be function pointers coerced
                 // to functions that return anyerror.
@@ -5670,7 +5670,7 @@ pub const FuncGen = struct {
         }
         const ptr = try self.resolveInst(un_op);
         const abi_ret_ty = try lowerFnRetTy(o, fn_info);
-        const alignment = ret_ty.abiAlignment(pt).toLlvm();
+        const alignment = ret_ty.abiAlignment(zcu).toLlvm();
         _ = try self.wip.ret(try self.wip.load(.normal, abi_ret_ty, ptr, alignment, ""));
         return .none;
     }
@@ -5688,16 +5688,17 @@ pub const FuncGen = struct {
     fn airCVaCopy(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const src_list = try self.resolveInst(ty_op.operand);
         const va_list_ty = ty_op.ty.toType();
         const llvm_va_list_ty = try o.lowerType(va_list_ty);
 
-        const result_alignment = va_list_ty.abiAlignment(pt).toLlvm();
+        const result_alignment = va_list_ty.abiAlignment(pt.zcu).toLlvm();
         const dest_list = try self.buildAllocaWorkaround(va_list_ty, result_alignment);
 
         _ = try self.wip.callIntrinsic(.normal, .none, .va_copy, &.{}, &.{ dest_list, src_list }, "");
-        return if (isByRef(va_list_ty, pt))
+        return if (isByRef(va_list_ty, zcu))
             dest_list
         else
             try self.wip.load(.normal, llvm_va_list_ty, dest_list, result_alignment, "");
@@ -5714,14 +5715,15 @@ pub const FuncGen = struct {
     fn airCVaStart(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
+        const zcu = pt.zcu;
         const va_list_ty = self.typeOfIndex(inst);
         const llvm_va_list_ty = try o.lowerType(va_list_ty);
 
-        const result_alignment = va_list_ty.abiAlignment(pt).toLlvm();
+        const result_alignment = va_list_ty.abiAlignment(pt.zcu).toLlvm();
         const dest_list = try self.buildAllocaWorkaround(va_list_ty, result_alignment);
 
         _ = try self.wip.callIntrinsic(.normal, .none, .va_start, &.{}, &.{dest_list}, "");
-        return if (isByRef(va_list_ty, pt))
+        return if (isByRef(va_list_ty, zcu))
             dest_list
         else
             try self.wip.load(.normal, llvm_va_list_ty, dest_list, result_alignment, "");
@@ -5779,21 +5781,21 @@ pub const FuncGen = struct {
     ) Allocator.Error!Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const scalar_ty = operand_ty.scalarType(mod);
-        const int_ty = switch (scalar_ty.zigTypeTag(mod)) {
-            .Enum => scalar_ty.intTagType(mod),
+        const zcu = pt.zcu;
+        const scalar_ty = operand_ty.scalarType(zcu);
+        const int_ty = switch (scalar_ty.zigTypeTag(zcu)) {
+            .Enum => scalar_ty.intTagType(zcu),
             .Int, .Bool, .Pointer, .ErrorSet => scalar_ty,
             .Optional => blk: {
-                const payload_ty = operand_ty.optionalChild(mod);
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt) or
-                    operand_ty.optionalReprIsPayload(mod))
+                const payload_ty = operand_ty.optionalChild(zcu);
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu) or
+                    operand_ty.optionalReprIsPayload(zcu))
                 {
                     break :blk operand_ty;
                 }
                 // We need to emit instructions to check for equality/inequality
                 // of optionals that are not pointers.
-                const is_by_ref = isByRef(scalar_ty, pt);
+                const is_by_ref = isByRef(scalar_ty, zcu);
                 const opt_llvm_ty = try o.lowerType(scalar_ty);
                 const lhs_non_null = try self.optCmpNull(.ne, opt_llvm_ty, lhs, is_by_ref);
                 const rhs_non_null = try self.optCmpNull(.ne, opt_llvm_ty, rhs, is_by_ref);
@@ -5860,7 +5862,7 @@ pub const FuncGen = struct {
             .Float => return self.buildFloatCmp(fast, op, operand_ty, .{ lhs, rhs }),
             else => unreachable,
         };
-        const is_signed = int_ty.isSignedInt(mod);
+        const is_signed = int_ty.isSignedInt(zcu);
         const cond: Builder.IntegerCondition = switch (op) {
             .eq => .eq,
             .neq => .ne,
@@ -5886,15 +5888,15 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst_ty = self.typeOfIndex(inst);
 
-        if (inst_ty.isNoReturn(mod)) {
+        if (inst_ty.isNoReturn(zcu)) {
             try self.genBodyDebugScope(maybe_inline_func, body);
             return .none;
         }
 
-        const have_block_result = inst_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt);
+        const have_block_result = inst_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu);
 
         var breaks: BreakList = if (have_block_result) .{ .list = .{} } else .{ .len = 0 };
         defer if (have_block_result) breaks.list.deinit(self.gpa);
@@ -5918,7 +5920,7 @@ pub const FuncGen = struct {
                 // a pointer to it. LLVM IR allows the call instruction to use function bodies instead
                 // of function pointers, however the phi makes it a runtime value and therefore
                 // the LLVM type has to be wrapped in a pointer.
-                if (inst_ty.zigTypeTag(mod) == .Fn or isByRef(inst_ty, pt)) {
+                if (inst_ty.zigTypeTag(zcu) == .Fn or isByRef(inst_ty, zcu)) {
                     break :ty .ptr;
                 }
                 break :ty raw_llvm_ty;
@@ -5936,13 +5938,13 @@ pub const FuncGen = struct {
 
     fn airBr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const pt = o.pt;
+        const zcu = o.pt.zcu;
         const branch = self.air.instructions.items(.data)[@intFromEnum(inst)].br;
         const block = self.blocks.get(branch.block_inst).?;
 
         // Add the values to the lists only if the break provides a value.
         const operand_ty = self.typeOf(branch.operand);
-        if (operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+        if (operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
             const val = try self.resolveInst(branch.operand);
 
             // For the phi node, we need the basic blocks and the values of the
@@ -5977,6 +5979,7 @@ pub const FuncGen = struct {
     fn airTry(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const err_union = try self.resolveInst(pl_op.operand);
@@ -5984,19 +5987,19 @@ pub const FuncGen = struct {
         const body: []const Air.Inst.Index = @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]);
         const err_union_ty = self.typeOf(pl_op.operand);
         const payload_ty = self.typeOfIndex(inst);
-        const can_elide_load = if (isByRef(payload_ty, pt)) self.canElideLoad(body_tail) else false;
+        const can_elide_load = if (isByRef(payload_ty, zcu)) self.canElideLoad(body_tail) else false;
         const is_unused = self.liveness.isUnused(inst);
         return lowerTry(self, err_union, body, err_union_ty, false, can_elide_load, is_unused);
     }
 
     fn airTryPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.TryPtr, ty_pl.payload);
         const err_union_ptr = try self.resolveInst(extra.data.ptr);
         const body: []const Air.Inst.Index = @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]);
-        const err_union_ty = self.typeOf(extra.data.ptr).childType(mod);
+        const err_union_ty = self.typeOf(extra.data.ptr).childType(zcu);
         const is_unused = self.liveness.isUnused(inst);
         return lowerTry(self, err_union_ptr, body, err_union_ty, true, true, is_unused);
     }
@@ -6012,13 +6015,13 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = fg.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
-        const payload_has_bits = payload_ty.hasRuntimeBitsIgnoreComptime(pt);
+        const zcu = pt.zcu;
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
+        const payload_has_bits = payload_ty.hasRuntimeBitsIgnoreComptime(zcu);
         const err_union_llvm_ty = try o.lowerType(err_union_ty);
         const error_type = try o.errorIntType();
 
-        if (!err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (!err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             const loaded = loaded: {
                 if (!payload_has_bits) {
                     // TODO add alignment to this load
@@ -6028,7 +6031,7 @@ pub const FuncGen = struct {
                         err_union;
                 }
                 const err_field_index = try errUnionErrorOffset(payload_ty, pt);
-                if (operand_is_ptr or isByRef(err_union_ty, pt)) {
+                if (operand_is_ptr or isByRef(err_union_ty, zcu)) {
                     const err_field_ptr =
                         try fg.wip.gepStruct(err_union_llvm_ty, err_union, err_field_index, "");
                     // TODO add alignment to this load
@@ -6059,10 +6062,10 @@ pub const FuncGen = struct {
         const offset = try errUnionPayloadOffset(payload_ty, pt);
         if (operand_is_ptr) {
             return fg.wip.gepStruct(err_union_llvm_ty, err_union, offset, "");
-        } else if (isByRef(err_union_ty, pt)) {
+        } else if (isByRef(err_union_ty, zcu)) {
             const payload_ptr = try fg.wip.gepStruct(err_union_llvm_ty, err_union, offset, "");
-            const payload_alignment = payload_ty.abiAlignment(pt).toLlvm();
-            if (isByRef(payload_ty, pt)) {
+            const payload_alignment = payload_ty.abiAlignment(zcu).toLlvm();
+            if (isByRef(payload_ty, zcu)) {
                 if (can_elide_load)
                     return payload_ptr;
 
@@ -6140,7 +6143,7 @@ pub const FuncGen = struct {
 
     fn airLoop(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const loop = self.air.extraData(Air.Block, ty_pl.payload);
         const body: []const Air.Inst.Index = @ptrCast(self.air.extra[loop.end..][0..loop.data.body_len]);
@@ -6156,7 +6159,7 @@ pub const FuncGen = struct {
         // would have been emitted already. Also the main loop in genBody can
         // be while(true) instead of for(body), which will eliminate 1 branch on
         // a hot path.
-        if (body.len == 0 or !self.typeOfIndex(body[body.len - 1]).isNoReturn(mod)) {
+        if (body.len == 0 or !self.typeOfIndex(body[body.len - 1]).isNoReturn(zcu)) {
             _ = try self.wip.br(loop_block);
         }
         return .none;
@@ -6165,15 +6168,15 @@ pub const FuncGen = struct {
     fn airArrayToSlice(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand_ty = self.typeOf(ty_op.operand);
-        const array_ty = operand_ty.childType(mod);
+        const array_ty = operand_ty.childType(zcu);
         const llvm_usize = try o.lowerType(Type.usize);
-        const len = try o.builder.intValue(llvm_usize, array_ty.arrayLen(mod));
+        const len = try o.builder.intValue(llvm_usize, array_ty.arrayLen(zcu));
         const slice_llvm_ty = try o.lowerType(self.typeOfIndex(inst));
         const operand = try self.resolveInst(ty_op.operand);
-        if (!array_ty.hasRuntimeBitsIgnoreComptime(pt))
+        if (!array_ty.hasRuntimeBitsIgnoreComptime(zcu))
             return self.wip.buildAggregate(slice_llvm_ty, &.{ operand, len }, "");
         const ptr = try self.wip.gep(.inbounds, try o.lowerType(array_ty), operand, &.{
             try o.builder.intValue(llvm_usize, 0), try o.builder.intValue(llvm_usize, 0),
@@ -6184,17 +6187,17 @@ pub const FuncGen = struct {
     fn airFloatFromInt(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
         const workaround_operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        const operand_scalar_ty = operand_ty.scalarType(mod);
-        const is_signed_int = operand_scalar_ty.isSignedInt(mod);
+        const operand_scalar_ty = operand_ty.scalarType(zcu);
+        const is_signed_int = operand_scalar_ty.isSignedInt(zcu);
 
         const operand = o: {
             // Work around LLVM bug. See https://github.com/ziglang/zig/issues/17381.
-            const bit_size = operand_scalar_ty.bitSize(pt);
+            const bit_size = operand_scalar_ty.bitSize(zcu);
             for ([_]u8{ 8, 16, 32, 64, 128 }) |b| {
                 if (bit_size < b) {
                     break :o try self.wip.cast(
@@ -6211,9 +6214,9 @@ pub const FuncGen = struct {
         };
 
         const dest_ty = self.typeOfIndex(inst);
-        const dest_scalar_ty = dest_ty.scalarType(mod);
+        const dest_scalar_ty = dest_ty.scalarType(zcu);
         const dest_llvm_ty = try o.lowerType(dest_ty);
-        const target = mod.getTarget();
+        const target = zcu.getTarget();
 
         if (intrinsicsAllowed(dest_scalar_ty, target)) return self.wip.conv(
             if (is_signed_int) .signed else .unsigned,
@@ -6222,7 +6225,7 @@ pub const FuncGen = struct {
             "",
         );
 
-        const rt_int_bits = compilerRtIntBits(@intCast(operand_scalar_ty.bitSize(pt)));
+        const rt_int_bits = compilerRtIntBits(@intCast(operand_scalar_ty.bitSize(zcu)));
         const rt_int_ty = try o.builder.intType(rt_int_bits);
         var extended = try self.wip.conv(
             if (is_signed_int) .signed else .unsigned,
@@ -6269,29 +6272,29 @@ pub const FuncGen = struct {
 
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const target = mod.getTarget();
+        const zcu = pt.zcu;
+        const target = zcu.getTarget();
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
 
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        const operand_scalar_ty = operand_ty.scalarType(mod);
+        const operand_scalar_ty = operand_ty.scalarType(zcu);
 
         const dest_ty = self.typeOfIndex(inst);
-        const dest_scalar_ty = dest_ty.scalarType(mod);
+        const dest_scalar_ty = dest_ty.scalarType(zcu);
         const dest_llvm_ty = try o.lowerType(dest_ty);
 
         if (intrinsicsAllowed(operand_scalar_ty, target)) {
             // TODO set fast math flag
             return self.wip.conv(
-                if (dest_scalar_ty.isSignedInt(mod)) .signed else .unsigned,
+                if (dest_scalar_ty.isSignedInt(zcu)) .signed else .unsigned,
                 operand,
                 dest_llvm_ty,
                 "",
             );
         }
 
-        const rt_int_bits = compilerRtIntBits(@intCast(dest_scalar_ty.bitSize(pt)));
+        const rt_int_bits = compilerRtIntBits(@intCast(dest_scalar_ty.bitSize(zcu)));
         const ret_ty = try o.builder.intType(rt_int_bits);
         const libc_ret_ty = if (rt_int_bits == 128 and (target.os.tag == .windows and target.cpu.arch == .x86_64)) b: {
             // On Windows x86-64, "ti" functions must use Vector(2, u64) instead of the standard
@@ -6303,7 +6306,7 @@ pub const FuncGen = struct {
         const compiler_rt_operand_abbrev = compilerRtFloatAbbrev(operand_bits);
 
         const compiler_rt_dest_abbrev = compilerRtIntAbbrev(rt_int_bits);
-        const sign_prefix = if (dest_scalar_ty.isSignedInt(mod)) "" else "uns";
+        const sign_prefix = if (dest_scalar_ty.isSignedInt(zcu)) "" else "uns";
 
         const fn_name = try o.builder.strtabStringFmt("__fix{s}{s}f{s}i", .{
             sign_prefix,
@@ -6330,29 +6333,29 @@ pub const FuncGen = struct {
 
     fn sliceOrArrayPtr(fg: *FuncGen, ptr: Builder.Value, ty: Type) Allocator.Error!Builder.Value {
         const o = fg.ng.object;
-        const mod = o.pt.zcu;
-        return if (ty.isSlice(mod)) fg.wip.extractValue(ptr, &.{0}, "") else ptr;
+        const zcu = o.pt.zcu;
+        return if (ty.isSlice(zcu)) fg.wip.extractValue(ptr, &.{0}, "") else ptr;
     }
 
     fn sliceOrArrayLenInBytes(fg: *FuncGen, ptr: Builder.Value, ty: Type) Allocator.Error!Builder.Value {
         const o = fg.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const llvm_usize = try o.lowerType(Type.usize);
-        switch (ty.ptrSize(mod)) {
+        switch (ty.ptrSize(zcu)) {
             .Slice => {
                 const len = try fg.wip.extractValue(ptr, &.{1}, "");
-                const elem_ty = ty.childType(mod);
-                const abi_size = elem_ty.abiSize(pt);
+                const elem_ty = ty.childType(zcu);
+                const abi_size = elem_ty.abiSize(zcu);
                 if (abi_size == 1) return len;
                 const abi_size_llvm_val = try o.builder.intValue(llvm_usize, abi_size);
                 return fg.wip.bin(.@"mul nuw", len, abi_size_llvm_val, "");
             },
             .One => {
-                const array_ty = ty.childType(mod);
-                const elem_ty = array_ty.childType(mod);
-                const abi_size = elem_ty.abiSize(pt);
-                return o.builder.intValue(llvm_usize, array_ty.arrayLen(mod) * abi_size);
+                const array_ty = ty.childType(zcu);
+                const elem_ty = array_ty.childType(zcu);
+                const abi_size = elem_ty.abiSize(zcu);
+                return o.builder.intValue(llvm_usize, array_ty.arrayLen(zcu) * abi_size);
             },
             .Many, .C => unreachable,
         }
@@ -6366,11 +6369,11 @@ pub const FuncGen = struct {
 
     fn airPtrSliceFieldPtr(self: *FuncGen, inst: Air.Inst.Index, index: c_uint) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const slice_ptr = try self.resolveInst(ty_op.operand);
         const slice_ptr_ty = self.typeOf(ty_op.operand);
-        const slice_llvm_ty = try o.lowerPtrElemTy(slice_ptr_ty.childType(mod));
+        const slice_llvm_ty = try o.lowerPtrElemTy(slice_ptr_ty.childType(zcu));
 
         return self.wip.gepStruct(slice_llvm_ty, slice_ptr, index, "");
     }
@@ -6378,21 +6381,21 @@ pub const FuncGen = struct {
     fn airSliceElemVal(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const slice_ty = self.typeOf(bin_op.lhs);
         const slice = try self.resolveInst(bin_op.lhs);
         const index = try self.resolveInst(bin_op.rhs);
-        const elem_ty = slice_ty.childType(mod);
+        const elem_ty = slice_ty.childType(zcu);
         const llvm_elem_ty = try o.lowerPtrElemTy(elem_ty);
         const base_ptr = try self.wip.extractValue(slice, &.{0}, "");
         const ptr = try self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, &.{index}, "");
-        if (isByRef(elem_ty, pt)) {
+        if (isByRef(elem_ty, zcu)) {
             if (self.canElideLoad(body_tail))
                 return ptr;
 
-            const elem_alignment = elem_ty.abiAlignment(pt).toLlvm();
+            const elem_alignment = elem_ty.abiAlignment(zcu).toLlvm();
             return self.loadByRef(ptr, elem_ty, elem_alignment, .normal);
         }
 
@@ -6401,14 +6404,14 @@ pub const FuncGen = struct {
 
     fn airSliceElemPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const slice_ty = self.typeOf(bin_op.lhs);
 
         const slice = try self.resolveInst(bin_op.lhs);
         const index = try self.resolveInst(bin_op.rhs);
-        const llvm_elem_ty = try o.lowerPtrElemTy(slice_ty.childType(mod));
+        const llvm_elem_ty = try o.lowerPtrElemTy(slice_ty.childType(zcu));
         const base_ptr = try self.wip.extractValue(slice, &.{0}, "");
         return self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, &.{index}, "");
     }
@@ -6416,7 +6419,7 @@ pub const FuncGen = struct {
     fn airArrayElemVal(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
 
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
@@ -6424,16 +6427,16 @@ pub const FuncGen = struct {
         const array_llvm_val = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const array_llvm_ty = try o.lowerType(array_ty);
-        const elem_ty = array_ty.childType(mod);
-        if (isByRef(array_ty, pt)) {
+        const elem_ty = array_ty.childType(zcu);
+        if (isByRef(array_ty, zcu)) {
             const indices: [2]Builder.Value = .{
                 try o.builder.intValue(try o.lowerType(Type.usize), 0), rhs,
             };
-            if (isByRef(elem_ty, pt)) {
+            if (isByRef(elem_ty, zcu)) {
                 const elem_ptr =
                     try self.wip.gep(.inbounds, array_llvm_ty, array_llvm_val, &indices, "");
                 if (canElideLoad(self, body_tail)) return elem_ptr;
-                const elem_alignment = elem_ty.abiAlignment(pt).toLlvm();
+                const elem_alignment = elem_ty.abiAlignment(zcu).toLlvm();
                 return self.loadByRef(elem_ptr, elem_ty, elem_alignment, .normal);
             } else {
                 const elem_ptr =
@@ -6449,23 +6452,23 @@ pub const FuncGen = struct {
     fn airPtrElemVal(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = ptr_ty.childType(mod);
+        const elem_ty = ptr_ty.childType(zcu);
         const llvm_elem_ty = try o.lowerPtrElemTy(elem_ty);
         const base_ptr = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         // TODO: when we go fully opaque pointers in LLVM 16 we can remove this branch
-        const ptr = try self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, if (ptr_ty.isSinglePointer(mod))
+        const ptr = try self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, if (ptr_ty.isSinglePointer(zcu))
             // If this is a single-item pointer to an array, we need another index in the GEP.
             &.{ try o.builder.intValue(try o.lowerType(Type.usize), 0), rhs }
         else
             &.{rhs}, "");
-        if (isByRef(elem_ty, pt)) {
+        if (isByRef(elem_ty, zcu)) {
             if (self.canElideLoad(body_tail)) return ptr;
-            const elem_alignment = elem_ty.abiAlignment(pt).toLlvm();
+            const elem_alignment = elem_ty.abiAlignment(zcu).toLlvm();
             return self.loadByRef(ptr, elem_ty, elem_alignment, .normal);
         }
 
@@ -6475,21 +6478,21 @@ pub const FuncGen = struct {
     fn airPtrElemPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = ptr_ty.childType(mod);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) return self.resolveInst(bin_op.lhs);
+        const elem_ty = ptr_ty.childType(zcu);
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) return self.resolveInst(bin_op.lhs);
 
         const base_ptr = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
 
         const elem_ptr = ty_pl.ty.toType();
-        if (elem_ptr.ptrInfo(mod).flags.vector_index != .none) return base_ptr;
+        if (elem_ptr.ptrInfo(zcu).flags.vector_index != .none) return base_ptr;
 
         const llvm_elem_ty = try o.lowerPtrElemTy(elem_ty);
-        return self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, if (ptr_ty.isSinglePointer(mod))
+        return self.wip.gep(.inbounds, llvm_elem_ty, base_ptr, if (ptr_ty.isSinglePointer(zcu))
             // If this is a single-item pointer to an array, we need another index in the GEP.
             &.{ try o.builder.intValue(try o.lowerType(Type.usize), 0), rhs }
         else
@@ -6518,35 +6521,35 @@ pub const FuncGen = struct {
     fn airStructFieldVal(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const struct_field = self.air.extraData(Air.StructField, ty_pl.payload).data;
         const struct_ty = self.typeOf(struct_field.struct_operand);
         const struct_llvm_val = try self.resolveInst(struct_field.struct_operand);
         const field_index = struct_field.field_index;
-        const field_ty = struct_ty.structFieldType(field_index, mod);
-        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) return .none;
+        const field_ty = struct_ty.structFieldType(field_index, zcu);
+        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) return .none;
 
-        if (!isByRef(struct_ty, pt)) {
-            assert(!isByRef(field_ty, pt));
-            switch (struct_ty.zigTypeTag(mod)) {
-                .Struct => switch (struct_ty.containerLayout(mod)) {
+        if (!isByRef(struct_ty, zcu)) {
+            assert(!isByRef(field_ty, zcu));
+            switch (struct_ty.zigTypeTag(zcu)) {
+                .Struct => switch (struct_ty.containerLayout(zcu)) {
                     .@"packed" => {
-                        const struct_type = mod.typeToStruct(struct_ty).?;
+                        const struct_type = zcu.typeToStruct(struct_ty).?;
                         const bit_offset = pt.structPackedFieldBitOffset(struct_type, field_index);
                         const containing_int = struct_llvm_val;
                         const shift_amt =
                             try o.builder.intValue(containing_int.typeOfWip(&self.wip), bit_offset);
                         const shifted_value = try self.wip.bin(.lshr, containing_int, shift_amt, "");
                         const elem_llvm_ty = try o.lowerType(field_ty);
-                        if (field_ty.zigTypeTag(mod) == .Float or field_ty.zigTypeTag(mod) == .Vector) {
-                            const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(pt)));
+                        if (field_ty.zigTypeTag(zcu) == .Float or field_ty.zigTypeTag(zcu) == .Vector) {
+                            const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(zcu)));
                             const truncated_int =
                                 try self.wip.cast(.trunc, shifted_value, same_size_int, "");
                             return self.wip.cast(.bitcast, truncated_int, elem_llvm_ty, "");
-                        } else if (field_ty.isPtrAtRuntime(mod)) {
-                            const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(pt)));
+                        } else if (field_ty.isPtrAtRuntime(zcu)) {
+                            const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(zcu)));
                             const truncated_int =
                                 try self.wip.cast(.trunc, shifted_value, same_size_int, "");
                             return self.wip.cast(.inttoptr, truncated_int, elem_llvm_ty, "");
@@ -6559,16 +6562,16 @@ pub const FuncGen = struct {
                     },
                 },
                 .Union => {
-                    assert(struct_ty.containerLayout(mod) == .@"packed");
+                    assert(struct_ty.containerLayout(zcu) == .@"packed");
                     const containing_int = struct_llvm_val;
                     const elem_llvm_ty = try o.lowerType(field_ty);
-                    if (field_ty.zigTypeTag(mod) == .Float or field_ty.zigTypeTag(mod) == .Vector) {
-                        const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(pt)));
+                    if (field_ty.zigTypeTag(zcu) == .Float or field_ty.zigTypeTag(zcu) == .Vector) {
+                        const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(zcu)));
                         const truncated_int =
                             try self.wip.cast(.trunc, containing_int, same_size_int, "");
                         return self.wip.cast(.bitcast, truncated_int, elem_llvm_ty, "");
-                    } else if (field_ty.isPtrAtRuntime(mod)) {
-                        const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(pt)));
+                    } else if (field_ty.isPtrAtRuntime(zcu)) {
+                        const same_size_int = try o.builder.intType(@intCast(field_ty.bitSize(zcu)));
                         const truncated_int =
                             try self.wip.cast(.trunc, containing_int, same_size_int, "");
                         return self.wip.cast(.inttoptr, truncated_int, elem_llvm_ty, "");
@@ -6579,20 +6582,20 @@ pub const FuncGen = struct {
             }
         }
 
-        switch (struct_ty.zigTypeTag(mod)) {
+        switch (struct_ty.zigTypeTag(zcu)) {
             .Struct => {
-                const layout = struct_ty.containerLayout(mod);
+                const layout = struct_ty.containerLayout(zcu);
                 assert(layout != .@"packed");
                 const struct_llvm_ty = try o.lowerType(struct_ty);
                 const llvm_field_index = o.llvmFieldIndex(struct_ty, field_index).?;
                 const field_ptr =
                     try self.wip.gepStruct(struct_llvm_ty, struct_llvm_val, llvm_field_index, "");
-                const alignment = struct_ty.structFieldAlign(field_index, pt);
+                const alignment = struct_ty.structFieldAlign(field_index, zcu);
                 const field_ptr_ty = try pt.ptrType(.{
                     .child = field_ty.toIntern(),
                     .flags = .{ .alignment = alignment },
                 });
-                if (isByRef(field_ty, pt)) {
+                if (isByRef(field_ty, zcu)) {
                     if (canElideLoad(self, body_tail))
                         return field_ptr;
 
@@ -6605,12 +6608,12 @@ pub const FuncGen = struct {
             },
             .Union => {
                 const union_llvm_ty = try o.lowerType(struct_ty);
-                const layout = struct_ty.unionGetLayout(pt);
+                const layout = struct_ty.unionGetLayout(zcu);
                 const payload_index = @intFromBool(layout.tag_align.compare(.gte, layout.payload_align));
                 const field_ptr =
                     try self.wip.gepStruct(union_llvm_ty, struct_llvm_val, payload_index, "");
                 const payload_alignment = layout.payload_align.toLlvm();
-                if (isByRef(field_ty, pt)) {
+                if (isByRef(field_ty, zcu)) {
                     if (canElideLoad(self, body_tail)) return field_ptr;
                     return self.loadByRef(field_ptr, field_ty, payload_alignment, .normal);
                 } else {
@@ -6624,14 +6627,14 @@ pub const FuncGen = struct {
     fn airFieldParentPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.FieldParentPtr, ty_pl.payload).data;
 
         const field_ptr = try self.resolveInst(extra.field_ptr);
 
-        const parent_ty = ty_pl.ty.toType().childType(mod);
-        const field_offset = parent_ty.structFieldOffset(extra.field_index, pt);
+        const parent_ty = ty_pl.ty.toType().childType(zcu);
+        const field_offset = parent_ty.structFieldOffset(extra.field_index, zcu);
         if (field_offset == 0) return field_ptr;
 
         const res_ty = try o.lowerType(ty_pl.ty.toType());
@@ -6686,7 +6689,7 @@ pub const FuncGen = struct {
 
     fn airDbgVarPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const operand = try self.resolveInst(pl_op.operand);
         const name: Air.NullTerminatedString = @enumFromInt(pl_op.payload);
@@ -6697,7 +6700,7 @@ pub const FuncGen = struct {
             self.file,
             self.scope,
             self.prev_dbg_line,
-            try o.lowerDebugType(ptr_ty.childType(mod)),
+            try o.lowerDebugType(ptr_ty.childType(zcu)),
         );
 
         _ = try self.wip.callIntrinsic(
@@ -6741,9 +6744,9 @@ pub const FuncGen = struct {
             try o.lowerDebugType(operand_ty),
         );
 
-        const pt = o.pt;
+        const zcu = o.pt.zcu;
         const owner_mod = self.ng.ownerModule();
-        if (isByRef(operand_ty, pt)) {
+        if (isByRef(operand_ty, zcu)) {
             _ = try self.wip.callIntrinsic(
                 .normal,
                 .none,
@@ -6760,7 +6763,7 @@ pub const FuncGen = struct {
             // We avoid taking this path for naked functions because there's no guarantee that such
             // functions even have a valid stack pointer, making the `alloca` + `store` unsafe.
 
-            const alignment = operand_ty.abiAlignment(pt).toLlvm();
+            const alignment = operand_ty.abiAlignment(zcu).toLlvm();
             const alloca = try self.buildAlloca(operand.typeOfWip(&self.wip), alignment);
             _ = try self.wip.store(.normal, operand, alloca, alignment);
             _ = try self.wip.callIntrinsic(
@@ -6832,8 +6835,8 @@ pub const FuncGen = struct {
         // if so, the element type itself.
         const llvm_param_attrs = try arena.alloc(Builder.Type, max_param_count);
         const pt = o.pt;
-        const mod = pt.zcu;
-        const target = mod.getTarget();
+        const zcu = pt.zcu;
+        const target = zcu.getTarget();
 
         var llvm_ret_i: usize = 0;
         var llvm_param_i: usize = 0;
@@ -6860,8 +6863,8 @@ pub const FuncGen = struct {
             if (output != .none) {
                 const output_inst = try self.resolveInst(output);
                 const output_ty = self.typeOf(output);
-                assert(output_ty.zigTypeTag(mod) == .Pointer);
-                const elem_llvm_ty = try o.lowerPtrElemTy(output_ty.childType(mod));
+                assert(output_ty.zigTypeTag(zcu) == .Pointer);
+                const elem_llvm_ty = try o.lowerPtrElemTy(output_ty.childType(zcu));
 
                 switch (constraint[0]) {
                     '=' => {},
@@ -6932,13 +6935,13 @@ pub const FuncGen = struct {
 
             const arg_llvm_value = try self.resolveInst(input);
             const arg_ty = self.typeOf(input);
-            const is_by_ref = isByRef(arg_ty, pt);
+            const is_by_ref = isByRef(arg_ty, zcu);
             if (is_by_ref) {
                 if (constraintAllowsMemory(constraint)) {
                     llvm_param_values[llvm_param_i] = arg_llvm_value;
                     llvm_param_types[llvm_param_i] = arg_llvm_value.typeOfWip(&self.wip);
                 } else {
-                    const alignment = arg_ty.abiAlignment(pt).toLlvm();
+                    const alignment = arg_ty.abiAlignment(zcu).toLlvm();
                     const arg_llvm_ty = try o.lowerType(arg_ty);
                     const load_inst =
                         try self.wip.load(.normal, arg_llvm_ty, arg_llvm_value, alignment, "");
@@ -6950,7 +6953,7 @@ pub const FuncGen = struct {
                     llvm_param_values[llvm_param_i] = arg_llvm_value;
                     llvm_param_types[llvm_param_i] = arg_llvm_value.typeOfWip(&self.wip);
                 } else {
-                    const alignment = arg_ty.abiAlignment(pt).toLlvm();
+                    const alignment = arg_ty.abiAlignment(zcu).toLlvm();
                     const arg_ptr = try self.buildAlloca(arg_llvm_value.typeOfWip(&self.wip), alignment);
                     _ = try self.wip.store(.normal, arg_llvm_value, arg_ptr, alignment);
                     llvm_param_values[llvm_param_i] = arg_ptr;
@@ -6978,7 +6981,7 @@ pub const FuncGen = struct {
             // In the case of indirect inputs, LLVM requires the callsite to have
             // an elementtype(<ty>) attribute.
             llvm_param_attrs[llvm_param_i] = if (constraint[0] == '*')
-                try o.lowerPtrElemTy(if (is_by_ref) arg_ty else arg_ty.childType(mod))
+                try o.lowerPtrElemTy(if (is_by_ref) arg_ty else arg_ty.childType(zcu))
             else
                 .none;
 
@@ -6997,12 +7000,12 @@ pub const FuncGen = struct {
             if (constraint[0] != '+') continue;
 
             const rw_ty = self.typeOf(output);
-            const llvm_elem_ty = try o.lowerPtrElemTy(rw_ty.childType(mod));
+            const llvm_elem_ty = try o.lowerPtrElemTy(rw_ty.childType(zcu));
             if (is_indirect) {
                 llvm_param_values[llvm_param_i] = llvm_rw_val;
                 llvm_param_types[llvm_param_i] = llvm_rw_val.typeOfWip(&self.wip);
             } else {
-                const alignment = rw_ty.abiAlignment(pt).toLlvm();
+                const alignment = rw_ty.abiAlignment(zcu).toLlvm();
                 const loaded = try self.wip.load(.normal, llvm_elem_ty, llvm_rw_val, alignment, "");
                 llvm_param_values[llvm_param_i] = loaded;
                 llvm_param_types[llvm_param_i] = llvm_elem_ty;
@@ -7163,7 +7166,7 @@ pub const FuncGen = struct {
                 const output_ptr = try self.resolveInst(output);
                 const output_ptr_ty = self.typeOf(output);
 
-                const alignment = output_ptr_ty.ptrAlignment(pt).toLlvm();
+                const alignment = output_ptr_ty.ptrAlignment(zcu).toLlvm();
                 _ = try self.wip.store(.normal, output_value, output_ptr, alignment);
             } else {
                 ret_val = output_value;
@@ -7182,23 +7185,23 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const operand = try self.resolveInst(un_op);
         const operand_ty = self.typeOf(un_op);
-        const optional_ty = if (operand_is_ptr) operand_ty.childType(mod) else operand_ty;
+        const optional_ty = if (operand_is_ptr) operand_ty.childType(zcu) else operand_ty;
         const optional_llvm_ty = try o.lowerType(optional_ty);
-        const payload_ty = optional_ty.optionalChild(mod);
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        const payload_ty = optional_ty.optionalChild(zcu);
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             const loaded = if (operand_is_ptr)
                 try self.wip.load(.normal, optional_llvm_ty, operand, .default, "")
             else
                 operand;
-            if (payload_ty.isSlice(mod)) {
+            if (payload_ty.isSlice(zcu)) {
                 const slice_ptr = try self.wip.extractValue(loaded, &.{0}, "");
                 const ptr_ty = try o.builder.ptrType(toLlvmAddressSpace(
-                    payload_ty.ptrAddressSpace(mod),
-                    mod.getTarget(),
+                    payload_ty.ptrAddressSpace(zcu),
+                    zcu.getTarget(),
                 ));
                 return self.wip.icmp(cond, slice_ptr, try o.builder.nullValue(ptr_ty), "");
             }
@@ -7207,7 +7210,7 @@ pub const FuncGen = struct {
 
         comptime assert(optional_layout_version == 3);
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             const loaded = if (operand_is_ptr)
                 try self.wip.load(.normal, optional_llvm_ty, operand, .default, "")
             else
@@ -7215,7 +7218,7 @@ pub const FuncGen = struct {
             return self.wip.icmp(cond, loaded, try o.builder.intValue(.i8, 0), "");
         }
 
-        const is_by_ref = operand_is_ptr or isByRef(optional_ty, pt);
+        const is_by_ref = operand_is_ptr or isByRef(optional_ty, zcu);
         return self.optCmpNull(cond, optional_llvm_ty, operand, is_by_ref);
     }
 
@@ -7227,16 +7230,16 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const operand = try self.resolveInst(un_op);
         const operand_ty = self.typeOf(un_op);
-        const err_union_ty = if (operand_is_ptr) operand_ty.childType(mod) else operand_ty;
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
+        const err_union_ty = if (operand_is_ptr) operand_ty.childType(zcu) else operand_ty;
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
         const error_type = try o.errorIntType();
         const zero = try o.builder.intValue(error_type, 0);
 
-        if (err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             const val: Builder.Constant = switch (cond) {
                 .eq => .true, // 0 == 0
                 .ne => .false, // 0 != 0
@@ -7245,7 +7248,7 @@ pub const FuncGen = struct {
             return val.toValue();
         }
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             const loaded = if (operand_is_ptr)
                 try self.wip.load(.normal, try o.lowerType(err_union_ty), operand, .default, "")
             else
@@ -7255,7 +7258,7 @@ pub const FuncGen = struct {
 
         const err_field_index = try errUnionErrorOffset(payload_ty, pt);
 
-        const loaded = if (operand_is_ptr or isByRef(err_union_ty, pt)) loaded: {
+        const loaded = if (operand_is_ptr or isByRef(err_union_ty, zcu)) loaded: {
             const err_union_llvm_ty = try o.lowerType(err_union_ty);
             const err_field_ptr =
                 try self.wip.gepStruct(err_union_llvm_ty, operand, err_field_index, "");
@@ -7267,17 +7270,17 @@ pub const FuncGen = struct {
     fn airOptionalPayloadPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
-        const optional_ty = self.typeOf(ty_op.operand).childType(mod);
-        const payload_ty = optional_ty.optionalChild(mod);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        const optional_ty = self.typeOf(ty_op.operand).childType(zcu);
+        const payload_ty = optional_ty.optionalChild(zcu);
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             // We have a pointer to a zero-bit value and we need to return
             // a pointer to a zero-bit value.
             return operand;
         }
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             // The payload and the optional are the same value.
             return operand;
         }
@@ -7289,18 +7292,18 @@ pub const FuncGen = struct {
 
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
-        const optional_ty = self.typeOf(ty_op.operand).childType(mod);
-        const payload_ty = optional_ty.optionalChild(mod);
+        const optional_ty = self.typeOf(ty_op.operand).childType(zcu);
+        const payload_ty = optional_ty.optionalChild(zcu);
         const non_null_bit = try o.builder.intValue(.i8, 1);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             // We have a pointer to a i8. We need to set it to 1 and then return the same pointer.
             _ = try self.wip.store(.normal, non_null_bit, operand, .default);
             return operand;
         }
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             // The payload and the optional are the same value.
             // Setting to non-null will be done when the payload is set.
             return operand;
@@ -7321,21 +7324,21 @@ pub const FuncGen = struct {
     fn airOptionalPayload(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const optional_ty = self.typeOf(ty_op.operand);
         const payload_ty = self.typeOfIndex(inst);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) return .none;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) return .none;
 
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             // Payload value is the same as the optional value.
             return operand;
         }
 
         const opt_llvm_ty = try o.lowerType(optional_ty);
-        const can_elide_load = if (isByRef(payload_ty, pt)) self.canElideLoad(body_tail) else false;
+        const can_elide_load = if (isByRef(payload_ty, zcu)) self.canElideLoad(body_tail) else false;
         return self.optPayloadHandle(opt_llvm_ty, operand, optional_ty, can_elide_load);
     }
 
@@ -7346,26 +7349,26 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        const err_union_ty = if (operand_is_ptr) operand_ty.childType(mod) else operand_ty;
+        const err_union_ty = if (operand_is_ptr) operand_ty.childType(zcu) else operand_ty;
         const result_ty = self.typeOfIndex(inst);
-        const payload_ty = if (operand_is_ptr) result_ty.childType(mod) else result_ty;
+        const payload_ty = if (operand_is_ptr) result_ty.childType(zcu) else result_ty;
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             return if (operand_is_ptr) operand else .none;
         }
         const offset = try errUnionPayloadOffset(payload_ty, pt);
         const err_union_llvm_ty = try o.lowerType(err_union_ty);
         if (operand_is_ptr) {
             return self.wip.gepStruct(err_union_llvm_ty, operand, offset, "");
-        } else if (isByRef(err_union_ty, pt)) {
-            const payload_alignment = payload_ty.abiAlignment(pt).toLlvm();
+        } else if (isByRef(err_union_ty, zcu)) {
+            const payload_alignment = payload_ty.abiAlignment(zcu).toLlvm();
             const payload_ptr = try self.wip.gepStruct(err_union_llvm_ty, operand, offset, "");
-            if (isByRef(payload_ty, pt)) {
+            if (isByRef(payload_ty, zcu)) {
                 if (self.canElideLoad(body_tail)) return payload_ptr;
                 return self.loadByRef(payload_ptr, payload_ty, payload_alignment, .normal);
             }
@@ -7382,13 +7385,13 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
         const error_type = try o.errorIntType();
-        const err_union_ty = if (operand_is_ptr) operand_ty.childType(mod) else operand_ty;
-        if (err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        const err_union_ty = if (operand_is_ptr) operand_ty.childType(zcu) else operand_ty;
+        if (err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             if (operand_is_ptr) {
                 return operand;
             } else {
@@ -7396,15 +7399,15 @@ pub const FuncGen = struct {
             }
         }
 
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             if (!operand_is_ptr) return operand;
             return self.wip.load(.normal, error_type, operand, .default, "");
         }
 
         const offset = try errUnionErrorOffset(payload_ty, pt);
 
-        if (operand_is_ptr or isByRef(err_union_ty, pt)) {
+        if (operand_is_ptr or isByRef(err_union_ty, zcu)) {
             const err_union_llvm_ty = try o.lowerType(err_union_ty);
             const err_field_ptr = try self.wip.gepStruct(err_union_llvm_ty, operand, offset, "");
             return self.wip.load(.normal, error_type, err_field_ptr, .default, "");
@@ -7416,21 +7419,21 @@ pub const FuncGen = struct {
     fn airErrUnionPayloadPtrSet(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
-        const err_union_ty = self.typeOf(ty_op.operand).childType(mod);
+        const err_union_ty = self.typeOf(ty_op.operand).childType(zcu);
 
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
         const non_error_val = try o.builder.intValue(try o.errorIntType(), 0);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             _ = try self.wip.store(.normal, non_error_val, operand, .default);
             return operand;
         }
         const err_union_llvm_ty = try o.lowerType(err_union_ty);
         {
             const err_int_ty = try pt.errorIntType();
-            const error_alignment = err_int_ty.abiAlignment(pt).toLlvm();
+            const error_alignment = err_int_ty.abiAlignment(zcu).toLlvm();
             const error_offset = try errUnionErrorOffset(payload_ty, pt);
             // First set the non-error value.
             const non_null_ptr = try self.wip.gepStruct(err_union_llvm_ty, operand, error_offset, "");
@@ -7457,7 +7460,7 @@ pub const FuncGen = struct {
     fn airSaveErrReturnTraceIndex(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
 
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const struct_ty = ty_pl.ty.toType();
@@ -7468,8 +7471,8 @@ pub const FuncGen = struct {
         assert(self.err_ret_trace != .none);
         const field_ptr =
             try self.wip.gepStruct(struct_llvm_ty, self.err_ret_trace, llvm_field_index, "");
-        const field_alignment = struct_ty.structFieldAlign(field_index, pt);
-        const field_ty = struct_ty.structFieldType(field_index, mod);
+        const field_alignment = struct_ty.structFieldAlign(field_index, zcu);
+        const field_ty = struct_ty.structFieldType(field_index, zcu);
         const field_ptr_ty = try pt.ptrType(.{
             .child = field_ty.toIntern(),
             .flags = .{ .alignment = field_alignment },
@@ -7503,23 +7506,23 @@ pub const FuncGen = struct {
     fn airWrapOptional(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const payload_ty = self.typeOf(ty_op.operand);
         const non_null_bit = try o.builder.intValue(.i8, 1);
         comptime assert(optional_layout_version == 3);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) return non_null_bit;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) return non_null_bit;
         const operand = try self.resolveInst(ty_op.operand);
         const optional_ty = self.typeOfIndex(inst);
-        if (optional_ty.optionalReprIsPayload(mod)) return operand;
+        if (optional_ty.optionalReprIsPayload(zcu)) return operand;
         const llvm_optional_ty = try o.lowerType(optional_ty);
-        if (isByRef(optional_ty, pt)) {
+        if (isByRef(optional_ty, zcu)) {
             const directReturn = self.isNextRet(body_tail);
             const optional_ptr = if (directReturn)
                 self.ret_ptr
             else brk: {
-                const alignment = optional_ty.abiAlignment(pt).toLlvm();
+                const alignment = optional_ty.abiAlignment(zcu).toLlvm();
                 const optional_ptr = try self.buildAllocaWorkaround(optional_ty, alignment);
                 break :brk optional_ptr;
             };
@@ -7537,12 +7540,13 @@ pub const FuncGen = struct {
     fn airWrapErrUnionPayload(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const err_un_ty = self.typeOfIndex(inst);
         const operand = try self.resolveInst(ty_op.operand);
         const payload_ty = self.typeOf(ty_op.operand);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             return operand;
         }
         const ok_err_code = try o.builder.intValue(try o.errorIntType(), 0);
@@ -7550,19 +7554,19 @@ pub const FuncGen = struct {
 
         const payload_offset = try errUnionPayloadOffset(payload_ty, pt);
         const error_offset = try errUnionErrorOffset(payload_ty, pt);
-        if (isByRef(err_un_ty, pt)) {
+        if (isByRef(err_un_ty, zcu)) {
             const directReturn = self.isNextRet(body_tail);
             const result_ptr = if (directReturn)
                 self.ret_ptr
             else brk: {
-                const alignment = err_un_ty.abiAlignment(pt).toLlvm();
+                const alignment = err_un_ty.abiAlignment(pt.zcu).toLlvm();
                 const result_ptr = try self.buildAllocaWorkaround(err_un_ty, alignment);
                 break :brk result_ptr;
             };
 
             const err_ptr = try self.wip.gepStruct(err_un_llvm_ty, result_ptr, error_offset, "");
             const err_int_ty = try pt.errorIntType();
-            const error_alignment = err_int_ty.abiAlignment(pt).toLlvm();
+            const error_alignment = err_int_ty.abiAlignment(pt.zcu).toLlvm();
             _ = try self.wip.store(.normal, ok_err_code, err_ptr, error_alignment);
             const payload_ptr = try self.wip.gepStruct(err_un_llvm_ty, result_ptr, payload_offset, "");
             const payload_ptr_ty = try pt.singleMutPtrType(payload_ty);
@@ -7578,30 +7582,30 @@ pub const FuncGen = struct {
     fn airWrapErrUnionErr(self: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const err_un_ty = self.typeOfIndex(inst);
-        const payload_ty = err_un_ty.errorUnionPayload(mod);
+        const payload_ty = err_un_ty.errorUnionPayload(zcu);
         const operand = try self.resolveInst(ty_op.operand);
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) return operand;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) return operand;
         const err_un_llvm_ty = try o.lowerType(err_un_ty);
 
         const payload_offset = try errUnionPayloadOffset(payload_ty, pt);
         const error_offset = try errUnionErrorOffset(payload_ty, pt);
-        if (isByRef(err_un_ty, pt)) {
+        if (isByRef(err_un_ty, zcu)) {
             const directReturn = self.isNextRet(body_tail);
             const result_ptr = if (directReturn)
                 self.ret_ptr
             else brk: {
-                const alignment = err_un_ty.abiAlignment(pt).toLlvm();
+                const alignment = err_un_ty.abiAlignment(zcu).toLlvm();
                 const result_ptr = try self.buildAllocaWorkaround(err_un_ty, alignment);
                 break :brk result_ptr;
             };
 
             const err_ptr = try self.wip.gepStruct(err_un_llvm_ty, result_ptr, error_offset, "");
             const err_int_ty = try pt.errorIntType();
-            const error_alignment = err_int_ty.abiAlignment(pt).toLlvm();
+            const error_alignment = err_int_ty.abiAlignment(zcu).toLlvm();
             _ = try self.wip.store(.normal, operand, err_ptr, error_alignment);
             const payload_ptr = try self.wip.gepStruct(err_un_llvm_ty, result_ptr, payload_offset, "");
             const payload_ptr_ty = try pt.singleMutPtrType(payload_ty);
@@ -7639,7 +7643,7 @@ pub const FuncGen = struct {
     fn airVectorStoreElem(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const data = self.air.instructions.items(.data)[@intFromEnum(inst)].vector_store_elem;
         const extra = self.air.extraData(Air.Bin, data.payload).data;
 
@@ -7649,9 +7653,9 @@ pub const FuncGen = struct {
         const operand = try self.resolveInst(extra.rhs);
 
         const access_kind: Builder.MemoryAccessKind =
-            if (vector_ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal;
-        const elem_llvm_ty = try o.lowerType(vector_ptr_ty.childType(mod));
-        const alignment = vector_ptr_ty.ptrAlignment(pt).toLlvm();
+            if (vector_ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal;
+        const elem_llvm_ty = try o.lowerType(vector_ptr_ty.childType(zcu));
+        const alignment = vector_ptr_ty.ptrAlignment(zcu).toLlvm();
         const loaded = try self.wip.load(access_kind, elem_llvm_ty, vector_ptr, alignment, "");
 
         const new_vector = try self.wip.insertElement(loaded, operand, index, "");
@@ -7661,18 +7665,18 @@ pub const FuncGen = struct {
 
     fn airMin(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.buildFloatOp(.fmin, .normal, inst_ty, 2, .{ lhs, rhs });
         return self.wip.callIntrinsic(
             .normal,
             .none,
-            if (scalar_ty.isSignedInt(mod)) .smin else .umin,
+            if (scalar_ty.isSignedInt(zcu)) .smin else .umin,
             &.{try o.lowerType(inst_ty)},
             &.{ lhs, rhs },
             "",
@@ -7681,18 +7685,18 @@ pub const FuncGen = struct {
 
     fn airMax(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.buildFloatOp(.fmax, .normal, inst_ty, 2, .{ lhs, rhs });
         return self.wip.callIntrinsic(
             .normal,
             .none,
-            if (scalar_ty.isSignedInt(mod)) .smax else .umax,
+            if (scalar_ty.isSignedInt(zcu)) .smax else .umax,
             &.{try o.lowerType(inst_ty)},
             &.{ lhs, rhs },
             "",
@@ -7711,15 +7715,15 @@ pub const FuncGen = struct {
 
     fn airAdd(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.buildFloatOp(.add, fast, inst_ty, 2, .{ lhs, rhs });
-        return self.wip.bin(if (scalar_ty.isSignedInt(mod)) .@"add nsw" else .@"add nuw", lhs, rhs, "");
+        return self.wip.bin(if (scalar_ty.isSignedInt(zcu)) .@"add nsw" else .@"add nuw", lhs, rhs, "");
     }
 
     fn airSafeArithmetic(
@@ -7729,15 +7733,15 @@ pub const FuncGen = struct {
         unsigned_intrinsic: Builder.Intrinsic,
     ) !Builder.Value {
         const o = fg.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
 
         const bin_op = fg.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try fg.resolveInst(bin_op.lhs);
         const rhs = try fg.resolveInst(bin_op.rhs);
         const inst_ty = fg.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
-        const intrinsic = if (scalar_ty.isSignedInt(mod)) signed_intrinsic else unsigned_intrinsic;
+        const intrinsic = if (scalar_ty.isSignedInt(zcu)) signed_intrinsic else unsigned_intrinsic;
         const llvm_inst_ty = try o.lowerType(inst_ty);
         const results =
             try fg.wip.callIntrinsic(.normal, .none, intrinsic, &.{llvm_inst_ty}, &.{ lhs, rhs }, "");
@@ -7777,18 +7781,18 @@ pub const FuncGen = struct {
 
     fn airAddSat(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.todo("saturating float add", .{});
         return self.wip.callIntrinsic(
             .normal,
             .none,
-            if (scalar_ty.isSignedInt(mod)) .@"sadd.sat" else .@"uadd.sat",
+            if (scalar_ty.isSignedInt(zcu)) .@"sadd.sat" else .@"uadd.sat",
             &.{try o.lowerType(inst_ty)},
             &.{ lhs, rhs },
             "",
@@ -7797,15 +7801,15 @@ pub const FuncGen = struct {
 
     fn airSub(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.buildFloatOp(.sub, fast, inst_ty, 2, .{ lhs, rhs });
-        return self.wip.bin(if (scalar_ty.isSignedInt(mod)) .@"sub nsw" else .@"sub nuw", lhs, rhs, "");
+        return self.wip.bin(if (scalar_ty.isSignedInt(zcu)) .@"sub nsw" else .@"sub nuw", lhs, rhs, "");
     }
 
     fn airSubWrap(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
@@ -7818,18 +7822,18 @@ pub const FuncGen = struct {
 
     fn airSubSat(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.todo("saturating float sub", .{});
         return self.wip.callIntrinsic(
             .normal,
             .none,
-            if (scalar_ty.isSignedInt(mod)) .@"ssub.sat" else .@"usub.sat",
+            if (scalar_ty.isSignedInt(zcu)) .@"ssub.sat" else .@"usub.sat",
             &.{try o.lowerType(inst_ty)},
             &.{ lhs, rhs },
             "",
@@ -7838,15 +7842,15 @@ pub const FuncGen = struct {
 
     fn airMul(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.buildFloatOp(.mul, fast, inst_ty, 2, .{ lhs, rhs });
-        return self.wip.bin(if (scalar_ty.isSignedInt(mod)) .@"mul nsw" else .@"mul nuw", lhs, rhs, "");
+        return self.wip.bin(if (scalar_ty.isSignedInt(zcu)) .@"mul nsw" else .@"mul nuw", lhs, rhs, "");
     }
 
     fn airMulWrap(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
@@ -7859,18 +7863,18 @@ pub const FuncGen = struct {
 
     fn airMulSat(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isAnyFloat()) return self.todo("saturating float mul", .{});
         return self.wip.callIntrinsic(
             .normal,
             .none,
-            if (scalar_ty.isSignedInt(mod)) .@"smul.fix.sat" else .@"umul.fix.sat",
+            if (scalar_ty.isSignedInt(zcu)) .@"smul.fix.sat" else .@"umul.fix.sat",
             &.{try o.lowerType(inst_ty)},
             &.{ lhs, rhs, .@"0" },
             "",
@@ -7888,34 +7892,34 @@ pub const FuncGen = struct {
 
     fn airDivTrunc(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isRuntimeFloat()) {
             const result = try self.buildFloatOp(.div, fast, inst_ty, 2, .{ lhs, rhs });
             return self.buildFloatOp(.trunc, fast, inst_ty, 1, .{result});
         }
-        return self.wip.bin(if (scalar_ty.isSignedInt(mod)) .sdiv else .udiv, lhs, rhs, "");
+        return self.wip.bin(if (scalar_ty.isSignedInt(zcu)) .sdiv else .udiv, lhs, rhs, "");
     }
 
     fn airDivFloor(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isRuntimeFloat()) {
             const result = try self.buildFloatOp(.div, fast, inst_ty, 2, .{ lhs, rhs });
             return self.buildFloatOp(.floor, fast, inst_ty, 1, .{result});
         }
-        if (scalar_ty.isSignedInt(mod)) {
+        if (scalar_ty.isSignedInt(zcu)) {
             const inst_llvm_ty = try o.lowerType(inst_ty);
             const bit_size_minus_one = try o.builder.splatValue(inst_llvm_ty, try o.builder.intConst(
                 inst_llvm_ty.scalarType(&o.builder),
@@ -7936,16 +7940,16 @@ pub const FuncGen = struct {
 
     fn airDivExact(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isRuntimeFloat()) return self.buildFloatOp(.div, fast, inst_ty, 2, .{ lhs, rhs });
         return self.wip.bin(
-            if (scalar_ty.isSignedInt(mod)) .@"sdiv exact" else .@"udiv exact",
+            if (scalar_ty.isSignedInt(zcu)) .@"sdiv exact" else .@"udiv exact",
             lhs,
             rhs,
             "",
@@ -7954,16 +7958,16 @@ pub const FuncGen = struct {
 
     fn airRem(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isRuntimeFloat())
             return self.buildFloatOp(.fmod, fast, inst_ty, 2, .{ lhs, rhs });
-        return self.wip.bin(if (scalar_ty.isSignedInt(mod))
+        return self.wip.bin(if (scalar_ty.isSignedInt(zcu))
             .srem
         else
             .urem, lhs, rhs, "");
@@ -7971,13 +7975,13 @@ pub const FuncGen = struct {
 
     fn airMod(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
         const inst_ty = self.typeOfIndex(inst);
         const inst_llvm_ty = try o.lowerType(inst_ty);
-        const scalar_ty = inst_ty.scalarType(mod);
+        const scalar_ty = inst_ty.scalarType(zcu);
 
         if (scalar_ty.isRuntimeFloat()) {
             const a = try self.buildFloatOp(.fmod, fast, inst_ty, 2, .{ lhs, rhs });
@@ -7987,7 +7991,7 @@ pub const FuncGen = struct {
             const ltz = try self.buildFloatCmp(fast, .lt, inst_ty, .{ lhs, zero });
             return self.wip.select(fast, ltz, c, a, "");
         }
-        if (scalar_ty.isSignedInt(mod)) {
+        if (scalar_ty.isSignedInt(zcu)) {
             const bit_size_minus_one = try o.builder.splatValue(inst_llvm_ty, try o.builder.intConst(
                 inst_llvm_ty.scalarType(&o.builder),
                 inst_llvm_ty.scalarBits(&o.builder) - 1,
@@ -8007,14 +8011,14 @@ pub const FuncGen = struct {
 
     fn airPtrAdd(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const ptr = try self.resolveInst(bin_op.lhs);
         const offset = try self.resolveInst(bin_op.rhs);
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const llvm_elem_ty = try o.lowerPtrElemTy(ptr_ty.childType(mod));
-        switch (ptr_ty.ptrSize(mod)) {
+        const llvm_elem_ty = try o.lowerPtrElemTy(ptr_ty.childType(zcu));
+        switch (ptr_ty.ptrSize(zcu)) {
             // It's a pointer to an array, so according to LLVM we need an extra GEP index.
             .One => return self.wip.gep(.inbounds, llvm_elem_ty, ptr, &.{
                 try o.builder.intValue(try o.lowerType(Type.usize), 0), offset,
@@ -8029,15 +8033,15 @@ pub const FuncGen = struct {
 
     fn airPtrSub(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const ptr = try self.resolveInst(bin_op.lhs);
         const offset = try self.resolveInst(bin_op.rhs);
         const negative_offset = try self.wip.neg(offset, "");
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const llvm_elem_ty = try o.lowerPtrElemTy(ptr_ty.childType(mod));
-        switch (ptr_ty.ptrSize(mod)) {
+        const llvm_elem_ty = try o.lowerPtrElemTy(ptr_ty.childType(zcu));
+        switch (ptr_ty.ptrSize(zcu)) {
             // It's a pointer to an array, so according to LLVM we need an extra GEP index.
             .One => return self.wip.gep(.inbounds, llvm_elem_ty, ptr, &.{
                 try o.builder.intValue(try o.lowerType(Type.usize), 0), negative_offset,
@@ -8058,7 +8062,7 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
 
@@ -8066,10 +8070,10 @@ pub const FuncGen = struct {
         const rhs = try self.resolveInst(extra.rhs);
 
         const lhs_ty = self.typeOf(extra.lhs);
-        const scalar_ty = lhs_ty.scalarType(mod);
+        const scalar_ty = lhs_ty.scalarType(zcu);
         const inst_ty = self.typeOfIndex(inst);
 
-        const intrinsic = if (scalar_ty.isSignedInt(mod)) signed_intrinsic else unsigned_intrinsic;
+        const intrinsic = if (scalar_ty.isSignedInt(zcu)) signed_intrinsic else unsigned_intrinsic;
         const llvm_inst_ty = try o.lowerType(inst_ty);
         const llvm_lhs_ty = try o.lowerType(lhs_ty);
         const results =
@@ -8081,8 +8085,8 @@ pub const FuncGen = struct {
         const result_index = o.llvmFieldIndex(inst_ty, 0).?;
         const overflow_index = o.llvmFieldIndex(inst_ty, 1).?;
 
-        if (isByRef(inst_ty, pt)) {
-            const result_alignment = inst_ty.abiAlignment(pt).toLlvm();
+        if (isByRef(inst_ty, zcu)) {
+            const result_alignment = inst_ty.abiAlignment(zcu).toLlvm();
             const alloca_inst = try self.buildAllocaWorkaround(inst_ty, result_alignment);
             {
                 const field_ptr = try self.wip.gepStruct(llvm_inst_ty, alloca_inst, result_index, "");
@@ -8165,9 +8169,9 @@ pub const FuncGen = struct {
         params: [2]Builder.Value,
     ) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
-        const target = mod.getTarget();
-        const scalar_ty = ty.scalarType(mod);
+        const zcu = o.pt.zcu;
+        const target = zcu.getTarget();
+        const scalar_ty = ty.scalarType(zcu);
         const scalar_llvm_ty = try o.lowerType(scalar_ty);
 
         if (intrinsicsAllowed(scalar_ty, target)) {
@@ -8205,8 +8209,8 @@ pub const FuncGen = struct {
             .gte => .sge,
         };
 
-        if (ty.zigTypeTag(mod) == .Vector) {
-            const vec_len = ty.vectorLen(mod);
+        if (ty.zigTypeTag(zcu) == .Vector) {
+            const vec_len = ty.vectorLen(zcu);
             const vector_result_ty = try o.builder.vectorType(.normal, vec_len, .i32);
 
             const init = try o.builder.poisonValue(vector_result_ty);
@@ -8271,9 +8275,9 @@ pub const FuncGen = struct {
         params: [params_len]Builder.Value,
     ) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
-        const target = mod.getTarget();
-        const scalar_ty = ty.scalarType(mod);
+        const zcu = o.pt.zcu;
+        const target = zcu.getTarget();
+        const scalar_ty = ty.scalarType(zcu);
         const llvm_ty = try o.lowerType(ty);
 
         if (op != .tan and intrinsicsAllowed(scalar_ty, target)) switch (op) {
@@ -8382,9 +8386,9 @@ pub const FuncGen = struct {
             ([1]Builder.Type{scalar_llvm_ty} ** 3)[0..params.len],
             scalar_llvm_ty,
         );
-        if (ty.zigTypeTag(mod) == .Vector) {
+        if (ty.zigTypeTag(zcu) == .Vector) {
             const result = try o.builder.poisonValue(llvm_ty);
-            return self.buildElementwiseCall(libc_fn, &params, result, ty.vectorLen(mod));
+            return self.buildElementwiseCall(libc_fn, &params, result, ty.vectorLen(zcu));
         }
 
         return self.wip.call(
@@ -8413,7 +8417,7 @@ pub const FuncGen = struct {
     fn airShlWithOverflow(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
 
@@ -8421,7 +8425,7 @@ pub const FuncGen = struct {
         const rhs = try self.resolveInst(extra.rhs);
 
         const lhs_ty = self.typeOf(extra.lhs);
-        const lhs_scalar_ty = lhs_ty.scalarType(mod);
+        const lhs_scalar_ty = lhs_ty.scalarType(zcu);
 
         const dest_ty = self.typeOfIndex(inst);
         const llvm_dest_ty = try o.lowerType(dest_ty);
@@ -8429,7 +8433,7 @@ pub const FuncGen = struct {
         const casted_rhs = try self.wip.conv(.unsigned, rhs, try o.lowerType(lhs_ty), "");
 
         const result = try self.wip.bin(.shl, lhs, casted_rhs, "");
-        const reconstructed = try self.wip.bin(if (lhs_scalar_ty.isSignedInt(mod))
+        const reconstructed = try self.wip.bin(if (lhs_scalar_ty.isSignedInt(zcu))
             .ashr
         else
             .lshr, result, casted_rhs, "");
@@ -8439,8 +8443,8 @@ pub const FuncGen = struct {
         const result_index = o.llvmFieldIndex(dest_ty, 0).?;
         const overflow_index = o.llvmFieldIndex(dest_ty, 1).?;
 
-        if (isByRef(dest_ty, pt)) {
-            const result_alignment = dest_ty.abiAlignment(pt).toLlvm();
+        if (isByRef(dest_ty, zcu)) {
+            const result_alignment = dest_ty.abiAlignment(zcu).toLlvm();
             const alloca_inst = try self.buildAllocaWorkaround(dest_ty, result_alignment);
             {
                 const field_ptr = try self.wip.gepStruct(llvm_dest_ty, alloca_inst, result_index, "");
@@ -8483,17 +8487,17 @@ pub const FuncGen = struct {
 
     fn airShlExact(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
 
         const lhs_ty = self.typeOf(bin_op.lhs);
-        const lhs_scalar_ty = lhs_ty.scalarType(mod);
+        const lhs_scalar_ty = lhs_ty.scalarType(zcu);
 
         const casted_rhs = try self.wip.conv(.unsigned, rhs, try o.lowerType(lhs_ty), "");
-        return self.wip.bin(if (lhs_scalar_ty.isSignedInt(mod))
+        return self.wip.bin(if (lhs_scalar_ty.isSignedInt(zcu))
             .@"shl nsw"
         else
             .@"shl nuw", lhs, casted_rhs, "");
@@ -8515,15 +8519,15 @@ pub const FuncGen = struct {
     fn airShlSat(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
 
         const lhs_ty = self.typeOf(bin_op.lhs);
-        const lhs_scalar_ty = lhs_ty.scalarType(mod);
-        const lhs_bits = lhs_scalar_ty.bitSize(pt);
+        const lhs_scalar_ty = lhs_ty.scalarType(zcu);
+        const lhs_bits = lhs_scalar_ty.bitSize(zcu);
 
         const casted_rhs = try self.wip.conv(.unsigned, rhs, try o.lowerType(lhs_ty), "");
 
@@ -8532,7 +8536,7 @@ pub const FuncGen = struct {
         const result = try self.wip.callIntrinsic(
             .normal,
             .none,
-            if (lhs_scalar_ty.isSignedInt(mod)) .@"sshl.sat" else .@"ushl.sat",
+            if (lhs_scalar_ty.isSignedInt(zcu)) .@"sshl.sat" else .@"ushl.sat",
             &.{llvm_lhs_ty},
             &.{ lhs, casted_rhs },
             "",
@@ -8557,17 +8561,17 @@ pub const FuncGen = struct {
 
     fn airShr(self: *FuncGen, inst: Air.Inst.Index, is_exact: bool) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
         const lhs = try self.resolveInst(bin_op.lhs);
         const rhs = try self.resolveInst(bin_op.rhs);
 
         const lhs_ty = self.typeOf(bin_op.lhs);
-        const lhs_scalar_ty = lhs_ty.scalarType(mod);
+        const lhs_scalar_ty = lhs_ty.scalarType(zcu);
 
         const casted_rhs = try self.wip.conv(.unsigned, rhs, try o.lowerType(lhs_ty), "");
-        const is_signed_int = lhs_scalar_ty.isSignedInt(mod);
+        const is_signed_int = lhs_scalar_ty.isSignedInt(zcu);
 
         return self.wip.bin(if (is_exact)
             if (is_signed_int) .@"ashr exact" else .@"lshr exact"
@@ -8576,13 +8580,13 @@ pub const FuncGen = struct {
 
     fn airAbs(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        const scalar_ty = operand_ty.scalarType(mod);
+        const scalar_ty = operand_ty.scalarType(zcu);
 
-        switch (scalar_ty.zigTypeTag(mod)) {
+        switch (scalar_ty.zigTypeTag(zcu)) {
             .Int => return self.wip.callIntrinsic(
                 .normal,
                 .none,
@@ -8598,13 +8602,13 @@ pub const FuncGen = struct {
 
     fn airIntCast(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const dest_ty = self.typeOfIndex(inst);
         const dest_llvm_ty = try o.lowerType(dest_ty);
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        const operand_info = operand_ty.intInfo(mod);
+        const operand_info = operand_ty.intInfo(zcu);
 
         return self.wip.conv(switch (operand_info.signedness) {
             .signed => .signed,
@@ -8622,12 +8626,12 @@ pub const FuncGen = struct {
 
     fn airFptrunc(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
         const dest_ty = self.typeOfIndex(inst);
-        const target = mod.getTarget();
+        const target = zcu.getTarget();
         const dest_bits = dest_ty.floatBits(target);
         const src_bits = operand_ty.floatBits(target);
 
@@ -8656,12 +8660,12 @@ pub const FuncGen = struct {
 
     fn airFpext(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
         const dest_ty = self.typeOfIndex(inst);
-        const target = mod.getTarget();
+        const target = zcu.getTarget();
 
         if (intrinsicsAllowed(dest_ty, target) and intrinsicsAllowed(operand_ty, target)) {
             return self.wip.cast(.fpext, operand, try o.lowerType(dest_ty), "");
@@ -8669,18 +8673,18 @@ pub const FuncGen = struct {
             const operand_llvm_ty = try o.lowerType(operand_ty);
             const dest_llvm_ty = try o.lowerType(dest_ty);
 
-            const dest_bits = dest_ty.scalarType(mod).floatBits(target);
-            const src_bits = operand_ty.scalarType(mod).floatBits(target);
+            const dest_bits = dest_ty.scalarType(zcu).floatBits(target);
+            const src_bits = operand_ty.scalarType(zcu).floatBits(target);
             const fn_name = try o.builder.strtabStringFmt("__extend{s}f{s}f2", .{
                 compilerRtFloatAbbrev(src_bits), compilerRtFloatAbbrev(dest_bits),
             });
 
             const libc_fn = try self.getLibcFunction(fn_name, &.{operand_llvm_ty}, dest_llvm_ty);
-            if (dest_ty.isVector(mod)) return self.buildElementwiseCall(
+            if (dest_ty.isVector(zcu)) return self.buildElementwiseCall(
                 libc_fn,
                 &.{operand},
                 try o.builder.poisonValue(dest_llvm_ty),
-                dest_ty.vectorLen(mod),
+                dest_ty.vectorLen(zcu),
             );
             return self.wip.call(
                 .normal,
@@ -8715,9 +8719,9 @@ pub const FuncGen = struct {
     fn bitCast(self: *FuncGen, operand: Builder.Value, operand_ty: Type, inst_ty: Type) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const operand_is_ref = isByRef(operand_ty, pt);
-        const result_is_ref = isByRef(inst_ty, pt);
+        const zcu = pt.zcu;
+        const operand_is_ref = isByRef(operand_ty, zcu);
+        const result_is_ref = isByRef(inst_ty, zcu);
         const llvm_dest_ty = try o.lowerType(inst_ty);
 
         if (operand_is_ref and result_is_ref) {
@@ -8731,18 +8735,18 @@ pub const FuncGen = struct {
             return self.wip.conv(.unsigned, operand, llvm_dest_ty, "");
         }
 
-        if (operand_ty.zigTypeTag(mod) == .Int and inst_ty.isPtrAtRuntime(mod)) {
+        if (operand_ty.zigTypeTag(zcu) == .Int and inst_ty.isPtrAtRuntime(zcu)) {
             return self.wip.cast(.inttoptr, operand, llvm_dest_ty, "");
         }
 
-        if (operand_ty.zigTypeTag(mod) == .Vector and inst_ty.zigTypeTag(mod) == .Array) {
-            const elem_ty = operand_ty.childType(mod);
+        if (operand_ty.zigTypeTag(zcu) == .Vector and inst_ty.zigTypeTag(zcu) == .Array) {
+            const elem_ty = operand_ty.childType(zcu);
             if (!result_is_ref) {
                 return self.ng.todo("implement bitcast vector to non-ref array", .{});
             }
-            const alignment = inst_ty.abiAlignment(pt).toLlvm();
+            const alignment = inst_ty.abiAlignment(zcu).toLlvm();
             const array_ptr = try self.buildAllocaWorkaround(inst_ty, alignment);
-            const bitcast_ok = elem_ty.bitSize(pt) == elem_ty.abiSize(pt) * 8;
+            const bitcast_ok = elem_ty.bitSize(zcu) == elem_ty.abiSize(zcu) * 8;
             if (bitcast_ok) {
                 _ = try self.wip.store(.normal, operand, array_ptr, alignment);
             } else {
@@ -8750,7 +8754,7 @@ pub const FuncGen = struct {
                 // a simple bitcast will not work, and we fall back to extractelement.
                 const llvm_usize = try o.lowerType(Type.usize);
                 const usize_zero = try o.builder.intValue(llvm_usize, 0);
-                const vector_len = operand_ty.arrayLen(mod);
+                const vector_len = operand_ty.arrayLen(zcu);
                 var i: u64 = 0;
                 while (i < vector_len) : (i += 1) {
                     const elem_ptr = try self.wip.gep(.inbounds, llvm_dest_ty, array_ptr, &.{
@@ -8762,16 +8766,16 @@ pub const FuncGen = struct {
                 }
             }
             return array_ptr;
-        } else if (operand_ty.zigTypeTag(mod) == .Array and inst_ty.zigTypeTag(mod) == .Vector) {
-            const elem_ty = operand_ty.childType(mod);
+        } else if (operand_ty.zigTypeTag(zcu) == .Array and inst_ty.zigTypeTag(zcu) == .Vector) {
+            const elem_ty = operand_ty.childType(zcu);
             const llvm_vector_ty = try o.lowerType(inst_ty);
             if (!operand_is_ref) return self.ng.todo("implement bitcast non-ref array to vector", .{});
 
-            const bitcast_ok = elem_ty.bitSize(pt) == elem_ty.abiSize(pt) * 8;
+            const bitcast_ok = elem_ty.bitSize(zcu) == elem_ty.abiSize(zcu) * 8;
             if (bitcast_ok) {
                 // The array is aligned to the element's alignment, while the vector might have a completely
                 // different alignment. This means we need to enforce the alignment of this load.
-                const alignment = elem_ty.abiAlignment(pt).toLlvm();
+                const alignment = elem_ty.abiAlignment(zcu).toLlvm();
                 return self.wip.load(.normal, llvm_vector_ty, operand, alignment, "");
             } else {
                 // If the ABI size of the element type is not evenly divisible by size in bits;
@@ -8780,7 +8784,7 @@ pub const FuncGen = struct {
                 const elem_llvm_ty = try o.lowerType(elem_ty);
                 const llvm_usize = try o.lowerType(Type.usize);
                 const usize_zero = try o.builder.intValue(llvm_usize, 0);
-                const vector_len = operand_ty.arrayLen(mod);
+                const vector_len = operand_ty.arrayLen(zcu);
                 var vector = try o.builder.poisonValue(llvm_vector_ty);
                 var i: u64 = 0;
                 while (i < vector_len) : (i += 1) {
@@ -8796,25 +8800,25 @@ pub const FuncGen = struct {
         }
 
         if (operand_is_ref) {
-            const alignment = operand_ty.abiAlignment(pt).toLlvm();
+            const alignment = operand_ty.abiAlignment(zcu).toLlvm();
             return self.wip.load(.normal, llvm_dest_ty, operand, alignment, "");
         }
 
         if (result_is_ref) {
-            const alignment = operand_ty.abiAlignment(pt).max(inst_ty.abiAlignment(pt)).toLlvm();
+            const alignment = operand_ty.abiAlignment(zcu).max(inst_ty.abiAlignment(zcu)).toLlvm();
             const result_ptr = try self.buildAllocaWorkaround(inst_ty, alignment);
             _ = try self.wip.store(.normal, operand, result_ptr, alignment);
             return result_ptr;
         }
 
         if (llvm_dest_ty.isStruct(&o.builder) or
-            ((operand_ty.zigTypeTag(mod) == .Vector or inst_ty.zigTypeTag(mod) == .Vector) and
-            operand_ty.bitSize(pt) != inst_ty.bitSize(pt)))
+            ((operand_ty.zigTypeTag(zcu) == .Vector or inst_ty.zigTypeTag(zcu) == .Vector) and
+            operand_ty.bitSize(zcu) != inst_ty.bitSize(zcu)))
         {
             // Both our operand and our result are values, not pointers,
             // but LLVM won't let us bitcast struct values or vectors with padding bits.
             // Therefore, we store operand to alloca, then load for result.
-            const alignment = operand_ty.abiAlignment(pt).max(inst_ty.abiAlignment(pt)).toLlvm();
+            const alignment = operand_ty.abiAlignment(zcu).max(inst_ty.abiAlignment(zcu)).toLlvm();
             const result_ptr = try self.buildAllocaWorkaround(inst_ty, alignment);
             _ = try self.wip.store(.normal, operand, result_ptr, alignment);
             return self.wip.load(.normal, llvm_dest_ty, result_ptr, alignment, "");
@@ -8868,7 +8872,7 @@ pub const FuncGen = struct {
         };
 
         const mod = self.ng.ownerModule();
-        if (isByRef(inst_ty, pt)) {
+        if (isByRef(inst_ty, zcu)) {
             _ = try self.wip.callIntrinsic(
                 .normal,
                 .none,
@@ -8882,7 +8886,7 @@ pub const FuncGen = struct {
                 "",
             );
         } else if (mod.optimize_mode == .Debug) {
-            const alignment = inst_ty.abiAlignment(pt).toLlvm();
+            const alignment = inst_ty.abiAlignment(zcu).toLlvm();
             const alloca = try self.buildAlloca(arg_val.typeOfWip(&self.wip), alignment);
             _ = try self.wip.store(.normal, arg_val, alloca, alignment);
             _ = try self.wip.callIntrinsic(
@@ -8919,28 +8923,28 @@ pub const FuncGen = struct {
     fn airAlloc(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ptr_ty = self.typeOfIndex(inst);
-        const pointee_type = ptr_ty.childType(mod);
-        if (!pointee_type.isFnOrHasRuntimeBitsIgnoreComptime(pt))
+        const pointee_type = ptr_ty.childType(zcu);
+        if (!pointee_type.isFnOrHasRuntimeBitsIgnoreComptime(zcu))
             return (try o.lowerPtrToVoid(ptr_ty)).toValue();
 
         //const pointee_llvm_ty = try o.lowerType(pointee_type);
-        const alignment = ptr_ty.ptrAlignment(pt).toLlvm();
+        const alignment = ptr_ty.ptrAlignment(zcu).toLlvm();
         return self.buildAllocaWorkaround(pointee_type, alignment);
     }
 
     fn airRetPtr(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ptr_ty = self.typeOfIndex(inst);
-        const ret_ty = ptr_ty.childType(mod);
-        if (!ret_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt))
+        const ret_ty = ptr_ty.childType(zcu);
+        if (!ret_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu))
             return (try o.lowerPtrToVoid(ptr_ty)).toValue();
         if (self.ret_ptr != .none) return self.ret_ptr;
         //const ret_llvm_ty = try o.lowerType(ret_ty);
-        const alignment = ptr_ty.ptrAlignment(pt).toLlvm();
+        const alignment = ptr_ty.ptrAlignment(zcu).toLlvm();
         return self.buildAllocaWorkaround(ret_ty, alignment);
     }
 
@@ -8962,19 +8966,19 @@ pub const FuncGen = struct {
         alignment: Builder.Alignment,
     ) Allocator.Error!Builder.Value {
         const o = self.ng.object;
-        return self.buildAlloca(try o.builder.arrayType(ty.abiSize(o.pt), .i8), alignment);
+        return self.buildAlloca(try o.builder.arrayType(ty.abiSize(o.pt.zcu), .i8), alignment);
     }
 
     fn airStore(self: *FuncGen, inst: Air.Inst.Index, safety: bool) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const dest_ptr = try self.resolveInst(bin_op.lhs);
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const operand_ty = ptr_ty.childType(mod);
+        const operand_ty = ptr_ty.childType(zcu);
 
-        const val_is_undef = if (try self.air.value(bin_op.rhs, pt)) |val| val.isUndefDeep(mod) else false;
+        const val_is_undef = if (try self.air.value(bin_op.rhs, pt)) |val| val.isUndefDeep(zcu) else false;
         if (val_is_undef) {
             const owner_mod = self.ng.ownerModule();
 
@@ -8991,7 +8995,7 @@ pub const FuncGen = struct {
                 return .none;
             }
 
-            const ptr_info = ptr_ty.ptrInfo(mod);
+            const ptr_info = ptr_ty.ptrInfo(zcu);
             const needs_bitmask = (ptr_info.packed_offset.host_size != 0);
             if (needs_bitmask) {
                 // TODO: only some bits are to be undef, we cannot write with a simple memset.
@@ -9000,13 +9004,13 @@ pub const FuncGen = struct {
                 return .none;
             }
 
-            const len = try o.builder.intValue(try o.lowerType(Type.usize), operand_ty.abiSize(pt));
+            const len = try o.builder.intValue(try o.lowerType(Type.usize), operand_ty.abiSize(zcu));
             _ = try self.wip.callMemSet(
                 dest_ptr,
-                ptr_ty.ptrAlignment(pt).toLlvm(),
+                ptr_ty.ptrAlignment(zcu).toLlvm(),
                 if (safety) try o.builder.intValue(.i8, 0xaa) else try o.builder.undefValue(.i8),
                 len,
-                if (ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal,
+                if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal,
             );
             if (safety and owner_mod.valgrind) {
                 try self.valgrindMarkUndef(dest_ptr, len);
@@ -9027,8 +9031,8 @@ pub const FuncGen = struct {
     /// The first instruction of `body_tail` is the one whose copy we want to elide.
     fn canElideLoad(fg: *FuncGen, body_tail: []const Air.Inst.Index) bool {
         const o = fg.ng.object;
-        const mod = o.pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = o.pt.zcu;
+        const ip = &zcu.intern_pool;
         for (body_tail[1..]) |body_inst| {
             switch (fg.liveness.categorizeOperand(fg.air, body_inst, body_tail[0], ip)) {
                 .none => continue,
@@ -9044,15 +9048,15 @@ pub const FuncGen = struct {
     fn airLoad(fg: *FuncGen, body_tail: []const Air.Inst.Index) !Builder.Value {
         const o = fg.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const inst = body_tail[0];
         const ty_op = fg.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const ptr_ty = fg.typeOf(ty_op.operand);
-        const ptr_info = ptr_ty.ptrInfo(mod);
+        const ptr_info = ptr_ty.ptrInfo(zcu);
         const ptr = try fg.resolveInst(ty_op.operand);
 
         elide: {
-            if (!isByRef(Type.fromInterned(ptr_info.child), pt)) break :elide;
+            if (!isByRef(Type.fromInterned(ptr_info.child), zcu)) break :elide;
             if (!canElideLoad(fg, body_tail)) break :elide;
             return ptr;
         }
@@ -9105,34 +9109,34 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Cmpxchg, ty_pl.payload).data;
         const ptr = try self.resolveInst(extra.ptr);
         const ptr_ty = self.typeOf(extra.ptr);
         var expected_value = try self.resolveInst(extra.expected_value);
         var new_value = try self.resolveInst(extra.new_value);
-        const operand_ty = ptr_ty.childType(mod);
+        const operand_ty = ptr_ty.childType(zcu);
         const llvm_operand_ty = try o.lowerType(operand_ty);
         const llvm_abi_ty = try o.getAtomicAbiType(operand_ty, false);
         if (llvm_abi_ty != .none) {
             // operand needs widening and truncating
             const signedness: Builder.Function.Instruction.Cast.Signedness =
-                if (operand_ty.isSignedInt(mod)) .signed else .unsigned;
+                if (operand_ty.isSignedInt(zcu)) .signed else .unsigned;
             expected_value = try self.wip.conv(signedness, expected_value, llvm_abi_ty, "");
             new_value = try self.wip.conv(signedness, new_value, llvm_abi_ty, "");
         }
 
         const result = try self.wip.cmpxchg(
             kind,
-            if (ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal,
+            if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal,
             ptr,
             expected_value,
             new_value,
             self.sync_scope,
             toLlvmAtomicOrdering(extra.successOrder()),
             toLlvmAtomicOrdering(extra.failureOrder()),
-            ptr_ty.ptrAlignment(pt).toLlvm(),
+            ptr_ty.ptrAlignment(zcu).toLlvm(),
             "",
         );
 
@@ -9142,7 +9146,7 @@ pub const FuncGen = struct {
         if (llvm_abi_ty != .none) payload = try self.wip.cast(.trunc, payload, llvm_operand_ty, "");
         const success_bit = try self.wip.extractValue(result, &.{1}, "");
 
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             const zero = try o.builder.zeroInitValue(payload.typeOfWip(&self.wip));
             return self.wip.select(.normal, success_bit, zero, payload, "");
         }
@@ -9156,14 +9160,14 @@ pub const FuncGen = struct {
     fn airAtomicRmw(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const extra = self.air.extraData(Air.AtomicRmw, pl_op.payload).data;
         const ptr = try self.resolveInst(pl_op.operand);
         const ptr_ty = self.typeOf(pl_op.operand);
-        const operand_ty = ptr_ty.childType(mod);
+        const operand_ty = ptr_ty.childType(zcu);
         const operand = try self.resolveInst(extra.operand);
-        const is_signed_int = operand_ty.isSignedInt(mod);
+        const is_signed_int = operand_ty.isSignedInt(zcu);
         const is_float = operand_ty.isRuntimeFloat();
         const op = toLlvmAtomicRmwBinOp(extra.op(), is_signed_int, is_float);
         const ordering = toLlvmAtomicOrdering(extra.ordering());
@@ -9171,8 +9175,8 @@ pub const FuncGen = struct {
         const llvm_operand_ty = try o.lowerType(operand_ty);
 
         const access_kind: Builder.MemoryAccessKind =
-            if (ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal;
-        const ptr_alignment = ptr_ty.ptrAlignment(pt).toLlvm();
+            if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal;
+        const ptr_alignment = ptr_ty.ptrAlignment(zcu).toLlvm();
 
         if (llvm_abi_ty != .none) {
             // operand needs widening and truncating or bitcasting.
@@ -9220,19 +9224,19 @@ pub const FuncGen = struct {
     fn airAtomicLoad(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const atomic_load = self.air.instructions.items(.data)[@intFromEnum(inst)].atomic_load;
         const ptr = try self.resolveInst(atomic_load.ptr);
         const ptr_ty = self.typeOf(atomic_load.ptr);
-        const info = ptr_ty.ptrInfo(mod);
+        const info = ptr_ty.ptrInfo(zcu);
         const elem_ty = Type.fromInterned(info.child);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) return .none;
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) return .none;
         const ordering = toLlvmAtomicOrdering(atomic_load.order);
         const llvm_abi_ty = try o.getAtomicAbiType(elem_ty, false);
         const ptr_alignment = (if (info.flags.alignment != .none)
             @as(InternPool.Alignment, info.flags.alignment)
         else
-            Type.fromInterned(info.child).abiAlignment(pt)).toLlvm();
+            Type.fromInterned(info.child).abiAlignment(zcu)).toLlvm();
         const access_kind: Builder.MemoryAccessKind =
             if (info.flags.is_volatile) .@"volatile" else .normal;
         const elem_llvm_ty = try o.lowerType(elem_ty);
@@ -9268,11 +9272,11 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const operand_ty = ptr_ty.childType(mod);
-        if (!operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) return .none;
+        const operand_ty = ptr_ty.childType(zcu);
+        if (!operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) return .none;
         const ptr = try self.resolveInst(bin_op.lhs);
         var element = try self.resolveInst(bin_op.rhs);
         const llvm_abi_ty = try o.getAtomicAbiType(operand_ty, false);
@@ -9280,7 +9284,7 @@ pub const FuncGen = struct {
         if (llvm_abi_ty != .none) {
             // operand needs widening
             element = try self.wip.conv(
-                if (operand_ty.isSignedInt(mod)) .signed else .unsigned,
+                if (operand_ty.isSignedInt(zcu)) .signed else .unsigned,
                 element,
                 llvm_abi_ty,
                 "",
@@ -9293,26 +9297,26 @@ pub const FuncGen = struct {
     fn airMemset(self: *FuncGen, inst: Air.Inst.Index, safety: bool) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const dest_slice = try self.resolveInst(bin_op.lhs);
         const ptr_ty = self.typeOf(bin_op.lhs);
         const elem_ty = self.typeOf(bin_op.rhs);
-        const dest_ptr_align = ptr_ty.ptrAlignment(pt).toLlvm();
+        const dest_ptr_align = ptr_ty.ptrAlignment(zcu).toLlvm();
         const dest_ptr = try self.sliceOrArrayPtr(dest_slice, ptr_ty);
         const access_kind: Builder.MemoryAccessKind =
-            if (ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal;
+            if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal;
 
         // Any WebAssembly runtime will trap when the destination pointer is out-of-bounds, regardless
         // of the length. This means we need to emit a check where we skip the memset when the length
         // is 0 as we allow for undefined pointers in 0-sized slices.
         // This logic can be removed once https://github.com/ziglang/zig/issues/16360 is done.
         const intrinsic_len0_traps = o.target.isWasm() and
-            ptr_ty.isSlice(mod) and
+            ptr_ty.isSlice(zcu) and
             std.Target.wasm.featureSetHas(o.target.cpu.features, .bulk_memory);
 
         if (try self.air.value(bin_op.rhs, pt)) |elem_val| {
-            if (elem_val.isUndefDeep(mod)) {
+            if (elem_val.isUndefDeep(zcu)) {
                 // Even if safety is disabled, we still emit a memset to undefined since it conveys
                 // extra information to LLVM. However, safety makes the difference between using
                 // 0xaa or actual undefined for the fill byte.
@@ -9350,7 +9354,7 @@ pub const FuncGen = struct {
         }
 
         const value = try self.resolveInst(bin_op.rhs);
-        const elem_abi_size = elem_ty.abiSize(pt);
+        const elem_abi_size = elem_ty.abiSize(zcu);
 
         if (elem_abi_size == 1) {
             // In this case we can take advantage of LLVM's intrinsic.
@@ -9387,9 +9391,9 @@ pub const FuncGen = struct {
         const end_block = try self.wip.block(1, "InlineMemsetEnd");
 
         const llvm_usize_ty = try o.lowerType(Type.usize);
-        const len = switch (ptr_ty.ptrSize(mod)) {
+        const len = switch (ptr_ty.ptrSize(zcu)) {
             .Slice => try self.wip.extractValue(dest_slice, &.{1}, ""),
-            .One => try o.builder.intValue(llvm_usize_ty, ptr_ty.childType(mod).arrayLen(mod)),
+            .One => try o.builder.intValue(llvm_usize_ty, ptr_ty.childType(zcu).arrayLen(zcu)),
             .Many, .C => unreachable,
         };
         const elem_llvm_ty = try o.lowerType(elem_ty);
@@ -9402,9 +9406,9 @@ pub const FuncGen = struct {
         _ = try self.wip.brCond(end, body_block, end_block);
 
         self.wip.cursor = .{ .block = body_block };
-        const elem_abi_align = elem_ty.abiAlignment(pt);
+        const elem_abi_align = elem_ty.abiAlignment(zcu);
         const it_ptr_align = InternPool.Alignment.fromLlvm(dest_ptr_align).min(elem_abi_align).toLlvm();
-        if (isByRef(elem_ty, pt)) {
+        if (isByRef(elem_ty, zcu)) {
             _ = try self.wip.callMemCpy(
                 it_ptr.toValue(),
                 it_ptr_align,
@@ -9447,7 +9451,7 @@ pub const FuncGen = struct {
     fn airMemcpy(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const dest_slice = try self.resolveInst(bin_op.lhs);
         const dest_ptr_ty = self.typeOf(bin_op.lhs);
@@ -9456,8 +9460,8 @@ pub const FuncGen = struct {
         const src_ptr = try self.sliceOrArrayPtr(src_slice, src_ptr_ty);
         const len = try self.sliceOrArrayLenInBytes(dest_slice, dest_ptr_ty);
         const dest_ptr = try self.sliceOrArrayPtr(dest_slice, dest_ptr_ty);
-        const access_kind: Builder.MemoryAccessKind = if (src_ptr_ty.isVolatilePtr(mod) or
-            dest_ptr_ty.isVolatilePtr(mod)) .@"volatile" else .normal;
+        const access_kind: Builder.MemoryAccessKind = if (src_ptr_ty.isVolatilePtr(zcu) or
+            dest_ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal;
 
         // When bulk-memory is enabled, this will be lowered to WebAssembly's memory.copy instruction.
         // This instruction will trap on an invalid address, regardless of the length.
@@ -9466,7 +9470,7 @@ pub const FuncGen = struct {
         // This logic can be removed once https://github.com/ziglang/zig/issues/16360 is done.
         if (o.target.isWasm() and
             std.Target.wasm.featureSetHas(o.target.cpu.features, .bulk_memory) and
-            dest_ptr_ty.isSlice(mod))
+            dest_ptr_ty.isSlice(zcu))
         {
             const usize_zero = try o.builder.intValue(try o.lowerType(Type.usize), 0);
             const cond = try self.cmp(.normal, .neq, Type.usize, len, usize_zero);
@@ -9476,9 +9480,9 @@ pub const FuncGen = struct {
             self.wip.cursor = .{ .block = memcpy_block };
             _ = try self.wip.callMemCpy(
                 dest_ptr,
-                dest_ptr_ty.ptrAlignment(pt).toLlvm(),
+                dest_ptr_ty.ptrAlignment(zcu).toLlvm(),
                 src_ptr,
-                src_ptr_ty.ptrAlignment(pt).toLlvm(),
+                src_ptr_ty.ptrAlignment(zcu).toLlvm(),
                 len,
                 access_kind,
             );
@@ -9489,9 +9493,9 @@ pub const FuncGen = struct {
 
         _ = try self.wip.callMemCpy(
             dest_ptr,
-            dest_ptr_ty.ptrAlignment(pt).toLlvm(),
+            dest_ptr_ty.ptrAlignment(zcu).toLlvm(),
             src_ptr,
-            src_ptr_ty.ptrAlignment(pt).toLlvm(),
+            src_ptr_ty.ptrAlignment(zcu).toLlvm(),
             len,
             access_kind,
         );
@@ -9501,10 +9505,10 @@ pub const FuncGen = struct {
     fn airSetUnionTag(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
-        const un_ty = self.typeOf(bin_op.lhs).childType(mod);
-        const layout = un_ty.unionGetLayout(pt);
+        const un_ty = self.typeOf(bin_op.lhs).childType(zcu);
+        const layout = un_ty.unionGetLayout(zcu);
         if (layout.tag_size == 0) return .none;
         const union_ptr = try self.resolveInst(bin_op.lhs);
         const new_tag = try self.resolveInst(bin_op.rhs);
@@ -9523,12 +9527,13 @@ pub const FuncGen = struct {
     fn airGetUnionTag(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const un_ty = self.typeOf(ty_op.operand);
-        const layout = un_ty.unionGetLayout(pt);
+        const layout = un_ty.unionGetLayout(zcu);
         if (layout.tag_size == 0) return .none;
         const union_handle = try self.resolveInst(ty_op.operand);
-        if (isByRef(un_ty, pt)) {
+        if (isByRef(un_ty, zcu)) {
             const llvm_un_ty = try o.lowerType(un_ty);
             if (layout.payload_size == 0)
                 return self.wip.load(.normal, llvm_un_ty, union_handle, .default, "");
@@ -9597,10 +9602,10 @@ pub const FuncGen = struct {
 
     fn airByteSwap(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
+        const zcu = o.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand_ty = self.typeOf(ty_op.operand);
-        var bits = operand_ty.intInfo(mod).bits;
+        var bits = operand_ty.intInfo(zcu).bits;
         assert(bits % 8 == 0);
 
         const inst_ty = self.typeOfIndex(inst);
@@ -9611,8 +9616,8 @@ pub const FuncGen = struct {
             // If not an even byte-multiple, we need zero-extend + shift-left 1 byte
             // The truncated result at the end will be the correct bswap
             const scalar_ty = try o.builder.intType(@intCast(bits + 8));
-            if (operand_ty.zigTypeTag(mod) == .Vector) {
-                const vec_len = operand_ty.vectorLen(mod);
+            if (operand_ty.zigTypeTag(zcu) == .Vector) {
+                const vec_len = operand_ty.vectorLen(zcu);
                 llvm_operand_ty = try o.builder.vectorType(.normal, vec_len, scalar_ty);
             } else llvm_operand_ty = scalar_ty;
 
@@ -9631,13 +9636,13 @@ pub const FuncGen = struct {
 
     fn airErrorSetHasValue(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = o.pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.resolveInst(ty_op.operand);
         const error_set_ty = ty_op.ty.toType();
 
-        const names = error_set_ty.errorSetNames(mod);
+        const names = error_set_ty.errorSetNames(zcu);
         const valid_block = try self.wip.block(@intCast(names.len), "Valid");
         const invalid_block = try self.wip.block(1, "Invalid");
         const end_block = try self.wip.block(2, "End");
@@ -9790,14 +9795,14 @@ pub const FuncGen = struct {
     fn airShuffle(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Shuffle, ty_pl.payload).data;
         const a = try self.resolveInst(extra.a);
         const b = try self.resolveInst(extra.b);
         const mask = Value.fromInterned(extra.mask);
         const mask_len = extra.mask_len;
-        const a_len = self.typeOf(extra.a).vectorLen(mod);
+        const a_len = self.typeOf(extra.a).vectorLen(zcu);
 
         // LLVM uses integers larger than the length of the first array to
         // index into the second array. This was deemed unnecessarily fragile
@@ -9809,10 +9814,10 @@ pub const FuncGen = struct {
 
         for (values, 0..) |*val, i| {
             const elem = try mask.elemValue(pt, i);
-            if (elem.isUndef(mod)) {
+            if (elem.isUndef(zcu)) {
                 val.* = try o.builder.undefConst(.i32);
             } else {
-                const int = elem.toSignedInt(pt);
+                const int = elem.toSignedInt(zcu);
                 const unsigned: u32 = @intCast(if (int >= 0) int else ~int + a_len);
                 val.* = try o.builder.intConst(.i32, unsigned);
             }
@@ -9899,8 +9904,8 @@ pub const FuncGen = struct {
 
     fn airReduce(self: *FuncGen, inst: Air.Inst.Index, fast: Builder.FastMathKind) !Builder.Value {
         const o = self.ng.object;
-        const mod = o.pt.zcu;
-        const target = mod.getTarget();
+        const zcu = o.pt.zcu;
+        const target = zcu.getTarget();
 
         const reduce = self.air.instructions.items(.data)[@intFromEnum(inst)].reduce;
         const operand = try self.resolveInst(reduce.operand);
@@ -9916,13 +9921,13 @@ pub const FuncGen = struct {
                 .Xor => .@"vector.reduce.xor",
                 else => unreachable,
             }, &.{llvm_operand_ty}, &.{operand}, ""),
-            .Min, .Max => switch (scalar_ty.zigTypeTag(mod)) {
+            .Min, .Max => switch (scalar_ty.zigTypeTag(zcu)) {
                 .Int => return self.wip.callIntrinsic(.normal, .none, switch (reduce.operation) {
-                    .Min => if (scalar_ty.isSignedInt(mod))
+                    .Min => if (scalar_ty.isSignedInt(zcu))
                         .@"vector.reduce.smin"
                     else
                         .@"vector.reduce.umin",
-                    .Max => if (scalar_ty.isSignedInt(mod))
+                    .Max => if (scalar_ty.isSignedInt(zcu))
                         .@"vector.reduce.smax"
                     else
                         .@"vector.reduce.umax",
@@ -9936,7 +9941,7 @@ pub const FuncGen = struct {
                     }, &.{llvm_operand_ty}, &.{operand}, ""),
                 else => unreachable,
             },
-            .Add, .Mul => switch (scalar_ty.zigTypeTag(mod)) {
+            .Add, .Mul => switch (scalar_ty.zigTypeTag(zcu)) {
                 .Int => return self.wip.callIntrinsic(.normal, .none, switch (reduce.operation) {
                     .Add => .@"vector.reduce.add",
                     .Mul => .@"vector.reduce.mul",
@@ -10004,21 +10009,21 @@ pub const FuncGen = struct {
             ))),
             else => unreachable,
         };
-        return self.buildReducedCall(libc_fn, operand, operand_ty.vectorLen(mod), init_val);
+        return self.buildReducedCall(libc_fn, operand, operand_ty.vectorLen(zcu), init_val);
     }
 
     fn airAggregateInit(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const result_ty = self.typeOfIndex(inst);
-        const len: usize = @intCast(result_ty.arrayLen(mod));
+        const len: usize = @intCast(result_ty.arrayLen(zcu));
         const elements: []const Air.Inst.Ref = @ptrCast(self.air.extra[ty_pl.payload..][0..len]);
         const llvm_result_ty = try o.lowerType(result_ty);
 
-        switch (result_ty.zigTypeTag(mod)) {
+        switch (result_ty.zigTypeTag(zcu)) {
             .Vector => {
                 var vector = try o.builder.poisonValue(llvm_result_ty);
                 for (elements, 0..) |elem, i| {
@@ -10029,21 +10034,21 @@ pub const FuncGen = struct {
                 return vector;
             },
             .Struct => {
-                if (mod.typeToPackedStruct(result_ty)) |struct_type| {
+                if (zcu.typeToPackedStruct(result_ty)) |struct_type| {
                     const backing_int_ty = struct_type.backingIntTypeUnordered(ip);
                     assert(backing_int_ty != .none);
-                    const big_bits = Type.fromInterned(backing_int_ty).bitSize(pt);
+                    const big_bits = Type.fromInterned(backing_int_ty).bitSize(zcu);
                     const int_ty = try o.builder.intType(@intCast(big_bits));
                     comptime assert(Type.packed_struct_layout_version == 2);
                     var running_int = try o.builder.intValue(int_ty, 0);
                     var running_bits: u16 = 0;
                     for (elements, struct_type.field_types.get(ip)) |elem, field_ty| {
-                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(pt)) continue;
+                        if (!Type.fromInterned(field_ty).hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
                         const non_int_val = try self.resolveInst(elem);
-                        const ty_bit_size: u16 = @intCast(Type.fromInterned(field_ty).bitSize(pt));
+                        const ty_bit_size: u16 = @intCast(Type.fromInterned(field_ty).bitSize(zcu));
                         const small_int_ty = try o.builder.intType(ty_bit_size);
-                        const small_int_val = if (Type.fromInterned(field_ty).isPtrAtRuntime(mod))
+                        const small_int_val = if (Type.fromInterned(field_ty).isPtrAtRuntime(zcu))
                             try self.wip.cast(.ptrtoint, non_int_val, small_int_ty, "")
                         else
                             try self.wip.cast(.bitcast, non_int_val, small_int_ty, "");
@@ -10057,12 +10062,12 @@ pub const FuncGen = struct {
                     return running_int;
                 }
 
-                assert(result_ty.containerLayout(mod) != .@"packed");
+                assert(result_ty.containerLayout(zcu) != .@"packed");
 
-                if (isByRef(result_ty, pt)) {
+                if (isByRef(result_ty, zcu)) {
                     // TODO in debug builds init to undef so that the padding will be 0xaa
                     // even if we fully populate the fields.
-                    const alignment = result_ty.abiAlignment(pt).toLlvm();
+                    const alignment = result_ty.abiAlignment(zcu).toLlvm();
                     const alloca_inst = try self.buildAllocaWorkaround(result_ty, alignment);
 
                     for (elements, 0..) |elem, i| {
@@ -10075,7 +10080,7 @@ pub const FuncGen = struct {
                         const field_ptr_ty = try pt.ptrType(.{
                             .child = self.typeOf(elem).toIntern(),
                             .flags = .{
-                                .alignment = result_ty.structFieldAlign(i, pt),
+                                .alignment = result_ty.structFieldAlign(i, zcu),
                             },
                         });
                         try self.store(field_ptr, field_ptr_ty, llvm_elem, .none);
@@ -10095,14 +10100,14 @@ pub const FuncGen = struct {
                 }
             },
             .Array => {
-                assert(isByRef(result_ty, pt));
+                assert(isByRef(result_ty, zcu));
 
                 const llvm_usize = try o.lowerType(Type.usize);
                 const usize_zero = try o.builder.intValue(llvm_usize, 0);
-                const alignment = result_ty.abiAlignment(pt).toLlvm();
+                const alignment = result_ty.abiAlignment(zcu).toLlvm();
                 const alloca_inst = try self.buildAllocaWorkaround(result_ty, alignment);
 
-                const array_info = result_ty.arrayInfo(mod);
+                const array_info = result_ty.arrayInfo(zcu);
                 const elem_ptr_ty = try pt.ptrType(.{
                     .child = array_info.elem_type.toIntern(),
                 });
@@ -10131,22 +10136,22 @@ pub const FuncGen = struct {
     fn airUnionInit(self: *FuncGen, inst: Air.Inst.Index) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.UnionInit, ty_pl.payload).data;
         const union_ty = self.typeOfIndex(inst);
         const union_llvm_ty = try o.lowerType(union_ty);
-        const layout = union_ty.unionGetLayout(pt);
-        const union_obj = mod.typeToUnion(union_ty).?;
+        const layout = union_ty.unionGetLayout(zcu);
+        const union_obj = zcu.typeToUnion(union_ty).?;
 
         if (union_obj.flagsUnordered(ip).layout == .@"packed") {
-            const big_bits = union_ty.bitSize(pt);
+            const big_bits = union_ty.bitSize(zcu);
             const int_llvm_ty = try o.builder.intType(@intCast(big_bits));
             const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[extra.field_index]);
             const non_int_val = try self.resolveInst(extra.init);
-            const small_int_ty = try o.builder.intType(@intCast(field_ty.bitSize(pt)));
-            const small_int_val = if (field_ty.isPtrAtRuntime(mod))
+            const small_int_ty = try o.builder.intType(@intCast(field_ty.bitSize(zcu)));
+            const small_int_val = if (field_ty.isPtrAtRuntime(zcu))
                 try self.wip.cast(.ptrtoint, non_int_val, small_int_ty, "")
             else
                 try self.wip.cast(.bitcast, non_int_val, small_int_ty, "");
@@ -10154,9 +10159,9 @@ pub const FuncGen = struct {
         }
 
         const tag_int_val = blk: {
-            const tag_ty = union_ty.unionTagTypeHypothetical(mod);
+            const tag_ty = union_ty.unionTagTypeHypothetical(zcu);
             const union_field_name = union_obj.loadTagType(ip).names.get(ip)[extra.field_index];
-            const enum_field_index = tag_ty.enumFieldIndex(union_field_name, mod).?;
+            const enum_field_index = tag_ty.enumFieldIndex(union_field_name, zcu).?;
             const tag_val = try pt.enumValueFieldIndex(tag_ty, enum_field_index);
             break :blk try tag_val.intFromEnum(tag_ty, pt);
         };
@@ -10164,12 +10169,12 @@ pub const FuncGen = struct {
             if (layout.tag_size == 0) {
                 return .none;
             }
-            assert(!isByRef(union_ty, pt));
+            assert(!isByRef(union_ty, zcu));
             var big_int_space: Value.BigIntSpace = undefined;
-            const tag_big_int = tag_int_val.toBigInt(&big_int_space, pt);
+            const tag_big_int = tag_int_val.toBigInt(&big_int_space, zcu);
             return try o.builder.bigIntValue(union_llvm_ty, tag_big_int);
         }
-        assert(isByRef(union_ty, pt));
+        assert(isByRef(union_ty, zcu));
         // The llvm type of the alloca will be the named LLVM union type, and will not
         // necessarily match the format that we need, depending on which tag is active.
         // We must construct the correct unnamed struct type here, in order to then set
@@ -10179,14 +10184,14 @@ pub const FuncGen = struct {
         const llvm_payload = try self.resolveInst(extra.init);
         const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[extra.field_index]);
         const field_llvm_ty = try o.lowerType(field_ty);
-        const field_size = field_ty.abiSize(pt);
-        const field_align = pt.unionFieldNormalAlignment(union_obj, extra.field_index);
+        const field_size = field_ty.abiSize(zcu);
+        const field_align = Type.unionFieldNormalAlignment(union_obj, extra.field_index, zcu);
         const llvm_usize = try o.lowerType(Type.usize);
         const usize_zero = try o.builder.intValue(llvm_usize, 0);
 
         const llvm_union_ty = t: {
             const payload_ty = p: {
-                if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     const padding_len = layout.payload_size;
                     break :p try o.builder.arrayType(padding_len, .i8);
                 }
@@ -10242,9 +10247,9 @@ pub const FuncGen = struct {
             const field_ptr = try self.wip.gep(.inbounds, llvm_union_ty, result_ptr, &indices, "");
             const tag_ty = try o.lowerType(Type.fromInterned(union_obj.enum_tag_ty));
             var big_int_space: Value.BigIntSpace = undefined;
-            const tag_big_int = tag_int_val.toBigInt(&big_int_space, pt);
+            const tag_big_int = tag_int_val.toBigInt(&big_int_space, zcu);
             const llvm_tag = try o.builder.bigIntValue(tag_ty, tag_big_int);
-            const tag_alignment = Type.fromInterned(union_obj.enum_tag_ty).abiAlignment(pt).toLlvm();
+            const tag_alignment = Type.fromInterned(union_obj.enum_tag_ty).abiAlignment(zcu).toLlvm();
             _ = try self.wip.store(.normal, llvm_tag, field_ptr, tag_alignment);
         }
 
@@ -10270,8 +10275,8 @@ pub const FuncGen = struct {
         // by the target.
         // To work around this, don't emit llvm.prefetch in this case.
         // See https://bugs.llvm.org/show_bug.cgi?id=21037
-        const mod = o.pt.zcu;
-        const target = mod.getTarget();
+        const zcu = o.pt.zcu;
+        const target = zcu.getTarget();
         switch (prefetch.cache) {
             .instruction => switch (target.cpu.arch) {
                 .x86_64,
@@ -10397,7 +10402,7 @@ pub const FuncGen = struct {
         variable_index.setMutability(.constant, &o.builder);
         variable_index.setUnnamedAddr(.unnamed_addr, &o.builder);
         variable_index.setAlignment(
-            Type.slice_const_u8_sentinel_0.abiAlignment(pt).toLlvm(),
+            Type.slice_const_u8_sentinel_0.abiAlignment(pt.zcu).toLlvm(),
             &o.builder,
         );
 
@@ -10436,15 +10441,15 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = fg.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const payload_ty = opt_ty.optionalChild(mod);
+        const zcu = pt.zcu;
+        const payload_ty = opt_ty.optionalChild(zcu);
 
-        if (isByRef(opt_ty, pt)) {
+        if (isByRef(opt_ty, zcu)) {
             // We have a pointer and we need to return a pointer to the first field.
             const payload_ptr = try fg.wip.gepStruct(opt_llvm_ty, opt_handle, 0, "");
 
-            const payload_alignment = payload_ty.abiAlignment(pt).toLlvm();
-            if (isByRef(payload_ty, pt)) {
+            const payload_alignment = payload_ty.abiAlignment(zcu).toLlvm();
+            if (isByRef(payload_ty, zcu)) {
                 if (can_elide_load)
                     return payload_ptr;
 
@@ -10453,7 +10458,7 @@ pub const FuncGen = struct {
             return fg.loadTruncate(.normal, payload_ty, payload_ptr, payload_alignment);
         }
 
-        assert(!isByRef(payload_ty, pt));
+        assert(!isByRef(payload_ty, zcu));
         return fg.wip.extractValue(opt_handle, &.{0}, "");
     }
 
@@ -10465,11 +10470,12 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
+        const zcu = pt.zcu;
         const optional_llvm_ty = try o.lowerType(optional_ty);
         const non_null_field = try self.wip.cast(.zext, non_null_bit, .i8, "");
 
-        if (isByRef(optional_ty, pt)) {
-            const payload_alignment = optional_ty.abiAlignment(pt).toLlvm();
+        if (isByRef(optional_ty, zcu)) {
+            const payload_alignment = optional_ty.abiAlignment(pt.zcu).toLlvm();
             const alloca_inst = try self.buildAllocaWorkaround(optional_ty, payload_alignment);
 
             {
@@ -10497,15 +10503,15 @@ pub const FuncGen = struct {
     ) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const struct_ty = struct_ptr_ty.childType(mod);
-        switch (struct_ty.zigTypeTag(mod)) {
-            .Struct => switch (struct_ty.containerLayout(mod)) {
+        const zcu = pt.zcu;
+        const struct_ty = struct_ptr_ty.childType(zcu);
+        switch (struct_ty.zigTypeTag(zcu)) {
+            .Struct => switch (struct_ty.containerLayout(zcu)) {
                 .@"packed" => {
                     const result_ty = self.typeOfIndex(inst);
-                    const result_ty_info = result_ty.ptrInfo(mod);
-                    const struct_ptr_ty_info = struct_ptr_ty.ptrInfo(mod);
-                    const struct_type = mod.typeToStruct(struct_ty).?;
+                    const result_ty_info = result_ty.ptrInfo(zcu);
+                    const struct_ptr_ty_info = struct_ptr_ty.ptrInfo(zcu);
+                    const struct_type = zcu.typeToStruct(struct_ty).?;
 
                     if (result_ty_info.packed_offset.host_size != 0) {
                         // From LLVM's perspective, a pointer to a packed struct and a pointer
@@ -10535,15 +10541,15 @@ pub const FuncGen = struct {
                         // the struct.
                         const llvm_index = try o.builder.intValue(
                             try o.lowerType(Type.usize),
-                            @intFromBool(struct_ty.hasRuntimeBitsIgnoreComptime(pt)),
+                            @intFromBool(struct_ty.hasRuntimeBitsIgnoreComptime(zcu)),
                         );
                         return self.wip.gep(.inbounds, struct_llvm_ty, struct_ptr, &.{llvm_index}, "");
                     }
                 },
             },
             .Union => {
-                const layout = struct_ty.unionGetLayout(pt);
-                if (layout.payload_size == 0 or struct_ty.containerLayout(mod) == .@"packed") return struct_ptr;
+                const layout = struct_ty.unionGetLayout(zcu);
+                if (layout.payload_size == 0 or struct_ty.containerLayout(zcu) == .@"packed") return struct_ptr;
                 const payload_index = @intFromBool(layout.tag_align.compare(.gte, layout.payload_align));
                 const union_llvm_ty = try o.lowerType(struct_ty);
                 return self.wip.gepStruct(union_llvm_ty, struct_ptr, payload_index, "");
@@ -10566,9 +10572,9 @@ pub const FuncGen = struct {
 
         const o = fg.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const payload_llvm_ty = try o.lowerType(payload_ty);
-        const abi_size = payload_ty.abiSize(pt);
+        const abi_size = payload_ty.abiSize(zcu);
 
         // llvm bug workarounds:
         const workaround_explicit_mask = o.target.cpu.arch == .powerpc and abi_size >= 4;
@@ -10580,7 +10586,7 @@ pub const FuncGen = struct {
             return try fg.wip.load(access_kind, payload_llvm_ty, payload_ptr, payload_alignment, "");
         }
 
-        const load_llvm_ty = if (payload_ty.isAbiInt(mod))
+        const load_llvm_ty = if (payload_ty.isAbiInt(zcu))
             try o.builder.intType(@intCast(abi_size * 8))
         else
             payload_llvm_ty;
@@ -10588,7 +10594,7 @@ pub const FuncGen = struct {
         const shifted = if (payload_llvm_ty != load_llvm_ty and o.target.cpu.arch.endian() == .big)
             try fg.wip.bin(.lshr, loaded, try o.builder.intValue(
                 load_llvm_ty,
-                (payload_ty.abiSize(pt) - (std.math.divCeil(u64, payload_ty.bitSize(pt), 8) catch unreachable)) * 8,
+                (payload_ty.abiSize(zcu) - (std.math.divCeil(u64, payload_ty.bitSize(zcu), 8) catch unreachable)) * 8,
             ), "")
         else
             loaded;
@@ -10614,9 +10620,10 @@ pub const FuncGen = struct {
         const o = fg.ng.object;
         const pt = o.pt;
         //const pointee_llvm_ty = try o.lowerType(pointee_type);
-        const result_align = InternPool.Alignment.fromLlvm(ptr_alignment).max(pointee_type.abiAlignment(pt)).toLlvm();
+        const result_align = InternPool.Alignment.fromLlvm(ptr_alignment)
+            .max(pointee_type.abiAlignment(pt.zcu)).toLlvm();
         const result_ptr = try fg.buildAllocaWorkaround(pointee_type, result_align);
-        const size_bytes = pointee_type.abiSize(pt);
+        const size_bytes = pointee_type.abiSize(pt.zcu);
         _ = try fg.wip.callMemCpy(
             result_ptr,
             result_align,
@@ -10634,15 +10641,15 @@ pub const FuncGen = struct {
     fn load(self: *FuncGen, ptr: Builder.Value, ptr_ty: Type) !Builder.Value {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const info = ptr_ty.ptrInfo(mod);
+        const zcu = pt.zcu;
+        const info = ptr_ty.ptrInfo(zcu);
         const elem_ty = Type.fromInterned(info.child);
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) return .none;
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) return .none;
 
         const ptr_alignment = (if (info.flags.alignment != .none)
             @as(InternPool.Alignment, info.flags.alignment)
         else
-            elem_ty.abiAlignment(pt)).toLlvm();
+            elem_ty.abiAlignment(zcu)).toLlvm();
 
         const access_kind: Builder.MemoryAccessKind =
             if (info.flags.is_volatile) .@"volatile" else .normal;
@@ -10658,7 +10665,7 @@ pub const FuncGen = struct {
         }
 
         if (info.packed_offset.host_size == 0) {
-            if (isByRef(elem_ty, pt)) {
+            if (isByRef(elem_ty, zcu)) {
                 return self.loadByRef(ptr, elem_ty, ptr_alignment, access_kind);
             }
             return self.loadTruncate(access_kind, elem_ty, ptr, ptr_alignment);
@@ -10668,13 +10675,13 @@ pub const FuncGen = struct {
         const containing_int =
             try self.wip.load(access_kind, containing_int_ty, ptr, ptr_alignment, "");
 
-        const elem_bits = ptr_ty.childType(mod).bitSize(pt);
+        const elem_bits = ptr_ty.childType(zcu).bitSize(zcu);
         const shift_amt = try o.builder.intValue(containing_int_ty, info.packed_offset.bit_offset);
         const shifted_value = try self.wip.bin(.lshr, containing_int, shift_amt, "");
         const elem_llvm_ty = try o.lowerType(elem_ty);
 
-        if (isByRef(elem_ty, pt)) {
-            const result_align = elem_ty.abiAlignment(pt).toLlvm();
+        if (isByRef(elem_ty, zcu)) {
+            const result_align = elem_ty.abiAlignment(zcu).toLlvm();
             const result_ptr = try self.buildAllocaWorkaround(elem_ty, result_align);
 
             const same_size_int = try o.builder.intType(@intCast(elem_bits));
@@ -10683,13 +10690,13 @@ pub const FuncGen = struct {
             return result_ptr;
         }
 
-        if (elem_ty.zigTypeTag(mod) == .Float or elem_ty.zigTypeTag(mod) == .Vector) {
+        if (elem_ty.zigTypeTag(zcu) == .Float or elem_ty.zigTypeTag(zcu) == .Vector) {
             const same_size_int = try o.builder.intType(@intCast(elem_bits));
             const truncated_int = try self.wip.cast(.trunc, shifted_value, same_size_int, "");
             return self.wip.cast(.bitcast, truncated_int, elem_llvm_ty, "");
         }
 
-        if (elem_ty.isPtrAtRuntime(mod)) {
+        if (elem_ty.isPtrAtRuntime(zcu)) {
             const same_size_int = try o.builder.intType(@intCast(elem_bits));
             const truncated_int = try self.wip.cast(.trunc, shifted_value, same_size_int, "");
             return self.wip.cast(.inttoptr, truncated_int, elem_llvm_ty, "");
@@ -10707,13 +10714,13 @@ pub const FuncGen = struct {
     ) !void {
         const o = self.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const info = ptr_ty.ptrInfo(mod);
+        const zcu = pt.zcu;
+        const info = ptr_ty.ptrInfo(zcu);
         const elem_ty = Type.fromInterned(info.child);
-        if (!elem_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+        if (!elem_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
             return;
         }
-        const ptr_alignment = ptr_ty.ptrAlignment(pt).toLlvm();
+        const ptr_alignment = ptr_ty.ptrAlignment(zcu).toLlvm();
         const access_kind: Builder.MemoryAccessKind =
             if (info.flags.is_volatile) .@"volatile" else .normal;
 
@@ -10737,12 +10744,12 @@ pub const FuncGen = struct {
             assert(ordering == .none);
             const containing_int =
                 try self.wip.load(access_kind, containing_int_ty, ptr, ptr_alignment, "");
-            const elem_bits = ptr_ty.childType(mod).bitSize(pt);
+            const elem_bits = ptr_ty.childType(zcu).bitSize(zcu);
             const shift_amt = try o.builder.intConst(containing_int_ty, info.packed_offset.bit_offset);
             // Convert to equally-sized integer type in order to perform the bit
             // operations on the value to store
             const value_bits_type = try o.builder.intType(@intCast(elem_bits));
-            const value_bits = if (elem_ty.isPtrAtRuntime(mod))
+            const value_bits = if (elem_ty.isPtrAtRuntime(zcu))
                 try self.wip.cast(.ptrtoint, elem, value_bits_type, "")
             else
                 try self.wip.cast(.bitcast, elem, value_bits_type, "");
@@ -10772,7 +10779,7 @@ pub const FuncGen = struct {
             _ = try self.wip.store(access_kind, ored_value, ptr, ptr_alignment);
             return;
         }
-        if (!isByRef(elem_ty, pt)) {
+        if (!isByRef(elem_ty, zcu)) {
             _ = try self.wip.storeAtomic(
                 access_kind,
                 elem,
@@ -10788,8 +10795,8 @@ pub const FuncGen = struct {
             ptr,
             ptr_alignment,
             elem,
-            elem_ty.abiAlignment(pt).toLlvm(),
-            try o.builder.intValue(try o.lowerType(Type.usize), elem_ty.abiSize(pt)),
+            elem_ty.abiAlignment(zcu).toLlvm(),
+            try o.builder.intValue(try o.lowerType(Type.usize), elem_ty.abiSize(zcu)),
             access_kind,
         );
     }
@@ -10816,12 +10823,12 @@ pub const FuncGen = struct {
     ) Allocator.Error!Builder.Value {
         const o = fg.ng.object;
         const pt = o.pt;
-        const mod = pt.zcu;
-        const target = mod.getTarget();
+        const zcu = pt.zcu;
+        const target = zcu.getTarget();
         if (!target_util.hasValgrindSupport(target)) return default_value;
 
         const llvm_usize = try o.lowerType(Type.usize);
-        const usize_alignment = Type.usize.abiAlignment(pt).toLlvm();
+        const usize_alignment = Type.usize.abiAlignment(zcu).toLlvm();
 
         const array_llvm_ty = try o.builder.arrayType(6, llvm_usize);
         const array_ptr = if (fg.valgrind_client_request_array == .none) a: {
@@ -10882,14 +10889,14 @@ pub const FuncGen = struct {
 
     fn typeOf(fg: *FuncGen, inst: Air.Inst.Ref) Type {
         const o = fg.ng.object;
-        const mod = o.pt.zcu;
-        return fg.air.typeOf(inst, &mod.intern_pool);
+        const zcu = o.pt.zcu;
+        return fg.air.typeOf(inst, &zcu.intern_pool);
     }
 
     fn typeOfIndex(fg: *FuncGen, inst: Air.Inst.Index) Type {
         const o = fg.ng.object;
-        const mod = o.pt.zcu;
-        return fg.air.typeOfIndex(inst, &mod.intern_pool);
+        const zcu = o.pt.zcu;
+        return fg.air.typeOfIndex(inst, &zcu.intern_pool);
     }
 };
 
@@ -11059,12 +11066,12 @@ fn toLlvmGlobalAddressSpace(wanted_address_space: std.builtin.AddressSpace, targ
     };
 }
 
-fn returnTypeByRef(pt: Zcu.PerThread, target: std.Target, ty: Type) bool {
-    if (isByRef(ty, pt)) {
+fn returnTypeByRef(zcu: *Zcu, target: std.Target, ty: Type) bool {
+    if (isByRef(ty, zcu)) {
         return true;
     } else if (target.cpu.arch.isX86() and
         !std.Target.x86.featureSetHas(target.cpu.features, .evex512) and
-        ty.totalVectorBits(pt) >= 512)
+        ty.totalVectorBits(zcu) >= 512)
     {
         // As of LLVM 18, passing a vector byval with fastcc that is 512 bits or more returns
         // "512-bit vector arguments require 'evex512' for AVX512"
@@ -11074,38 +11081,38 @@ fn returnTypeByRef(pt: Zcu.PerThread, target: std.Target, ty: Type) bool {
     }
 }
 
-fn firstParamSRet(fn_info: InternPool.Key.FuncType, pt: Zcu.PerThread, target: std.Target) bool {
+fn firstParamSRet(fn_info: InternPool.Key.FuncType, zcu: *Zcu, target: std.Target) bool {
     const return_type = Type.fromInterned(fn_info.return_type);
-    if (!return_type.hasRuntimeBitsIgnoreComptime(pt)) return false;
+    if (!return_type.hasRuntimeBitsIgnoreComptime(zcu)) return false;
 
     return switch (fn_info.cc) {
-        .Unspecified, .Inline => returnTypeByRef(pt, target, return_type),
+        .Unspecified, .Inline => returnTypeByRef(zcu, target, return_type),
         .C => switch (target.cpu.arch) {
             .mips, .mipsel => false,
-            .x86 => isByRef(return_type, pt),
+            .x86 => isByRef(return_type, zcu),
             .x86_64 => switch (target.os.tag) {
-                .windows => x86_64_abi.classifyWindows(return_type, pt) == .memory,
-                else => firstParamSRetSystemV(return_type, pt, target),
+                .windows => x86_64_abi.classifyWindows(return_type, zcu) == .memory,
+                else => firstParamSRetSystemV(return_type, zcu, target),
             },
-            .wasm32 => wasm_c_abi.classifyType(return_type, pt)[0] == .indirect,
-            .aarch64, .aarch64_be => aarch64_c_abi.classifyType(return_type, pt) == .memory,
-            .arm, .armeb => switch (arm_c_abi.classifyType(return_type, pt, .ret)) {
+            .wasm32 => wasm_c_abi.classifyType(return_type, zcu)[0] == .indirect,
+            .aarch64, .aarch64_be => aarch64_c_abi.classifyType(return_type, zcu) == .memory,
+            .arm, .armeb => switch (arm_c_abi.classifyType(return_type, zcu, .ret)) {
                 .memory, .i64_array => true,
                 .i32_array => |size| size != 1,
                 .byval => false,
             },
-            .riscv32, .riscv64 => riscv_c_abi.classifyType(return_type, pt) == .memory,
+            .riscv32, .riscv64 => riscv_c_abi.classifyType(return_type, zcu) == .memory,
             else => false, // TODO investigate C ABI for other architectures
         },
-        .SysV => firstParamSRetSystemV(return_type, pt, target),
-        .Win64 => x86_64_abi.classifyWindows(return_type, pt) == .memory,
-        .Stdcall => !isScalar(pt.zcu, return_type),
+        .SysV => firstParamSRetSystemV(return_type, zcu, target),
+        .Win64 => x86_64_abi.classifyWindows(return_type, zcu) == .memory,
+        .Stdcall => !isScalar(zcu, return_type),
         else => false,
     };
 }
 
-fn firstParamSRetSystemV(ty: Type, pt: Zcu.PerThread, target: std.Target) bool {
-    const class = x86_64_abi.classifySystemV(ty, pt, target, .ret);
+fn firstParamSRetSystemV(ty: Type, zcu: *Zcu, target: std.Target) bool {
+    const class = x86_64_abi.classifySystemV(ty, zcu, target, .ret);
     if (class[0] == .memory) return true;
     if (class[0] == .x87 and class[2] != .none) return true;
     return false;
@@ -11116,62 +11123,62 @@ fn firstParamSRetSystemV(ty: Type, pt: Zcu.PerThread, target: std.Target) bool {
 /// be effectively bitcasted to the actual return type.
 fn lowerFnRetTy(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Builder.Type {
     const pt = o.pt;
-    const mod = pt.zcu;
+    const zcu = pt.zcu;
     const return_type = Type.fromInterned(fn_info.return_type);
-    if (!return_type.hasRuntimeBitsIgnoreComptime(pt)) {
+    if (!return_type.hasRuntimeBitsIgnoreComptime(zcu)) {
         // If the return type is an error set or an error union, then we make this
         // anyerror return type instead, so that it can be coerced into a function
         // pointer type which has anyerror as the return type.
-        return if (return_type.isError(mod)) try o.errorIntType() else .void;
+        return if (return_type.isError(zcu)) try o.errorIntType() else .void;
     }
-    const target = mod.getTarget();
+    const target = zcu.getTarget();
     switch (fn_info.cc) {
         .Unspecified,
         .Inline,
-        => return if (returnTypeByRef(pt, target, return_type)) .void else o.lowerType(return_type),
+        => return if (returnTypeByRef(zcu, target, return_type)) .void else o.lowerType(return_type),
 
         .C => {
             switch (target.cpu.arch) {
                 .mips, .mipsel => return o.lowerType(return_type),
-                .x86 => return if (isByRef(return_type, pt)) .void else o.lowerType(return_type),
+                .x86 => return if (isByRef(return_type, zcu)) .void else o.lowerType(return_type),
                 .x86_64 => switch (target.os.tag) {
                     .windows => return lowerWin64FnRetTy(o, fn_info),
                     else => return lowerSystemVFnRetTy(o, fn_info),
                 },
                 .wasm32 => {
-                    if (isScalar(mod, return_type)) {
+                    if (isScalar(zcu, return_type)) {
                         return o.lowerType(return_type);
                     }
-                    const classes = wasm_c_abi.classifyType(return_type, pt);
+                    const classes = wasm_c_abi.classifyType(return_type, zcu);
                     if (classes[0] == .indirect or classes[0] == .none) {
                         return .void;
                     }
 
                     assert(classes[0] == .direct and classes[1] == .none);
-                    const scalar_type = wasm_c_abi.scalarType(return_type, pt);
-                    return o.builder.intType(@intCast(scalar_type.abiSize(pt) * 8));
+                    const scalar_type = wasm_c_abi.scalarType(return_type, zcu);
+                    return o.builder.intType(@intCast(scalar_type.abiSize(zcu) * 8));
                 },
                 .aarch64, .aarch64_be => {
-                    switch (aarch64_c_abi.classifyType(return_type, pt)) {
+                    switch (aarch64_c_abi.classifyType(return_type, zcu)) {
                         .memory => return .void,
                         .float_array => return o.lowerType(return_type),
                         .byval => return o.lowerType(return_type),
-                        .integer => return o.builder.intType(@intCast(return_type.bitSize(pt))),
+                        .integer => return o.builder.intType(@intCast(return_type.bitSize(zcu))),
                         .double_integer => return o.builder.arrayType(2, .i64),
                     }
                 },
                 .arm, .armeb => {
-                    switch (arm_c_abi.classifyType(return_type, pt, .ret)) {
+                    switch (arm_c_abi.classifyType(return_type, zcu, .ret)) {
                         .memory, .i64_array => return .void,
                         .i32_array => |len| return if (len == 1) .i32 else .void,
                         .byval => return o.lowerType(return_type),
                     }
                 },
                 .riscv32, .riscv64 => {
-                    switch (riscv_c_abi.classifyType(return_type, pt)) {
+                    switch (riscv_c_abi.classifyType(return_type, zcu)) {
                         .memory => return .void,
                         .integer => {
-                            return o.builder.intType(@intCast(return_type.bitSize(pt)));
+                            return o.builder.intType(@intCast(return_type.bitSize(zcu)));
                         },
                         .double_integer => {
                             return o.builder.structType(.normal, &.{ .i64, .i64 });
@@ -11180,9 +11187,9 @@ fn lowerFnRetTy(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Bu
                         .fields => {
                             var types_len: usize = 0;
                             var types: [8]Builder.Type = undefined;
-                            for (0..return_type.structFieldCount(mod)) |field_index| {
-                                const field_ty = return_type.structFieldType(field_index, mod);
-                                if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                            for (0..return_type.structFieldCount(zcu)) |field_index| {
+                                const field_ty = return_type.structFieldType(field_index, zcu);
+                                if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
                                 types[types_len] = try o.lowerType(field_ty);
                                 types_len += 1;
                             }
@@ -11196,20 +11203,20 @@ fn lowerFnRetTy(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Bu
         },
         .Win64 => return lowerWin64FnRetTy(o, fn_info),
         .SysV => return lowerSystemVFnRetTy(o, fn_info),
-        .Stdcall => return if (isScalar(mod, return_type)) o.lowerType(return_type) else .void,
+        .Stdcall => return if (isScalar(zcu, return_type)) o.lowerType(return_type) else .void,
         else => return o.lowerType(return_type),
     }
 }
 
 fn lowerWin64FnRetTy(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Builder.Type {
-    const pt = o.pt;
+    const zcu = o.pt.zcu;
     const return_type = Type.fromInterned(fn_info.return_type);
-    switch (x86_64_abi.classifyWindows(return_type, pt)) {
+    switch (x86_64_abi.classifyWindows(return_type, zcu)) {
         .integer => {
-            if (isScalar(pt.zcu, return_type)) {
+            if (isScalar(zcu, return_type)) {
                 return o.lowerType(return_type);
             } else {
-                return o.builder.intType(@intCast(return_type.abiSize(pt) * 8));
+                return o.builder.intType(@intCast(return_type.abiSize(zcu) * 8));
             }
         },
         .win_i128 => return o.builder.vectorType(.normal, 2, .i64),
@@ -11221,14 +11228,14 @@ fn lowerWin64FnRetTy(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Err
 
 fn lowerSystemVFnRetTy(o: *Object, fn_info: InternPool.Key.FuncType) Allocator.Error!Builder.Type {
     const pt = o.pt;
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     const return_type = Type.fromInterned(fn_info.return_type);
-    if (isScalar(mod, return_type)) {
+    if (isScalar(zcu, return_type)) {
         return o.lowerType(return_type);
     }
-    const target = mod.getTarget();
-    const classes = x86_64_abi.classifySystemV(return_type, pt, target, .ret);
+    const target = zcu.getTarget();
+    const classes = x86_64_abi.classifySystemV(return_type, zcu, target, .ret);
     if (classes[0] == .memory) return .void;
     var types_index: u32 = 0;
     var types_buffer: [8]Builder.Type = undefined;
@@ -11345,7 +11352,7 @@ const ParamTypeIterator = struct {
         const zcu = pt.zcu;
         const target = zcu.getTarget();
 
-        if (!ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             it.zig_index += 1;
             return .no_bits;
         }
@@ -11358,11 +11365,11 @@ const ParamTypeIterator = struct {
                 {
                     it.llvm_index += 1;
                     return .slice;
-                } else if (isByRef(ty, pt)) {
+                } else if (isByRef(ty, zcu)) {
                     return .byref;
                 } else if (target.cpu.arch.isX86() and
                     !std.Target.x86.featureSetHas(target.cpu.features, .evex512) and
-                    ty.totalVectorBits(pt) >= 512)
+                    ty.totalVectorBits(zcu) >= 512)
                 {
                     // As of LLVM 18, passing a vector byval with fastcc that is 512 bits or more returns
                     // "512-bit vector arguments require 'evex512' for AVX512"
@@ -11390,7 +11397,7 @@ const ParamTypeIterator = struct {
                     if (isScalar(zcu, ty)) {
                         return .byval;
                     }
-                    const classes = wasm_c_abi.classifyType(ty, pt);
+                    const classes = wasm_c_abi.classifyType(ty, zcu);
                     if (classes[0] == .indirect) {
                         return .byref;
                     }
@@ -11399,7 +11406,7 @@ const ParamTypeIterator = struct {
                 .aarch64, .aarch64_be => {
                     it.zig_index += 1;
                     it.llvm_index += 1;
-                    switch (aarch64_c_abi.classifyType(ty, pt)) {
+                    switch (aarch64_c_abi.classifyType(ty, zcu)) {
                         .memory => return .byref_mut,
                         .float_array => |len| return Lowering{ .float_array = len },
                         .byval => return .byval,
@@ -11414,7 +11421,7 @@ const ParamTypeIterator = struct {
                 .arm, .armeb => {
                     it.zig_index += 1;
                     it.llvm_index += 1;
-                    switch (arm_c_abi.classifyType(ty, pt, .arg)) {
+                    switch (arm_c_abi.classifyType(ty, zcu, .arg)) {
                         .memory => {
                             it.byval_attr = true;
                             return .byref;
@@ -11429,7 +11436,7 @@ const ParamTypeIterator = struct {
                     it.llvm_index += 1;
                     if (ty.toIntern() == .f16_type and
                         !std.Target.riscv.featureSetHas(target.cpu.features, .d)) return .as_u16;
-                    switch (riscv_c_abi.classifyType(ty, pt)) {
+                    switch (riscv_c_abi.classifyType(ty, zcu)) {
                         .memory => return .byref_mut,
                         .byval => return .byval,
                         .integer => return .abi_sized_int,
@@ -11438,7 +11445,7 @@ const ParamTypeIterator = struct {
                             it.types_len = 0;
                             for (0..ty.structFieldCount(zcu)) |field_index| {
                                 const field_ty = ty.structFieldType(field_index, zcu);
-                                if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                                if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
                                 it.types_buffer[it.types_len] = try it.object.lowerType(field_ty);
                                 it.types_len += 1;
                             }
@@ -11476,10 +11483,10 @@ const ParamTypeIterator = struct {
     }
 
     fn nextWin64(it: *ParamTypeIterator, ty: Type) ?Lowering {
-        const pt = it.object.pt;
-        switch (x86_64_abi.classifyWindows(ty, pt)) {
+        const zcu = it.object.pt.zcu;
+        switch (x86_64_abi.classifyWindows(ty, zcu)) {
             .integer => {
-                if (isScalar(pt.zcu, ty)) {
+                if (isScalar(zcu, ty)) {
                     it.zig_index += 1;
                     it.llvm_index += 1;
                     return .byval;
@@ -11509,17 +11516,17 @@ const ParamTypeIterator = struct {
     }
 
     fn nextSystemV(it: *ParamTypeIterator, ty: Type) Allocator.Error!?Lowering {
-        const pt = it.object.pt;
-        const ip = &pt.zcu.intern_pool;
-        const target = pt.zcu.getTarget();
-        const classes = x86_64_abi.classifySystemV(ty, pt, target, .arg);
+        const zcu = it.object.pt.zcu;
+        const ip = &zcu.intern_pool;
+        const target = zcu.getTarget();
+        const classes = x86_64_abi.classifySystemV(ty, zcu, target, .arg);
         if (classes[0] == .memory) {
             it.zig_index += 1;
             it.llvm_index += 1;
             it.byval_attr = true;
             return .byref;
         }
-        if (isScalar(pt.zcu, ty)) {
+        if (isScalar(zcu, ty)) {
             it.zig_index += 1;
             it.llvm_index += 1;
             return .byval;
@@ -11620,17 +11627,17 @@ fn iterateParamTypes(object: *Object, fn_info: InternPool.Key.FuncType) ParamTyp
 
 fn ccAbiPromoteInt(
     cc: std.builtin.CallingConvention,
-    mod: *Zcu,
+    zcu: *Zcu,
     ty: Type,
 ) ?std.builtin.Signedness {
-    const target = mod.getTarget();
+    const target = zcu.getTarget();
     switch (cc) {
         .Unspecified, .Inline, .Async => return null,
         else => {},
     }
-    const int_info = switch (ty.zigTypeTag(mod)) {
-        .Bool => Type.u1.intInfo(mod),
-        .Int, .Enum, .ErrorSet => ty.intInfo(mod),
+    const int_info = switch (ty.zigTypeTag(zcu)) {
+        .Bool => Type.u1.intInfo(zcu),
+        .Int, .Enum, .ErrorSet => ty.intInfo(zcu),
         else => return null,
     };
     return switch (target.os.tag) {
@@ -11668,13 +11675,13 @@ fn ccAbiPromoteInt(
 
 /// This is the one source of truth for whether a type is passed around as an LLVM pointer,
 /// or as an LLVM value.
-fn isByRef(ty: Type, pt: Zcu.PerThread) bool {
+fn isByRef(ty: Type, zcu: *Zcu) bool {
     // For tuples and structs, if there are more than this many non-void
     // fields, then we make it byref, otherwise byval.
     const max_fields_byval = 0;
-    const ip = &pt.zcu.intern_pool;
+    const ip = &zcu.intern_pool;
 
-    switch (ty.zigTypeTag(pt.zcu)) {
+    switch (ty.zigTypeTag(zcu)) {
         .Type,
         .ComptimeInt,
         .ComptimeFloat,
@@ -11697,17 +11704,17 @@ fn isByRef(ty: Type, pt: Zcu.PerThread) bool {
         .AnyFrame,
         => return false,
 
-        .Array, .Frame => return ty.hasRuntimeBits(pt),
+        .Array, .Frame => return ty.hasRuntimeBits(zcu),
         .Struct => {
             const struct_type = switch (ip.indexToKey(ty.toIntern())) {
                 .anon_struct_type => |tuple| {
                     var count: usize = 0;
                     for (tuple.types.get(ip), tuple.values.get(ip)) |field_ty, field_val| {
-                        if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(pt)) continue;
+                        if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(zcu)) continue;
 
                         count += 1;
                         if (count > max_fields_byval) return true;
-                        if (isByRef(Type.fromInterned(field_ty), pt)) return true;
+                        if (isByRef(Type.fromInterned(field_ty), zcu)) return true;
                     }
                     return false;
                 },
@@ -11725,27 +11732,27 @@ fn isByRef(ty: Type, pt: Zcu.PerThread) bool {
                 count += 1;
                 if (count > max_fields_byval) return true;
                 const field_ty = Type.fromInterned(field_types[field_index]);
-                if (isByRef(field_ty, pt)) return true;
+                if (isByRef(field_ty, zcu)) return true;
             }
             return false;
         },
-        .Union => switch (ty.containerLayout(pt.zcu)) {
+        .Union => switch (ty.containerLayout(zcu)) {
             .@"packed" => return false,
-            else => return ty.hasRuntimeBits(pt),
+            else => return ty.hasRuntimeBits(zcu),
         },
         .ErrorUnion => {
-            const payload_ty = ty.errorUnionPayload(pt.zcu);
-            if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            const payload_ty = ty.errorUnionPayload(zcu);
+            if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 return false;
             }
             return true;
         },
         .Optional => {
-            const payload_ty = ty.optionalChild(pt.zcu);
-            if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+            const payload_ty = ty.optionalChild(zcu);
+            if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                 return false;
             }
-            if (ty.optionalReprIsPayload(pt.zcu)) {
+            if (ty.optionalReprIsPayload(zcu)) {
                 return false;
             }
             return true;
@@ -11753,8 +11760,8 @@ fn isByRef(ty: Type, pt: Zcu.PerThread) bool {
     }
 }
 
-fn isScalar(mod: *Zcu, ty: Type) bool {
-    return switch (ty.zigTypeTag(mod)) {
+fn isScalar(zcu: *Zcu, ty: Type) bool {
+    return switch (ty.zigTypeTag(zcu)) {
         .Void,
         .Bool,
         .NoReturn,
@@ -11768,8 +11775,8 @@ fn isScalar(mod: *Zcu, ty: Type) bool {
         .Vector,
         => true,
 
-        .Struct => ty.containerLayout(mod) == .@"packed",
-        .Union => ty.containerLayout(mod) == .@"packed",
+        .Struct => ty.containerLayout(zcu) == .@"packed",
+        .Union => ty.containerLayout(zcu) == .@"packed",
         else => false,
     };
 }
@@ -11892,13 +11899,15 @@ fn buildAllocaInner(
 }
 
 fn errUnionPayloadOffset(payload_ty: Type, pt: Zcu.PerThread) !u1 {
+    const zcu = pt.zcu;
     const err_int_ty = try pt.errorIntType();
-    return @intFromBool(err_int_ty.abiAlignment(pt).compare(.gt, payload_ty.abiAlignment(pt)));
+    return @intFromBool(err_int_ty.abiAlignment(zcu).compare(.gt, payload_ty.abiAlignment(zcu)));
 }
 
 fn errUnionErrorOffset(payload_ty: Type, pt: Zcu.PerThread) !u1 {
+    const zcu = pt.zcu;
     const err_int_ty = try pt.errorIntType();
-    return @intFromBool(err_int_ty.abiAlignment(pt).compare(.lte, payload_ty.abiAlignment(pt)));
+    return @intFromBool(err_int_ty.abiAlignment(zcu).compare(.lte, payload_ty.abiAlignment(zcu)));
 }
 
 /// Returns true for asm constraint (e.g. "=*m", "=r") if it accepts a memory location

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -864,7 +864,7 @@ pub const Object = struct {
             // into the garbage can by converting into absolute paths. What
             // a terrible tragedy.
             const compile_unit_dir = blk: {
-                if (comp.module) |zcu| m: {
+                if (comp.zcu) |zcu| m: {
                     const d = try zcu.main_mod.root.joinString(arena, "");
                     if (d.len == 0) break :m;
                     if (std.fs.path.isAbsolute(d)) break :blk d;
@@ -955,7 +955,7 @@ pub const Object = struct {
             .gpa = gpa,
             .builder = builder,
             .pt = .{
-                .zcu = comp.module.?,
+                .zcu = comp.zcu.?,
                 .tid = .main,
             },
             .debug_compile_unit = debug_compile_unit,

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -436,16 +436,16 @@ const NavGen = struct {
     /// Fetch the result-id for a previously generated instruction or constant.
     fn resolve(self: *NavGen, inst: Air.Inst.Ref) !IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         if (try self.air.value(inst, pt)) |val| {
             const ty = self.typeOf(inst);
-            if (ty.zigTypeTag(mod) == .Fn) {
-                const fn_nav = switch (mod.intern_pool.indexToKey(val.ip_index)) {
+            if (ty.zigTypeTag(zcu) == .Fn) {
+                const fn_nav = switch (zcu.intern_pool.indexToKey(val.ip_index)) {
                     .@"extern" => |@"extern"| @"extern".owner_nav,
                     .func => |func| func.owner_nav,
                     else => unreachable,
                 };
-                const spv_decl_index = try self.object.resolveNav(mod, fn_nav);
+                const spv_decl_index = try self.object.resolveNav(zcu, fn_nav);
                 try self.func.decl_deps.put(self.spv.gpa, spv_decl_index, {});
                 return self.spv.declPtr(spv_decl_index).result_id;
             }
@@ -459,8 +459,8 @@ const NavGen = struct {
     fn resolveUav(self: *NavGen, val: InternPool.Index) !IdRef {
         // TODO: This cannot be a function at this point, but it should probably be handled anyway.
 
-        const mod = self.pt.zcu;
-        const ty = Type.fromInterned(mod.intern_pool.typeOf(val));
+        const zcu = self.pt.zcu;
+        const ty = Type.fromInterned(zcu.intern_pool.typeOf(val));
         const decl_ptr_ty_id = try self.ptrType(ty, .Generic);
 
         const spv_decl_index = blk: {
@@ -639,15 +639,15 @@ const NavGen = struct {
 
     /// Checks whether the type can be directly translated to SPIR-V vectors
     fn isSpvVector(self: *NavGen, ty: Type) bool {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const target = self.getTarget();
-        if (ty.zigTypeTag(mod) != .Vector) return false;
+        if (ty.zigTypeTag(zcu) != .Vector) return false;
 
         // TODO: This check must be expanded for types that can be represented
         // as integers (enums / packed structs?) and types that are represented
         // by multiple SPIR-V values.
-        const scalar_ty = ty.scalarType(mod);
-        switch (scalar_ty.zigTypeTag(mod)) {
+        const scalar_ty = ty.scalarType(zcu);
+        switch (scalar_ty.zigTypeTag(zcu)) {
             .Bool,
             .Int,
             .Float,
@@ -655,24 +655,24 @@ const NavGen = struct {
             else => return false,
         }
 
-        const elem_ty = ty.childType(mod);
+        const elem_ty = ty.childType(zcu);
 
-        const len = ty.vectorLen(mod);
-        const is_scalar = elem_ty.isNumeric(mod) or elem_ty.toIntern() == .bool_type;
+        const len = ty.vectorLen(zcu);
+        const is_scalar = elem_ty.isNumeric(zcu) or elem_ty.toIntern() == .bool_type;
         const spirv_len = len > 1 and len <= 4;
         const opencl_len = if (target.os.tag == .opencl) (len == 8 or len == 16) else false;
         return is_scalar and (spirv_len or opencl_len);
     }
 
     fn arithmeticTypeInfo(self: *NavGen, ty: Type) ArithmeticTypeInfo {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const target = self.getTarget();
-        var scalar_ty = ty.scalarType(mod);
-        if (scalar_ty.zigTypeTag(mod) == .Enum) {
-            scalar_ty = scalar_ty.intTagType(mod);
+        var scalar_ty = ty.scalarType(zcu);
+        if (scalar_ty.zigTypeTag(zcu) == .Enum) {
+            scalar_ty = scalar_ty.intTagType(zcu);
         }
-        const vector_len = if (ty.isVector(mod)) ty.vectorLen(mod) else null;
-        return switch (scalar_ty.zigTypeTag(mod)) {
+        const vector_len = if (ty.isVector(zcu)) ty.vectorLen(zcu) else null;
+        return switch (scalar_ty.zigTypeTag(zcu)) {
             .Bool => ArithmeticTypeInfo{
                 .bits = 1, // Doesn't matter for this class.
                 .backing_bits = self.backingIntBits(1).?,
@@ -688,7 +688,7 @@ const NavGen = struct {
                 .class = .float,
             },
             .Int => blk: {
-                const int_info = scalar_ty.intInfo(mod);
+                const int_info = scalar_ty.intInfo(zcu);
                 // TODO: Maybe it's useful to also return this value.
                 const maybe_backing_bits = self.backingIntBits(int_info.bits);
                 break :blk ArithmeticTypeInfo{
@@ -741,9 +741,9 @@ const NavGen = struct {
     /// the value to an unsigned int first for Kernels.
     fn constInt(self: *NavGen, ty: Type, value: anytype, repr: Repr) !IdRef {
         // TODO: Cache?
-        const mod = self.pt.zcu;
-        const scalar_ty = ty.scalarType(mod);
-        const int_info = scalar_ty.intInfo(mod);
+        const zcu = self.pt.zcu;
+        const scalar_ty = ty.scalarType(zcu);
+        const int_info = scalar_ty.intInfo(zcu);
         // Use backing bits so that negatives are sign extended
         const backing_bits = self.backingIntBits(int_info.bits).?; // Assertion failure means big int
 
@@ -783,11 +783,11 @@ const NavGen = struct {
             else => unreachable, // TODO: Large integer constants
         }
 
-        if (!ty.isVector(mod)) {
+        if (!ty.isVector(zcu)) {
             return result_id;
         }
 
-        const n = ty.vectorLen(mod);
+        const n = ty.vectorLen(zcu);
         const ids = try self.gpa.alloc(IdRef, n);
         defer self.gpa.free(ids);
         @memset(ids, result_id);
@@ -821,8 +821,8 @@ const NavGen = struct {
     /// Construct a vector at runtime.
     /// ty must be an vector type.
     fn constructVector(self: *NavGen, ty: Type, constituents: []const IdRef) !IdRef {
-        const mod = self.pt.zcu;
-        assert(ty.vectorLen(mod) == constituents.len);
+        const zcu = self.pt.zcu;
+        assert(ty.vectorLen(zcu) == constituents.len);
 
         // Note: older versions of the Khronos SPRIV-LLVM translator crash on this instruction
         // because it cannot construct structs which' operands are not constant.
@@ -845,8 +845,8 @@ const NavGen = struct {
     /// Construct a vector at runtime with all lanes set to the same value.
     /// ty must be an vector type.
     fn constructVectorSplat(self: *NavGen, ty: Type, constituent: IdRef) !IdRef {
-        const mod = self.pt.zcu;
-        const n = ty.vectorLen(mod);
+        const zcu = self.pt.zcu;
+        const n = ty.vectorLen(zcu);
 
         const constituents = try self.gpa.alloc(IdRef, n);
         defer self.gpa.free(constituents);
@@ -884,13 +884,13 @@ const NavGen = struct {
         }
 
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const target = self.getTarget();
         const result_ty_id = try self.resolveType(ty, repr);
-        const ip = &mod.intern_pool;
+        const ip = &zcu.intern_pool;
 
         log.debug("lowering constant: ty = {}, val = {}", .{ ty.fmt(pt), val.fmtValue(pt) });
-        if (val.isUndefDeep(mod)) {
+        if (val.isUndefDeep(zcu)) {
             return self.spv.constUndef(result_ty_id);
         }
 
@@ -937,17 +937,17 @@ const NavGen = struct {
                     .false, .true => break :cache try self.constBool(val.toBool(), repr),
                 },
                 .int => {
-                    if (ty.isSignedInt(mod)) {
-                        break :cache try self.constInt(ty, val.toSignedInt(pt), repr);
+                    if (ty.isSignedInt(zcu)) {
+                        break :cache try self.constInt(ty, val.toSignedInt(zcu), repr);
                     } else {
-                        break :cache try self.constInt(ty, val.toUnsignedInt(pt), repr);
+                        break :cache try self.constInt(ty, val.toUnsignedInt(zcu), repr);
                     }
                 },
                 .float => {
                     const lit: spec.LiteralContextDependentNumber = switch (ty.floatBits(target)) {
-                        16 => .{ .uint32 = @as(u16, @bitCast(val.toFloat(f16, pt))) },
-                        32 => .{ .float32 = val.toFloat(f32, pt) },
-                        64 => .{ .float64 = val.toFloat(f64, pt) },
+                        16 => .{ .uint32 = @as(u16, @bitCast(val.toFloat(f16, zcu))) },
+                        32 => .{ .float32 = val.toFloat(f32, zcu) },
+                        64 => .{ .float64 = val.toFloat(f64, zcu) },
                         80, 128 => unreachable, // TODO
                         else => unreachable,
                     };
@@ -968,17 +968,17 @@ const NavGen = struct {
                     // allows it. For now, just generate it here regardless.
                     const err_int_ty = try pt.errorIntType();
                     const err_ty = switch (error_union.val) {
-                        .err_name => ty.errorUnionSet(mod),
+                        .err_name => ty.errorUnionSet(zcu),
                         .payload => err_int_ty,
                     };
                     const err_val = switch (error_union.val) {
                         .err_name => |err_name| Value.fromInterned(try pt.intern(.{ .err = .{
-                            .ty = ty.errorUnionSet(mod).toIntern(),
+                            .ty = ty.errorUnionSet(zcu).toIntern(),
                             .name = err_name,
                         } })),
                         .payload => try pt.intValue(err_int_ty, 0),
                     };
-                    const payload_ty = ty.errorUnionPayload(mod);
+                    const payload_ty = ty.errorUnionPayload(zcu);
                     const eu_layout = self.errorUnionLayout(payload_ty);
                     if (!eu_layout.payload_has_bits) {
                         // We use the error type directly as the type.
@@ -1006,12 +1006,12 @@ const NavGen = struct {
                 },
                 .enum_tag => {
                     const int_val = try val.intFromEnum(ty, pt);
-                    const int_ty = ty.intTagType(mod);
+                    const int_ty = ty.intTagType(zcu);
                     break :cache try self.constant(int_ty, int_val, repr);
                 },
                 .ptr => return self.constantPtr(val),
                 .slice => |slice| {
-                    const ptr_ty = ty.slicePtrFieldType(mod);
+                    const ptr_ty = ty.slicePtrFieldType(zcu);
                     const ptr_id = try self.constantPtr(Value.fromInterned(slice.ptr));
                     const len_id = try self.constant(Type.usize, Value.fromInterned(slice.len), .indirect);
                     return self.constructStruct(
@@ -1021,12 +1021,12 @@ const NavGen = struct {
                     );
                 },
                 .opt => {
-                    const payload_ty = ty.optionalChild(mod);
-                    const maybe_payload_val = val.optionalValue(mod);
+                    const payload_ty = ty.optionalChild(zcu);
+                    const maybe_payload_val = val.optionalValue(zcu);
 
-                    if (!payload_ty.hasRuntimeBits(pt)) {
+                    if (!payload_ty.hasRuntimeBits(zcu)) {
                         break :cache try self.constBool(maybe_payload_val != null, .indirect);
-                    } else if (ty.optionalReprIsPayload(mod)) {
+                    } else if (ty.optionalReprIsPayload(zcu)) {
                         // Optional representation is a nullable pointer or slice.
                         if (maybe_payload_val) |payload_val| {
                             return try self.constant(payload_ty, payload_val, .indirect);
@@ -1054,7 +1054,7 @@ const NavGen = struct {
                     inline .array_type, .vector_type => |array_type, tag| {
                         const elem_ty = Type.fromInterned(array_type.child);
 
-                        const constituents = try self.gpa.alloc(IdRef, @intCast(ty.arrayLenIncludingSentinel(mod)));
+                        const constituents = try self.gpa.alloc(IdRef, @intCast(ty.arrayLenIncludingSentinel(zcu)));
                         defer self.gpa.free(constituents);
 
                         const child_repr: Repr = switch (tag) {
@@ -1088,7 +1088,7 @@ const NavGen = struct {
                         }
                     },
                     .struct_type => {
-                        const struct_type = mod.typeToStruct(ty).?;
+                        const struct_type = zcu.typeToStruct(ty).?;
                         if (struct_type.layout == .@"packed") {
                             return self.todo("packed struct constants", .{});
                         }
@@ -1102,7 +1102,7 @@ const NavGen = struct {
                         var it = struct_type.iterateRuntimeOrder(ip);
                         while (it.next()) |field_index| {
                             const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
-                            if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                            if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                                 // This is a zero-bit field - we only needed it for the alignment.
                                 continue;
                             }
@@ -1121,10 +1121,10 @@ const NavGen = struct {
                     else => unreachable,
                 },
                 .un => |un| {
-                    const active_field = ty.unionTagFieldIndex(Value.fromInterned(un.tag), mod).?;
-                    const union_obj = mod.typeToUnion(ty).?;
+                    const active_field = ty.unionTagFieldIndex(Value.fromInterned(un.tag), zcu).?;
+                    const union_obj = zcu.typeToUnion(ty).?;
                     const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[active_field]);
-                    const payload = if (field_ty.hasRuntimeBitsIgnoreComptime(pt))
+                    const payload = if (field_ty.hasRuntimeBitsIgnoreComptime(zcu))
                         try self.constant(field_ty, Value.fromInterned(un.val), .direct)
                     else
                         null;
@@ -1232,8 +1232,8 @@ const NavGen = struct {
         // TODO: Merge this function with constantDeclRef.
 
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_id = try self.resolveType(ty, .direct);
         const uav_ty = Type.fromInterned(ip.typeOf(uav.val));
 
@@ -1243,14 +1243,14 @@ const NavGen = struct {
             else => {},
         }
 
-        // const is_fn_body = decl_ty.zigTypeTag(mod) == .Fn;
-        if (!uav_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+        // const is_fn_body = decl_ty.zigTypeTag(zcu) == .Fn;
+        if (!uav_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
             // Pointer to nothing - return undefined
             return self.spv.constUndef(ty_id);
         }
 
         // Uav refs are always generic.
-        assert(ty.ptrAddressSpace(mod) == .generic);
+        assert(ty.ptrAddressSpace(zcu) == .generic);
         const decl_ptr_ty_id = try self.ptrType(uav_ty, .Generic);
         const ptr_id = try self.resolveUav(uav.val);
 
@@ -1270,12 +1270,12 @@ const NavGen = struct {
 
     fn constantNavRef(self: *NavGen, ty: Type, nav_index: InternPool.Nav.Index) !IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_id = try self.resolveType(ty, .direct);
         const nav = ip.getNav(nav_index);
-        const nav_val = mod.navValue(nav_index);
-        const nav_ty = nav_val.typeOf(mod);
+        const nav_val = zcu.navValue(nav_index);
+        const nav_ty = nav_val.typeOf(zcu);
 
         switch (ip.indexToKey(nav_val.toIntern())) {
             .func => {
@@ -1287,12 +1287,12 @@ const NavGen = struct {
             else => {},
         }
 
-        if (!nav_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+        if (!nav_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
             // Pointer to nothing - return undefined.
             return self.spv.constUndef(ty_id);
         }
 
-        const spv_decl_index = try self.object.resolveNav(mod, nav_index);
+        const spv_decl_index = try self.object.resolveNav(zcu, nav_index);
         const spv_decl = self.spv.declPtr(spv_decl_index);
 
         const decl_id = switch (spv_decl.kind) {
@@ -1452,9 +1452,9 @@ const NavGen = struct {
     ///  }
     /// If any of the fields' size is 0, it will be omitted.
     fn resolveUnionType(self: *NavGen, ty: Type) !IdRef {
-        const mod = self.pt.zcu;
-        const ip = &mod.intern_pool;
-        const union_obj = mod.typeToUnion(ty).?;
+        const zcu = self.pt.zcu;
+        const ip = &zcu.intern_pool;
+        const union_obj = zcu.typeToUnion(ty).?;
 
         if (union_obj.flagsUnordered(ip).layout == .@"packed") {
             return self.todo("packed union types", .{});
@@ -1503,12 +1503,12 @@ const NavGen = struct {
     }
 
     fn resolveFnReturnType(self: *NavGen, ret_ty: Type) !IdRef {
-        const pt = self.pt;
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        const zcu = self.pt.zcu;
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             // If the return type is an error set or an error union, then we make this
             // anyerror return type instead, so that it can be coerced into a function
             // pointer type which has anyerror as the return type.
-            if (ret_ty.isError(pt.zcu)) {
+            if (ret_ty.isError(zcu)) {
                 return self.resolveType(Type.anyerror, .direct);
             } else {
                 return self.resolveType(Type.void, .direct);
@@ -1531,14 +1531,14 @@ const NavGen = struct {
 
     fn resolveTypeInner(self: *NavGen, ty: Type, repr: Repr) Error!IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         log.debug("resolveType: ty = {}", .{ty.fmt(pt)});
         const target = self.getTarget();
 
         const section = &self.spv.sections.types_globals_constants;
 
-        switch (ty.zigTypeTag(mod)) {
+        switch (ty.zigTypeTag(zcu)) {
             .NoReturn => {
                 assert(repr == .direct);
                 return try self.spv.voidType();
@@ -1562,7 +1562,7 @@ const NavGen = struct {
                 .indirect => return try self.resolveType(Type.u1, .indirect),
             },
             .Int => {
-                const int_info = ty.intInfo(mod);
+                const int_info = ty.intInfo(zcu);
                 if (int_info.bits == 0) {
                     // Some times, the backend will be asked to generate a pointer to i0. OpTypeInt
                     // with 0 bits is invalid, so return an opaque type in this case.
@@ -1577,7 +1577,7 @@ const NavGen = struct {
                 return try self.intType(int_info.signedness, int_info.bits);
             },
             .Enum => {
-                const tag_ty = ty.intTagType(mod);
+                const tag_ty = ty.intTagType(zcu);
                 return try self.resolveType(tag_ty, repr);
             },
             .Float => {
@@ -1599,13 +1599,13 @@ const NavGen = struct {
                 return try self.spv.floatType(bits);
             },
             .Array => {
-                const elem_ty = ty.childType(mod);
+                const elem_ty = ty.childType(zcu);
                 const elem_ty_id = try self.resolveType(elem_ty, .indirect);
-                const total_len = std.math.cast(u32, ty.arrayLenIncludingSentinel(mod)) orelse {
-                    return self.fail("array type of {} elements is too large", .{ty.arrayLenIncludingSentinel(mod)});
+                const total_len = std.math.cast(u32, ty.arrayLenIncludingSentinel(zcu)) orelse {
+                    return self.fail("array type of {} elements is too large", .{ty.arrayLenIncludingSentinel(zcu)});
                 };
 
-                if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     // The size of the array would be 0, but that is not allowed in SPIR-V.
                     // This path can be reached when the backend is asked to generate a pointer to
                     // an array of some zero-bit type. This should always be an indirect path.
@@ -1635,7 +1635,7 @@ const NavGen = struct {
             },
             .Fn => switch (repr) {
                 .direct => {
-                    const fn_info = mod.typeToFunc(ty).?;
+                    const fn_info = zcu.typeToFunc(ty).?;
 
                     comptime assert(zig_call_abi_ver == 3);
                     switch (fn_info.cc) {
@@ -1653,7 +1653,7 @@ const NavGen = struct {
                     var param_index: usize = 0;
                     for (fn_info.param_types.get(ip)) |param_ty_index| {
                         const param_ty = Type.fromInterned(param_ty_index);
-                        if (!param_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                        if (!param_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
                         param_ty_ids[param_index] = try self.resolveType(param_ty, .direct);
                         param_index += 1;
@@ -1677,7 +1677,7 @@ const NavGen = struct {
                 },
             },
             .Pointer => {
-                const ptr_info = ty.ptrInfo(mod);
+                const ptr_info = ty.ptrInfo(zcu);
 
                 const storage_class = self.spvStorageClass(ptr_info.flags.address_space);
                 const ptr_ty_id = try self.ptrType(Type.fromInterned(ptr_info.child), storage_class);
@@ -1693,9 +1693,9 @@ const NavGen = struct {
                 );
             },
             .Vector => {
-                const elem_ty = ty.childType(mod);
+                const elem_ty = ty.childType(zcu);
                 const elem_ty_id = try self.resolveType(elem_ty, repr);
-                const len = ty.vectorLen(mod);
+                const len = ty.vectorLen(zcu);
 
                 if (self.isSpvVector(ty)) {
                     return try self.spv.vectorType(len, elem_ty_id);
@@ -1711,7 +1711,7 @@ const NavGen = struct {
 
                         var member_index: usize = 0;
                         for (tuple.types.get(ip), tuple.values.get(ip)) |field_ty, field_val| {
-                            if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(pt)) continue;
+                            if (field_val != .none or !Type.fromInterned(field_ty).hasRuntimeBits(zcu)) continue;
 
                             member_types[member_index] = try self.resolveType(Type.fromInterned(field_ty), .indirect);
                             member_index += 1;
@@ -1740,13 +1740,13 @@ const NavGen = struct {
                 var it = struct_type.iterateRuntimeOrder(ip);
                 while (it.next()) |field_index| {
                     const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
-                    if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                    if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                         // This is a zero-bit field - we only needed it for the alignment.
                         continue;
                     }
 
                     const field_name = struct_type.fieldName(ip, field_index).unwrap() orelse
-                        try ip.getOrPutStringFmt(mod.gpa, pt.tid, "{d}", .{field_index}, .no_embedded_nulls);
+                        try ip.getOrPutStringFmt(zcu.gpa, pt.tid, "{d}", .{field_index}, .no_embedded_nulls);
                     try member_types.append(try self.resolveType(field_ty, .indirect));
                     try member_names.append(field_name.toSlice(ip));
                 }
@@ -1758,8 +1758,8 @@ const NavGen = struct {
                 return result_id;
             },
             .Optional => {
-                const payload_ty = ty.optionalChild(mod);
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                const payload_ty = ty.optionalChild(zcu);
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     // Just use a bool.
                     // Note: Always generate the bool with indirect format, to save on some sanity
                     // Perform the conversion to a direct bool when the field is extracted.
@@ -1767,7 +1767,7 @@ const NavGen = struct {
                 }
 
                 const payload_ty_id = try self.resolveType(payload_ty, .indirect);
-                if (ty.optionalReprIsPayload(mod)) {
+                if (ty.optionalReprIsPayload(zcu)) {
                     // Optional is actually a pointer or a slice.
                     return payload_ty_id;
                 }
@@ -1782,7 +1782,7 @@ const NavGen = struct {
             .Union => return try self.resolveUnionType(ty),
             .ErrorSet => return try self.resolveType(Type.u16, repr),
             .ErrorUnion => {
-                const payload_ty = ty.errorUnionPayload(mod);
+                const payload_ty = ty.errorUnionPayload(zcu);
                 const error_ty_id = try self.resolveType(Type.anyerror, .indirect);
 
                 const eu_layout = self.errorUnionLayout(payload_ty);
@@ -1877,13 +1877,14 @@ const NavGen = struct {
 
     fn errorUnionLayout(self: *NavGen, payload_ty: Type) ErrorUnionLayout {
         const pt = self.pt;
+        const zcu = pt.zcu;
 
-        const error_align = Type.anyerror.abiAlignment(pt);
-        const payload_align = payload_ty.abiAlignment(pt);
+        const error_align = Type.anyerror.abiAlignment(zcu);
+        const payload_align = payload_ty.abiAlignment(zcu);
 
         const error_first = error_align.compare(.gt, payload_align);
         return .{
-            .payload_has_bits = payload_ty.hasRuntimeBitsIgnoreComptime(pt),
+            .payload_has_bits = payload_ty.hasRuntimeBitsIgnoreComptime(zcu),
             .error_first = error_first,
         };
     }
@@ -1908,10 +1909,10 @@ const NavGen = struct {
 
     fn unionLayout(self: *NavGen, ty: Type) UnionLayout {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
-        const layout = ty.unionGetLayout(pt);
-        const union_obj = mod.typeToUnion(ty).?;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
+        const layout = ty.unionGetLayout(zcu);
+        const union_obj = zcu.typeToUnion(ty).?;
 
         var union_layout = UnionLayout{
             .has_payload = layout.payload_size != 0,
@@ -1931,7 +1932,7 @@ const NavGen = struct {
             const most_aligned_field = layout.most_aligned_field;
             const most_aligned_field_ty = Type.fromInterned(union_obj.field_types.get(ip)[most_aligned_field]);
             union_layout.payload_ty = most_aligned_field_ty;
-            union_layout.payload_size = @intCast(most_aligned_field_ty.abiSize(pt));
+            union_layout.payload_size = @intCast(most_aligned_field_ty.abiSize(zcu));
         } else {
             union_layout.payload_size = 0;
         }
@@ -1998,12 +1999,12 @@ const NavGen = struct {
         }
 
         fn materialize(self: Temporary, ng: *NavGen) !IdResult {
-            const mod = ng.pt.zcu;
+            const zcu = ng.pt.zcu;
             switch (self.value) {
                 .singleton => |id| return id,
                 .exploded_vector => |range| {
-                    assert(self.ty.isVector(mod));
-                    assert(self.ty.vectorLen(mod) == range.len);
+                    assert(self.ty.isVector(zcu));
+                    assert(self.ty.vectorLen(zcu) == range.len);
                     const consituents = try ng.gpa.alloc(IdRef, range.len);
                     defer ng.gpa.free(consituents);
                     for (consituents, 0..range.len) |*id, i| {
@@ -2028,18 +2029,18 @@ const NavGen = struct {
         /// 'Explode' a temporary into separate elements. This turns a vector
         /// into a bag of elements.
         fn explode(self: Temporary, ng: *NavGen) !IdRange {
-            const mod = ng.pt.zcu;
+            const zcu = ng.pt.zcu;
 
             // If the value is a scalar, then this is a no-op.
-            if (!self.ty.isVector(mod)) {
+            if (!self.ty.isVector(zcu)) {
                 return switch (self.value) {
                     .singleton => |id| .{ .base = @intFromEnum(id), .len = 1 },
                     .exploded_vector => |range| range,
                 };
             }
 
-            const ty_id = try ng.resolveType(self.ty.scalarType(mod), .direct);
-            const n = self.ty.vectorLen(mod);
+            const ty_id = try ng.resolveType(self.ty.scalarType(zcu), .direct);
+            const n = self.ty.vectorLen(zcu);
             const results = ng.spv.allocIds(n);
 
             const id = switch (self.value) {
@@ -2087,13 +2088,13 @@ const NavGen = struct {
         /// only checks the size, but the source-of-truth is implemented
         /// by `isSpvVector()`.
         fn fromType(ty: Type, ng: *NavGen) Vectorization {
-            const mod = ng.pt.zcu;
-            if (!ty.isVector(mod)) {
+            const zcu = ng.pt.zcu;
+            if (!ty.isVector(zcu)) {
                 return .scalar;
             } else if (ng.isSpvVector(ty)) {
-                return .{ .spv_vectorized = ty.vectorLen(mod) };
+                return .{ .spv_vectorized = ty.vectorLen(zcu) };
             } else {
-                return .{ .unrolled = ty.vectorLen(mod) };
+                return .{ .unrolled = ty.vectorLen(zcu) };
             }
         }
 
@@ -2339,10 +2340,10 @@ const NavGen = struct {
     /// This function builds an OpSConvert of OpUConvert depending on the
     /// signedness of the types.
     fn buildIntConvert(self: *NavGen, dst_ty: Type, src: Temporary) !Temporary {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
 
-        const dst_ty_id = try self.resolveType(dst_ty.scalarType(mod), .direct);
-        const src_ty_id = try self.resolveType(src.ty.scalarType(mod), .direct);
+        const dst_ty_id = try self.resolveType(dst_ty.scalarType(zcu), .direct);
+        const src_ty_id = try self.resolveType(src.ty.scalarType(zcu), .direct);
 
         const v = self.vectorization(.{ dst_ty, src });
         const result_ty = try v.resultType(self, dst_ty);
@@ -2363,7 +2364,7 @@ const NavGen = struct {
         const op_result_ty = try v.operationType(self, dst_ty);
         const op_result_ty_id = try self.resolveType(op_result_ty, .direct);
 
-        const opcode: Opcode = if (dst_ty.isSignedInt(mod)) .OpSConvert else .OpUConvert;
+        const opcode: Opcode = if (dst_ty.isSignedInt(zcu)) .OpSConvert else .OpUConvert;
 
         const op_src = try v.prepare(self, src);
 
@@ -2418,7 +2419,7 @@ const NavGen = struct {
     }
 
     fn buildSelect(self: *NavGen, condition: Temporary, lhs: Temporary, rhs: Temporary) !Temporary {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
 
         const v = self.vectorization(.{ condition, lhs, rhs });
         const ops = v.operations();
@@ -2428,7 +2429,7 @@ const NavGen = struct {
         const op_result_ty_id = try self.resolveType(op_result_ty, .direct);
         const result_ty = try v.resultType(self, lhs.ty);
 
-        assert(condition.ty.scalarType(mod).zigTypeTag(mod) == .Bool);
+        assert(condition.ty.scalarType(zcu).zigTypeTag(zcu) == .Bool);
 
         const cond = try v.prepare(self, condition);
         const object_1 = try v.prepare(self, lhs);
@@ -2764,9 +2765,9 @@ const NavGen = struct {
         rhs: Temporary,
     ) !struct { Temporary, Temporary } {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const target = self.getTarget();
-        const ip = &mod.intern_pool;
+        const ip = &zcu.intern_pool;
 
         const v = lhs.vectorization(self).unify(rhs.vectorization(self));
         const ops = v.operations();
@@ -2814,7 +2815,7 @@ const NavGen = struct {
                     // where T is maybe vectorized.
                     const types = [2]InternPool.Index{ arith_op_ty.toIntern(), arith_op_ty.toIntern() };
                     const values = [2]InternPool.Index{ .none, .none };
-                    const index = try ip.getAnonStructType(mod.gpa, pt.tid, .{
+                    const index = try ip.getAnonStructType(zcu.gpa, pt.tid, .{
                         .types = &types,
                         .values = &values,
                         .names = &.{},
@@ -2941,17 +2942,17 @@ const NavGen = struct {
 
     fn genNav(self: *NavGen) !void {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
-        const spv_decl_index = try self.object.resolveNav(mod, self.owner_nav);
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
+        const spv_decl_index = try self.object.resolveNav(zcu, self.owner_nav);
         const result_id = self.spv.declPtr(spv_decl_index).result_id;
 
         const nav = ip.getNav(self.owner_nav);
-        const val = mod.navValue(self.owner_nav);
-        const ty = val.typeOf(mod);
+        const val = zcu.navValue(self.owner_nav);
+        const ty = val.typeOf(zcu);
         switch (self.spv.declPtr(spv_decl_index).kind) {
             .func => {
-                const fn_info = mod.typeToFunc(ty).?;
+                const fn_info = zcu.typeToFunc(ty).?;
                 const return_ty_id = try self.resolveFnReturnType(Type.fromInterned(fn_info.return_type));
 
                 const prototype_ty_id = try self.resolveType(ty, .direct);
@@ -2969,7 +2970,7 @@ const NavGen = struct {
                 try self.args.ensureUnusedCapacity(self.gpa, fn_info.param_types.len);
                 for (fn_info.param_types.get(ip)) |param_ty_index| {
                     const param_ty = Type.fromInterned(param_ty_index);
-                    if (!param_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+                    if (!param_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
 
                     const param_type_id = try self.resolveType(param_ty, .direct);
                     const arg_result_id = self.spv.allocId();
@@ -3116,8 +3117,8 @@ const NavGen = struct {
     /// Convert representation from indirect (in memory) to direct (in 'register')
     /// This converts the argument type from resolveType(ty, .indirect) to resolveType(ty, .direct).
     fn convertToDirect(self: *NavGen, ty: Type, operand_id: IdRef) !IdRef {
-        const mod = self.pt.zcu;
-        switch (ty.scalarType(mod).zigTypeTag(mod)) {
+        const zcu = self.pt.zcu;
+        switch (ty.scalarType(zcu).zigTypeTag(zcu)) {
             .Bool => {
                 const false_id = try self.constBool(false, .indirect);
                 // The operation below requires inputs in direct representation, but the operand
@@ -3142,8 +3143,8 @@ const NavGen = struct {
     /// Convert representation from direct (in 'register) to direct (in memory)
     /// This converts the argument type from resolveType(ty, .direct) to resolveType(ty, .indirect).
     fn convertToIndirect(self: *NavGen, ty: Type, operand_id: IdRef) !IdRef {
-        const mod = self.pt.zcu;
-        switch (ty.scalarType(mod).zigTypeTag(mod)) {
+        const zcu = self.pt.zcu;
+        switch (ty.scalarType(zcu).zigTypeTag(zcu)) {
             .Bool => {
                 const result = try self.intFromBool(Temporary.init(ty, operand_id));
                 return try result.materialize(self);
@@ -3219,8 +3220,8 @@ const NavGen = struct {
     }
 
     fn genInst(self: *NavGen, inst: Air.Inst.Index) !void {
-        const mod = self.pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = self.pt.zcu;
+        const ip = &zcu.intern_pool;
         if (self.liveness.isUnused(inst) and !self.air.mustLower(inst, ip))
             return;
 
@@ -3399,7 +3400,7 @@ const NavGen = struct {
     }
 
     fn airShift(self: *NavGen, inst: Air.Inst.Index, unsigned: BinaryOp, signed: BinaryOp) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
 
         const base = try self.temporary(bin_op.lhs);
@@ -3420,7 +3421,7 @@ const NavGen = struct {
         // Note: The sign may differ here between the shift and the base type, in case
         // of an arithmetic right shift. SPIR-V still expects the same type,
         // so in that case we have to cast convert to signed.
-        const casted_shift = try self.buildIntConvert(base.ty.scalarType(mod), shift);
+        const casted_shift = try self.buildIntConvert(base.ty.scalarType(zcu), shift);
 
         const shifted = switch (info.signedness) {
             .unsigned => try self.buildBinary(unsigned, base, casted_shift),
@@ -3477,7 +3478,7 @@ const NavGen = struct {
     /// All other values are returned unmodified (this makes strange integer
     /// wrapping easier to use in generic operations).
     fn normalize(self: *NavGen, value: Temporary, info: ArithmeticTypeInfo) !Temporary {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ty = value.ty;
         switch (info.class) {
             .integer, .bool, .float => return value,
@@ -3485,13 +3486,13 @@ const NavGen = struct {
             .strange_integer => switch (info.signedness) {
                 .unsigned => {
                     const mask_value = if (info.bits == 64) 0xFFFF_FFFF_FFFF_FFFF else (@as(u64, 1) << @as(u6, @intCast(info.bits))) - 1;
-                    const mask_id = try self.constInt(ty.scalarType(mod), mask_value, .direct);
-                    return try self.buildBinary(.bit_and, value, Temporary.init(ty.scalarType(mod), mask_id));
+                    const mask_id = try self.constInt(ty.scalarType(zcu), mask_value, .direct);
+                    return try self.buildBinary(.bit_and, value, Temporary.init(ty.scalarType(zcu), mask_id));
                 },
                 .signed => {
                     // Shift left and right so that we can copy the sight bit that way.
-                    const shift_amt_id = try self.constInt(ty.scalarType(mod), info.backing_bits - info.bits, .direct);
-                    const shift_amt = Temporary.init(ty.scalarType(mod), shift_amt_id);
+                    const shift_amt_id = try self.constInt(ty.scalarType(zcu), info.backing_bits - info.bits, .direct);
+                    const shift_amt = Temporary.init(ty.scalarType(zcu), shift_amt_id);
                     const left = try self.buildBinary(.sll, value, shift_amt);
                     return try self.buildBinary(.sra, left, shift_amt);
                 },
@@ -3897,7 +3898,7 @@ const NavGen = struct {
     }
 
     fn airShlOverflow(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
 
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Bin, ty_pl.payload).data;
@@ -3916,7 +3917,7 @@ const NavGen = struct {
 
         // Sometimes Zig doesn't make both of the arguments the same types here. SPIR-V expects that,
         // so just manually upcast it if required.
-        const casted_shift = try self.buildIntConvert(base.ty.scalarType(mod), shift);
+        const casted_shift = try self.buildIntConvert(base.ty.scalarType(zcu), shift);
 
         const left = try self.buildBinary(.sll, base, casted_shift);
         const result = try self.normalize(left, info);
@@ -3955,12 +3956,12 @@ const NavGen = struct {
     fn airClzCtz(self: *NavGen, inst: Air.Inst.Index, op: UnaryOp) !?IdRef {
         if (self.liveness.isUnused(inst)) return null;
 
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const target = self.getTarget();
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand = try self.temporary(ty_op.operand);
 
-        const scalar_result_ty = self.typeOfIndex(inst).scalarType(mod);
+        const scalar_result_ty = self.typeOfIndex(inst).scalarType(zcu);
 
         const info = self.arithmeticTypeInfo(operand.ty);
         switch (info.class) {
@@ -4004,16 +4005,16 @@ const NavGen = struct {
     }
 
     fn airReduce(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const reduce = self.air.instructions.items(.data)[@intFromEnum(inst)].reduce;
         const operand = try self.resolve(reduce.operand);
         const operand_ty = self.typeOf(reduce.operand);
-        const scalar_ty = operand_ty.scalarType(mod);
+        const scalar_ty = operand_ty.scalarType(zcu);
         const scalar_ty_id = try self.resolveType(scalar_ty, .direct);
 
         const info = self.arithmeticTypeInfo(operand_ty);
 
-        const len = operand_ty.vectorLen(mod);
+        const len = operand_ty.vectorLen(zcu);
 
         const first = try self.extractVectorComponent(scalar_ty, operand, 0);
 
@@ -4080,7 +4081,7 @@ const NavGen = struct {
 
     fn airShuffle(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Shuffle, ty_pl.payload).data;
         const a = try self.resolve(extra.a);
@@ -4092,7 +4093,7 @@ const NavGen = struct {
         const a_ty = self.typeOf(extra.a);
         const b_ty = self.typeOf(extra.b);
 
-        const scalar_ty = result_ty.scalarType(mod);
+        const scalar_ty = result_ty.scalarType(zcu);
         const scalar_ty_id = try self.resolveType(scalar_ty, .direct);
 
         // If all of the types are SPIR-V vectors, we can use OpVectorShuffle.
@@ -4100,20 +4101,20 @@ const NavGen = struct {
             // The SPIR-V shuffle instruction is similar to the Air instruction, except that the elements are
             // numbered consecutively instead of using negatives.
 
-            const components = try self.gpa.alloc(Word, result_ty.vectorLen(mod));
+            const components = try self.gpa.alloc(Word, result_ty.vectorLen(zcu));
             defer self.gpa.free(components);
 
-            const a_len = a_ty.vectorLen(mod);
+            const a_len = a_ty.vectorLen(zcu);
 
             for (components, 0..) |*component, i| {
                 const elem = try mask.elemValue(pt, i);
-                if (elem.isUndef(mod)) {
+                if (elem.isUndef(zcu)) {
                     // This is explicitly valid for OpVectorShuffle, it indicates undefined.
                     component.* = 0xFFFF_FFFF;
                     continue;
                 }
 
-                const index = elem.toSignedInt(pt);
+                const index = elem.toSignedInt(zcu);
                 if (index >= 0) {
                     component.* = @intCast(index);
                 } else {
@@ -4134,17 +4135,17 @@ const NavGen = struct {
 
         // Fall back to manually extracting and inserting components.
 
-        const components = try self.gpa.alloc(IdRef, result_ty.vectorLen(mod));
+        const components = try self.gpa.alloc(IdRef, result_ty.vectorLen(zcu));
         defer self.gpa.free(components);
 
         for (components, 0..) |*id, i| {
             const elem = try mask.elemValue(pt, i);
-            if (elem.isUndef(mod)) {
+            if (elem.isUndef(zcu)) {
                 id.* = try self.spv.constUndef(scalar_ty_id);
                 continue;
             }
 
-            const index = elem.toSignedInt(pt);
+            const index = elem.toSignedInt(zcu);
             if (index >= 0) {
                 id.* = try self.extractVectorComponent(scalar_ty, a, @intCast(index));
             } else {
@@ -4218,10 +4219,10 @@ const NavGen = struct {
     }
 
     fn ptrAdd(self: *NavGen, result_ty: Type, ptr_ty: Type, ptr_id: IdRef, offset_id: IdRef) !IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const result_ty_id = try self.resolveType(result_ty, .direct);
 
-        switch (ptr_ty.ptrSize(mod)) {
+        switch (ptr_ty.ptrSize(zcu)) {
             .One => {
                 // Pointer to array
                 // TODO: Is this correct?
@@ -4275,15 +4276,15 @@ const NavGen = struct {
         rhs: Temporary,
     ) !Temporary {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const scalar_ty = lhs.ty.scalarType(mod);
-        const is_vector = lhs.ty.isVector(mod);
+        const zcu = pt.zcu;
+        const scalar_ty = lhs.ty.scalarType(zcu);
+        const is_vector = lhs.ty.isVector(zcu);
 
-        switch (scalar_ty.zigTypeTag(mod)) {
+        switch (scalar_ty.zigTypeTag(zcu)) {
             .Int, .Bool, .Float => {},
             .Enum => {
                 assert(!is_vector);
-                const ty = lhs.ty.intTagType(mod);
+                const ty = lhs.ty.intTagType(zcu);
                 return try self.cmp(op, lhs.pun(ty), rhs.pun(ty));
             },
             .ErrorSet => {
@@ -4321,10 +4322,10 @@ const NavGen = struct {
 
                 const ty = lhs.ty;
 
-                const payload_ty = ty.optionalChild(mod);
-                if (ty.optionalReprIsPayload(mod)) {
-                    assert(payload_ty.hasRuntimeBitsIgnoreComptime(pt));
-                    assert(!payload_ty.isSlice(mod));
+                const payload_ty = ty.optionalChild(zcu);
+                if (ty.optionalReprIsPayload(zcu)) {
+                    assert(payload_ty.hasRuntimeBitsIgnoreComptime(zcu));
+                    assert(!payload_ty.isSlice(zcu));
 
                     return try self.cmp(op, lhs.pun(payload_ty), rhs.pun(payload_ty));
                 }
@@ -4332,12 +4333,12 @@ const NavGen = struct {
                 const lhs_id = try lhs.materialize(self);
                 const rhs_id = try rhs.materialize(self);
 
-                const lhs_valid_id = if (payload_ty.hasRuntimeBitsIgnoreComptime(pt))
+                const lhs_valid_id = if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu))
                     try self.extractField(Type.bool, lhs_id, 1)
                 else
                     try self.convertToDirect(Type.bool, lhs_id);
 
-                const rhs_valid_id = if (payload_ty.hasRuntimeBitsIgnoreComptime(pt))
+                const rhs_valid_id = if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu))
                     try self.extractField(Type.bool, rhs_id, 1)
                 else
                     try self.convertToDirect(Type.bool, rhs_id);
@@ -4345,7 +4346,7 @@ const NavGen = struct {
                 const lhs_valid = Temporary.init(Type.bool, lhs_valid_id);
                 const rhs_valid = Temporary.init(Type.bool, rhs_valid_id);
 
-                if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+                if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
                     return try self.cmp(op, lhs_valid, rhs_valid);
                 }
 
@@ -4465,7 +4466,7 @@ const NavGen = struct {
         src_ty: Type,
         src_id: IdRef,
     ) !IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const src_ty_id = try self.resolveType(src_ty, .direct);
         const dst_ty_id = try self.resolveType(dst_ty, .direct);
 
@@ -4477,7 +4478,7 @@ const NavGen = struct {
             // TODO: Some more cases are missing here
             //   See fn bitCast in llvm.zig
 
-            if (src_ty.zigTypeTag(mod) == .Int and dst_ty.isPtrAtRuntime(mod)) {
+            if (src_ty.zigTypeTag(zcu) == .Int and dst_ty.isPtrAtRuntime(zcu)) {
                 const result_id = self.spv.allocId();
                 try self.func.body.emit(self.spv.gpa, .OpConvertUToPtr, .{
                     .id_result_type = dst_ty_id,
@@ -4490,7 +4491,7 @@ const NavGen = struct {
             // We can only use OpBitcast for specific conversions: between numerical types, and
             // between pointers. If the resolved spir-v types fall into this category then emit OpBitcast,
             // otherwise use a temporary and perform a pointer cast.
-            const can_bitcast = (src_ty.isNumeric(mod) and dst_ty.isNumeric(mod)) or (src_ty.isPtrAtRuntime(mod) and dst_ty.isPtrAtRuntime(mod));
+            const can_bitcast = (src_ty.isNumeric(zcu) and dst_ty.isNumeric(zcu)) or (src_ty.isPtrAtRuntime(zcu) and dst_ty.isPtrAtRuntime(zcu));
             if (can_bitcast) {
                 const result_id = self.spv.allocId();
                 try self.func.body.emit(self.spv.gpa, .OpBitcast, .{
@@ -4519,7 +4520,7 @@ const NavGen = struct {
         // the result here.
         // TODO: This detail could cause stuff like @as(*const i1, @ptrCast(&@as(u1, 1))) to break
         // should we change the representation of strange integers?
-        if (dst_ty.zigTypeTag(mod) == .Int) {
+        if (dst_ty.zigTypeTag(zcu) == .Int) {
             const info = self.arithmeticTypeInfo(dst_ty);
             const result = try self.normalize(Temporary.init(dst_ty, result_id), info);
             return try result.materialize(self);
@@ -4675,19 +4676,19 @@ const NavGen = struct {
 
     fn airArrayToSlice(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const array_ptr_ty = self.typeOf(ty_op.operand);
-        const array_ty = array_ptr_ty.childType(mod);
+        const array_ty = array_ptr_ty.childType(zcu);
         const slice_ty = self.typeOfIndex(inst);
-        const elem_ptr_ty = slice_ty.slicePtrFieldType(mod);
+        const elem_ptr_ty = slice_ty.slicePtrFieldType(zcu);
 
         const elem_ptr_ty_id = try self.resolveType(elem_ptr_ty, .direct);
 
         const array_ptr_id = try self.resolve(ty_op.operand);
-        const len_id = try self.constInt(Type.usize, array_ty.arrayLen(mod), .direct);
+        const len_id = try self.constInt(Type.usize, array_ty.arrayLen(zcu), .direct);
 
-        const elem_ptr_id = if (!array_ty.hasRuntimeBitsIgnoreComptime(pt))
+        const elem_ptr_id = if (!array_ty.hasRuntimeBitsIgnoreComptime(zcu))
             // Note: The pointer is something like *opaque{}, so we need to bitcast it to the element type.
             try self.bitCast(elem_ptr_ty, array_ptr_ty, array_ptr_id)
         else
@@ -4720,16 +4721,16 @@ const NavGen = struct {
 
     fn airAggregateInit(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const result_ty = self.typeOfIndex(inst);
-        const len: usize = @intCast(result_ty.arrayLen(mod));
+        const len: usize = @intCast(result_ty.arrayLen(zcu));
         const elements: []const Air.Inst.Ref = @ptrCast(self.air.extra[ty_pl.payload..][0..len]);
 
-        switch (result_ty.zigTypeTag(mod)) {
+        switch (result_ty.zigTypeTag(zcu)) {
             .Struct => {
-                if (mod.typeToPackedStruct(result_ty)) |struct_type| {
+                if (zcu.typeToPackedStruct(result_ty)) |struct_type| {
                     _ = struct_type;
                     unreachable; // TODO
                 }
@@ -4744,7 +4745,7 @@ const NavGen = struct {
                     .anon_struct_type => |tuple| {
                         for (tuple.types.get(ip), elements, 0..) |field_ty, element, i| {
                             if ((try result_ty.structFieldValueComptime(pt, i)) != null) continue;
-                            assert(Type.fromInterned(field_ty).hasRuntimeBits(pt));
+                            assert(Type.fromInterned(field_ty).hasRuntimeBits(zcu));
 
                             const id = try self.resolve(element);
                             types[index] = Type.fromInterned(field_ty);
@@ -4759,7 +4760,7 @@ const NavGen = struct {
                             const field_index = it.next().?;
                             if ((try result_ty.structFieldValueComptime(pt, i)) != null) continue;
                             const field_ty = Type.fromInterned(struct_type.field_types.get(ip)[field_index]);
-                            assert(field_ty.hasRuntimeBitsIgnoreComptime(pt));
+                            assert(field_ty.hasRuntimeBitsIgnoreComptime(zcu));
 
                             const id = try self.resolve(element);
                             types[index] = field_ty;
@@ -4777,7 +4778,7 @@ const NavGen = struct {
                 );
             },
             .Vector => {
-                const n_elems = result_ty.vectorLen(mod);
+                const n_elems = result_ty.vectorLen(zcu);
                 const elem_ids = try self.gpa.alloc(IdRef, n_elems);
                 defer self.gpa.free(elem_ids);
 
@@ -4788,8 +4789,8 @@ const NavGen = struct {
                 return try self.constructVector(result_ty, elem_ids);
             },
             .Array => {
-                const array_info = result_ty.arrayInfo(mod);
-                const n_elems: usize = @intCast(result_ty.arrayLenIncludingSentinel(mod));
+                const array_info = result_ty.arrayInfo(zcu);
+                const n_elems: usize = @intCast(result_ty.arrayLenIncludingSentinel(zcu));
                 const elem_ids = try self.gpa.alloc(IdRef, n_elems);
                 defer self.gpa.free(elem_ids);
 
@@ -4810,14 +4811,14 @@ const NavGen = struct {
 
     fn sliceOrArrayLen(self: *NavGen, operand_id: IdRef, ty: Type) !IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
-        switch (ty.ptrSize(mod)) {
+        const zcu = pt.zcu;
+        switch (ty.ptrSize(zcu)) {
             .Slice => return self.extractField(Type.usize, operand_id, 1),
             .One => {
-                const array_ty = ty.childType(mod);
-                const elem_ty = array_ty.childType(mod);
-                const abi_size = elem_ty.abiSize(pt);
-                const size = array_ty.arrayLenIncludingSentinel(mod) * abi_size;
+                const array_ty = ty.childType(zcu);
+                const elem_ty = array_ty.childType(zcu);
+                const abi_size = elem_ty.abiSize(zcu);
+                const size = array_ty.arrayLenIncludingSentinel(zcu) * abi_size;
                 return try self.constInt(Type.usize, size, .direct);
             },
             .Many, .C => unreachable,
@@ -4825,9 +4826,9 @@ const NavGen = struct {
     }
 
     fn sliceOrArrayPtr(self: *NavGen, operand_id: IdRef, ty: Type) !IdRef {
-        const mod = self.pt.zcu;
-        if (ty.isSlice(mod)) {
-            const ptr_ty = ty.slicePtrFieldType(mod);
+        const zcu = self.pt.zcu;
+        if (ty.isSlice(zcu)) {
+            const ptr_ty = ty.slicePtrFieldType(zcu);
             return self.extractField(ptr_ty, operand_id, 0);
         }
         return operand_id;
@@ -4857,11 +4858,11 @@ const NavGen = struct {
     }
 
     fn airSliceElemPtr(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const slice_ty = self.typeOf(bin_op.lhs);
-        if (!slice_ty.isVolatilePtr(mod) and self.liveness.isUnused(inst)) return null;
+        if (!slice_ty.isVolatilePtr(zcu) and self.liveness.isUnused(inst)) return null;
 
         const slice_id = try self.resolve(bin_op.lhs);
         const index_id = try self.resolve(bin_op.rhs);
@@ -4874,28 +4875,28 @@ const NavGen = struct {
     }
 
     fn airSliceElemVal(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const slice_ty = self.typeOf(bin_op.lhs);
-        if (!slice_ty.isVolatilePtr(mod) and self.liveness.isUnused(inst)) return null;
+        if (!slice_ty.isVolatilePtr(zcu) and self.liveness.isUnused(inst)) return null;
 
         const slice_id = try self.resolve(bin_op.lhs);
         const index_id = try self.resolve(bin_op.rhs);
 
-        const ptr_ty = slice_ty.slicePtrFieldType(mod);
+        const ptr_ty = slice_ty.slicePtrFieldType(zcu);
         const ptr_ty_id = try self.resolveType(ptr_ty, .direct);
 
         const slice_ptr = try self.extractField(ptr_ty, slice_id, 0);
         const elem_ptr = try self.ptrAccessChain(ptr_ty_id, slice_ptr, index_id, &.{});
-        return try self.load(slice_ty.childType(mod), elem_ptr, .{ .is_volatile = slice_ty.isVolatilePtr(mod) });
+        return try self.load(slice_ty.childType(zcu), elem_ptr, .{ .is_volatile = slice_ty.isVolatilePtr(zcu) });
     }
 
     fn ptrElemPtr(self: *NavGen, ptr_ty: Type, ptr_id: IdRef, index_id: IdRef) !IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         // Construct new pointer type for the resulting pointer
-        const elem_ty = ptr_ty.elemType2(mod); // use elemType() so that we get T for *[N]T.
-        const elem_ptr_ty_id = try self.ptrType(elem_ty, self.spvStorageClass(ptr_ty.ptrAddressSpace(mod)));
-        if (ptr_ty.isSinglePointer(mod)) {
+        const elem_ty = ptr_ty.elemType2(zcu); // use elemType() so that we get T for *[N]T.
+        const elem_ptr_ty_id = try self.ptrType(elem_ty, self.spvStorageClass(ptr_ty.ptrAddressSpace(zcu)));
+        if (ptr_ty.isSinglePointer(zcu)) {
             // Pointer-to-array. In this case, the resulting pointer is not of the same type
             // as the ptr_ty (we want a *T, not a *[N]T), and hence we need to use accessChain.
             return try self.accessChainId(elem_ptr_ty_id, ptr_id, &.{index_id});
@@ -4907,14 +4908,14 @@ const NavGen = struct {
 
     fn airPtrElemPtr(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const bin_op = self.air.extraData(Air.Bin, ty_pl.payload).data;
         const src_ptr_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = src_ptr_ty.childType(mod);
+        const elem_ty = src_ptr_ty.childType(zcu);
         const ptr_id = try self.resolve(bin_op.lhs);
 
-        if (!elem_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!elem_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             const dst_ptr_ty = self.typeOfIndex(inst);
             return try self.bitCast(dst_ptr_ty, src_ptr_ty, ptr_id);
         }
@@ -4924,10 +4925,10 @@ const NavGen = struct {
     }
 
     fn airArrayElemVal(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const array_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = array_ty.childType(mod);
+        const elem_ty = array_ty.childType(zcu);
         const array_id = try self.resolve(bin_op.lhs);
         const index_id = try self.resolve(bin_op.rhs);
 
@@ -4946,7 +4947,7 @@ const NavGen = struct {
         // For now, just generate a temporary and use that.
         // TODO: This backend probably also should use isByRef from llvm...
 
-        const is_vector = array_ty.isVector(mod);
+        const is_vector = array_ty.isVector(zcu);
 
         const elem_repr: Repr = if (is_vector) .direct else .indirect;
         const ptr_array_ty_id = try self.ptrType2(array_ty, .Function, .direct);
@@ -4985,26 +4986,26 @@ const NavGen = struct {
     }
 
     fn airPtrElemVal(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const ptr_ty = self.typeOf(bin_op.lhs);
         const elem_ty = self.typeOfIndex(inst);
         const ptr_id = try self.resolve(bin_op.lhs);
         const index_id = try self.resolve(bin_op.rhs);
         const elem_ptr_id = try self.ptrElemPtr(ptr_ty, ptr_id, index_id);
-        return try self.load(elem_ty, elem_ptr_id, .{ .is_volatile = ptr_ty.isVolatilePtr(mod) });
+        return try self.load(elem_ty, elem_ptr_id, .{ .is_volatile = ptr_ty.isVolatilePtr(zcu) });
     }
 
     fn airVectorStoreElem(self: *NavGen, inst: Air.Inst.Index) !void {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const data = self.air.instructions.items(.data)[@intFromEnum(inst)].vector_store_elem;
         const extra = self.air.extraData(Air.Bin, data.payload).data;
 
         const vector_ptr_ty = self.typeOf(data.vector_ptr);
-        const vector_ty = vector_ptr_ty.childType(mod);
-        const scalar_ty = vector_ty.scalarType(mod);
+        const vector_ty = vector_ptr_ty.childType(zcu);
+        const scalar_ty = vector_ty.scalarType(zcu);
 
-        const storage_class = self.spvStorageClass(vector_ptr_ty.ptrAddressSpace(mod));
+        const storage_class = self.spvStorageClass(vector_ptr_ty.ptrAddressSpace(zcu));
         const scalar_ptr_ty_id = try self.ptrType(scalar_ty, storage_class);
 
         const vector_ptr = try self.resolve(data.vector_ptr);
@@ -5013,30 +5014,30 @@ const NavGen = struct {
 
         const elem_ptr_id = try self.accessChainId(scalar_ptr_ty_id, vector_ptr, &.{index});
         try self.store(scalar_ty, elem_ptr_id, operand, .{
-            .is_volatile = vector_ptr_ty.isVolatilePtr(mod),
+            .is_volatile = vector_ptr_ty.isVolatilePtr(zcu),
         });
     }
 
     fn airSetUnionTag(self: *NavGen, inst: Air.Inst.Index) !void {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const un_ptr_ty = self.typeOf(bin_op.lhs);
-        const un_ty = un_ptr_ty.childType(mod);
+        const un_ty = un_ptr_ty.childType(zcu);
         const layout = self.unionLayout(un_ty);
 
         if (layout.tag_size == 0) return;
 
-        const tag_ty = un_ty.unionTagTypeSafety(mod).?;
-        const tag_ptr_ty_id = try self.ptrType(tag_ty, self.spvStorageClass(un_ptr_ty.ptrAddressSpace(mod)));
+        const tag_ty = un_ty.unionTagTypeSafety(zcu).?;
+        const tag_ptr_ty_id = try self.ptrType(tag_ty, self.spvStorageClass(un_ptr_ty.ptrAddressSpace(zcu)));
 
         const union_ptr_id = try self.resolve(bin_op.lhs);
         const new_tag_id = try self.resolve(bin_op.rhs);
 
         if (!layout.has_payload) {
-            try self.store(tag_ty, union_ptr_id, new_tag_id, .{ .is_volatile = un_ptr_ty.isVolatilePtr(mod) });
+            try self.store(tag_ty, union_ptr_id, new_tag_id, .{ .is_volatile = un_ptr_ty.isVolatilePtr(zcu) });
         } else {
             const ptr_id = try self.accessChain(tag_ptr_ty_id, union_ptr_id, &.{layout.tag_index});
-            try self.store(tag_ty, ptr_id, new_tag_id, .{ .is_volatile = un_ptr_ty.isVolatilePtr(mod) });
+            try self.store(tag_ty, ptr_id, new_tag_id, .{ .is_volatile = un_ptr_ty.isVolatilePtr(zcu) });
         }
     }
 
@@ -5044,14 +5045,14 @@ const NavGen = struct {
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const un_ty = self.typeOf(ty_op.operand);
 
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const layout = self.unionLayout(un_ty);
         if (layout.tag_size == 0) return null;
 
         const union_handle = try self.resolve(ty_op.operand);
         if (!layout.has_payload) return union_handle;
 
-        const tag_ty = un_ty.unionTagTypeSafety(mod).?;
+        const tag_ty = un_ty.unionTagTypeSafety(zcu).?;
         return try self.extractField(tag_ty, union_handle, layout.tag_index);
     }
 
@@ -5068,9 +5069,9 @@ const NavGen = struct {
         // Note: The result here is not cached, because it generates runtime code.
 
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
-        const union_ty = mod.typeToUnion(ty).?;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
+        const union_ty = zcu.typeToUnion(ty).?;
         const tag_ty = Type.fromInterned(union_ty.enum_tag_ty);
 
         if (union_ty.flagsUnordered(ip).layout == .@"packed") {
@@ -5082,7 +5083,7 @@ const NavGen = struct {
         const tag_int = if (layout.tag_size != 0) blk: {
             const tag_val = try pt.enumValueFieldIndex(tag_ty, active_field);
             const tag_int_val = try tag_val.intFromEnum(tag_ty, pt);
-            break :blk tag_int_val.toUnsignedInt(pt);
+            break :blk tag_int_val.toUnsignedInt(zcu);
         } else 0;
 
         if (!layout.has_payload) {
@@ -5099,7 +5100,7 @@ const NavGen = struct {
         }
 
         const payload_ty = Type.fromInterned(union_ty.field_types.get(ip)[active_field]);
-        if (payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             const pl_ptr_ty_id = try self.ptrType(layout.payload_ty, .Function);
             const pl_ptr_id = try self.accessChain(pl_ptr_ty_id, tmp_id, &.{layout.payload_index});
             const active_pl_ptr_ty_id = try self.ptrType(payload_ty, .Function);
@@ -5123,15 +5124,15 @@ const NavGen = struct {
 
     fn airUnionInit(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
-        const ip = &mod.intern_pool;
+        const zcu = pt.zcu;
+        const ip = &zcu.intern_pool;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.UnionInit, ty_pl.payload).data;
         const ty = self.typeOfIndex(inst);
 
-        const union_obj = mod.typeToUnion(ty).?;
+        const union_obj = zcu.typeToUnion(ty).?;
         const field_ty = Type.fromInterned(union_obj.field_types.get(ip)[extra.field_index]);
-        const payload = if (field_ty.hasRuntimeBitsIgnoreComptime(pt))
+        const payload = if (field_ty.hasRuntimeBitsIgnoreComptime(zcu))
             try self.resolve(extra.init)
         else
             null;
@@ -5140,23 +5141,23 @@ const NavGen = struct {
 
     fn airStructFieldVal(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const struct_field = self.air.extraData(Air.StructField, ty_pl.payload).data;
 
         const object_ty = self.typeOf(struct_field.struct_operand);
         const object_id = try self.resolve(struct_field.struct_operand);
         const field_index = struct_field.field_index;
-        const field_ty = object_ty.structFieldType(field_index, mod);
+        const field_ty = object_ty.structFieldType(field_index, zcu);
 
-        if (!field_ty.hasRuntimeBitsIgnoreComptime(pt)) return null;
+        if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) return null;
 
-        switch (object_ty.zigTypeTag(mod)) {
-            .Struct => switch (object_ty.containerLayout(mod)) {
+        switch (object_ty.zigTypeTag(zcu)) {
+            .Struct => switch (object_ty.containerLayout(zcu)) {
                 .@"packed" => unreachable, // TODO
                 else => return try self.extractField(field_ty, object_id, field_index),
             },
-            .Union => switch (object_ty.containerLayout(mod)) {
+            .Union => switch (object_ty.containerLayout(zcu)) {
                 .@"packed" => unreachable, // TODO
                 else => {
                     // Store, ptr-elem-ptr, pointer-cast, load
@@ -5185,16 +5186,16 @@ const NavGen = struct {
 
     fn airFieldParentPtr(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.FieldParentPtr, ty_pl.payload).data;
 
-        const parent_ty = ty_pl.ty.toType().childType(mod);
+        const parent_ty = ty_pl.ty.toType().childType(zcu);
         const result_ty_id = try self.resolveType(ty_pl.ty.toType(), .indirect);
 
         const field_ptr = try self.resolve(extra.field_ptr);
         const field_ptr_int = try self.intFromPtr(field_ptr);
-        const field_offset = parent_ty.structFieldOffset(extra.field_index, pt);
+        const field_offset = parent_ty.structFieldOffset(extra.field_index, zcu);
 
         const base_ptr_int = base_ptr_int: {
             if (field_offset == 0) break :base_ptr_int field_ptr_int;
@@ -5319,10 +5320,10 @@ const NavGen = struct {
     }
 
     fn airAlloc(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ptr_ty = self.typeOfIndex(inst);
-        assert(ptr_ty.ptrAddressSpace(mod) == .generic);
-        const child_ty = ptr_ty.childType(mod);
+        assert(ptr_ty.ptrAddressSpace(zcu) == .generic);
+        const child_ty = ptr_ty.childType(zcu);
         return try self.alloc(child_ty, .{});
     }
 
@@ -5494,9 +5495,9 @@ const NavGen = struct {
         // ir.Block in a different SPIR-V block.
 
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty = self.typeOfIndex(inst);
-        const have_block_result = ty.isFnOrHasRuntimeBitsIgnoreComptime(pt);
+        const have_block_result = ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu);
 
         const cf = switch (self.control_flow) {
             .structured => |*cf| cf,
@@ -5570,7 +5571,7 @@ const NavGen = struct {
 
         const sblock = cf.block_stack.getLast();
 
-        if (ty.isNoReturn(mod)) {
+        if (ty.isNoReturn(zcu)) {
             // If this block is noreturn, this instruction is the last of a block,
             // and we must simply jump to the block's merge unconditionally.
             try self.structuredBreak(next_block);
@@ -5626,13 +5627,13 @@ const NavGen = struct {
     }
 
     fn airBr(self: *NavGen, inst: Air.Inst.Index) !void {
-        const pt = self.pt;
+        const zcu = self.pt.zcu;
         const br = self.air.instructions.items(.data)[@intFromEnum(inst)].br;
         const operand_ty = self.typeOf(br.operand);
 
         switch (self.control_flow) {
             .structured => |*cf| {
-                if (operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+                if (operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
                     const operand_id = try self.resolve(br.operand);
                     const block_result_var_id = cf.block_results.get(br.block_inst).?;
                     try self.store(operand_ty, block_result_var_id, operand_id, .{});
@@ -5643,7 +5644,7 @@ const NavGen = struct {
             },
             .unstructured => |cf| {
                 const block = cf.blocks.get(br.block_inst).?;
-                if (operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(pt)) {
+                if (operand_ty.isFnOrHasRuntimeBitsIgnoreComptime(zcu)) {
                     const operand_id = try self.resolve(br.operand);
                     // current_block_label should not be undefined here, lest there
                     // is a br or br_void in the function's body.
@@ -5770,35 +5771,35 @@ const NavGen = struct {
     }
 
     fn airLoad(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const ptr_ty = self.typeOf(ty_op.operand);
         const elem_ty = self.typeOfIndex(inst);
         const operand = try self.resolve(ty_op.operand);
-        if (!ptr_ty.isVolatilePtr(mod) and self.liveness.isUnused(inst)) return null;
+        if (!ptr_ty.isVolatilePtr(zcu) and self.liveness.isUnused(inst)) return null;
 
-        return try self.load(elem_ty, operand, .{ .is_volatile = ptr_ty.isVolatilePtr(mod) });
+        return try self.load(elem_ty, operand, .{ .is_volatile = ptr_ty.isVolatilePtr(zcu) });
     }
 
     fn airStore(self: *NavGen, inst: Air.Inst.Index) !void {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const bin_op = self.air.instructions.items(.data)[@intFromEnum(inst)].bin_op;
         const ptr_ty = self.typeOf(bin_op.lhs);
-        const elem_ty = ptr_ty.childType(mod);
+        const elem_ty = ptr_ty.childType(zcu);
         const ptr = try self.resolve(bin_op.lhs);
         const value = try self.resolve(bin_op.rhs);
 
-        try self.store(elem_ty, ptr, value, .{ .is_volatile = ptr_ty.isVolatilePtr(mod) });
+        try self.store(elem_ty, ptr, value, .{ .is_volatile = ptr_ty.isVolatilePtr(zcu) });
     }
 
     fn airRet(self: *NavGen, inst: Air.Inst.Index) !void {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const operand = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const ret_ty = self.typeOf(operand);
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-            const fn_info = mod.typeToFunc(mod.navValue(self.owner_nav).typeOf(mod)).?;
-            if (Type.fromInterned(fn_info.return_type).isError(mod)) {
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+            const fn_info = zcu.typeToFunc(zcu.navValue(self.owner_nav).typeOf(zcu)).?;
+            if (Type.fromInterned(fn_info.return_type).isError(zcu)) {
                 // Functions with an empty error set are emitted with an error code
                 // return type and return zero so they can be function pointers coerced
                 // to functions that return anyerror.
@@ -5815,14 +5816,14 @@ const NavGen = struct {
 
     fn airRetLoad(self: *NavGen, inst: Air.Inst.Index) !void {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const ptr_ty = self.typeOf(un_op);
-        const ret_ty = ptr_ty.childType(mod);
+        const ret_ty = ptr_ty.childType(zcu);
 
-        if (!ret_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-            const fn_info = mod.typeToFunc(mod.navValue(self.owner_nav).typeOf(mod)).?;
-            if (Type.fromInterned(fn_info.return_type).isError(mod)) {
+        if (!ret_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+            const fn_info = zcu.typeToFunc(zcu.navValue(self.owner_nav).typeOf(zcu)).?;
+            if (Type.fromInterned(fn_info.return_type).isError(zcu)) {
                 // Functions with an empty error set are emitted with an error code
                 // return type and return zero so they can be function pointers coerced
                 // to functions that return anyerror.
@@ -5834,14 +5835,14 @@ const NavGen = struct {
         }
 
         const ptr = try self.resolve(un_op);
-        const value = try self.load(ret_ty, ptr, .{ .is_volatile = ptr_ty.isVolatilePtr(mod) });
+        const value = try self.load(ret_ty, ptr, .{ .is_volatile = ptr_ty.isVolatilePtr(zcu) });
         try self.func.body.emit(self.spv.gpa, .OpReturnValue, .{
             .value = value,
         });
     }
 
     fn airTry(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const err_union_id = try self.resolve(pl_op.operand);
         const extra = self.air.extraData(Air.Try, pl_op.payload);
@@ -5854,7 +5855,7 @@ const NavGen = struct {
 
         const eu_layout = self.errorUnionLayout(payload_ty);
 
-        if (!err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (!err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             const err_id = if (eu_layout.payload_has_bits)
                 try self.extractField(Type.anyerror, err_union_id, eu_layout.errorFieldIndex())
             else
@@ -5911,18 +5912,18 @@ const NavGen = struct {
     }
 
     fn airErrUnionErr(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand_id = try self.resolve(ty_op.operand);
         const err_union_ty = self.typeOf(ty_op.operand);
         const err_ty_id = try self.resolveType(Type.anyerror, .direct);
 
-        if (err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             // No error possible, so just return undefined.
             return try self.spv.constUndef(err_ty_id);
         }
 
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
         const eu_layout = self.errorUnionLayout(payload_ty);
 
         if (!eu_layout.payload_has_bits) {
@@ -5947,10 +5948,10 @@ const NavGen = struct {
     }
 
     fn airWrapErrUnionErr(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const err_union_ty = self.typeOfIndex(inst);
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
         const operand_id = try self.resolve(ty_op.operand);
         const eu_layout = self.errorUnionLayout(payload_ty);
 
@@ -5995,28 +5996,28 @@ const NavGen = struct {
 
     fn airIsNull(self: *NavGen, inst: Air.Inst.Index, is_pointer: bool, pred: enum { is_null, is_non_null }) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const operand_id = try self.resolve(un_op);
         const operand_ty = self.typeOf(un_op);
-        const optional_ty = if (is_pointer) operand_ty.childType(mod) else operand_ty;
-        const payload_ty = optional_ty.optionalChild(mod);
+        const optional_ty = if (is_pointer) operand_ty.childType(zcu) else operand_ty;
+        const payload_ty = optional_ty.optionalChild(zcu);
 
         const bool_ty_id = try self.resolveType(Type.bool, .direct);
 
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             // Pointer payload represents nullability: pointer or slice.
             const loaded_id = if (is_pointer)
                 try self.load(optional_ty, operand_id, .{})
             else
                 operand_id;
 
-            const ptr_ty = if (payload_ty.isSlice(mod))
-                payload_ty.slicePtrFieldType(mod)
+            const ptr_ty = if (payload_ty.isSlice(zcu))
+                payload_ty.slicePtrFieldType(zcu)
             else
                 payload_ty;
 
-            const ptr_id = if (payload_ty.isSlice(mod))
+            const ptr_id = if (payload_ty.isSlice(zcu))
                 try self.extractField(ptr_ty, loaded_id, 0)
             else
                 loaded_id;
@@ -6036,8 +6037,8 @@ const NavGen = struct {
 
         const is_non_null_id = blk: {
             if (is_pointer) {
-                if (payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
-                    const storage_class = self.spvStorageClass(operand_ty.ptrAddressSpace(mod));
+                if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
+                    const storage_class = self.spvStorageClass(operand_ty.ptrAddressSpace(zcu));
                     const bool_ptr_ty_id = try self.ptrType(Type.bool, storage_class);
                     const tag_ptr_id = try self.accessChain(bool_ptr_ty_id, operand_id, &.{1});
                     break :blk try self.load(Type.bool, tag_ptr_id, .{});
@@ -6046,7 +6047,7 @@ const NavGen = struct {
                 break :blk try self.load(Type.bool, operand_id, .{});
             }
 
-            break :blk if (payload_ty.hasRuntimeBitsIgnoreComptime(pt))
+            break :blk if (payload_ty.hasRuntimeBitsIgnoreComptime(zcu))
                 try self.extractField(Type.bool, operand_id, 1)
             else
                 // Optional representation is bool indicating whether the optional is set
@@ -6071,16 +6072,16 @@ const NavGen = struct {
     }
 
     fn airIsErr(self: *NavGen, inst: Air.Inst.Index, pred: enum { is_err, is_non_err }) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const operand_id = try self.resolve(un_op);
         const err_union_ty = self.typeOf(un_op);
 
-        if (err_union_ty.errorUnionSet(mod).errorSetIsEmpty(mod)) {
+        if (err_union_ty.errorUnionSet(zcu).errorSetIsEmpty(zcu)) {
             return try self.constBool(pred == .is_non_err, .direct);
         }
 
-        const payload_ty = err_union_ty.errorUnionPayload(mod);
+        const payload_ty = err_union_ty.errorUnionPayload(zcu);
         const eu_layout = self.errorUnionLayout(payload_ty);
         const bool_ty_id = try self.resolveType(Type.bool, .direct);
 
@@ -6105,15 +6106,15 @@ const NavGen = struct {
 
     fn airUnwrapOptional(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand_id = try self.resolve(ty_op.operand);
         const optional_ty = self.typeOf(ty_op.operand);
         const payload_ty = self.typeOfIndex(inst);
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) return null;
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) return null;
 
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             return operand_id;
         }
 
@@ -6122,22 +6123,22 @@ const NavGen = struct {
 
     fn airUnwrapOptionalPtr(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const operand_id = try self.resolve(ty_op.operand);
         const operand_ty = self.typeOf(ty_op.operand);
-        const optional_ty = operand_ty.childType(mod);
-        const payload_ty = optional_ty.optionalChild(mod);
+        const optional_ty = operand_ty.childType(zcu);
+        const payload_ty = optional_ty.optionalChild(zcu);
         const result_ty = self.typeOfIndex(inst);
         const result_ty_id = try self.resolveType(result_ty, .direct);
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             // There is no payload, but we still need to return a valid pointer.
             // We can just return anything here, so just return a pointer to the operand.
             return try self.bitCast(result_ty, operand_ty, operand_id);
         }
 
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             // They are the same value.
             return try self.bitCast(result_ty, operand_ty, operand_id);
         }
@@ -6147,18 +6148,18 @@ const NavGen = struct {
 
     fn airWrapOptional(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const ty_op = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_op;
         const payload_ty = self.typeOf(ty_op.operand);
 
-        if (!payload_ty.hasRuntimeBitsIgnoreComptime(pt)) {
+        if (!payload_ty.hasRuntimeBitsIgnoreComptime(zcu)) {
             return try self.constBool(true, .indirect);
         }
 
         const operand_id = try self.resolve(ty_op.operand);
 
         const optional_ty = self.typeOfIndex(inst);
-        if (optional_ty.optionalReprIsPayload(mod)) {
+        if (optional_ty.optionalReprIsPayload(zcu)) {
             return operand_id;
         }
 
@@ -6170,7 +6171,7 @@ const NavGen = struct {
 
     fn airSwitchBr(self: *NavGen, inst: Air.Inst.Index) !void {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const target = self.getTarget();
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const cond_ty = self.typeOf(pl_op.operand);
@@ -6178,18 +6179,18 @@ const NavGen = struct {
         var cond_indirect = try self.convertToIndirect(cond_ty, cond);
         const switch_br = self.air.extraData(Air.SwitchBr, pl_op.payload);
 
-        const cond_words: u32 = switch (cond_ty.zigTypeTag(mod)) {
+        const cond_words: u32 = switch (cond_ty.zigTypeTag(zcu)) {
             .Bool, .ErrorSet => 1,
             .Int => blk: {
-                const bits = cond_ty.intInfo(mod).bits;
+                const bits = cond_ty.intInfo(zcu).bits;
                 const backing_bits = self.backingIntBits(bits) orelse {
                     return self.todo("implement composite int switch", .{});
                 };
                 break :blk if (backing_bits <= 32) 1 else 2;
             },
             .Enum => blk: {
-                const int_ty = cond_ty.intTagType(mod);
-                const int_info = int_ty.intInfo(mod);
+                const int_ty = cond_ty.intTagType(zcu);
+                const int_info = int_ty.intInfo(zcu);
                 const backing_bits = self.backingIntBits(int_info.bits) orelse {
                     return self.todo("implement composite int switch", .{});
                 };
@@ -6200,7 +6201,7 @@ const NavGen = struct {
                 break :blk target.ptrBitWidth() / 32;
             },
             // TODO: Figure out which types apply here, and work around them as we can only do integers.
-            else => return self.todo("implement switch for type {s}", .{@tagName(cond_ty.zigTypeTag(mod))}),
+            else => return self.todo("implement switch for type {s}", .{@tagName(cond_ty.zigTypeTag(zcu))}),
         };
 
         const num_cases = switch_br.data.cases_len;
@@ -6255,14 +6256,14 @@ const NavGen = struct {
 
                 for (items) |item| {
                     const value = (try self.air.value(item, pt)) orelse unreachable;
-                    const int_val: u64 = switch (cond_ty.zigTypeTag(mod)) {
-                        .Bool, .Int => if (cond_ty.isSignedInt(mod)) @bitCast(value.toSignedInt(pt)) else value.toUnsignedInt(pt),
+                    const int_val: u64 = switch (cond_ty.zigTypeTag(zcu)) {
+                        .Bool, .Int => if (cond_ty.isSignedInt(zcu)) @bitCast(value.toSignedInt(zcu)) else value.toUnsignedInt(zcu),
                         .Enum => blk: {
                             // TODO: figure out of cond_ty is correct (something with enum literals)
-                            break :blk (try value.intFromEnum(cond_ty, pt)).toUnsignedInt(pt); // TODO: composite integer constants
+                            break :blk (try value.intFromEnum(cond_ty, pt)).toUnsignedInt(zcu); // TODO: composite integer constants
                         },
-                        .ErrorSet => value.getErrorInt(mod),
-                        .Pointer => value.toUnsignedInt(pt),
+                        .ErrorSet => value.getErrorInt(zcu),
+                        .Pointer => value.toUnsignedInt(zcu),
                         else => unreachable,
                     };
                     const int_lit: spec.LiteralContextDependentNumber = switch (cond_words) {
@@ -6343,9 +6344,9 @@ const NavGen = struct {
 
     fn airDbgStmt(self: *NavGen, inst: Air.Inst.Index) !void {
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const dbg_stmt = self.air.instructions.items(.data)[@intFromEnum(inst)].dbg_stmt;
-        const path = mod.navFileScope(self.owner_nav).sub_file_path;
+        const path = zcu.navFileScope(self.owner_nav).sub_file_path;
         try self.func.body.emit(self.spv.gpa, .OpLine, .{
             .file = try self.spv.resolveString(path),
             .line = self.base_line + dbg_stmt.line + 1,
@@ -6354,12 +6355,12 @@ const NavGen = struct {
     }
 
     fn airDbgInlineBlock(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const inst_datas = self.air.instructions.items(.data);
         const extra = self.air.extraData(Air.DbgInlineBlock, inst_datas[@intFromEnum(inst)].ty_pl.payload);
         const old_base_line = self.base_line;
         defer self.base_line = old_base_line;
-        self.base_line = mod.navSrcLine(mod.funcInfo(extra.data.func).owner_nav);
+        self.base_line = zcu.navSrcLine(zcu.funcInfo(extra.data.func).owner_nav);
         return self.lowerBlock(inst, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
     }
 
@@ -6371,7 +6372,7 @@ const NavGen = struct {
     }
 
     fn airAssembly(self: *NavGen, inst: Air.Inst.Index) !?IdRef {
-        const mod = self.pt.zcu;
+        const zcu = self.pt.zcu;
         const ty_pl = self.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const extra = self.air.extraData(Air.Asm, ty_pl.payload);
 
@@ -6453,20 +6454,20 @@ const NavGen = struct {
                 // TODO: Translate proper error locations.
                 assert(as.errors.items.len != 0);
                 assert(self.error_msg == null);
-                const src_loc = mod.navSrcLoc(self.owner_nav);
-                self.error_msg = try Zcu.ErrorMsg.create(mod.gpa, src_loc, "failed to assemble SPIR-V inline assembly", .{});
-                const notes = try mod.gpa.alloc(Zcu.ErrorMsg, as.errors.items.len);
+                const src_loc = zcu.navSrcLoc(self.owner_nav);
+                self.error_msg = try Zcu.ErrorMsg.create(zcu.gpa, src_loc, "failed to assemble SPIR-V inline assembly", .{});
+                const notes = try zcu.gpa.alloc(Zcu.ErrorMsg, as.errors.items.len);
 
                 // Sub-scope to prevent `return error.CodegenFail` from running the errdefers.
                 {
-                    errdefer mod.gpa.free(notes);
+                    errdefer zcu.gpa.free(notes);
                     var i: usize = 0;
                     errdefer for (notes[0..i]) |*note| {
-                        note.deinit(mod.gpa);
+                        note.deinit(zcu.gpa);
                     };
 
                     while (i < as.errors.items.len) : (i += 1) {
-                        notes[i] = try Zcu.ErrorMsg.init(mod.gpa, src_loc, "{s}", .{as.errors.items[i].msg});
+                        notes[i] = try Zcu.ErrorMsg.init(zcu.gpa, src_loc, "{s}", .{as.errors.items[i].msg});
                     }
                 }
                 self.error_msg.?.notes = notes;
@@ -6503,17 +6504,17 @@ const NavGen = struct {
         _ = modifier;
 
         const pt = self.pt;
-        const mod = pt.zcu;
+        const zcu = pt.zcu;
         const pl_op = self.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const extra = self.air.extraData(Air.Call, pl_op.payload);
         const args: []const Air.Inst.Ref = @ptrCast(self.air.extra[extra.end..][0..extra.data.args_len]);
         const callee_ty = self.typeOf(pl_op.operand);
-        const zig_fn_ty = switch (callee_ty.zigTypeTag(mod)) {
+        const zig_fn_ty = switch (callee_ty.zigTypeTag(zcu)) {
             .Fn => callee_ty,
             .Pointer => return self.fail("cannot call function pointers", .{}),
             else => unreachable,
         };
-        const fn_info = mod.typeToFunc(zig_fn_ty).?;
+        const fn_info = zcu.typeToFunc(zig_fn_ty).?;
         const return_type = fn_info.return_type;
 
         const result_type_id = try self.resolveFnReturnType(Type.fromInterned(return_type));
@@ -6529,7 +6530,7 @@ const NavGen = struct {
             // before starting to emit OpFunctionCall instructions. Hence the
             // temporary params buffer.
             const arg_ty = self.typeOf(arg);
-            if (!arg_ty.hasRuntimeBitsIgnoreComptime(pt)) continue;
+            if (!arg_ty.hasRuntimeBitsIgnoreComptime(zcu)) continue;
             const arg_id = try self.resolve(arg);
 
             params[n_params] = arg_id;
@@ -6547,7 +6548,7 @@ const NavGen = struct {
             try self.func.body.emit(self.spv.gpa, .OpUnreachable, {});
         }
 
-        if (self.liveness.isUnused(inst) or !Type.fromInterned(return_type).hasRuntimeBitsIgnoreComptime(pt)) {
+        if (self.liveness.isUnused(inst) or !Type.fromInterned(return_type).hasRuntimeBitsIgnoreComptime(zcu)) {
             return null;
         }
 
@@ -6604,12 +6605,12 @@ const NavGen = struct {
     }
 
     fn typeOf(self: *NavGen, inst: Air.Inst.Ref) Type {
-        const mod = self.pt.zcu;
-        return self.air.typeOf(inst, &mod.intern_pool);
+        const zcu = self.pt.zcu;
+        return self.air.typeOf(inst, &zcu.intern_pool);
     }
 
     fn typeOfIndex(self: *NavGen, inst: Air.Inst.Index) Type {
-        const mod = self.pt.zcu;
-        return self.air.typeOfIndex(inst, &mod.intern_pool);
+        const zcu = self.pt.zcu;
+        return self.air.typeOfIndex(inst, &zcu.intern_pool);
     }
 };

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -5148,7 +5148,7 @@ const NavGen = struct {
         const object_ty = self.typeOf(struct_field.struct_operand);
         const object_id = try self.resolve(struct_field.struct_operand);
         const field_index = struct_field.field_index;
-        const field_ty = object_ty.structFieldType(field_index, zcu);
+        const field_ty = object_ty.fieldType(field_index, zcu);
 
         if (!field_ty.hasRuntimeBitsIgnoreComptime(zcu)) return null;
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -755,7 +755,7 @@ pub const File = struct {
         const directory = base.emit.root_dir; // Just an alias to make it shorter to type.
         const full_out_path = try directory.join(arena, &[_][]const u8{base.emit.sub_path});
         const full_out_path_z = try arena.dupeZ(u8, full_out_path);
-        const opt_zcu = comp.module;
+        const opt_zcu = comp.zcu;
 
         // If there is no Zig code to compile, then we should skip flushing the output file
         // because it will not be part of the linker line anyway.

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -327,7 +327,7 @@ pub fn updateNav(self: *C, pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) !
         .variable => |variable| variable.init,
         else => nav.status.resolved.val,
     };
-    if (nav_init != .none and !Value.fromInterned(nav_init).typeOf(zcu).hasRuntimeBits(pt)) return;
+    if (nav_init != .none and !Value.fromInterned(nav_init).typeOf(zcu).hasRuntimeBits(zcu)) return;
 
     const gop = try self.navs.getOrPut(gpa, nav_index);
     errdefer _ = self.navs.pop();

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -418,7 +418,7 @@ pub fn flushModule(self: *C, arena: Allocator, tid: Zcu.PerThread.Id, prog_node:
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
-    const zcu = self.base.comp.module.?;
+    const zcu = self.base.comp.zcu.?;
     const ip = &zcu.intern_pool;
     const pt: Zcu.PerThread = .{ .zcu = zcu, .tid = tid };
 

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1354,7 +1354,7 @@ pub fn getOrCreateAtomForNav(self: *Coff, nav_index: InternPool.Nav.Index) !Atom
 }
 
 fn getNavOutputSection(self: *Coff, nav_index: InternPool.Nav.Index) u16 {
-    const zcu = self.base.comp.module.?;
+    const zcu = self.base.comp.zcu.?;
     const ip = &zcu.intern_pool;
     const nav = ip.getNav(nav_index);
     const ty = Type.fromInterned(nav.typeOf(ip));
@@ -1609,7 +1609,7 @@ pub fn deleteExport(
         .nav => |nav| self.navs.getPtr(nav),
         .uav => |uav| self.uavs.getPtr(uav),
     } orelse return;
-    const zcu = self.base.comp.module.?;
+    const zcu = self.base.comp.zcu.?;
     const name_slice = name.toSlice(&zcu.intern_pool);
     const sym_index = metadata.getExportPtr(self, name_slice) orelse return;
 
@@ -1691,7 +1691,7 @@ pub fn flushModule(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
     defer sub_prog_node.end();
 
     const pt: Zcu.PerThread = .{
-        .zcu = comp.module orelse return error.LinkingWithoutZigSourceUnimplemented,
+        .zcu = comp.zcu orelse return error.LinkingWithoutZigSourceUnimplemented,
         .tid = tid,
     };
 

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1259,8 +1259,8 @@ fn updateLazySymbolAtom(
     atom_index: Atom.Index,
     section_index: u16,
 ) !void {
-    const mod = pt.zcu;
-    const gpa = mod.gpa;
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
 
     var required_alignment: InternPool.Alignment = .none;
     var code_buffer = std.ArrayList(u8).init(gpa);
@@ -1275,7 +1275,7 @@ fn updateLazySymbolAtom(
     const atom = self.getAtomPtr(atom_index);
     const local_sym_index = atom.getSymbolIndex().?;
 
-    const src = Type.fromInterned(sym.ty).srcLocOrNull(mod) orelse Module.LazySrcLoc.unneeded;
+    const src = Type.fromInterned(sym.ty).srcLocOrNull(zcu) orelse Zcu.LazySrcLoc.unneeded;
     const res = try codegen.generateLazySymbol(
         &self.base,
         pt,
@@ -1849,7 +1849,7 @@ pub fn lowerUav(
     const gpa = zcu.gpa;
     const val = Value.fromInterned(uav);
     const uav_alignment = switch (explicit_alignment) {
-        .none => val.typeOf(zcu).abiAlignment(pt),
+        .none => val.typeOf(zcu).abiAlignment(zcu),
         else => explicit_alignment,
     };
     if (self.uavs.get(uav)) |metadata| {

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1221,7 +1221,7 @@ pub fn updateNav(
         else => nav_val,
     };
 
-    if (nav_init.typeOf(zcu).hasRuntimeBits(pt)) {
+    if (nav_init.typeOf(zcu).hasRuntimeBits(zcu)) {
         const atom_index = try self.getOrCreateAtomForNav(nav_index);
         Atom.freeRelocations(self, atom_index);
         const atom = self.getAtom(atom_index);

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -32,7 +32,7 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
 
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
-    const module_obj_path: ?[]const u8 = if (comp.module != null) blk: {
+    const module_obj_path: ?[]const u8 = if (comp.zcu != null) blk: {
         try self.flushModule(arena, tid, prog_node);
 
         if (fs.path.dirname(full_out_path)) |dirname| {
@@ -296,7 +296,7 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
             if (self.subsystem) |explicit| break :blk explicit;
             switch (target.os.tag) {
                 .windows => {
-                    if (comp.module) |module| {
+                    if (comp.zcu) |module| {
                         if (module.stage1_flags.have_dllmain_crt_startup or is_dyn_lib)
                             break :blk null;
                         if (module.stage1_flags.have_c_main or comp.config.is_test or
@@ -440,7 +440,7 @@ pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
                 } else {
                     try argv.append("-NODEFAULTLIB");
                     if (!is_lib and entry_name == null) {
-                        if (comp.module) |module| {
+                        if (comp.zcu) |module| {
                             if (module.stage1_flags.have_winmain_crt_startup) {
                                 try argv.append("-ENTRY:WinMainCRTStartup");
                             } else {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -212,7 +212,7 @@ pub fn createEmpty(
 
     const use_lld = build_options.have_llvm and comp.config.use_lld;
     const use_llvm = comp.config.use_llvm;
-    const opt_zcu = comp.module;
+    const opt_zcu = comp.zcu;
     const output_mode = comp.config.output_mode;
     const link_mode = comp.config.link_mode;
     const optimize_mode = comp.root_mod.optimize_mode;
@@ -2084,7 +2084,7 @@ fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: s
 
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
-    const module_obj_path: ?[]const u8 = if (comp.module != null) blk: {
+    const module_obj_path: ?[]const u8 = if (comp.zcu != null) blk: {
         try self.flushModule(arena, tid, prog_node);
 
         if (fs.path.dirname(full_out_path)) |dirname| {

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -157,7 +157,7 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
     }
 
     if (build_options.enable_logging) {
-        const pt: Zcu.PerThread = .{ .zcu = elf_file.base.comp.module.?, .tid = tid };
+        const pt: Zcu.PerThread = .{ .zcu = elf_file.base.comp.zcu.?, .tid = tid };
         for (self.navs.keys(), self.navs.values()) |nav_index, meta| {
             checkNavAllocated(pt, nav_index, meta);
         }
@@ -167,7 +167,7 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
     }
 
     if (self.dwarf) |*dwarf| {
-        const pt: Zcu.PerThread = .{ .zcu = elf_file.base.comp.module.?, .tid = tid };
+        const pt: Zcu.PerThread = .{ .zcu = elf_file.base.comp.zcu.?, .tid = tid };
         try dwarf.flushModule(pt);
 
         const gpa = elf_file.base.comp.gpa;
@@ -1306,7 +1306,7 @@ pub fn updateNav(
         else => nav.status.resolved.val,
     };
 
-    if (nav_init != .none and Value.fromInterned(nav_init).typeOf(zcu).hasRuntimeBits(pt)) {
+    if (nav_init != .none and Value.fromInterned(nav_init).typeOf(zcu).hasRuntimeBits(zcu)) {
         const sym_index = try self.getOrCreateMetadataForNav(elf_file, nav_index);
         self.symbol(sym_index).atom(elf_file).?.freeRelocs(self);
 

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -128,7 +128,7 @@ pub fn deinit(self: *ZigObject, allocator: Allocator) void {
 pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !void {
     // Handle any lazy symbols that were emitted by incremental compilation.
     if (self.lazy_syms.getPtr(.anyerror_type)) |metadata| {
-        const pt: Zcu.PerThread = .{ .zcu = elf_file.base.comp.module.?, .tid = tid };
+        const pt: Zcu.PerThread = .{ .zcu = elf_file.base.comp.zcu.?, .tid = tid };
 
         // Most lazy symbols can be updated on first use, but
         // anyerror needs to wait for everything to be flushed.
@@ -949,7 +949,7 @@ pub fn getOrCreateMetadataForNav(
     if (!gop.found_existing) {
         const any_non_single_threaded = elf_file.base.comp.config.any_non_single_threaded;
         const symbol_index = try self.newSymbolWithAtom(gpa, 0);
-        const zcu = elf_file.base.comp.module.?;
+        const zcu = elf_file.base.comp.zcu.?;
         const nav_val = Value.fromInterned(zcu.intern_pool.getNav(nav_index).status.resolved.val);
         const sym = self.symbol(symbol_index);
         if (nav_val.getVariable(zcu)) |variable| {
@@ -1626,7 +1626,7 @@ pub fn deleteExport(
         .nav => |nav| self.navs.getPtr(nav),
         .uav => |uav| self.uavs.getPtr(uav),
     } orelse return;
-    const mod = elf_file.base.comp.module.?;
+    const mod = elf_file.base.comp.zcu.?;
     const exp_name = name.toSlice(&mod.intern_pool);
     const esym_index = metadata.@"export"(self, exp_name) orelse return;
     log.debug("deleting export '{s}'", .{exp_name});

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -849,7 +849,7 @@ pub fn lowerUav(
     const gpa = zcu.gpa;
     const val = Value.fromInterned(uav);
     const uav_alignment = switch (explicit_alignment) {
-        .none => val.typeOf(zcu).abiAlignment(pt),
+        .none => val.typeOf(zcu).abiAlignment(zcu),
         else => explicit_alignment,
     };
     if (self.uavs.get(uav)) |metadata| {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -3026,7 +3026,7 @@ pub fn updateNavLineNumber(self: *MachO, pt: Zcu.PerThread, nav: InternPool.NavI
 pub fn updateExports(
     self: *MachO,
     pt: Zcu.PerThread,
-    exported: Module.Exported,
+    exported: Zcu.Exported,
     export_indices: []const u32,
 ) link.File.UpdateExportsError!void {
     if (build_options.skip_non_native and builtin.object_format != .macho) {
@@ -3060,7 +3060,7 @@ pub fn lowerUav(
     pt: Zcu.PerThread,
     uav: InternPool.Index,
     explicit_alignment: InternPool.Alignment,
-    src_loc: Module.LazySrcLoc,
+    src_loc: Zcu.LazySrcLoc,
 ) !codegen.GenResult {
     return self.getZigObject().?.lowerUav(self, pt, uav, explicit_alignment, src_loc);
 }
@@ -4634,8 +4634,6 @@ const Liveness = @import("../Liveness.zig");
 const LlvmObject = @import("../codegen/llvm.zig").Object;
 const Md5 = std.crypto.hash.Md5;
 const Zcu = @import("../Zcu.zig");
-/// Deprecated.
-const Module = Zcu;
 const InternPool = @import("../InternPool.zig");
 const Rebase = @import("MachO/dyld_info/Rebase.zig");
 pub const Relocation = @import("MachO/Relocation.zig");

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -164,7 +164,7 @@ pub fn createEmpty(
 
     const gpa = comp.gpa;
     const use_llvm = comp.config.use_llvm;
-    const opt_zcu = comp.module;
+    const opt_zcu = comp.zcu;
     const optimize_mode = comp.root_mod.optimize_mode;
     const output_mode = comp.config.output_mode;
     const link_mode = comp.config.link_mode;

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -688,7 +688,7 @@ pub fn lowerUav(
     const gpa = zcu.gpa;
     const val = Value.fromInterned(uav);
     const uav_alignment = switch (explicit_alignment) {
-        .none => val.typeOf(zcu).abiAlignment(pt),
+        .none => val.typeOf(zcu).abiAlignment(zcu),
         else => explicit_alignment,
     };
     if (self.uavs.get(uav)) |metadata| {

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -595,7 +595,7 @@ pub fn flushModule(self: *ZigObject, macho_file: *MachO, tid: Zcu.PerThread.Id) 
     }
 
     if (self.dwarf) |*dwarf| {
-        const pt: Zcu.PerThread = .{ .zcu = macho_file.base.comp.module.?, .tid = tid };
+        const pt: Zcu.PerThread = .{ .zcu = macho_file.base.comp.zcu.?, .tid = tid };
         try dwarf.flushModule(pt);
 
         self.debug_abbrev_dirty = false;
@@ -887,7 +887,7 @@ pub fn updateNav(
         else => nav.status.resolved.val,
     };
 
-    if (nav_init != .none and Value.fromInterned(nav_init).typeOf(zcu).hasRuntimeBits(pt)) {
+    if (nav_init != .none and Value.fromInterned(nav_init).typeOf(zcu).hasRuntimeBits(zcu)) {
         const sym_index = try self.getOrCreateMetadataForNav(macho_file, nav_index);
         self.symbols.items[sym_index].getAtom(macho_file).?.freeRelocs(macho_file);
 

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -566,7 +566,7 @@ pub fn getInputSection(self: ZigObject, atom: Atom, macho_file: *MachO) macho.se
 pub fn flushModule(self: *ZigObject, macho_file: *MachO, tid: Zcu.PerThread.Id) !void {
     // Handle any lazy symbols that were emitted by incremental compilation.
     if (self.lazy_syms.getPtr(.anyerror_type)) |metadata| {
-        const pt: Zcu.PerThread = .{ .zcu = macho_file.base.comp.module.?, .tid = tid };
+        const pt: Zcu.PerThread = .{ .zcu = macho_file.base.comp.zcu.?, .tid = tid };
 
         // Most lazy symbols can be updated on first use, but
         // anyerror needs to wait for everything to be flushed.
@@ -1437,7 +1437,7 @@ pub fn deleteExport(
     exported: Zcu.Exported,
     name: InternPool.NullTerminatedString,
 ) void {
-    const mod = macho_file.base.comp.module.?;
+    const mod = macho_file.base.comp.zcu.?;
 
     const metadata = switch (exported) {
         .nav => |nav| self.navs.getPtr(nav),
@@ -1545,7 +1545,7 @@ pub fn getOrCreateMetadataForLazySymbol(
 fn isThreadlocal(macho_file: *MachO, nav_index: InternPool.Nav.Index) bool {
     if (!macho_file.base.comp.config.any_non_single_threaded)
         return false;
-    const ip = &macho_file.base.comp.module.?.intern_pool;
+    const ip = &macho_file.base.comp.zcu.?.intern_pool;
     return switch (ip.indexToKey(ip.getNav(nav_index).status.resolved.val)) {
         .variable => |variable| variable.is_threadlocal,
         .@"extern" => |@"extern"| @"extern".is_threadlocal,

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -457,7 +457,7 @@ pub fn updateNav(self: *Plan9, pt: Zcu.PerThread, nav_index: InternPool.Nav.Inde
         else => nav_val,
     };
 
-    if (nav_init.typeOf(zcu).hasRuntimeBits(pt)) {
+    if (nav_init.typeOf(zcu).hasRuntimeBits(zcu)) {
         const atom_idx = try self.seeNav(pt, nav_index);
 
         var code_buffer = std.ArrayList(u8).init(gpa);

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -229,7 +229,7 @@ pub fn flushModule(self: *SpirV, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
     defer error_info.deinit();
 
     try error_info.appendSlice("zig_errors:");
-    const ip = &self.base.comp.module.?.intern_pool;
+    const ip = &self.base.comp.zcu.?.intern_pool;
     for (ip.global_error_set.getNamesFromMainThread()) |name| {
         // Errors can contain pretty much any character - to encode them in a string we must escape
         // them somehow. Easiest here is to use some established scheme, one which also preseves the

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -556,7 +556,7 @@ pub fn createEmpty(
         }
     }
 
-    if (comp.module) |zcu| {
+    if (comp.zcu) |zcu| {
         if (!use_llvm) {
             const index: File.Index = @enumFromInt(wasm.files.len);
             var zig_object: ZigObject = .{
@@ -3352,7 +3352,7 @@ fn linkWithLLD(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: 
 
     // If there is no Zig code to compile, then we should skip flushing the output file because it
     // will not be part of the linker line anyway.
-    const module_obj_path: ?[]const u8 = if (comp.module != null) blk: {
+    const module_obj_path: ?[]const u8 = if (comp.zcu != null) blk: {
         try wasm.flushModule(arena, tid, prog_node);
 
         if (fs.path.dirname(full_out_path)) |dirname| {

--- a/src/link/Wasm/ZigObject.zig
+++ b/src/link/Wasm/ZigObject.zig
@@ -259,7 +259,7 @@ pub fn updateNav(
         else => .{ false, .none, nav_val },
     };
 
-    if (nav_init.typeOf(zcu).hasRuntimeBits(pt)) {
+    if (nav_init.typeOf(zcu).hasRuntimeBits(zcu)) {
         const gpa = wasm_file.base.comp.gpa;
         const atom_index = try zig_object.getOrCreateAtomForNav(wasm_file, pt, nav_index);
         const atom = wasm_file.getAtomPtr(atom_index);

--- a/src/mutable_value.zig
+++ b/src/mutable_value.zig
@@ -369,7 +369,7 @@ pub const MutableValue = union(enum) {
             .bytes => |b| {
                 assert(is_trivial_int);
                 assert(field_val.typeOf(zcu).toIntern() == .u8_type);
-                b.data[field_idx] = @intCast(Value.fromInterned(field_val.interned).toUnsignedInt(pt));
+                b.data[field_idx] = @intCast(Value.fromInterned(field_val.interned).toUnsignedInt(zcu));
             },
             .repeated => |r| {
                 if (field_val.eqlTrivial(r.child.*)) return;
@@ -382,9 +382,9 @@ pub const MutableValue = union(enum) {
                 {
                     // We can use the `bytes` representation.
                     const bytes = try arena.alloc(u8, @intCast(len_inc_sent));
-                    const repeated_byte = Value.fromInterned(r.child.interned).toUnsignedInt(pt);
+                    const repeated_byte = Value.fromInterned(r.child.interned).toUnsignedInt(zcu);
                     @memset(bytes, @intCast(repeated_byte));
-                    bytes[field_idx] = @intCast(Value.fromInterned(field_val.interned).toUnsignedInt(pt));
+                    bytes[field_idx] = @intCast(Value.fromInterned(field_val.interned).toUnsignedInt(zcu));
                     mv.* = .{ .bytes = .{
                         .ty = r.ty,
                         .data = bytes,
@@ -431,7 +431,7 @@ pub const MutableValue = union(enum) {
                     } else {
                         const bytes = try arena.alloc(u8, a.elems.len);
                         for (a.elems, bytes) |elem_val, *b| {
-                            b.* = @intCast(Value.fromInterned(elem_val.interned).toUnsignedInt(pt));
+                            b.* = @intCast(Value.fromInterned(elem_val.interned).toUnsignedInt(zcu));
                         }
                         mv.* = .{ .bytes = .{
                             .ty = a.ty,

--- a/src/mutable_value.zig
+++ b/src/mutable_value.zig
@@ -223,7 +223,7 @@ pub const MutableValue = union(enum) {
                                     @memset(elems[0..@intCast(len_no_sent)], .{ .interned = undef_elem });
                                 },
                                 .Struct => for (elems[0..@intCast(len_no_sent)], 0..) |*mut_elem, i| {
-                                    const field_ty = ty.structFieldType(i, zcu).toIntern();
+                                    const field_ty = ty.fieldType(i, zcu).toIntern();
                                     mut_elem.* = .{ .interned = try pt.intern(.{ .undef = field_ty }) };
                                 },
                                 else => unreachable,

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -428,10 +428,10 @@ const Writer = struct {
     }
 
     fn writeAggregateInit(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
-        const mod = w.pt.zcu;
+        const zcu = w.pt.zcu;
         const ty_pl = w.air.instructions.items(.data)[@intFromEnum(inst)].ty_pl;
         const vector_ty = ty_pl.ty.toType();
-        const len = @as(usize, @intCast(vector_ty.arrayLen(mod)));
+        const len = @as(usize, @intCast(vector_ty.arrayLen(zcu)));
         const elements = @as([]const Air.Inst.Ref, @ptrCast(w.air.extra[ty_pl.payload..][0..len]));
 
         try w.writeType(s, vector_ty);
@@ -508,11 +508,11 @@ const Writer = struct {
     }
 
     fn writeSelect(w: *Writer, s: anytype, inst: Air.Inst.Index) @TypeOf(s).Error!void {
-        const mod = w.pt.zcu;
+        const zcu = w.pt.zcu;
         const pl_op = w.air.instructions.items(.data)[@intFromEnum(inst)].pl_op;
         const extra = w.air.extraData(Air.Bin, pl_op.payload).data;
 
-        const elem_ty = w.typeOfIndex(inst).childType(mod);
+        const elem_ty = w.typeOfIndex(inst).childType(zcu);
         try w.writeType(s, elem_ty);
         try s.writeAll(", ");
         try w.writeOperand(s, inst, 0, pl_op.operand);
@@ -974,7 +974,7 @@ const Writer = struct {
     }
 
     fn typeOfIndex(w: *Writer, inst: Air.Inst.Index) Type {
-        const mod = w.pt.zcu;
-        return w.air.typeOfIndex(inst, &mod.intern_pool);
+        const zcu = w.pt.zcu;
+        return w.air.typeOfIndex(inst, &zcu.intern_pool);
     }
 };

--- a/src/print_value.zig
+++ b/src/print_value.zig
@@ -95,11 +95,11 @@ pub fn print(
         .int => |int| switch (int.storage) {
             inline .u64, .i64, .big_int => |x| try writer.print("{}", .{x}),
             .lazy_align => |ty| if (have_sema) {
-                const a = (try Type.fromInterned(ty).abiAlignmentAdvanced(pt, .sema)).scalar;
+                const a = try Type.fromInterned(ty).abiAlignmentSema(pt);
                 try writer.print("{}", .{a.toByteUnits() orelse 0});
             } else try writer.print("@alignOf({})", .{Type.fromInterned(ty).fmt(pt)}),
             .lazy_size => |ty| if (have_sema) {
-                const s = (try Type.fromInterned(ty).abiSizeAdvanced(pt, .sema)).scalar;
+                const s = try Type.fromInterned(ty).abiSizeSema(pt);
                 try writer.print("{}", .{s});
             } else try writer.print("@sizeOf({})", .{Type.fromInterned(ty).fmt(pt)}),
         },
@@ -245,7 +245,7 @@ fn printAggregate(
                     if (ty.childType(zcu).toIntern() != .u8_type) break :one_byte_str;
                     const elem_val = Value.fromInterned(aggregate.storage.values()[0]);
                     if (elem_val.isUndef(zcu)) break :one_byte_str;
-                    const byte = elem_val.toUnsignedInt(pt);
+                    const byte = elem_val.toUnsignedInt(zcu);
                     try writer.print("\"{}\"", .{std.zig.fmtEscapes(&.{@intCast(byte)})});
                     if (!is_ref) try writer.writeAll(".*");
                     return;

--- a/src/print_value.zig
+++ b/src/print_value.zig
@@ -62,8 +62,8 @@ pub fn print(
     comptime have_sema: bool,
     sema: if (have_sema) *Sema else void,
 ) (@TypeOf(writer).Error || Zcu.CompileError)!void {
-    const mod = pt.zcu;
-    const ip = &mod.intern_pool;
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
     switch (ip.indexToKey(val.toIntern())) {
         .int_type,
         .ptr_type,
@@ -116,7 +116,7 @@ pub fn print(
             enum_literal.fmt(ip),
         }),
         .enum_tag => |enum_tag| {
-            const enum_type = ip.loadEnumType(val.typeOf(mod).toIntern());
+            const enum_type = ip.loadEnumType(val.typeOf(zcu).toIntern());
             if (enum_type.tagValueIndex(ip, val.toIntern())) |tag_index| {
                 return writer.print(".{i}", .{enum_type.names.get(ip)[tag_index].fmt(ip)});
             }
@@ -173,7 +173,7 @@ pub fn print(
                 return;
             }
             if (un.tag == .none) {
-                const backing_ty = try val.typeOf(mod).unionBackingType(pt);
+                const backing_ty = try val.typeOf(zcu).unionBackingType(pt);
                 try writer.print("@bitCast(@as({}, ", .{backing_ty.fmt(pt)});
                 try print(Value.fromInterned(un.val), writer, level - 1, pt, have_sema, sema);
                 try writer.writeAll("))");

--- a/src/target.zig
+++ b/src/target.zig
@@ -526,7 +526,11 @@ pub fn zigBackend(target: std.Target, use_llvm: bool) std.builtin.CompilerBacken
 pub inline fn backendSupportsFeature(backend: std.builtin.CompilerBackend, comptime feature: Feature) bool {
     return switch (feature) {
         .panic_fn => switch (backend) {
-            .stage2_c, .stage2_llvm, .stage2_x86_64, .stage2_riscv64 => true,
+            .stage2_c,
+            .stage2_llvm,
+            .stage2_x86_64,
+            .stage2_riscv64,
+            => true,
             else => false,
         },
         .panic_unwrap_error => switch (backend) {


### PR DESCRIPTION
This PR changes up a couple of patterns.

- Don't ask for a `PerThread` when it isn't needed. The goal is to guarantee that there will be no modifications to the intern pool, which is done by not having a `tid`. Things like `abiSize` and `abiAlignment` run on already resolved types, so we can guarantee calling them won't modify the intern pool. Now there is a variant of the functions called `abiSizeSema` which does take a `PerThread` and will do type resolution and needed to get the information you want.

- Finally finish renaming things to `zcu` when needed. The codes become clear!

- When calling `resolve{Struct,Union]Inner` we would construct a `sema` and then immediately discard it, creating a new one further down. This is wasteful and there's little purpose to this. Now we have a single `sema` created, which acts as the point of reference.

A lot of this PR is just slog and whitespace, hence the large change count. The meaningful changes are all clean-ups and no behavior is changed here.