### PR TITLE
`std`: Fix assembler comment syntax for sparc.

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -1221,12 +1221,12 @@ const LinuxThreadImpl = struct {
                     \\  ba 1b
                     \\  restore
                     \\ 2:
-                    \\  mov 73, %%g1 # SYS_munmap
+                    \\  mov 73, %%g1 // SYS_munmap
                     \\  mov %[ptr], %%o0
                     \\  mov %[len], %%o1
                     \\  t 0x3 # ST_FLUSH_WINDOWS
                     \\  t 0x10
-                    \\  mov 1, %%g1 # SYS_exit
+                    \\  mov 1, %%g1 // SYS_exit
                     \\  mov 0, %%o0
                     \\  t 0x10
                     :
@@ -1246,14 +1246,14 @@ const LinuxThreadImpl = struct {
                     \\  ba 1b
                     \\  restore
                     \\ 2:
-                    \\  mov 73, %%g1 # SYS_munmap
+                    \\  mov 73, %%g1 // SYS_munmap
                     \\  mov %[ptr], %%o0
                     \\  mov %[len], %%o1
                     \\  # Flush register window contents to prevent background
                     \\  # memory access before unmapping the stack.
                     \\  flushw
                     \\  t 0x6d
-                    \\  mov 1, %%g1 # SYS_exit
+                    \\  mov 1, %%g1 // SYS_exit
                     \\  mov 0, %%o0
                     \\  t 0x6d
                     :

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -190,7 +190,7 @@ pub fn clone() callconv(.Naked) usize {
         \\ mov %%i0, %%g2
         \\ mov %%i3, %%g3
         \\ # Shuffle the arguments
-        \\ mov 217, %%g1 # SYS_clone
+        \\ mov 217, %%g1 // SYS_clone
         \\ mov %%i2, %%o0
         \\ # Add some extra space for the initial frame
         \\ sub %%i1, 176 + 2047, %%o1
@@ -214,7 +214,7 @@ pub fn clone() callconv(.Naked) usize {
         \\ call %%g2
         \\ mov %%g3, %%o0
         \\ # Exit
-        \\ mov 1, %%g1 # SYS_exit
+        \\ mov 1, %%g1 // SYS_exit
         \\ t 0x6d
         \\2:
         \\ # The syscall failed


### PR DESCRIPTION
Assemblers suck. :neutral_face: