### PR TITLE
`llvm`: Pass `EmitOptions` to libzigcpp by pointer.

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1325,7 +1325,7 @@ pub const Object = struct {
             },
         };
         if (options.asm_path != null and options.bin_path != null) {
-            if (target_machine.emitToFile(module, &error_message, lowered_options)) {
+            if (target_machine.emitToFile(module, &error_message, &lowered_options)) {
                 defer llvm.disposeMessage(error_message);
                 log.err("LLVM failed to emit bin={s} ir={s}: {s}", .{
                     emit_bin_msg, post_llvm_ir_msg, error_message,
@@ -1337,7 +1337,7 @@ pub const Object = struct {
         }
 
         lowered_options.asm_filename = options.asm_path;
-        if (target_machine.emitToFile(module, &error_message, lowered_options)) {
+        if (target_machine.emitToFile(module, &error_message, &lowered_options)) {
             defer llvm.disposeMessage(error_message);
             log.err("LLVM failed to emit asm={s} bin={s} ir={s} bc={s}: {s}", .{
                 emit_asm_msg,  emit_bin_msg, post_llvm_ir_msg, post_llvm_bc_msg,

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -130,7 +130,7 @@ pub const TargetMachine = opaque {
         T: *TargetMachine,
         M: *Module,
         ErrorMessage: *[*:0]const u8,
-        options: EmitOptions,
+        options: *const EmitOptions,
     ) bool;
 
     pub const createTargetDataLayout = LLVMCreateTargetDataLayout;

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -67,7 +67,7 @@ struct ZigLLVMEmitOptions {
 };
 
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
-        char **error_message, struct ZigLLVMEmitOptions options);
+        char **error_message, const struct ZigLLVMEmitOptions *options);
 
 enum ZigLLVMABIType {
     ZigLLVMABITypeDefault, // Target-specific (either soft or hard depending on triple, etc).


### PR DESCRIPTION
Passing it by value means that bringup on new architectures is harder for no real benefit. Passing it by pointer allows to get the compiler running without needing to figure out the C calling convention details first. This manifested in practice on LoongArch, for example.

See: https://github.com/ziglang/zig-bootstrap/issues/166#issuecomment-2313778111

The intent here is *not* to sweep the problem under the rug; I have plans to go through and improve our C calling convention conformance across the board. This just makes initial porting easier.

cc @yxd-ym please test this and see if it gets you unblocked.