### PR TITLE
Prevent failure with empty struct in `std.meta.DeclEnum`

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -628,7 +628,7 @@ pub fn DeclEnum(comptime T: type) type {
     }
     return @Type(.{
         .@"enum" = .{
-            .tag_type = std.math.IntFittingRange(0, fieldInfos.len - 1),
+            .tag_type = std.math.IntFittingRange(0, if (fieldInfos.len == 0) 0 else fieldInfos.len - 1),
             .fields = &enumDecls,
             .decls = &decls,
             .is_exhaustive = true,
@@ -654,9 +654,12 @@ test DeclEnum {
         pub const b: void = {};
         pub const c: f32 = 0;
     };
+    const D = struct {};
+
     try expectEqualEnum(enum { a }, DeclEnum(A));
     try expectEqualEnum(enum { a, b, c }, DeclEnum(B));
     try expectEqualEnum(enum { a, b, c }, DeclEnum(C));
+    try expectEqualEnum(enum {}, DeclEnum(D));
 }
 
 pub fn Tag(comptime T: type) type {


### PR DESCRIPTION
I'm using `std.meta.DeclEnum` with a struct that may be empty, current implementation fails with:
```
error: overflow of integer type 'usize' with value '-1'
            .tag_type = std.math.IntFittingRange(0, fieldInfos.len - 1),
```