### PR TITLE
Fix MIPS PIC level and work around an LLVM bug for `mips(el)-linux-gnueabi(hf)`

### DIFF
--- a/lib/std/zig/Server.zig
+++ b/lib/std/zig/Server.zig
@@ -124,9 +124,9 @@ pub fn receiveMessage(s: *Server) !InMessage.Header {
         const buf = fifo.readableSlice(0);
         assert(fifo.readableLength() == buf.len);
         if (buf.len >= @sizeOf(Header)) {
-            // workaround for https://github.com/ziglang/zig/issues/14904
-            const bytes_len = bswap_and_workaround_u32(buf[4..][0..4]);
-            const tag = bswap_and_workaround_tag(buf[0..][0..4]);
+            const header: *align(1) const Header = @ptrCast(buf[0..@sizeOf(Header)]);
+            const bytes_len = bswap(header.bytes_len);
+            const tag = bswap(header.tag);
 
             if (buf.len - @sizeOf(Header) >= bytes_len) {
                 fifo.discard(@sizeOf(Header));
@@ -305,17 +305,6 @@ fn bswap(x: anytype) @TypeOf(x) {
 fn bswap_u32_array(slice: []u32) void {
     comptime assert(need_bswap);
     for (slice) |*elem| elem.* = @byteSwap(elem.*);
-}
-
-/// workaround for https://github.com/ziglang/zig/issues/14904
-fn bswap_and_workaround_u32(bytes_ptr: *const [4]u8) u32 {
-    return std.mem.readInt(u32, bytes_ptr, .little);
-}
-
-/// workaround for https://github.com/ziglang/zig/issues/14904
-fn bswap_and_workaround_tag(bytes_ptr: *const [4]u8) InMessage.Tag {
-    const int = std.mem.readInt(u32, bytes_ptr, .little);
-    return @as(InMessage.Tag, @enumFromInt(int));
 }
 
 const OutMessage = std.zig.Server.Message;

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1280,6 +1280,8 @@ pub const Object = struct {
             .tsan = options.sanitize_thread,
             .sancov = options.fuzz,
             .lto = options.lto,
+            // https://github.com/ziglang/zig/issues/21215
+            .allow_fast_isel = !comp.root_mod.resolved_target.result.cpu.arch.isMIPS(),
             .asm_filename = null,
             .bin_filename = options.bin_path,
             .llvm_ir_filename = options.post_ir_path,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1259,8 +1259,11 @@ pub const Object = struct {
         );
         errdefer target_machine.dispose();
 
-        if (pic) module.setModulePICLevel();
-        if (comp.config.pie) module.setModulePIELevel();
+        const large_pic = target_util.usesLargePIC(comp.root_mod.resolved_target.result);
+
+        if (pic) module.setModulePICLevel(large_pic);
+        if (comp.config.pie) module.setModulePIELevel(large_pic);
+
         if (code_model != .Default) module.setModuleCodeModel(code_model);
 
         if (comp.llvm_opt_bisect_limit >= 0) {

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -91,6 +91,7 @@ pub const TargetMachine = opaque {
         tsan: bool,
         sancov: bool,
         lto: bool,
+        allow_fast_isel: bool,
         asm_filename: ?[*:0]const u8,
         bin_filename: ?[*:0]const u8,
         llvm_ir_filename: ?[*:0]const u8,

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -53,10 +53,10 @@ pub const Module = opaque {
     extern fn LLVMDisposeModule(*Module) void;
 
     pub const setModulePICLevel = ZigLLVMSetModulePICLevel;
-    extern fn ZigLLVMSetModulePICLevel(module: *Module) void;
+    extern fn ZigLLVMSetModulePICLevel(module: *Module, big: bool) void;
 
     pub const setModulePIELevel = ZigLLVMSetModulePIELevel;
-    extern fn ZigLLVMSetModulePIELevel(module: *Module) void;
+    extern fn ZigLLVMSetModulePIELevel(module: *Module, large: bool) void;
 
     pub const setModuleCodeModel = ZigLLVMSetModuleCodeModel;
     extern fn ZigLLVMSetModuleCodeModel(module: *Module, code_model: CodeModel) void;

--- a/src/target.zig
+++ b/src/target.zig
@@ -49,6 +49,12 @@ pub fn requiresPIC(target: std.Target, linking_libc: bool) bool {
         (target.abi == .ohos and target.cpu.arch == .aarch64);
 }
 
+pub fn usesLargePIC(target: std.Target) bool {
+    // MIPS always uses PIC level 1; other platforms vary in their default PIC levels, but they
+    // support both level 1 and 2, in which case we prefer 2.
+    return !target.cpu.arch.isMIPS();
+}
+
 /// This is not whether the target supports Position Independent Code, but whether the -fPIC
 /// C compiler argument is valid to Clang.
 pub fn supports_fpic(target: std.Target) bool {

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -258,7 +258,6 @@ ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machi
                               options.bin_filename? options.bin_filename : options.asm_filename);
 
     TargetMachine &target_machine = *reinterpret_cast<TargetMachine*>(targ_machine_ref);
-    target_machine.setO0WantsFastISel(true);
 
     Module &llvm_module = *unwrap(module_ref);
 
@@ -367,6 +366,12 @@ ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machi
             *error_message = strdup("TargetMachine can't emit an assembly file");
             return true;
         }
+    }
+
+    if (options.allow_fast_isel) {
+        target_machine.setO0WantsFastISel(true);
+    } else {
+        target_machine.setFastISel(false);
     }
 
     // Optimization phase

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -81,7 +81,7 @@ static const bool assertions_on = false;
 
 LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Triple,
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
-    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, ZigLLVMABIType float_abi, 
+    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, ZigLLVMABIType float_abi,
     const char *abi_name)
 {
     std::optional<Reloc::Model> RM;
@@ -430,12 +430,12 @@ void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv) {
     cl::ParseCommandLineOptions(argc, argv);
 }
 
-void ZigLLVMSetModulePICLevel(LLVMModuleRef module) {
-    unwrap(module)->setPICLevel(PICLevel::Level::BigPIC);
+void ZigLLVMSetModulePICLevel(LLVMModuleRef module, bool big) {
+    unwrap(module)->setPICLevel(big ? PICLevel::Level::BigPIC : PICLevel::Level::SmallPIC);
 }
 
-void ZigLLVMSetModulePIELevel(LLVMModuleRef module) {
-    unwrap(module)->setPIELevel(PIELevel::Level::Large);
+void ZigLLVMSetModulePIELevel(LLVMModuleRef module, bool large) {
+    unwrap(module)->setPIELevel(large ? PIELevel::Level::Large : PIELevel::Level::Small);
 }
 
 void ZigLLVMSetModuleCodeModel(LLVMModuleRef module, LLVMCodeModel code_model) {

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -59,6 +59,7 @@ struct ZigLLVMEmitOptions {
     bool tsan;
     bool sancov;
     bool lto;
+    bool allow_fast_isel;
     const char *asm_filename;
     const char *bin_filename;
     const char *llvm_ir_filename;

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -77,7 +77,7 @@ enum ZigLLVMABIType {
 
 ZIG_EXTERN_C LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Triple,
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
-    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, enum ZigLLVMABIType float_abi, 
+    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, enum ZigLLVMABIType float_abi,
     const char *abi_name);
 
 ZIG_EXTERN_C void ZigLLVMSetOptBisectLimit(LLVMContextRef context_ref, int limit);
@@ -154,8 +154,8 @@ enum ZigLLVM_CallingConv {
     ZigLLVM_MaxID = 1023,
 };
 
-ZIG_EXTERN_C void ZigLLVMSetModulePICLevel(LLVMModuleRef module);
-ZIG_EXTERN_C void ZigLLVMSetModulePIELevel(LLVMModuleRef module);
+ZIG_EXTERN_C void ZigLLVMSetModulePICLevel(LLVMModuleRef module, bool big);
+ZIG_EXTERN_C void ZigLLVMSetModulePIELevel(LLVMModuleRef module, bool large);
 ZIG_EXTERN_C void ZigLLVMSetModuleCodeModel(LLVMModuleRef module, LLVMCodeModel code_model);
 
 ZIG_EXTERN_C void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv);


### PR DESCRIPTION
* Set the correct PIC level for MIPS.
* Work around https://github.com/ziglang/zig/issues/21215 until https://github.com/llvm/llvm-project/pull/106231 trickles down.
* Revert the workaround for https://github.com/ziglang/zig/issues/14904.

This makes `zig build test-modules -fqemu --glibc-runtimes <...> -Dtest-slow-targets -Dtest-target-filter=mips-linux.4.19...6.10.3-gnueabi -Dtest-target-filter=mipsel-linux.4.19...6.10.3-gnueabi` mostly work, save for an `fchmodat` test failure that I still need to investigate.