### PR TITLE
std.fs: support `Lock.none` on Windows

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1691,7 +1691,7 @@ pub fn tryLock(file: File, l: Lock) LockError!bool {
     if (is_windows) {
         var io_status_block: windows.IO_STATUS_BLOCK = undefined;
         const exclusive = switch (l) {
-            .none => return,
+            .none => return true,
             .shared => false,
             .exclusive => true,
         };

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1632,7 +1632,7 @@ pub fn lock(file: File, l: Lock) LockError!void {
                 null,
             ) catch |err| switch (err) {
                 error.RangeNotLocked => unreachable, // The file is assumed to be locked.
-                error.Unexpected => unreachable, // Resource deallocation must succeed.
+                error.Unexpected => return error.Unexpected,
             },
             .shared => false,
             .exclusive => true,
@@ -1709,7 +1709,7 @@ pub fn tryLock(file: File, l: Lock) LockError!bool {
                     null,
                 ) catch |err| switch (err) {
                     error.RangeNotLocked => unreachable, // The file is assumed to be locked.
-                    error.Unexpected => unreachable, // Resource deallocation must succeed.
+                    error.Unexpected => return error.Unexpected,
                 };
 
                 return true;
@@ -1780,7 +1780,7 @@ pub fn downgradeLock(file: File) LockError!void {
             null,
         ) catch |err| switch (err) {
             error.RangeNotLocked => unreachable, // File was not locked.
-            error.Unexpected => unreachable, // Resource deallocation must succeed.
+            error.Unexpected => return error.Unexpected,
         };
     } else {
         return posix.flock(file.handle, posix.LOCK.SH | posix.LOCK.NB) catch |err| switch (err) {

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1994,31 +1994,6 @@ test "delete a setAsCwd directory on Windows" {
     tmp.parent_dir.close();
 }
 
-test "use Lock.none on Windows" {
-    if (native_os != .windows) return error.SkipZigTest;
-
-    var tmp = tmpDir(.{});
-    defer tmp.cleanup();
-
-    // Create a locked file.
-    const test_file = try tmp.dir.createFile("test_file", .{ .lock = .exclusive, .lock_nonblocking = true });
-    defer test_file.close();
-
-    // Attempt to unlock the file via fs.lock with Lock.none.
-    try File.lock(test_file, .none);
-
-    // Attempt to open the file now that it should be unlocked.
-    const test_file2 = try tmp.dir.openFile("test_file", .{ .lock = .exclusive, .lock_nonblocking = true });
-    defer test_file2.close();
-
-    // Make sure Lock.none works with tryLock as well.
-    try testing.expect(try File.tryLock(test_file2, .none));
-
-    // Attempt to open the file since it should be unlocked again.
-    const test_file3 = try tmp.dir.openFile("test_file", .{});
-    test_file3.close();
-}
-
 test "invalid UTF-8/WTF-8 paths" {
     const expected_err = switch (native_os) {
         .wasi => error.InvalidUtf8,

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1969,6 +1969,31 @@ test "delete a setAsCwd directory on Windows" {
     tmp.parent_dir.close();
 }
 
+test "use Lock.none on Windows" {
+    if (native_os != .windows) return error.SkipZigTest;
+
+    var tmp = tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Create a locked file.
+    const test_file = try tmp.dir.createFile("test_file", .{ .lock = .exclusive, .lock_nonblocking = true });
+    defer test_file.close();
+
+    // Attempt to unlock the file via fs.lock with Lock.none.
+    try File.lock(test_file, .none);
+
+    // Attempt to open the file now that it should be unlocked.
+    const test_file2 = try tmp.dir.openFile("test_file", .{ .lock = .exclusive, .lock_nonblocking = true });
+    defer test_file2.close();
+
+    // Make sure Lock.none works with tryLock as well.
+    try testing.expect(try File.tryLock(test_file2, .none));
+
+    // Attempt to open the file since it should be unlocked again.
+    const test_file3 = try tmp.dir.openFile("test_file", .{});
+    test_file3.close();
+}
+
 test "invalid UTF-8/WTF-8 paths" {
     const expected_err = switch (native_os) {
         .wasi => error.InvalidUtf8,

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1923,6 +1923,31 @@ test "File.PermissionsUnix" {
     try testing.expect(!permissions_unix.unixHas(.other, .execute));
 }
 
+test "use Lock.none to unlock files" {
+    if (native_os == .wasi) return error.SkipZigTest;
+
+    var tmp = tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Create a locked file.
+    const test_file = try tmp.dir.createFile("test_file", .{ .lock = .exclusive, .lock_nonblocking = true });
+    defer test_file.close();
+
+    // Attempt to unlock the file via fs.lock with Lock.none.
+    try File.lock(test_file, .none);
+
+    // Attempt to open the file now that it should be unlocked.
+    const test_file2 = try tmp.dir.openFile("test_file", .{ .lock = .exclusive, .lock_nonblocking = true });
+    defer test_file2.close();
+
+    // Make sure Lock.none works with tryLock as well.
+    try testing.expect(try File.tryLock(test_file2, .none));
+
+    // Attempt to open the file since it should be unlocked again.
+    const test_file3 = try tmp.dir.openFile("test_file", .{});
+    test_file3.close();
+}
+
 test "delete a read-only file on windows" {
     if (native_os != .windows)
         return error.SkipZigTest;

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -2054,7 +2054,7 @@ pub fn LockFile(
     Key: ?*ULONG,
     FailImmediately: BOOLEAN,
     ExclusiveLock: BOOLEAN,
-) !void {
+) LockFileError!void {
     const rc = ntdll.NtLockFile(
         FileHandle,
         Event,
@@ -2086,7 +2086,7 @@ pub fn UnlockFile(
     ByteOffset: *const LARGE_INTEGER,
     Length: *const LARGE_INTEGER,
     Key: ?*ULONG,
-) !void {
+) UnlockFileError!void {
     const rc = ntdll.NtUnlockFile(FileHandle, IoStatusBlock, ByteOffset, Length, Key);
     switch (rc) {
         .SUCCESS => return,


### PR DESCRIPTION
Fixes #18430. Borrows code from #18566.

I also made `std.windows.LockFile` and `std.windows.UnlockFile` use the relevant explicit error set. 

The doc comments and Windows API for `File.lock` `File.tryLock` have been changed to match the POSIX implimentation.