### PR TITLE
`test`: Re-enable `vector shift operators` and `vector reduce operation`

### DIFF
--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -743,23 +743,6 @@ test "vector shift operators" {
         }
     };
 
-    switch (builtin.target.cpu.arch) {
-        .aarch64_be,
-        .armeb,
-        .thumb,
-        .thumbeb,
-        .mips,
-        .mips64,
-        .mips64el,
-        .sparc64,
-        => {
-            // LLVM miscompiles on this architecture
-            // https://github.com/ziglang/zig/issues/4951
-            return error.SkipZigTest;
-        },
-        else => {},
-    }
-
     try S.doTheTest();
     try comptime S.doTheTest();
 }

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -805,14 +805,8 @@ test "vector reduce operation" {
             try testReduce(.Min, [4]u16{ 1, 2, 3, 4 }, @as(u16, 1));
             try testReduce(.Min, [4]i32{ 1234567, -386, 0, 3 }, @as(i32, -386));
             try testReduce(.Min, [4]u32{ 99, 9999, 9, 99999 }, @as(u32, 9));
-
-            // LLVM 11 ERROR: Cannot select type
-            // https://github.com/ziglang/zig/issues/7138
-            if (builtin.zig_backend != .stage2_llvm or builtin.target.cpu.arch != .aarch64) {
-                try testReduce(.Min, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, -386));
-                try testReduce(.Min, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 9));
-            }
-
+            try testReduce(.Min, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, -386));
+            try testReduce(.Min, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 9));
             try testReduce(.Min, [4]i128{ 1234567, -386, 0, 3 }, @as(i128, -386));
             try testReduce(.Min, [4]u128{ 99, 9999, 9, 99999 }, @as(u128, 9));
             try testReduce(.Min, [4]f16{ -10.3, 10.0e9, 13.0, -100.0 }, @as(f16, -100.0));
@@ -823,14 +817,8 @@ test "vector reduce operation" {
             try testReduce(.Max, [4]u16{ 1, 2, 3, 4 }, @as(u16, 4));
             try testReduce(.Max, [4]i32{ 1234567, -386, 0, 3 }, @as(i32, 1234567));
             try testReduce(.Max, [4]u32{ 99, 9999, 9, 99999 }, @as(u32, 99999));
-
-            // LLVM 11 ERROR: Cannot select type
-            // https://github.com/ziglang/zig/issues/7138
-            if (builtin.zig_backend != .stage2_llvm or builtin.target.cpu.arch != .aarch64) {
-                try testReduce(.Max, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, 1234567));
-                try testReduce(.Max, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 99999));
-            }
-
+            try testReduce(.Max, [4]i64{ 1234567, -386, 0, 3 }, @as(i64, 1234567));
+            try testReduce(.Max, [4]u64{ 99, 9999, 9, 99999 }, @as(u64, 99999));
             try testReduce(.Max, [4]i128{ 1234567, -386, 0, 3 }, @as(i128, 1234567));
             try testReduce(.Max, [4]u128{ 99, 9999, 9, 99999 }, @as(u128, 99999));
             try testReduce(.Max, [4]f16{ -10.3, 10.0e9, 13.0, -100.0 }, @as(f16, 10.0e9));
@@ -872,17 +860,13 @@ test "vector reduce operation" {
             try testReduce(.Add, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, f32_nan);
             try testReduce(.Add, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, f64_nan);
 
-            // LLVM 11 ERROR: Cannot select type
-            // https://github.com/ziglang/zig/issues/7138
-            if (builtin.zig_backend != .stage2_llvm) {
-                try testReduce(.Min, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, @as(f16, -1.9));
-                try testReduce(.Min, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, @as(f32, -1.9));
-                try testReduce(.Min, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, @as(f64, -1.9));
+            try testReduce(.Min, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, @as(f16, -1.9));
+            try testReduce(.Min, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, @as(f32, -1.9));
+            try testReduce(.Min, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, @as(f64, -1.9));
 
-                try testReduce(.Max, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, @as(f16, 100.0));
-                try testReduce(.Max, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, @as(f32, 100.0));
-                try testReduce(.Max, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, @as(f64, 100.0));
-            }
+            try testReduce(.Max, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, @as(f16, 100.0));
+            try testReduce(.Max, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, @as(f32, 100.0));
+            try testReduce(.Max, [4]f64{ -1.9, 5.1, f64_nan, 100.0 }, @as(f64, 100.0));
 
             try testReduce(.Mul, [4]f16{ -1.9, 5.1, f16_nan, 100.0 }, f16_nan);
             try testReduce(.Mul, [4]f32{ -1.9, 5.1, f32_nan, 100.0 }, f32_nan);


### PR DESCRIPTION
These seem to work now.