### PR TITLE
package-manager: add application/x-tar-gz mime type

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1067,7 +1067,8 @@ fn unpackResource(
 
             if (ascii.eqlIgnoreCase(mime_type, "application/gzip") or
                 ascii.eqlIgnoreCase(mime_type, "application/x-gzip") or
-                ascii.eqlIgnoreCase(mime_type, "application/tar+gzip"))
+                ascii.eqlIgnoreCase(mime_type, "application/tar+gzip") or
+                ascii.eqlIgnoreCase(mime_type, "application/x-tar-gz"))
             {
                 break :ft .@"tar.gz";
             }


### PR DESCRIPTION
Closes #21314

This allows the package manger to download tar.gz bitbucket urls.

I've verified that this works for the url in the linked issue.