### PR TITLE
`glibc`: Avoid building and linking stub libraries that were emptied in 2.34

### DIFF
--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -16,6 +16,7 @@ const Module = @import("Package/Module.zig");
 pub const Lib = struct {
     name: []const u8,
     sover: u8,
+    removed_in: ?Version = null,
 };
 
 pub const ABI = struct {
@@ -34,12 +35,12 @@ pub const ABI = struct {
 // The order of the elements in this array defines the linking order.
 pub const libs = [_]Lib{
     .{ .name = "m", .sover = 6 },
-    .{ .name = "pthread", .sover = 0 },
+    .{ .name = "pthread", .sover = 0, .removed_in = .{ .major = 2, .minor = 34, .patch = 0 } },
     .{ .name = "c", .sover = 6 },
-    .{ .name = "dl", .sover = 2 },
-    .{ .name = "rt", .sover = 1 },
+    .{ .name = "dl", .sover = 2, .removed_in = .{ .major = 2, .minor = 34, .patch = 0 } },
+    .{ .name = "rt", .sover = 1, .removed_in = .{ .major = 2, .minor = 34, .patch = 0 } },
     .{ .name = "ld", .sover = 2 },
-    .{ .name = "util", .sover = 1 },
+    .{ .name = "util", .sover = 1, .removed_in = .{ .major = 2, .minor = 34, .patch = 0 } },
     .{ .name = "resolv", .sover = 2 },
 };
 
@@ -797,6 +798,10 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
     defer stubs_asm.deinit();
 
     for (libs, 0..) |lib, lib_i| {
+        if (lib.removed_in) |rem_in| {
+            if (target_version.order(rem_in) != .lt) continue;
+        }
+
         stubs_asm.shrinkRetainingCapacity(0);
         try stubs_asm.appendSlice(".text\n");
 

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -840,6 +840,10 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
         } else if (target.isGnuLibC()) {
             try system_libs.ensureUnusedCapacity(glibc.libs.len + 1);
             for (glibc.libs) |lib| {
+                if (lib.removed_in) |rem_in| {
+                    if (target.os.version_range.linux.glibc.order(rem_in) != .lt) continue;
+                }
+
                 const lib_path = try std.fmt.allocPrint(arena, "{s}{c}lib{s}.so.{d}", .{
                     comp.glibc_so_files.?.dir_path, fs.path.sep, lib.name, lib.sover,
                 });
@@ -1286,6 +1290,10 @@ fn dumpArgv(self: *Elf, comp: *Compilation) !void {
                 if (needs_grouping) try argv.append("--end-group");
             } else if (target.isGnuLibC()) {
                 for (glibc.libs) |lib| {
+                    if (lib.removed_in) |rem_in| {
+                        if (target.os.version_range.linux.glibc.order(rem_in) != .lt) continue;
+                    }
+
                     const lib_path = try std.fmt.allocPrint(arena, "{s}{c}lib{s}.so.{d}", .{
                         comp.glibc_so_files.?.dir_path, fs.path.sep, lib.name, lib.sover,
                     });
@@ -2288,6 +2296,10 @@ fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: s
                     if (needs_grouping) try argv.append("--end-group");
                 } else if (target.isGnuLibC()) {
                     for (glibc.libs) |lib| {
+                        if (lib.removed_in) |rem_in| {
+                            if (target.os.version_range.linux.glibc.order(rem_in) != .lt) continue;
+                        }
+
                         const lib_path = try std.fmt.allocPrint(arena, "{s}{c}lib{s}.so.{d}", .{
                             comp.glibc_so_files.?.dir_path, fs.path.sep, lib.name, lib.sover,
                         });


### PR DESCRIPTION
Closes #20919.

```console
❯ zig4 cc system.c -target x86_64-linux-gnu.2.33
❯ ldd a.out
        linux-vdso.so.1 (0x00007ffc0ba83000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x0000795644147000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000795643e00000)
        /lib64/ld-linux-x86-64.so.2 (0x0000795644181000)
❯ zig4 cc system.c -target x86_64-linux-gnu.2.34
❯ ldd a.out
        linux-vdso.so.1 (0x00007ffd4eb0f000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000075bec1200000)
        /lib64/ld-linux-x86-64.so.2 (0x000075bec14ba000)
```

See: https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html (note: this includes librt too, despite it not being mentioned)