### PR TITLE
AstGen: update @errorCast to maybe eval to err

### DIFF
--- a/lib/std/zig/BuiltinFn.zig
+++ b/lib/std/zig/BuiltinFn.zig
@@ -482,7 +482,7 @@ pub const list = list: {
             "@errorCast",
             .{
                 .tag = .error_cast,
-                .eval_to_error = .always,
+                .eval_to_error = .maybe,
                 .param_count = 1,
             },
         },


### PR DESCRIPTION
Consequently, `AstGen.ret()` now passes the error code to `.defer_error_code`. Previously, the error union value was passed.

closes #20371