### PR TITLE
llvm: lower tagged union payload as byte array

### DIFF
--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -2339,3 +2339,25 @@ test "signed enum tag with negative value" {
 
     try expect(e.a == i);
 }
+
+test "init tagged union with underaligned payload" {
+    if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    const U = union(enum) {
+        a: u64 align(1),
+        b: void,
+    };
+
+    var x: u32 = undefined;
+    x = 123;
+
+    const u: U = .{ .a = x };
+
+    try expect(u == .a);
+    try expect(u.a == 123);
+}


### PR DESCRIPTION
At this point, I feel more comfortable with this lowering than I do further complicating this type lowering logic. I do wonder whether we ought to start lowering other types as byte arrays, and using byte-level GEPs -- it would make lowering less error-prone, and I highly doubt would actually hinder LLVM's ability to optimize.

Resolves: #21343