### PR TITLE
Some fixes for `thumb-linux-*` support

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -283,7 +283,9 @@ fn _start() callconv(.Naked) noreturn {
             \\ mov fp, #0
             \\ mov lr, #0
             \\ mov a1, sp
-            \\ and sp, #-16
+            \\ mov ip, sp
+            \\ and ip, ip, #-16
+            \\ mov sp, ip
             \\ b %[posixCallMainAndExit]
             ,
             .csky =>

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5636,10 +5636,6 @@ pub fn addCCArgs(
                 try argv.append("-Werror=date-time");
             }
 
-            if (target_util.supports_fpic(target) and mod.pic) {
-                try argv.append("-fPIC");
-            }
-
             if (mod.unwind_tables) {
                 try argv.append("-funwind-tables");
             } else {
@@ -5728,6 +5724,10 @@ pub fn addCCArgs(
                 }
             }
         },
+    }
+
+    if (target_util.supports_fpic(target) and mod.pic) {
+        try argv.append("-fPIC");
     }
 
     try argv.ensureUnusedCapacity(2);

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5536,10 +5536,6 @@ pub fn addCCArgs(
                 else => {},
             }
 
-            if (target.cpu.arch.isThumb()) {
-                try argv.append("-mthumb");
-            }
-
             {
                 var san_arg: std.ArrayListUnmanaged(u8) = .{};
                 const prefix = "-fsanitize=";
@@ -5724,6 +5720,10 @@ pub fn addCCArgs(
                 }
             }
         },
+    }
+
+    if (target.cpu.arch.isThumb()) {
+        try argv.append("-mthumb");
     }
 
     if (target_util.supports_fpic(target) and mod.pic) {

--- a/src/musl.zig
+++ b/src/musl.zig
@@ -384,6 +384,7 @@ fn addCcArgs(
     try args.appendSlice(&[_][]const u8{
         "-std=c99",
         "-ffreestanding",
+        "-fno-builtin",
         "-fexcess-precision=standard",
         "-frounding-math",
         "-fno-strict-aliasing",
@@ -422,6 +423,10 @@ fn addCcArgs(
         "-Qunused-arguments",
         "-w", // disable all warnings
     });
+
+    if (target.cpu.arch.isThumb()) {
+        try args.append("-mimplicit-it=always");
+    }
 }
 
 fn start_asm_path(comp: *Compilation, arena: Allocator, basename: []const u8) ![]const u8 {


### PR DESCRIPTION
Now we can actually build both Zig and (musl) C programs for these.

I'll probably find time to get the test suite passing and added to CI after LLVM 19.