### PR TITLE
Disable no longer used clock IDs in Linux

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -4532,8 +4532,12 @@ pub const clockid_t = enum(u32) {
     BOOTTIME = 7,
     REALTIME_ALARM = 8,
     BOOTTIME_ALARM = 9,
-    SGI_CYCLE = 10,
-    TAI = 11,
+    // In the linux kernel header file (time.h) is the following note:
+    // * The driver implementing this got removed. The clock ID is kept as a
+    // * place holder. Do not reuse!
+    // Therefore, calling timerfd_create() with these IDs will result in an error.
+    // SGI_CYCLE = 10,
+    // TAI = 11,
     _,
 };
 


### PR DESCRIPTION
In the linux kernel header file (time.h) is the note, that the driver implementing the clock IDs
- SGI_CYCLE
- TAI
got removed. Therefore, calling timerfd_create() with these IDs will result in an error. So I disabled them.

fixes #20334