### PR TITLE
Force ELFv2 for PPC64 and add `powerpc64-linux-(none,musl)` to CI

### DIFF
--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1891,7 +1891,7 @@ test "reinterpret packed union" {
     try comptime S.doTheTest();
 
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
-    if (builtin.cpu.arch.isPowerPC32()) return error.SkipZigTest; // TODO
+    if (builtin.cpu.arch.isPowerPC()) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21050
     if (builtin.cpu.arch.isMIPS()) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21050
     if (builtin.cpu.arch.isWasm()) return error.SkipZigTest; // TODO
     try S.doTheTest();

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -1450,6 +1450,7 @@ test "store vector with memset" {
             .mips64el,
             .riscv64,
             .powerpc,
+            .powerpc64,
             => {
                 // LLVM 16 ERROR: "Converting bits to bytes lost precision"
                 // https://github.com/ziglang/zig/issues/16177

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -440,6 +440,30 @@ const test_targets = blk: {
 
         .{
             .target = .{
+                .cpu_arch = .powerpc64,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+        },
+        .{
+            .target = .{
+                .cpu_arch = .powerpc64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
+        // Requires ELFv1 linker support.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .powerpc64,
+        //         .os_tag = .linux,
+        //         .abi = .gnu,
+        //     },
+        //     .link_libc = true,
+        // },
+        .{
+            .target = .{
                 .cpu_arch = .powerpc64le,
                 .os_tag = .linux,
                 .abi = .none,


### PR DESCRIPTION
See commit messages and comments.

The main motivators for this change are to make it so that you can actually build binaries for `powerpc64-linux-none`, and to make it so we have CI coverage for big-endian PPC64.