### PR TITLE
std.time.epoch: change getDaysInMonth to accept the year as an argument

### DIFF
--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -607,11 +607,10 @@ const Date = struct {
         }
 
         {
-            const is_leap = std.time.epoch.isLeapYear(date.year);
             var month: u4 = 1;
             while (month < date.month) : (month += 1) {
                 const days: u64 = std.time.epoch.getDaysInMonth(
-                    @as(std.time.epoch.YearLeapKind, @enumFromInt(@intFromBool(is_leap))),
+                    date.year,
                     @as(std.time.epoch.Month, @enumFromInt(month)),
                 );
                 sec += days * std.time.epoch.secs_per_day;

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -141,11 +141,10 @@ pub const Time = extern struct {
     pub const unspecified_timezone: i16 = 0x7ff;
 
     fn daysInYear(year: u16, max_month: u4) u9 {
-        const leap_year: std.time.epoch.YearLeapKind = if (std.time.epoch.isLeapYear(year)) .leap else .not_leap;
         var days: u9 = 0;
         var month: u4 = 0;
         while (month < max_month) : (month += 1) {
-            days += std.time.epoch.getDaysInMonth(leap_year, @enumFromInt(month + 1));
+            days += std.time.epoch.getDaysInMonth(year, @enumFromInt(month + 1));
         }
         return days;
     }

--- a/lib/std/time/epoch.zig
+++ b/lib/std/time/epoch.zig
@@ -64,8 +64,6 @@ pub fn getDaysInYear(year: Year) u9 {
     return if (isLeapYear(year)) 366 else 365;
 }
 
-pub const YearLeapKind = enum(u1) { not_leap, leap };
-
 pub const Month = enum(u4) {
     jan = 1,
     feb,
@@ -87,13 +85,13 @@ pub const Month = enum(u4) {
     }
 };
 
-/// Get the number of days in the given month
-pub fn getDaysInMonth(leap_year: YearLeapKind, month: Month) u5 {
+/// Get the number of days in the given month and year
+pub fn getDaysInMonth(year: Year, month: Month) u5 {
     return switch (month) {
         .jan => 31,
-        .feb => @as(u5, switch (leap_year) {
-            .leap => 29,
-            .not_leap => 28,
+        .feb => @as(u5, switch (isLeapYear(year)) {
+            true => 29,
+            false => 28,
         }),
         .mar => 31,
         .apr => 30,
@@ -116,9 +114,8 @@ pub const YearAndDay = struct {
     pub fn calculateMonthDay(self: YearAndDay) MonthAndDay {
         var month: Month = .jan;
         var days_left = self.day;
-        const leap_kind: YearLeapKind = if (isLeapYear(self.year)) .leap else .not_leap;
         while (true) {
-            const days_in_month = getDaysInMonth(leap_kind, month);
+            const days_in_month = getDaysInMonth(self.year, month);
             if (days_left < days_in_month)
                 break;
             days_left -= days_in_month;


### PR DESCRIPTION
Changes `getDaysInMonth` to accept the year as an argument instead of `YearLeapKind`. I also deleted `YearLeapKind` since it was only being used for `getDaysInMonth` but I can bring it back if wanted.