### PR TITLE
Format json structs

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -11,6 +11,7 @@ const unicode = std.unicode;
 const meta = std.meta;
 const lossyCast = math.lossyCast;
 const expectFmt = std.testing.expectFmt;
+const json = std.json;
 
 pub const default_max_depth = 3;
 
@@ -587,6 +588,9 @@ pub fn formatType(
             }
         },
         .@"struct" => |info| {
+            if (actual_fmt.len > 0 and actual_fmt[0] == 'j') {
+                try json.stringify(value, .{}, writer);
+            }
             if (actual_fmt.len != 0) invalidFmtError(fmt, value);
             if (info.is_tuple) {
                 // Skip the type and field names when formatting tuples.


### PR DESCRIPTION
Hi,

this is a prototype to simplify formatting/printing of structs that contain strings (which fall back to list of characters using the default formatter). It uses the specifier 'j' to json.stringify the struct.

Please consider this a "request for comment" - is this a good idea? Alternatively, maybe enable use of 's' specifier to format structs as ZON (with "proper" handling of strings).

Looking forward to comments.