### PR TITLE
Only set `contents: read` permission in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ concurrency:
   # Cancels pending runs when a PR gets updated.
   group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}
   cancel-in-progress: true
+permissions:
+  # Sets permission policy for `GITHUB_TOKEN`
+  contents: read
 jobs:
   x86_64-linux-debug:
     timeout-minutes: 420


### PR DESCRIPTION
Sets minimal required number of permissions in GitHub Actions. Docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

By default it is set to: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

It allows much more than needed by default.
`zig` only needs `contents: read`, so the repo contents can be read and tested.

We have this set in CPython as a part of our security: https://github.com/python/cpython/blob/fe85a8291d9aa11c9ce9e207c39ea0a0c35f9625/.github/workflows/build.yml#L14-L15