### PR TITLE
translate-c: support GCC/Clang pointer subtraction extension

### DIFF
--- a/test/cases/translate_c/void_pointer_subtraction.c
+++ b/test/cases/translate_c/void_pointer_subtraction.c
@@ -1,0 +1,16 @@
+#include <stddef.h>
+ptrdiff_t sub_ptr(void *a, void *b) {
+    return a - b;
+}
+
+// translate-c
+// c_frontend=clang
+// target=x86_64-linux
+//
+// pub export fn sub_ptr(arg_a: ?*anyopaque, arg_b: ?*anyopaque) ptrdiff_t {
+//     var a = arg_a;
+//     _ = &a;
+//     var b = arg_b;
+//     _ = &b;
+//     return @as(c_long, @bitCast(@intFromPtr(a) -% @intFromPtr(b)));
+// }


### PR DESCRIPTION
Pointer subtraction on `void *` or function pointers is UB by the C spec, but is permitted by GCC and Clang as an extension. So, avoid crashing translate-c in such cases, and follow the extension behavior -- there's nothing else that could really be intended.