### PR TITLE
std.math: rename make_f80 to F80.toFloat and break_f80 to F80.fromFloat 

### DIFF
--- a/lib/compiler_rt/comparef.zig
+++ b/lib/compiler_rt/comparef.zig
@@ -61,8 +61,8 @@ pub inline fn cmpf2(comptime T: type, comptime RT: type, a: T, b: T) RT {
 }
 
 pub inline fn cmp_f80(comptime RT: type, a: f80, b: f80) RT {
-    const a_rep = std.math.break_f80(a);
-    const b_rep = std.math.break_f80(b);
+    const a_rep = std.math.F80.fromFloat(a);
+    const b_rep = std.math.F80.fromFloat(b);
     const sig_bits = std.math.floatMantissaBits(f80);
     const int_bit = 0x8000000000000000;
     const sign_bit = 0x8000;

--- a/lib/compiler_rt/extendf.zig
+++ b/lib/compiler_rt/extendf.zig
@@ -131,7 +131,7 @@ pub inline fn extend_f80(comptime src_t: type, a: std.meta.Int(.unsigned, @typeI
     }
 
     dst.exp |= sign;
-    return std.math.make_f80(dst);
+    return dst.toFloat();
 }
 
 test {

--- a/lib/compiler_rt/extendxftf2.zig
+++ b/lib/compiler_rt/extendxftf2.zig
@@ -18,7 +18,7 @@ fn __extendxftf2(a: f80) callconv(.C) f128 {
     const dst_min_normal = @as(u128, 1) << dst_sig_bits;
 
     // Break a into a sign and representation of the absolute value
-    var a_rep = std.math.break_f80(a);
+    var a_rep = std.math.F80.fromFloat(a);
     const sign = a_rep.exp & 0x8000;
     a_rep.exp &= 0x7FFF;
     var abs_result: u128 = undefined;

--- a/lib/compiler_rt/subxf3.zig
+++ b/lib/compiler_rt/subxf3.zig
@@ -8,8 +8,8 @@ comptime {
 }
 
 fn __subxf3(a: f80, b: f80) callconv(.C) f80 {
-    var b_rep = std.math.break_f80(b);
+    var b_rep = std.math.F80.fromFloat(b);
     b_rep.exp ^= 0x8000;
-    const neg_b = std.math.make_f80(b_rep);
+    const neg_b = b_rep.toFloat();
     return a + neg_b;
 }

--- a/lib/compiler_rt/truncf.zig
+++ b/lib/compiler_rt/truncf.zig
@@ -121,7 +121,7 @@ pub inline fn trunc_f80(comptime dst_t: type, a: f80) dst_t {
     const dst_nan_mask = dst_qnan - 1;
 
     // Break a into a sign and representation of the absolute value
-    var a_rep = std.math.break_f80(a);
+    var a_rep = std.math.F80.fromFloat(a);
     const sign = a_rep.exp & 0x8000;
     a_rep.exp &= 0x7FFF;
     a_rep.fraction &= 0x7FFFFFFFFFFFFFFF;

--- a/lib/compiler_rt/trunctfxf2.zig
+++ b/lib/compiler_rt/trunctfxf2.zig
@@ -64,5 +64,5 @@ pub fn __trunctfxf2(a: f128) callconv(.C) f80 {
     }
 
     res.exp |= sign;
-    return math.make_f80(res);
+    return res.toFloat();
 }

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1720,20 +1720,20 @@ pub fn comptimeMod(num: anytype, comptime denom: comptime_int) IntFittingRange(0
 pub const F80 = struct {
     fraction: u64,
     exp: u16,
+
+    pub fn toFloat(self: F80) f80 {
+        const int = (@as(u80, self.exp) << 64) | self.fraction;
+        return @as(f80, @bitCast(int));
+    }
+
+    pub fn fromFloat(x: f80) F80 {
+        const int = @as(u80, @bitCast(x));
+        return .{
+            .fraction = @as(u64, @truncate(int)),
+            .exp = @as(u16, @truncate(int >> 64)),
+        };
+    }
 };
-
-pub fn make_f80(repr: F80) f80 {
-    const int = (@as(u80, repr.exp) << 64) | repr.fraction;
-    return @as(f80, @bitCast(int));
-}
-
-pub fn break_f80(x: f80) F80 {
-    const int = @as(u80, @bitCast(x));
-    return .{
-        .fraction = @as(u64, @truncate(int)),
-        .exp = @as(u16, @truncate(int >> 64)),
-    };
-}
 
 /// Returns -1, 0, or 1.
 /// Supports integer and float types and vectors of integer and float types.

--- a/lib/std/math/nextafter.zig
+++ b/lib/std/math/nextafter.zig
@@ -61,7 +61,7 @@ fn nextAfterFloat(comptime T: type, x: T, y: T) T {
         const integer_bit_mask = 1 << math.floatFractionalBits(f80);
         const exponent_bits_mask = (1 << math.floatExponentBits(f80)) - 1;
 
-        var x_parts = math.break_f80(x);
+        var x_parts = math.F80.fromFloat(x);
 
         // Bitwise increment/decrement the fractional part while also taking care to update the
         // exponent if we overflow the fractional part. This might flip the integer bit; this is
@@ -88,7 +88,7 @@ fn nextAfterFloat(comptime T: type, x: T, y: T) T {
         // set to cleared (if the old value was normal) or remained cleared (if the old value was
         // subnormal), both of which are the outcomes we want.
 
-        return math.make_f80(x_parts);
+        return x_parts.toFloat();
     } else {
         const Bits = std.meta.Int(.unsigned, @bitSizeOf(T));
         var x_bits: Bits = @bitCast(x);


### PR DESCRIPTION
The motivation behind this is to make these functions follow the naming convention for functions. I can change them back to be just regular functions if that is what is wanted and can change them to makeF80 and breakf80 or something else if wanted also.