### PR TITLE
std: make debug.dumpStackPointerAddr compile

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1349,7 +1349,7 @@ pub fn dumpStackPointerAddr(prefix: []const u8) void {
     const sp = asm (""
         : [argc] "={rsp}" (-> usize),
     );
-    std.debug.print("{} sp = 0x{x}\n", .{ prefix, sp });
+    std.debug.print("{s} sp = 0x{x}\n", .{ prefix, sp });
 }
 
 test "manage resources correctly" {


### PR DESCRIPTION
Very simply add the format specifier to the print statement. Since debug.print is hard coded I couldn't come up with a reasonable way to add a test, and since this function is simple enough I doubt it's useful.

fixes one part of #21094