### PR TITLE
Improve efficiency of buffered_reader.

### DIFF
--- a/lib/std/io/buffered_reader.zig
+++ b/lib/std/io/buffered_reader.zig
@@ -27,7 +27,7 @@ pub fn BufferedReader(comptime buffer_size: usize, comptime ReaderType: type) ty
             }
 
             // If dest is large, read from the unbuffered reader directly into the destination.
-            if (dest.len > buffer_size) {
+            if (dest.len >= buffer_size) {
                 return self.unbuffered_reader.read(dest);
             }
 
@@ -135,12 +135,13 @@ test "Block" {
         var test_buf_reader: BufferedReader(4, BlockReader) = .{
             .unbuffered_reader = BlockReader.init(block, 2),
         };
+        const reader = test_buf_reader.reader();
         var out_buf: [4]u8 = undefined;
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, block);
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, block);
-        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+        try testing.expectEqual(try reader.readAll(&out_buf), 0);
     }
 
     // len out < block
@@ -148,14 +149,15 @@ test "Block" {
         var test_buf_reader: BufferedReader(4, BlockReader) = .{
             .unbuffered_reader = BlockReader.init(block, 2),
         };
+        const reader = test_buf_reader.reader();
         var out_buf: [3]u8 = undefined;
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, "012");
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, "301");
-        const n = try test_buf_reader.read(&out_buf);
+        const n = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, out_buf[0..n], "23");
-        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+        try testing.expectEqual(try reader.readAll(&out_buf), 0);
     }
 
     // len out > block
@@ -163,12 +165,13 @@ test "Block" {
         var test_buf_reader: BufferedReader(4, BlockReader) = .{
             .unbuffered_reader = BlockReader.init(block, 2),
         };
+        const reader = test_buf_reader.reader();
         var out_buf: [5]u8 = undefined;
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, "01230");
-        const n = try test_buf_reader.read(&out_buf);
+        const n = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, out_buf[0..n], "123");
-        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+        try testing.expectEqual(try reader.readAll(&out_buf), 0);
     }
 
     // len out == 0
@@ -176,8 +179,9 @@ test "Block" {
         var test_buf_reader: BufferedReader(4, BlockReader) = .{
             .unbuffered_reader = BlockReader.init(block, 2),
         };
+        const reader = test_buf_reader.reader();
         var out_buf: [0]u8 = undefined;
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, "");
     }
 
@@ -186,11 +190,12 @@ test "Block" {
         var test_buf_reader: BufferedReader(5, BlockReader) = .{
             .unbuffered_reader = BlockReader.init(block, 2),
         };
+        const reader = test_buf_reader.reader();
         var out_buf: [4]u8 = undefined;
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, block);
-        _ = try test_buf_reader.read(&out_buf);
+        _ = try reader.readAll(&out_buf);
         try testing.expectEqualSlices(u8, &out_buf, block);
-        try testing.expectEqual(try test_buf_reader.read(&out_buf), 0);
+        try testing.expectEqual(try reader.readAll(&out_buf), 0);
     }
 }

--- a/lib/std/io/buffered_reader.zig
+++ b/lib/std/io/buffered_reader.zig
@@ -17,26 +17,87 @@ pub fn BufferedReader(comptime buffer_size: usize, comptime ReaderType: type) ty
         const Self = @This();
 
         pub fn read(self: *Self, dest: []u8) Error!usize {
-            var dest_index: usize = 0;
+            // This functions has 3 steps:
+            // 1- Dump the already buffered data onto the destination.
+            // 2- Read from the unbuffered reader directly into the destination,
+            //    until we are close the end.
+            // 3- Read from the unbuffered reader into our own internal buffer,
+            //    and dump the final data onto destination.
 
-            while (dest_index < dest.len) {
-                const written = @min(dest.len - dest_index, self.end - self.start);
-                @memcpy(dest[dest_index..][0..written], self.buf[self.start..][0..written]);
-                if (written == 0) {
-                    // buf empty, fill it
-                    const n = try self.unbuffered_reader.read(self.buf[0..]);
-                    if (n == 0) {
-                        // reading from the unbuffered stream returned nothing
-                        // so we have nothing left to read.
-                        return dest_index;
-                    }
-                    self.start = 0;
-                    self.end = n;
-                }
-                self.start += written;
-                dest_index += written;
+            // Step 1- Dump the already buffered data onto the destination.
+            const current = self.buf[self.start..self.end];
+            if (dest.len <= current.len) {
+                // If we have enough buffered data to fulfill the request, we are done.
+                @memcpy(dest, current[0..dest.len]);
+                self.start += dest.len;
+                return dest.len;
             }
-            return dest.len;
+            // Otherwise, dump whatever we have onto the destination and move on
+            // to the next steps.
+            @memcpy(dest[0..current.len], current[0..current.len]);
+
+            // This marks that we don't have any buffered data. If we exit early,
+            // the reader is in a valid state.
+            self.start = self.end;
+
+            // Step 2- Read from the unbuffered reader directly into the destination,
+            //         until we are close the end.
+            var remaining_dest = dest[current.len..];
+            while (remaining_dest.len > buffer_size) {
+                const n = self.unbuffered_reader.read(remaining_dest) catch |err| {
+                    // If we already dumped something onto the destination, we are not going
+                    // to report an error.
+                    const bytes_read = dest.len - remaining_dest.len;
+
+                    return if (bytes_read == 0)
+                        err
+                    else
+                        bytes_read;
+                };
+                if (n == 0) {
+                    // reading from the unbuffered stream returned nothing,
+                    // so we have nothing left to read.
+                    return dest.len - remaining_dest.len;
+                }
+                remaining_dest = remaining_dest[n..];
+            }
+
+            // Step 3- Read from the unbuffered reader into our own internal buffer,
+            //         and dump the final data onto destination.
+            // We are going to keep reading until we have at least fulfilled the request.
+            // Hopefully we'll have something buffered for the next call.
+            while (true) {
+                self.end = self.unbuffered_reader.read(&self.buf) catch |err| {
+                    // Since we have been using self.end, we need to reset the state
+                    // of the buffer to indicate we have nothing buffered.
+                    self.start = 0;
+                    self.end = 0;
+
+                    // If we already dumped something onto the destination, we are not going
+                    // to report an error.
+                    const bytes_read = dest.len - remaining_dest.len;
+                    return if (bytes_read == 0)
+                        err
+                    else
+                        bytes_read;
+                };
+                if (self.end == 0) {
+                    // reading from the unbuffered stream returned nothing,
+                    // so we have nothing left to read.
+                    self.start = 0;
+                    return dest.len - remaining_dest.len;
+                } else if (self.end < remaining_dest.len) {
+                    // We got some data, but no enough to fulfill the request.
+                    @memcpy(remaining_dest[0..self.end], self.buf[0..self.end]);
+                    remaining_dest = remaining_dest[self.end..];
+                } else {
+                    // We have enough data to fulfill the request, and we may have
+                    // some buffered data left.
+                    @memcpy(remaining_dest, self.buf[0..remaining_dest.len]);
+                    self.start = remaining_dest.len;
+                    return dest.len;
+                }
+            }
         }
 
         pub fn reader(self: *Self) Reader {


### PR DESCRIPTION
The current implementation of buffered_reader always reads from the unbuffered reader into the internal buffer, and then dumps the data onto the destination. This is inefficient, as sometimes it's possible to read directly into the destination. The current strategy generates more memory copies and unbuffered reads than necessary. This PR implements a 3-step algorithm to buffered_reader to resolve these problems.