### PR TITLE
LLVM: Set module flags through Builder instead of LLVM API bindings

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1107,12 +1107,12 @@ pub const Object = struct {
             const behavior_max = try o.builder.metadataConstant(try o.builder.intConst(.i32, 7));
             const behavior_min = try o.builder.metadataConstant(try o.builder.intConst(.i32, 8));
 
-            const large_pic = target_util.usesLargePIC(comp.root_mod.resolved_target.result);
+            const pic_level = target_util.picLevel(comp.root_mod.resolved_target.result);
             if (comp.root_mod.pic) {
                 module_flags.appendAssumeCapacity(try o.builder.metadataModuleFlag(
                     behavior_min,
                     try o.builder.metadataString("PIC Level"),
-                    try o.builder.metadataConstant(try o.builder.intConst(.i32, @as(i32, if (large_pic) 2 else 1))),
+                    try o.builder.metadataConstant(try o.builder.intConst(.i32, pic_level)),
                 ));
             }
 
@@ -1120,7 +1120,7 @@ pub const Object = struct {
                 module_flags.appendAssumeCapacity(try o.builder.metadataModuleFlag(
                     behavior_max,
                     try o.builder.metadataString("PIE Level"),
-                    try o.builder.metadataConstant(try o.builder.intConst(.i32, @as(i32, if (large_pic) 2 else 1))),
+                    try o.builder.metadataConstant(try o.builder.intConst(.i32, pic_level)),
                 ));
             }
 

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -11899,10 +11899,10 @@ pub fn trailingMetadataStringAssumeCapacity(self: *Builder) MetadataString {
     return @enumFromInt(gop.index);
 }
 
-pub fn debugNamed(self: *Builder, name: MetadataString, operands: []const Metadata) Allocator.Error!void {
+pub fn metadataNamed(self: *Builder, name: MetadataString, operands: []const Metadata) Allocator.Error!void {
     try self.metadata_extra.ensureUnusedCapacity(self.gpa, operands.len);
     try self.metadata_named.ensureUnusedCapacity(self.gpa, 1);
-    self.debugNamedAssumeCapacity(name, operands);
+    self.metadataNamedAssumeCapacity(name, operands);
 }
 
 fn metadataNone(self: *Builder) Allocator.Error!Metadata {
@@ -12213,14 +12213,14 @@ pub fn strTuple(
     return self.strTupleAssumeCapacity(str, elements);
 }
 
-pub fn debugModuleFlag(
+pub fn metadataModuleFlag(
     self: *Builder,
     behavior: Metadata,
     name: MetadataString,
     constant: Metadata,
 ) Allocator.Error!Metadata {
     try self.ensureUnusedMetadataCapacity(1, Metadata.ModuleFlag, 0);
-    return self.debugModuleFlagAssumeCapacity(behavior, name, constant);
+    return self.metadataModuleFlagAssumeCapacity(behavior, name, constant);
 }
 
 pub fn debugLocalVar(
@@ -12365,8 +12365,7 @@ fn metadataDistinctAssumeCapacity(self: *Builder, tag: Metadata.Tag, value: anyt
     return @enumFromInt(gop.index);
 }
 
-fn debugNamedAssumeCapacity(self: *Builder, name: MetadataString, operands: []const Metadata) void {
-    assert(!self.strip);
+fn metadataNamedAssumeCapacity(self: *Builder, name: MetadataString, operands: []const Metadata) void {
     assert(name != .none);
     const extra_index: u32 = @intCast(self.metadata_extra.items.len);
     self.metadata_extra.appendSliceAssumeCapacity(@ptrCast(operands));
@@ -12949,13 +12948,12 @@ fn strTupleAssumeCapacity(
     return @enumFromInt(gop.index);
 }
 
-fn debugModuleFlagAssumeCapacity(
+fn metadataModuleFlagAssumeCapacity(
     self: *Builder,
     behavior: Metadata,
     name: MetadataString,
     constant: Metadata,
 ) Metadata {
-    assert(!self.strip);
     return self.metadataSimpleAssumeCapacity(.module_flag, Metadata.ModuleFlag{
         .behavior = behavior,
         .name = name,

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -51,15 +51,6 @@ pub const Context = opaque {
 pub const Module = opaque {
     pub const dispose = LLVMDisposeModule;
     extern fn LLVMDisposeModule(*Module) void;
-
-    pub const setModulePICLevel = ZigLLVMSetModulePICLevel;
-    extern fn ZigLLVMSetModulePICLevel(module: *Module, big: bool) void;
-
-    pub const setModulePIELevel = ZigLLVMSetModulePIELevel;
-    extern fn ZigLLVMSetModulePIELevel(module: *Module, large: bool) void;
-
-    pub const setModuleCodeModel = ZigLLVMSetModuleCodeModel;
-    extern fn ZigLLVMSetModuleCodeModel(module: *Module, code_model: CodeModel) void;
 };
 
 pub const disposeMessage = LLVMDisposeMessage;

--- a/src/target.zig
+++ b/src/target.zig
@@ -49,10 +49,10 @@ pub fn requiresPIC(target: std.Target, linking_libc: bool) bool {
         (target.abi == .ohos and target.cpu.arch == .aarch64);
 }
 
-pub fn usesLargePIC(target: std.Target) bool {
+pub fn picLevel(target: std.Target) u32 {
     // MIPS always uses PIC level 1; other platforms vary in their default PIC levels, but they
     // support both level 1 and 2, in which case we prefer 2.
-    return !target.cpu.arch.isMIPS();
+    return if (target.cpu.arch.isMIPS()) 1 else 2;
 }
 
 /// This is not whether the target supports Position Independent Code, but whether the -fPIC

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -435,20 +435,6 @@ void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv) {
     cl::ParseCommandLineOptions(argc, argv);
 }
 
-void ZigLLVMSetModulePICLevel(LLVMModuleRef module, bool big) {
-    unwrap(module)->setPICLevel(big ? PICLevel::Level::BigPIC : PICLevel::Level::SmallPIC);
-}
-
-void ZigLLVMSetModulePIELevel(LLVMModuleRef module, bool large) {
-    unwrap(module)->setPIELevel(large ? PIELevel::Level::Large : PIELevel::Level::Small);
-}
-
-void ZigLLVMSetModuleCodeModel(LLVMModuleRef module, LLVMCodeModel code_model) {
-    bool JIT;
-    unwrap(module)->setCodeModel(*unwrap(code_model, JIT));
-    assert(!JIT);
-}
-
 bool ZigLLVMWriteImportLibrary(const char *def_path, const ZigLLVM_ArchType arch,
                                const char *output_lib_path, bool kill_at)
 {

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -155,10 +155,6 @@ enum ZigLLVM_CallingConv {
     ZigLLVM_MaxID = 1023,
 };
 
-ZIG_EXTERN_C void ZigLLVMSetModulePICLevel(LLVMModuleRef module, bool big);
-ZIG_EXTERN_C void ZigLLVMSetModulePIELevel(LLVMModuleRef module, bool large);
-ZIG_EXTERN_C void ZigLLVMSetModuleCodeModel(LLVMModuleRef module, LLVMCodeModel code_model);
-
 ZIG_EXTERN_C void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv);
 
 // synchronize with llvm/include/ADT/Triple.h::ArchType


### PR DESCRIPTION
Closes #21238

This PR also now sets the module flag behaviors to match what LLVM and clang does, before it set everything to warning