### PR TITLE
`glibc`: Patch to work around missing features in LLVM's s390x assembler.

### DIFF
--- a/lib/libc/glibc/sysdeps/s390/s390-32/start-2.33.S
+++ b/lib/libc/glibc/sysdeps/s390/s390-32/start-2.33.S
@@ -61,7 +61,8 @@
 _start:
 	cfi_startproc
 	/* Mark r14 as undefined in order to stop unwinding here!  */
-	cfi_undefined (r14)
+	/* zig patch: r14 -> %r14. revert with llvm 20. */
+	cfi_undefined (%r14)
 
 	/* Check if the kernel provides highgprs facility if needed by
 	   the binary.  */

--- a/lib/libc/glibc/sysdeps/s390/s390-32/start.S
+++ b/lib/libc/glibc/sysdeps/s390/s390-32/start.S
@@ -60,7 +60,8 @@
 _start:
 	cfi_startproc
 	/* Mark r14 as undefined in order to stop unwinding here!  */
-	cfi_undefined (r14)
+	/* zig patch: r14 -> %r14. revert with llvm 20. */
+	cfi_undefined (%r14)
 
 	/* Check if the kernel provides highgprs facility if needed by
 	   the binary.  */

--- a/lib/libc/glibc/sysdeps/s390/s390-64/crti.S
+++ b/lib/libc/glibc/sysdeps/s390/s390-64/crti.S
@@ -67,7 +67,8 @@ _init:
 	stg	%r1,0(%r15)
 	larl	%r12,_GLOBAL_OFFSET_TABLE_
 #if PREINIT_FUNCTION_WEAK
-	larl	%r1,PREINIT_FUNCTION@GOTENT
+	/* zig patch: GOTENT -> GOT. revert with llvm 20. */
+	larl	%r1,PREINIT_FUNCTION@GOT
 	lg	%r1,0(%r1)
 	ltgr	%r1,%r1
 	je	1f

--- a/lib/libc/glibc/sysdeps/s390/s390-64/start-2.33.S
+++ b/lib/libc/glibc/sysdeps/s390/s390-64/start-2.33.S
@@ -61,7 +61,8 @@
 _start:
 	cfi_startproc
 	/* Mark r14 as undefined in order to stop unwinding here!  */
-	cfi_undefined (r14)
+	/* zig patch: r14 -> %r14. revert with llvm 20. */
+	cfi_undefined (%r14)
 	/* Load argc and argv from stack.  */
 	la	%r4,8(%r15)		# get argv
 	lg	%r3,0(%r15)		# get argc
@@ -85,7 +86,8 @@ _start:
 
 	/* Ok, now branch to the libc main routine.  */
 #ifdef PIC
-	larl	%r2,main@GOTENT		# load pointer to main
+	/* zig patch: GOTENT -> GOT. revert with llvm 20. */
+	larl	%r2,main@GOT		# load pointer to main
 	lg	%r2,0(%r2)
 	brasl	%r14,__libc_start_main@plt
 #else

--- a/lib/libc/glibc/sysdeps/s390/s390-64/start.S
+++ b/lib/libc/glibc/sysdeps/s390/s390-64/start.S
@@ -60,7 +60,8 @@
 _start:
 	cfi_startproc
 	/* Mark r14 as undefined in order to stop unwinding here!  */
-	cfi_undefined (r14)
+	/* zig patch: r14 -> %r14. revert with llvm 20. */
+	cfi_undefined (%r14)
 	/* Load argc and argv from stack.  */
 	la	%r4,8(%r15)		# get argv
 	lg	%r3,0(%r15)		# get argc
@@ -87,7 +88,8 @@ _start:
 # ifdef SHARED
 	/* Used for dynamic linked position independent executable.
 	   => Scrt1.o  */
-	larl	%r2,main@GOTENT		# load pointer to main
+	/* zig patch: GOTENT -> GOT. revert with llvm 20. */
+	larl	%r2,main@GOT		# load pointer to main
 	lg	%r2,0(%r2)
 # else
 	/* Used for dynamic linked position dependent executable.
@@ -119,7 +121,8 @@ _start:
 	   use of GOT relocations before __libc_start_main is called.  */
 __wrap_main:
 	cfi_startproc
-	larl	%r1,main@GOTENT		# load pointer to main
+	/* zig patch: GOTENT -> GOT. revert with llvm 20. */
+	larl	%r1,main@GOT		# load pointer to main
 	lg	%r1,0(%r1)
 	br	%r1
 	cfi_endproc


### PR DESCRIPTION
This should be reverted with LLVM 20. PRs that add the missing functionality:

* https://github.com/llvm/llvm-project/pull/107032
* https://github.com/llvm/llvm-project/pull/107038

With this patch plus #21037 and #21195, this now works:

```console
❯ zig4 cc main.c -target s390x-linux-gnu
❯ qemu-s390x -L /opt/glibc/s390x-linux-gnu ./a.out
hello world
```

Next step is adding the `std.os.linux` arch bits and Zig should have ~full support for s390x.