### PR TITLE
exclude unreachable code paths from having coverage instrumentation

### DIFF
--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -166,6 +166,7 @@ fn mainServer() !void {
                     if (log_err_count != 0) @panic("error logs detected");
                     if (first) {
                         first = false;
+                        const entry_addr = @intFromPtr(test_fn.func);
                         try server.serveU64Message(.fuzz_start_addr, entry_addr);
                     }
                 }
@@ -347,7 +348,6 @@ const FuzzerSlice = extern struct {
 };
 
 var is_fuzz_test: bool = undefined;
-var entry_addr: usize = 0;
 
 extern fn fuzzer_next() FuzzerSlice;
 extern fn fuzzer_init(cache_dir: FuzzerSlice) void;
@@ -358,7 +358,6 @@ pub fn fuzzInput(options: testing.FuzzInputOptions) []const u8 {
     if (crippled) return "";
     is_fuzz_test = true;
     if (builtin.fuzz) {
-        if (entry_addr == 0) entry_addr = @returnAddress();
         return fuzzer_next().toSlice();
     }
     if (options.corpus.len == 0) return "";

--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -30,19 +30,6 @@ fn logOverride(
 
 export threadlocal var __sancov_lowest_stack: usize = std.math.maxInt(usize);
 
-var module_count_8bc: usize = 0;
-var module_count_pcs: usize = 0;
-
-export fn __sanitizer_cov_8bit_counters_init(start: [*]u8, end: [*]u8) void {
-    assert(@atomicRmw(usize, &module_count_8bc, .Add, 1, .monotonic) == 0);
-    fuzzer.pc_counters = start[0 .. end - start];
-}
-
-export fn __sanitizer_cov_pcs_init(start: [*]const Fuzzer.FlaggedPc, end: [*]const Fuzzer.FlaggedPc) void {
-    assert(@atomicRmw(usize, &module_count_pcs, .Add, 1, .monotonic) == 0);
-    fuzzer.flagged_pcs = start[0 .. end - start];
-}
-
 export fn __sanitizer_cov_trace_const_cmp1(arg1: u8, arg2: u8) void {
     handleCmp(@returnAddress(), arg1, arg2);
 }
@@ -105,7 +92,7 @@ const Fuzzer = struct {
     gpa: Allocator,
     rng: std.Random.DefaultPrng,
     input: std.ArrayListUnmanaged(u8),
-    flagged_pcs: []const FlaggedPc,
+    pcs: []const usize,
     pc_counters: []u8,
     n_runs: usize,
     recent_cases: RunMap,
@@ -174,32 +161,18 @@ const Fuzzer = struct {
         }
     };
 
-    const FlaggedPc = extern struct {
-        addr: usize,
-        flags: packed struct(usize) {
-            entry: bool,
-            _: @Type(.{ .int = .{ .signedness = .unsigned, .bits = @bitSizeOf(usize) - 1 } }),
-        },
-    };
-
     const Analysis = struct {
         score: usize,
         id: Run.Id,
     };
 
-    fn init(f: *Fuzzer, cache_dir: std.fs.Dir) !void {
-        const flagged_pcs = f.flagged_pcs;
-
+    fn init(f: *Fuzzer, cache_dir: std.fs.Dir, pc_counters: []u8, pcs: []const usize) !void {
         f.cache_dir = cache_dir;
+        f.pc_counters = pc_counters;
+        f.pcs = pcs;
 
         // Choose a file name for the coverage based on a hash of the PCs that will be stored within.
-        const pc_digest = d: {
-            var hasher = std.hash.Wyhash.init(0);
-            for (flagged_pcs) |flagged_pc| {
-                hasher.update(std.mem.asBytes(&flagged_pc.addr));
-            }
-            break :d f.coverage.run_id_hasher.final();
-        };
+        const pc_digest = std.hash.Wyhash.hash(0, std.mem.sliceAsBytes(pcs));
         f.coverage_id = pc_digest;
         const hex_digest = std.fmt.hex(pc_digest);
         const coverage_file_path = "v/" ++ hex_digest;
@@ -213,12 +186,12 @@ const Fuzzer = struct {
             .truncate = false,
         });
         defer coverage_file.close();
-        const n_bitset_elems = (flagged_pcs.len + @bitSizeOf(usize) - 1) / @bitSizeOf(usize);
+        const n_bitset_elems = (pcs.len + @bitSizeOf(usize) - 1) / @bitSizeOf(usize);
         comptime assert(SeenPcsHeader.trailing[0] == .pc_bits_usize);
         comptime assert(SeenPcsHeader.trailing[1] == .pc_addr);
         const bytes_len = @sizeOf(SeenPcsHeader) +
             n_bitset_elems * @sizeOf(usize) +
-            flagged_pcs.len * @sizeOf(usize);
+            pcs.len * @sizeOf(usize);
         const existing_len = coverage_file.getEndPos() catch |err| {
             fatal("unable to check len of coverage file: {s}", .{@errorName(err)});
         };
@@ -233,12 +206,12 @@ const Fuzzer = struct {
             fatal("unable to init coverage memory map: {s}", .{@errorName(err)});
         };
         if (existing_len != 0) {
-            const existing_pcs_bytes = f.seen_pcs.items[@sizeOf(SeenPcsHeader) + @sizeOf(usize) * n_bitset_elems ..][0 .. flagged_pcs.len * @sizeOf(usize)];
+            const existing_pcs_bytes = f.seen_pcs.items[@sizeOf(SeenPcsHeader) + @sizeOf(usize) * n_bitset_elems ..][0 .. pcs.len * @sizeOf(usize)];
             const existing_pcs = std.mem.bytesAsSlice(usize, existing_pcs_bytes);
-            for (existing_pcs, flagged_pcs, 0..) |old, new, i| {
-                if (old != new.addr) {
+            for (existing_pcs, pcs, 0..) |old, new, i| {
+                if (old != new) {
                     fatal("incompatible existing coverage file (differing PC at index {d}: {x} != {x})", .{
-                        i, old, new.addr,
+                        i, old, new,
                     });
                 }
             }
@@ -246,14 +219,12 @@ const Fuzzer = struct {
             const header: SeenPcsHeader = .{
                 .n_runs = 0,
                 .unique_runs = 0,
-                .pcs_len = flagged_pcs.len,
+                .pcs_len = pcs.len,
                 .lowest_stack = std.math.maxInt(usize),
             };
             f.seen_pcs.appendSliceAssumeCapacity(std.mem.asBytes(&header));
             f.seen_pcs.appendNTimesAssumeCapacity(0, n_bitset_elems * @sizeOf(usize));
-            for (flagged_pcs) |flagged_pc| {
-                f.seen_pcs.appendSliceAssumeCapacity(std.mem.asBytes(&flagged_pc.addr));
-            }
+            f.seen_pcs.appendSliceAssumeCapacity(std.mem.sliceAsBytes(pcs));
         }
     }
 
@@ -307,8 +278,8 @@ const Fuzzer = struct {
                     // Track code coverage from all runs.
                     comptime assert(SeenPcsHeader.trailing[0] == .pc_bits_usize);
                     const header_end_ptr: [*]volatile usize = @ptrCast(f.seen_pcs.items[@sizeOf(SeenPcsHeader)..]);
-                    const remainder = f.flagged_pcs.len % @bitSizeOf(usize);
-                    const aligned_len = f.flagged_pcs.len - remainder;
+                    const remainder = f.pcs.len % @bitSizeOf(usize);
+                    const aligned_len = f.pcs.len - remainder;
                     const seen_pcs = header_end_ptr[0..aligned_len];
                     const pc_counters = std.mem.bytesAsSlice([@bitSizeOf(usize)]u8, f.pc_counters[0..aligned_len]);
                     const V = @Vector(@bitSizeOf(usize), u8);
@@ -433,7 +404,7 @@ var fuzzer: Fuzzer = .{
     .gpa = general_purpose_allocator.allocator(),
     .rng = std.Random.DefaultPrng.init(0),
     .input = .{},
-    .flagged_pcs = undefined,
+    .pcs = undefined,
     .pc_counters = undefined,
     .n_runs = 0,
     .recent_cases = .{},
@@ -455,8 +426,32 @@ export fn fuzzer_next() Fuzzer.Slice {
 }
 
 export fn fuzzer_init(cache_dir_struct: Fuzzer.Slice) void {
-    if (module_count_8bc == 0) fatal("__sanitizer_cov_8bit_counters_init was never called", .{});
-    if (module_count_pcs == 0) fatal("__sanitizer_cov_pcs_init was never called", .{});
+    // Linkers are expected to automatically add `__start_<section>` and
+    // `__stop_<section>` symbols when section names are valid C identifiers.
+
+    const pc_counters_start = @extern([*]u8, .{
+        .name = "__start___sancov_cntrs",
+        .linkage = .weak,
+    }) orelse fatal("missing __start___sancov_cntrs symbol");
+
+    const pc_counters_end = @extern([*]u8, .{
+        .name = "__stop___sancov_cntrs",
+        .linkage = .weak,
+    }) orelse fatal("missing __stop___sancov_cntrs symbol");
+
+    const pc_counters = pc_counters_start[0 .. pc_counters_end - pc_counters_start];
+
+    const pcs_start = @extern([*]usize, .{
+        .name = "__start___sancov_pcs1",
+        .linkage = .weak,
+    }) orelse fatal("missing __start___sancov_pcs1 symbol");
+
+    const pcs_end = @extern([*]usize, .{
+        .name = "__stop___sancov_pcs1",
+        .linkage = .weak,
+    }) orelse fatal("missing __stop___sancov_pcs1 symbol");
+
+    const pcs = pcs_start[0 .. pcs_end - pcs_start];
 
     const cache_dir_path = cache_dir_struct.toZig();
     const cache_dir = if (cache_dir_path.len == 0)
@@ -466,7 +461,8 @@ export fn fuzzer_init(cache_dir_struct: Fuzzer.Slice) void {
             fatal("unable to open fuzz directory '{s}': {s}", .{ cache_dir_path, @errorName(err) });
         };
 
-    fuzzer.init(cache_dir) catch |err| fatal("unable to init fuzzer: {s}", .{@errorName(err)});
+    fuzzer.init(cache_dir, pc_counters, pcs) catch |err|
+        fatal("unable to init fuzzer: {s}", .{@errorName(err)});
 }
 
 /// Like `std.ArrayListUnmanaged(u8)` but backed by memory mapping.

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -218,12 +218,18 @@ no_builtin: bool = false,
 /// Managed by the build runner, not user build script.
 zig_process: ?*Step.ZigProcess,
 
-/// Enables deprecated coverage instrumentation that is only useful if you
-/// are using third party fuzzers that depend on it. Otherwise, slows down
-/// the instrumented binary with unnecessary function calls.
+/// Enables coverage instrumentation that is only useful if you are using third
+/// party fuzzers that depend on it. Otherwise, slows down the instrumented
+/// binary with unnecessary function calls.
 ///
-/// To enable fuzz testing instrumentation on a compilation, see the `fuzz`
-/// flag in `Module`.
+/// This kind of coverage instrumentation is used by AFLplusplus v4.21c,
+/// however, modern fuzzers - including Zig - have switched to using "inline
+/// 8-bit counters" or "inline bool flag" which incurs only a single
+/// instruction for coverage, along with "trace cmp" which instruments
+/// comparisons and reports the operands.
+///
+/// To instead enable fuzz testing instrumentation on a compilation using Zig's
+/// builtin fuzzer, see the `fuzz` flag in `Module`.
 sanitize_coverage_trace_pc_guard: ?bool = null,
 
 pub const ExpectedCompileErrors = union(enum) {

--- a/src/Air.zig
+++ b/src/Air.zig
@@ -1126,7 +1126,9 @@ pub const CondBr = struct {
     pub const BranchHints = packed struct(u32) {
         true: std.builtin.BranchHint,
         false: std.builtin.BranchHint,
-        _: u26 = 0,
+        then_cov: CoveragePoint,
+        else_cov: CoveragePoint,
+        _: u24 = 0,
     };
 };
 
@@ -1903,3 +1905,12 @@ pub fn unwrapSwitch(air: *const Air, switch_inst: Inst.Index) UnwrappedSwitch {
 pub const typesFullyResolved = types_resolved.typesFullyResolved;
 pub const typeFullyResolved = types_resolved.checkType;
 pub const valFullyResolved = types_resolved.checkVal;
+
+pub const CoveragePoint = enum(u1) {
+    /// Indicates the block is not a place of interest corresponding to
+    /// a source location for coverage purposes.
+    none,
+    /// Point of interest. The next instruction emitted corresponds to
+    /// a source location used for coverage instrumentation.
+    poi,
+};

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1275,7 +1275,7 @@ pub const Object = struct {
             .is_small = options.is_small,
             .time_report = options.time_report,
             .tsan = options.sanitize_thread,
-            .sancov = sanCovPassEnabled(comp.config.san_cov_trace_pc_guard),
+            .sancov = options.fuzz,
             .lto = options.lto,
             .asm_filename = null,
             .bin_filename = options.bin_path,
@@ -1283,16 +1283,21 @@ pub const Object = struct {
             .bitcode_filename = null,
             .coverage = .{
                 .CoverageType = .Edge,
+                // Works in tandem with Inline8bitCounters or InlineBoolFlag.
+                // Zig does not yet implement its own version of this but it
+                // needs to for better fuzzing logic.
                 .IndirectCalls = false,
                 .TraceBB = false,
-                .TraceCmp = false,
+                .TraceCmp = true,
                 .TraceDiv = false,
                 .TraceGep = false,
                 .Use8bitCounters = false,
                 .TracePC = false,
                 .TracePCGuard = comp.config.san_cov_trace_pc_guard,
+                // Zig emits its own inline 8-bit counters instrumentation.
                 .Inline8bitCounters = false,
                 .InlineBoolFlag = false,
+                // Zig emits its own PC table instrumentation.
                 .PCTable = false,
                 .NoPrune = false,
                 .StackDepth = false,
@@ -12272,8 +12277,4 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
         .spu_2,
         => unreachable,
     }
-}
-
-fn sanCovPassEnabled(trace_pc_guard: bool) bool {
-    return trace_pc_guard;
 }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1664,6 +1664,7 @@ pub const Object = struct {
             if (!owner_mod.fuzz) break :f null;
             if (func_analysis.disable_instrumentation) break :f null;
             if (is_naked) break :f null;
+            if (comp.config.san_cov_trace_pc_guard) break :f null;
 
             // The void type used here is a placeholder to be replaced with an
             // array of the appropriate size after the POI count is known.

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -3994,7 +3994,6 @@ pub const Function = struct {
     names: [*]const String = &[0]String{},
     value_indices: [*]const u32 = &[0]u32{},
     strip: bool,
-    any_nosanitize: bool,
     debug_locations: std.AutoHashMapUnmanaged(Instruction.Index, DebugLocation) = .{},
     debug_values: []const Instruction.Index = &.{},
     extra: []const u32 = &.{},
@@ -4091,7 +4090,6 @@ pub const Function = struct {
             block,
             br,
             br_cond,
-            br_cond_nosanitize,
             call,
             @"call fast",
             cmpxchg,
@@ -4347,13 +4345,6 @@ pub const Function = struct {
                     else => unreachable,
                 };
             }
-
-            pub fn isNosanitize(self: Tag) bool {
-                return switch (self) {
-                    .br_cond_nosanitize => true,
-                    else => false,
-                };
-            }
         };
 
         pub const Index = enum(u32) {
@@ -4376,7 +4367,6 @@ pub const Function = struct {
                 return switch (wip.instructions.items(.tag)[@intFromEnum(self)]) {
                     .br,
                     .br_cond,
-                    .br_cond_nosanitize,
                     .ret,
                     .@"ret void",
                     .@"switch",
@@ -4390,7 +4380,6 @@ pub const Function = struct {
                 return switch (wip.instructions.items(.tag)[@intFromEnum(self)]) {
                     .br,
                     .br_cond,
-                    .br_cond_nosanitize,
                     .fence,
                     .ret,
                     .@"ret void",
@@ -4481,7 +4470,6 @@ pub const Function = struct {
                     .block => .label,
                     .br,
                     .br_cond,
-                    .br_cond_nosanitize,
                     .fence,
                     .ret,
                     .@"ret void",
@@ -4668,7 +4656,6 @@ pub const Function = struct {
                     .block => .label,
                     .br,
                     .br_cond,
-                    .br_cond_nosanitize,
                     .fence,
                     .ret,
                     .@"ret void",
@@ -5113,7 +5100,6 @@ pub const WipFunction = struct {
     instructions: std.MultiArrayList(Instruction),
     names: std.ArrayListUnmanaged(String),
     strip: bool,
-    any_nosanitize: bool,
     debug_locations: std.AutoArrayHashMapUnmanaged(Instruction.Index, DebugLocation),
     debug_values: std.AutoArrayHashMapUnmanaged(Instruction.Index, void),
     extra: std.ArrayListUnmanaged(u32),
@@ -5160,7 +5146,6 @@ pub const WipFunction = struct {
             .instructions = .{},
             .names = .{},
             .strip = options.strip,
-            .any_nosanitize = false,
             .debug_locations = .{},
             .debug_values = .{},
             .extra = .{},
@@ -6452,7 +6437,7 @@ pub const WipFunction = struct {
                     .@"ret void",
                     .@"unreachable",
                     => {},
-                    .br_cond, .br_cond_nosanitize => {
+                    .br_cond => {
                         const extra = self.extraData(Instruction.BrCond, instruction.data);
                         instruction.data = wip_extra.addExtra(Instruction.BrCond{
                             .cond = instructions.map(extra.cond),
@@ -6639,7 +6624,6 @@ pub const WipFunction = struct {
         function.names = names.ptr;
         function.value_indices = value_indices.ptr;
         function.strip = self.strip;
-        function.any_nosanitize = self.any_nosanitize;
         function.debug_locations = debug_locations;
         function.debug_values = debug_values;
     }
@@ -8553,7 +8537,6 @@ pub fn init(options: Options) Allocator.Error!Builder {
 
     try self.metadata_string_indices.append(self.gpa, 0);
     assert(try self.metadataString("") == .none);
-    assert(try self.debugTuple(&.{}) == .empty_tuple);
 
     return self;
 }
@@ -8951,7 +8934,6 @@ pub fn addFunctionAssumeCapacity(
             .kind = .{ .function = function_index },
         }),
         .strip = undefined,
-        .any_nosanitize = false,
     });
     return function_index;
 }
@@ -9599,12 +9581,6 @@ pub fn printUnbuffered(
             });
         }
         if (function.instructions.len > 0) {
-            const maybe_empty_tuple: ?u32 = if (!function.any_nosanitize) null else b: {
-                const gop = try metadata_formatter.map.getOrPut(self.gpa, .{
-                    .metadata = .empty_tuple,
-                });
-                break :b @intCast(gop.index);
-            };
             var block_incoming_len: u32 = undefined;
             try writer.writeAll(" {\n");
             var maybe_dbg_index: ?u32 = null;
@@ -9793,14 +9769,6 @@ pub fn printUnbuffered(
                                 try metadata_formatter.fmt(", !prof ", @as(Metadata, @enumFromInt(@intFromEnum(extra.weights)))),
                             }),
                         }
-                    },
-                    .br_cond_nosanitize => {
-                        const extra = function.extraData(Function.Instruction.BrCond, instruction.data);
-                        try writer.print("  br {%}, {%}, {%}", .{
-                            extra.cond.fmt(function_index, self),
-                            extra.then.toInst(&function).fmt(function_index, self),
-                            extra.@"else".toInst(&function).fmt(function_index, self),
-                        });
                     },
                     .call,
                     .@"call fast",
@@ -10079,9 +10047,6 @@ pub fn printUnbuffered(
 
                 if (maybe_dbg_index) |dbg_index| {
                     try writer.print(", !dbg !{}", .{dbg_index});
-                }
-                if (instruction.tag.isNosanitize()) {
-                    try writer.print(", !nosanitize !{d}", .{maybe_empty_tuple.?});
                 }
                 try writer.writeByte('\n');
             }

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -795,6 +795,9 @@ const Writer = struct {
         if (extra.data.branch_hints.true != .none) {
             try s.print(" {s}", .{@tagName(extra.data.branch_hints.true)});
         }
+        if (extra.data.branch_hints.then_cov != .none) {
+            try s.print(" {s}", .{@tagName(extra.data.branch_hints.then_cov)});
+        }
         try s.writeAll(" {\n");
         const old_indent = w.indent;
         w.indent += 2;
@@ -813,6 +816,9 @@ const Writer = struct {
         try s.writeAll("},");
         if (extra.data.branch_hints.false != .none) {
             try s.print(" {s}", .{@tagName(extra.data.branch_hints.false)});
+        }
+        if (extra.data.branch_hints.else_cov != .none) {
+            try s.print(" {s}", .{@tagName(extra.data.branch_hints.else_cov)});
         }
         try s.writeAll(" {\n");
 

--- a/src/print_air.zig
+++ b/src/print_air.zig
@@ -791,7 +791,11 @@ const Writer = struct {
 
         try w.writeOperand(s, inst, 0, pl_op.operand);
         if (w.skip_body) return s.writeAll(", ...");
-        try s.writeAll(", {\n");
+        try s.writeAll(",");
+        if (extra.data.branch_hints.true != .none) {
+            try s.print(" {s}", .{@tagName(extra.data.branch_hints.true)});
+        }
+        try s.writeAll(" {\n");
         const old_indent = w.indent;
         w.indent += 2;
 
@@ -806,7 +810,11 @@ const Writer = struct {
 
         try w.writeBody(s, then_body);
         try s.writeByteNTimes(' ', old_indent);
-        try s.writeAll("}, {\n");
+        try s.writeAll("},");
+        if (extra.data.branch_hints.false != .none) {
+            try s.print(" {s}", .{@tagName(extra.data.branch_hints.false)});
+        }
+        try s.writeAll(" {\n");
 
         if (liveness_condbr.else_deaths.len != 0) {
             try s.writeByteNTimes(' ', w.indent);


### PR DESCRIPTION
Follow-up to #21075.

Closes #20992 by moving code coverage instrumentation to the LLVM backend explicitly, leaving LLVM's sancov pass to only do TraceCmp.

cc @kristoff-it - implications for https://github.com/kristoff-it/zig-afl-kit/ are that you can remove these:

```c
void __sanitizer_cov_trace_pc_indir () {}
void __sanitizer_cov_8bit_counters_init () {}
void __sanitizer_cov_pcs_init () {}
```

Although leaving them in is harmless. And meanwhile you should see a speedup in iterations per second since it no longer has redundant instrumentation. Unfortunately you have to leave `__sancov_lowest_stack` for now due to https://github.com/llvm/llvm-project/pull/106464.

## Before:

This is after it reaches the panic line:

![image](https://github.com/user-attachments/assets/da3a1eff-3f22-4a1d-9d4a-092806ae76b6)

## After

![image](https://github.com/user-attachments/assets/7f7744ce-f528-4c45-8607-a08abb90609d)

The extra green dots on the panic line are the "else" clauses from each if statement. This is tracked by #20989 and will be solved by making empty else blocks not emit points of interest.

The final red dot is because when the input is found that triggers the panic, the process crashes, including libfuzzer, including the test runner, so the coverage is not reported. Ideally, any block that is terminated with a `@panic` would also be excluded from coverage for the same reason as auto-generated safety checks.