### PR TITLE
`test`: Re-enable a bunch of behavior tests with LLVM.

### DIFF
--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -582,10 +582,6 @@ test "comptime alloc alignment" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest; // flaky
-    if (builtin.zig_backend == .stage2_llvm and builtin.target.cpu.arch == .x86) {
-        // https://github.com/ziglang/zig/issues/18034
-        return error.SkipZigTest;
-    }
 
     comptime var bytes1 = [_]u8{0};
     _ = &bytes1;

--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -152,11 +152,6 @@ test "cmpxchg on a global variable" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/10627
-        return error.SkipZigTest;
-    }
-
     _ = @cmpxchgWeak(u32, &a_global_variable, 1234, 42, .acquire, .monotonic);
     try expect(a_global_variable == 42);
 }
@@ -202,10 +197,6 @@ test "atomicrmw with floats" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/10627
-        return error.SkipZigTest;
-    }
     try testAtomicRmwFloat();
     try comptime testAtomicRmwFloat();
 }
@@ -305,9 +296,6 @@ test "atomicrmw with 128-bit ints" {
     if (!supports_128_bit_atomics) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
-
-    // TODO "ld.lld: undefined symbol: __sync_lock_test_and_set_16" on -mcpu x86_64
-    if (builtin.cpu.arch == .x86_64 and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
 
     try testAtomicRmwInt128(.signed);
     try testAtomicRmwInt128(.unsigned);

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -1426,10 +1426,6 @@ test "allocation and looping over 3-byte integer" {
         return error.SkipZigTest; // TODO
     }
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .wasm32) {
-        return error.SkipZigTest; // TODO
-    }
-
     try expect(@sizeOf(u24) == 4);
     try expect(@sizeOf([1]u24) == 4);
     try expect(@alignOf(u24) == 4);

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -343,11 +343,6 @@ test "comptime @bitCast packed struct to int and back" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and native_endian == .big) {
-        // https://github.com/ziglang/zig/issues/13782
-        return error.SkipZigTest;
-    }
-
     const S = packed struct {
         void: void = {},
         uint: u8 = 13,

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -275,8 +275,7 @@ test "forced tail call" {
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_llvm) {
-        // Only attempt this test on targets we know have tail call support in LLVM.
-        if (builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) {
+        if (builtin.cpu.arch.isMIPS() or builtin.cpu.arch.isPowerPC() or builtin.cpu.arch.isWasm()) {
             return error.SkipZigTest;
         }
     }
@@ -311,8 +310,7 @@ test "inline call preserves tail call" {
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
     if (builtin.zig_backend == .stage2_llvm) {
-        // Only attempt this test on targets we know have tail call support in LLVM.
-        if (builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) {
+        if (builtin.cpu.arch.isMIPS() or builtin.cpu.arch.isPowerPC() or builtin.cpu.arch.isWasm()) {
             return error.SkipZigTest;
         }
     }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -1310,11 +1310,6 @@ test "@trunc f16" {
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.isMIPS()) {
-        // https://github.com/ziglang/zig/issues/16846
-        return error.SkipZigTest;
-    }
-
     try testTrunc(f16);
     try comptime testTrunc(f16);
 }
@@ -1325,11 +1320,6 @@ test "@trunc f32/f64" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.isMIPS()) {
-        // https://github.com/ziglang/zig/issues/16846
-        return error.SkipZigTest;
-    }
 
     try testTrunc(f32);
     try comptime testTrunc(f32);

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -194,12 +194,6 @@ test "@ctz vectors" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .aarch64) {
-        // This regressed with LLVM 14:
-        // https://github.com/ziglang/zig/issues/12013
-        return error.SkipZigTest;
-    }
-
     try testCtzVectors();
     try comptime testCtzVectors();
 }
@@ -478,11 +472,6 @@ test "division" {
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.isMIPS()) {
-        // https://github.com/ziglang/zig/issues/16846
-        return error.SkipZigTest;
-    }
-
     try testIntDivision();
     try comptime testIntDivision();
 
@@ -720,11 +709,6 @@ fn negateWrap(comptime T: type, x: T) T {
 test "unsigned 64-bit division" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-
-    if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.isMIPS()) {
-        // https://github.com/ziglang/zig/issues/16846
-        return error.SkipZigTest;
-    }
 
     try test_u64_div();
     try comptime test_u64_div();

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -170,11 +170,6 @@ test "@shuffle bool 2" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm) {
-        // https://github.com/ziglang/zig/issues/3246
-        return error.SkipZigTest;
-    }
-
     const S = struct {
         fn doTheTest() !void {
             var x: @Vector(3, bool) = [3]bool{ false, true, false };

--- a/test/behavior/threadlocal.zig
+++ b/test/behavior/threadlocal.zig
@@ -6,10 +6,6 @@ test "thread local variable" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_llvm) switch (builtin.cpu.arch) {
-        .x86_64, .x86 => {},
-        else => return error.SkipZigTest,
-    }; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     if (builtin.zig_backend == .stage2_x86_64 and builtin.os.tag == .macos) {
@@ -28,10 +24,6 @@ test "pointer to thread local array" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_llvm) switch (builtin.cpu.arch) {
-        .x86_64, .x86 => {},
-        else => return error.SkipZigTest,
-    }; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     const s = "Hello world";
@@ -45,10 +37,6 @@ test "reference a global threadlocal variable" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_llvm) switch (builtin.cpu.arch) {
-        .x86_64, .x86 => {},
-        else => return error.SkipZigTest,
-    }; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
     _ = nrfx_uart_rx(&g_uart0);

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -557,7 +557,6 @@ test "vector division operators" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_llvm and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
@@ -1570,11 +1569,6 @@ test "@reduce on bool vector" {
     if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
-
-    if (comptime builtin.zig_backend == .stage2_llvm and builtin.cpu.arch.endian() == .big) {
-        // https://github.com/ziglang/zig/issues/13782
-        return error.SkipZigTest;
-    }
 
     const a = @Vector(2, bool){ true, true };
     const b = @Vector(1, bool){true};


### PR DESCRIPTION
Closes #10627.
Closes #12013.
Closes #18034.

These pass for me on Linux at least; let's see what macOS and Windows say.