### PR TITLE
compiler: implement decl literals

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -510,6 +510,8 @@ pub fn ArrayHashMap(
 /// `store_hash` is `false` and the number of entries in the map is less than 9,
 /// the overhead cost of using `ArrayHashMapUnmanaged` rather than `std.ArrayList` is
 /// only a single pointer-sized integer.
+///
+/// Default initialization of this struct is deprecated; use `.empty` instead.
 pub fn ArrayHashMapUnmanaged(
     comptime K: type,
     comptime V: type,
@@ -537,6 +539,12 @@ pub fn ArrayHashMapUnmanaged(
 
         /// Used to detect memory safety violations.
         pointer_stability: std.debug.SafetyLock = .{},
+
+        /// A map containing no keys or values.
+        pub const empty: Self = .{
+            .entries = .{},
+            .index_header = null,
+        };
 
         /// Modifying the key is allowed only if it does not change the hash.
         /// Modifying the value is allowed.

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -618,6 +618,8 @@ pub fn ArrayListUnmanaged(comptime T: type) type {
 /// Functions that potentially allocate memory accept an `Allocator` parameter.
 /// Initialize directly or with `initCapacity`, and deinitialize with `deinit`
 /// or use `toOwnedSlice`.
+///
+/// Default initialization of this struct is deprecated; use `.empty` instead.
 pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) type {
     if (alignment) |a| {
         if (a == @alignOf(T)) {
@@ -637,6 +639,12 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// How many T values this list can hold without allocating
         /// additional memory.
         capacity: usize = 0,
+
+        /// An ArrayList containing no elements.
+        pub const empty: Self = .{
+            .items = &.{},
+            .capacity = 0,
+        };
 
         pub const Slice = if (alignment) |a| ([]align(a) T) else []T;
 

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -721,6 +721,8 @@ pub fn HashMap(
 /// the price of handling size with u32, which should be reasonable enough
 /// for almost all uses.
 /// Deletions are achieved with tombstones.
+///
+/// Default initialization of this struct is deprecated; use `.empty` instead.
 pub fn HashMapUnmanaged(
     comptime K: type,
     comptime V: type,
@@ -761,6 +763,13 @@ pub fn HashMapUnmanaged(
         // This is purely empirical and not a /very smart magic constant™/.
         /// Capacity of the first grow when bootstrapping the hashmap.
         const minimal_capacity = 8;
+
+        /// A map containing no keys or values.
+        pub const empty: Self = .{
+            .metadata = null,
+            .size = 0,
+            .available = 0,
+        };
 
         // This hashmap is specially designed for sizes that fit in a u32.
         pub const Size = u32;

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -157,6 +157,7 @@ pub const Config = struct {
 
 pub const Check = enum { ok, leak };
 
+/// Default initialization of this struct is deprecated; use `.init` instead.
 pub fn GeneralPurposeAllocator(comptime config: Config) type {
     return struct {
         backing_allocator: Allocator = std.heap.page_allocator,
@@ -173,6 +174,16 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
         mutex: @TypeOf(mutex_init) = mutex_init,
 
         const Self = @This();
+
+        /// The initial state of a `GeneralPurposeAllocator`, containing no allocations and backed by the system page allocator.
+        pub const init: Self = .{
+            .backing_allocator = std.heap.page_allocator,
+            .buckets = [1]Buckets{.{}} ** small_bucket_count,
+            .cur_buckets = [1]?*BucketHeader{null} ** small_bucket_count,
+            .large_allocations = .{},
+            .empty_buckets = if (config.retain_metadata) .{} else {},
+            .bucket_node_pool = .init(std.heap.page_allocator),
+        };
 
         const total_requested_bytes_init = if (config.enable_memory_limit) @as(usize, 0) else {};
         const requested_memory_limit_init = if (config.enable_memory_limit) @as(usize, math.maxInt(usize)) else {};

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -684,6 +684,14 @@ pub const Inst = struct {
         /// operator. Emit a compile error if not.
         /// Uses the `un_tok` union field. Token is the `&` operator. Operand is the type.
         validate_ref_ty,
+        /// Given a type `T`, construct the type `E!T`, where `E` is this function's error set, to be used
+        /// as the result type of a `try` operand. Generic poison is propagated.
+        /// Uses the `un_node` union field. Node is the `try` expression. Operand is the type `T`.
+        try_operand_ty,
+        /// Given a type `*T`, construct the type `*E!T`, where `E` is this function's error set, to be used
+        /// as the result type of a `try` operand whose address is taken with `&`. Generic poison is propagated.
+        /// Uses the `un_node` union field. Node is the `try` expression. Operand is the type `*T`.
+        try_ref_operand_ty,
 
         // The following tags all relate to struct initialization expressions.
 
@@ -1254,6 +1262,8 @@ pub const Inst = struct {
                 .array_init_elem_type,
                 .array_init_elem_ptr,
                 .validate_ref_ty,
+                .try_operand_ty,
+                .try_ref_operand_ty,
                 .restore_err_ret_index_unconditional,
                 .restore_err_ret_index_fn_entry,
                 => false,
@@ -1324,6 +1334,8 @@ pub const Inst = struct {
                 .validate_array_init_result_ty,
                 .validate_ptr_array_init,
                 .validate_ref_ty,
+                .try_operand_ty,
+                .try_ref_operand_ty,
                 => true,
 
                 .param,
@@ -1698,6 +1710,8 @@ pub const Inst = struct {
                 .opt_eu_base_ptr_init = .un_node,
                 .coerce_ptr_elem_ty = .pl_node,
                 .validate_ref_ty = .un_tok,
+                .try_operand_ty = .un_node,
+                .try_ref_operand_ty = .un_node,
 
                 .int_from_ptr = .un_node,
                 .compile_error = .un_node,
@@ -3834,6 +3848,8 @@ fn findDeclsInner(
         .opt_eu_base_ptr_init,
         .coerce_ptr_elem_ty,
         .validate_ref_ty,
+        .try_operand_ty,
+        .try_ref_operand_ty,
         .struct_init_empty,
         .struct_init_empty_result,
         .struct_init_empty_ref_result,

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -651,6 +651,14 @@ pub const Inst = struct {
         err_union_code_ptr,
         /// An enum literal. Uses the `str_tok` union field.
         enum_literal,
+        /// A decl literal. This is similar to `field`, but unwraps error unions and optionals,
+        /// and coerces the result to the given type.
+        /// Uses the `pl_node` union field. Payload is `Field`.
+        decl_literal,
+        /// The same as `decl_literal`, but the coercion is omitted. This is used for decl literal
+        /// function call syntax, i.e. `.foo()`.
+        /// Uses the `pl_node` union field. Payload is `Field`.
+        decl_literal_no_coerce,
         /// A switch expression. Uses the `pl_node` union field.
         /// AST node is the switch, payload is `SwitchBlock`.
         switch_block,
@@ -1144,6 +1152,8 @@ pub const Inst = struct {
                 .err_union_code_ptr,
                 .ptr_type,
                 .enum_literal,
+                .decl_literal,
+                .decl_literal_no_coerce,
                 .merge_error_sets,
                 .error_union_type,
                 .bit_not,
@@ -1442,6 +1452,8 @@ pub const Inst = struct {
                 .err_union_code_ptr,
                 .ptr_type,
                 .enum_literal,
+                .decl_literal,
+                .decl_literal_no_coerce,
                 .merge_error_sets,
                 .error_union_type,
                 .bit_not,
@@ -1697,6 +1709,8 @@ pub const Inst = struct {
                 .err_union_code = .un_node,
                 .err_union_code_ptr = .un_node,
                 .enum_literal = .str_tok,
+                .decl_literal = .pl_node,
+                .decl_literal_no_coerce = .pl_node,
                 .switch_block = .pl_node,
                 .switch_block_ref = .pl_node,
                 .switch_block_err_union = .pl_node,
@@ -3842,6 +3856,8 @@ fn findDeclsInner(
         .err_union_code,
         .err_union_code_ptr,
         .enum_literal,
+        .decl_literal,
+        .decl_literal_no_coerce,
         .validate_deref,
         .validate_destructure,
         .field_type_ref,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -462,6 +462,8 @@ const Writer = struct {
 
             .field_val,
             .field_ptr,
+            .decl_literal,
+            .decl_literal_no_coerce,
             => try self.writePlNodeField(stream, inst),
 
             .field_ptr_named,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -277,6 +277,8 @@ const Writer = struct {
             .opt_eu_base_ptr_init,
             .restore_err_ret_index_unconditional,
             .restore_err_ret_index_fn_entry,
+            .try_operand_ty,
+            .try_ref_operand_ty,
             => try self.writeUnNode(stream, inst),
 
             .ref,

--- a/test/behavior.zig
+++ b/test/behavior.zig
@@ -21,6 +21,7 @@ test {
     _ = @import("behavior/cast_int.zig");
     _ = @import("behavior/comptime_memory.zig");
     _ = @import("behavior/const_slice_child.zig");
+    _ = @import("behavior/decl_literals.zig");
     _ = @import("behavior/decltest.zig");
     _ = @import("behavior/duplicated_test_names.zig");
     _ = @import("behavior/defer.zig");

--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -164,8 +164,6 @@ const Piece = packed struct {
 };
 
 test "load non byte-sized optional value" {
-    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-
     // Originally reported at https://github.com/ziglang/zig/issues/14200
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
@@ -181,8 +179,6 @@ test "load non byte-sized optional value" {
 }
 
 test "load non byte-sized value in struct" {
-    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-
     if (builtin.cpu.arch.endian() != .little) return error.SkipZigTest; // packed struct TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 

--- a/test/behavior/decl_literals.zig
+++ b/test/behavior/decl_literals.zig
@@ -1,0 +1,38 @@
+const builtin = @import("builtin");
+const std = @import("std");
+const expect = std.testing.expect;
+
+test "decl literal" {
+    const S = struct {
+        x: u32,
+        const foo: @This() = .{ .x = 123 };
+    };
+
+    const val: S = .foo;
+    try expect(val.x == 123);
+}
+
+test "call decl literal" {
+    const S = struct {
+        x: u32,
+        fn init() @This() {
+            return .{ .x = 123 };
+        }
+    };
+
+    const val: S = .init();
+    try expect(val.x == 123);
+}
+
+test "call decl literal with error union" {
+    const S = struct {
+        x: u32,
+        fn init(err: bool) !@This() {
+            if (err) return error.Bad;
+            return .{ .x = 123 };
+        }
+    };
+
+    const val: S = try .init(false);
+    try expect(val.x == 123);
+}

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1214,7 +1214,6 @@ test "anon init through error union" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
     const S = struct {
         a: u32,

--- a/test/behavior/try.zig
+++ b/test/behavior/try.zig
@@ -67,3 +67,22 @@ test "`try`ing an if/else expression" {
 
     try std.testing.expectError(error.Test, S.getError2());
 }
+
+test "try forwards result location" {
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn foo(err: bool) error{Foo}!u32 {
+            const result: error{ Foo, Bar }!u32 = if (err) error.Foo else 123;
+            const res_int: u32 = try @errorCast(result);
+            return res_int;
+        }
+    };
+
+    try expect((S.foo(false) catch return error.TestUnexpectedResult) == 123);
+    try std.testing.expectError(error.Foo, S.foo(true));
+}

--- a/test/behavior/while.zig
+++ b/test/behavior/while.zig
@@ -347,7 +347,6 @@ test "try terminating an infinite loop" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
-    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
     // Test coverage for https://github.com/ziglang/zig/issues/13546
     const Foo = struct {

--- a/test/cases/compile_errors/cast_enum_literal_to_enum_but_it_doesnt_match.zig
+++ b/test/cases/compile_errors/cast_enum_literal_to_enum_but_it_doesnt_match.zig
@@ -11,5 +11,5 @@ export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :6:21: error: no field named 'c' in enum 'tmp.Foo'
+// :6:21: error: enum 'tmp.Foo' has no member named 'c'
 // :1:13: note: enum declared here

--- a/test/cases/compile_errors/comptime_arg_to_generic_fn_callee_error.zig
+++ b/test/cases/compile_errors/comptime_arg_to_generic_fn_callee_error.zig
@@ -17,5 +17,5 @@ pub export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :7:28: error: no field named 'c' in enum 'meta.FieldEnum(tmp.MyStruct)'
+// :7:28: error: enum 'meta.FieldEnum(tmp.MyStruct)' has no member named 'c'
 // :?:?: note: enum declared here


### PR DESCRIPTION
Pretty straightforward -- see commit messages. I also added "default initialization" decls to `ArrayListUnmanaged`, `HashMapUnmanaged`, `ArrayHashMapUnmanaged`, and `GeneralPurposeAllocator`.

I am not yet using these in the compiler or standard library to avoid a need for a zig1.wasm update.

## Release Notes

Zig 0.14.0 extends the "enum literal" syntax (`.foo`) to provide a new feature, known as "decl literals". Now, an enum literal `.foo` doesn't necessarily refer to an enum variant, but, using \[Result Location Semantics\]\(langref link\), can also refer to any declaration on the target type. For instance, consider the following example:
```zig
const S = struct {
    x: u32,
    const default: S = .{ .x = 123 };
};
test "decl literal" {
    const val: S = .default;
    try std.testing.expectEqual(123, val.x);
}
const std = @import("std");
```
Since the initialization expression of `val` has a result type of `S`, the initialization is effectively equivalent to `S.default`. This can be particularly useful when initializing struct fields to avoid having to specify the type again:
```zig
const S = struct {
    x: u32,
    y: u32,
    const default: S = .{ .x = 1, .y = 2 };
    const other: S = .{ .x = 3, .y = 4 };
};
const Wrapper = struct {
    val: S = .default,
};
test "decl literal initializing struct field" {
    const a: Wrapper = .{};
    try std.testing.expectEqual(1, a.val.x);
    try std.testing.expectEqual(2, a.val.y);
    const b: Wrapper = .{ .val = .other };
    try std.testing.expectEqual(3, b.val.x);
    try std.testing.expectEqual(4, b.val.y);
}
const std = @import("std");
```
It can also help in avoiding \[Faulty Default Field Values\]\(langref link\), like in the following example:
```zig
/// `ptr` points to a `[len]u32`.
pub const BufferA = extern struct {
    ptr: ?[*]u32 = null,
    len: usize = 0
};
// The default values given above are trying to make the buffer default to "empty".
var empty_buf_a: BufferA = .{};
// However, they violate the guidance given in the language reference, because you can write this:
var bad_buf_a: BufferA = .{ .len = 10 };
// That's not safe, because the `null` and `0` defaults are "tied together". Decl literals make it
// convenient to represent this case correctly:

/// `ptr` points to a `[len]u32`.
pub const BufferB = extern struct {
    ptr: ?[*]u32,
    len: usize,
    pub const empty: BufferB = .{ .ptr = null, .len = 0 };
};
// We can still easily create an empty buffer:
var empty_buf_b: BufferB = .empty;
// ...but the language no longer hides incorrect field overrides from us!
// If we want to override a field, we'd have to specify both, making the error obvious:
var bad_buf_b: BufferB = .{ .ptr = null, .len = 10 }; // clearly wrong!
```

Many existing uses of field default values may be more appropriately handled by a declaration named `default` or `empty` or similar, to ensure data invariants are not violated by overriding single fields.

Decl literals also support function calls, like this:
```zig
const S = struct {
    x: u32,
    y: u32,
    fn init(val: u32) S {
        return .{ .x = val + 1, .y = val + 2 };
    }
};
test "call decl literal" {
    const a: S = .init(100);
    try std.testing.expectEqual(101, a.val.x);
    try std.testing.expectEqual(102, a.val.y);
}
const std = @import("std");
```

As before, this syntax can be particularly useful when initializing struct fields. It also supports calling functions which return error unions via `try`. The following example uses these in combination to initialize a thin wrapper around an `ArrayListUnmanaged`:
```zig
const Buffer = struct {
    data: std.ArrayListUnmanaged(u32),
    fn initCapacity(allocator: std.mem.Allocator, capacity: usize) !Buffer {
        return .{ .data = try .initCapacity(allocator, capacity) };
    }
};
test "initialize Buffer with decl literal" {
    var b: Buffer = try .initCapacity(std.testing.allocator, 5);
    defer b.data.deinit(std.testing.allocator);
    b.data.appendAssumeCapacity(123);
    try std.testing.expectEqual(1, b.data.items.len);
    try std.testing.expectEqual(123, b.data.items[0]);
}
```

The introduction of decl literals comes with some standard library changes. In particular, unmanaged containers, including `ArrayListUnmanaged` and `HashMapUnmanaged`, should no longer be default-initialized with `.{}`, because the default field values here violate the guidance discussed above. Instead, they should be initialized using their `empty` declaration, which can be conveniently accessed via decl literals:
```zig
const Buffer = struct {
    foo: std.ArrayListUnmanaged(u32) = .empty,
};
test "default initialize Buffer" {
    var b: Buffer = .{};
    defer b.data.deinit(std.testing.allocator);
    b.data.appendAssumeCapacity(123);
    try std.testing.expectEqual(1, b.data.items.len);
    try std.testing.expectEqual(123, b.data.items[0]);
}
```
Similarly, `std.heap.GeneralPurposeAllocator` should now be initialized with its `.init` declaration.

The deprecated default field values for these data structures will be removed in the next release cycle.