### PR TITLE
Dwarf: fix issues with emitted debug info

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -3825,7 +3825,7 @@ pub fn flushModule(dwarf: *Dwarf, pt: Zcu.PerThread) FlushError!void {
                         sleb128(header.fixedWriter(), dwarf.debug_frame.header.data_alignment_factor) catch unreachable;
                         uleb128(header.fixedWriter(), dwarf.debug_frame.header.return_address_register) catch unreachable;
                         uleb128(header.fixedWriter(), 1) catch unreachable;
-                        header.appendAssumeCapacity(0x10 | 0x08 | 0x03);
+                        header.appendAssumeCapacity(DW.EH.PE.pcrel | DW.EH.PE.sdata4);
                         header.appendAssumeCapacity(DW.CFA.def_cfa_sf);
                         uleb128(header.fixedWriter(), Register.rsp.dwarfNum()) catch unreachable;
                         sleb128(header.fixedWriter(), -1) catch unreachable;

--- a/src/link/Elf/eh_frame.zig
+++ b/src/link/Elf/eh_frame.zig
@@ -482,9 +482,9 @@ pub fn writeEhFrameHdr(elf_file: *Elf, writer: anytype) !void {
     const gpa = comp.gpa;
 
     try writer.writeByte(1); // version
-    try writer.writeByte(EH_PE.pcrel | EH_PE.sdata4);
-    try writer.writeByte(EH_PE.udata4);
-    try writer.writeByte(EH_PE.datarel | EH_PE.sdata4);
+    try writer.writeByte(DW_EH_PE.pcrel | DW_EH_PE.sdata4);
+    try writer.writeByte(DW_EH_PE.udata4);
+    try writer.writeByte(DW_EH_PE.datarel | DW_EH_PE.sdata4);
 
     const shdrs = elf_file.sections.items(.shdr);
     const eh_frame_shdr = shdrs[elf_file.eh_frame_section_index.?];
@@ -543,25 +543,6 @@ pub fn writeEhFrameHdr(elf_file: *Elf, writer: anytype) !void {
 
 const eh_frame_hdr_header_size: usize = 12;
 
-const EH_PE = struct {
-    pub const absptr = 0x00;
-    pub const uleb128 = 0x01;
-    pub const udata2 = 0x02;
-    pub const udata4 = 0x03;
-    pub const udata8 = 0x04;
-    pub const sleb128 = 0x09;
-    pub const sdata2 = 0x0A;
-    pub const sdata4 = 0x0B;
-    pub const sdata8 = 0x0C;
-    pub const pcrel = 0x10;
-    pub const textrel = 0x20;
-    pub const datarel = 0x30;
-    pub const funcrel = 0x40;
-    pub const aligned = 0x50;
-    pub const indirect = 0x80;
-    pub const omit = 0xFF;
-};
-
 const x86_64 = struct {
     fn resolveReloc(rec: anytype, elf_file: *Elf, rel: elf.Elf64_Rela, source: i64, target: i64, data: []u8) !void {
         const r_type: elf.R_X86_64 = @enumFromInt(rel.r_type());
@@ -619,6 +600,7 @@ const relocation = @import("relocation.zig");
 
 const Allocator = std.mem.Allocator;
 const Atom = @import("Atom.zig");
+const DW_EH_PE = std.dwarf.EH.PE;
 const Elf = @import("../Elf.zig");
 const Object = @import("Object.zig");
 const Symbol = @import("Symbol.zig");


### PR DESCRIPTION
 * `llvm-dwarfdump --verify` passes again after unrelated zir changes revealed a dwarf bug.
 * stack traces work again now that an offset stored in `.eh_frame_hdr` is written correctly.