### PR TITLE
Add support for implicit linker scripts

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -618,6 +618,12 @@ pub fn addRPathSpecial(m: *Module, bytes: []const u8) void {
     m.rpaths.append(b.allocator, .{ .special = b.dupe(bytes) }) catch @panic("OOM");
 }
 
+pub fn addImplicitLinkerScript(m: *Module, linker_script: LazyPath) void {
+    const b = m.owner;
+    m.link_objects.append(b.allocator, .{ .static_path = linker_script.dupe(b) }) catch @panic("OOM");
+    addLazyPathDependenciesOnly(m, linker_script);
+}
+
 /// Equvialent to the following C code, applied to all C source files owned by
 /// this `Module`:
 /// ```c

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -940,6 +940,10 @@ pub fn addFrameworkPath(compile: *Compile, directory_path: LazyPath) void {
     compile.root_module.addFrameworkPath(directory_path);
 }
 
+pub fn addImplicitLinkerScript(compile: *Compile, linker_script: LazyPath) void {
+    compile.root_module.addImplicitLinkerScript(linker_script);
+}
+
 pub fn setExecCmd(compile: *Compile, args: []const ?[]const u8) void {
     const b = compile.step.owner;
     assert(compile.kind == .@"test");

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5638,7 +5638,7 @@ pub fn addCCArgs(
                 try argv.append("-fno-unwind-tables");
             }
         },
-        .shared_library, .ll, .bc, .unknown, .static_library, .object, .def, .zig, .res, .manifest => {},
+        .shared_library, .ll, .bc, .unknown, .static_library, .object, .def, .zig, .res, .manifest, .linker_script => {},
         .assembly, .assembly_with_cpp => {
             if (ext == .assembly_with_cpp) {
                 const c_headers_dir = try std.fs.path.join(arena, &[_][]const u8{ comp.zig_lib_directory.path.?, "include" });
@@ -5884,6 +5884,7 @@ pub const FileExt = enum {
     rc,
     res,
     manifest,
+    linker_script,
     unknown,
 
     pub fn clangSupportsDiagnostics(ext: FileExt) bool {
@@ -5900,6 +5901,7 @@ pub const FileExt = enum {
             .rc,
             .res,
             .manifest,
+            .linker_script,
             .unknown,
             => false,
         };
@@ -5921,6 +5923,7 @@ pub const FileExt = enum {
             .rc,
             .res,
             .manifest,
+            .linker_script,
             .unknown,
             => false,
         };
@@ -5949,6 +5952,7 @@ pub const FileExt = enum {
             .rc => ".rc",
             .res => ".res",
             .manifest => ".manifest",
+            .linker_script => ".ld",
             .unknown => "",
         };
     }
@@ -6010,6 +6014,10 @@ pub fn hasSharedLibraryExt(filename: []const u8) bool {
     return true;
 }
 
+pub fn hasLinkerScriptExt(filename: []const u8) bool {
+    return mem.endsWith(u8, filename, ".ld") or mem.endsWith(u8, filename, ".lds");
+}
+
 pub fn classifyFileExt(filename: []const u8) FileExt {
     if (hasCExt(filename)) {
         return .c;
@@ -6047,6 +6055,8 @@ pub fn classifyFileExt(filename: []const u8) FileExt {
         return .res;
     } else if (std.ascii.endsWithIgnoreCase(filename, ".manifest")) {
         return .manifest;
+    } else if (hasLinkerScriptExt(filename)) {
+        return .linker_script;
     } else {
         return .unknown;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -408,6 +408,7 @@ const usage_build_generic =
     \\                          .mm    Objective-C++ source code (requires LLVM extensions)
     \\                          .bc    LLVM IR Module (requires LLVM extensions)
     \\                          .cu    Cuda source code (requires LLVM extensions)
+    \\                     .ld .lds    Implicit linker script (requires LLVM extensions)
     \\
     \\General Options:
     \\  -h, --help                Print this help and exit
@@ -1724,7 +1725,7 @@ fn buildOutputType(
                         try create_module.link_objects.append(arena, .{ .path = arg });
                         create_module.opts.any_dyn_libs = true;
                     },
-                    .object, .static_library => {
+                    .object, .static_library, .linker_script => {
                         try create_module.link_objects.append(arena, .{ .path = arg });
                     },
                     .res => {
@@ -1846,7 +1847,7 @@ fn buildOutputType(
                             });
                             create_module.opts.any_dyn_libs = true;
                         },
-                        .unknown, .object, .static_library => {
+                        .unknown, .object, .static_library, .linker_script => {
                             try create_module.link_objects.append(arena, .{
                                 .path = it.only_arg,
                                 .must_link = must_link,


### PR DESCRIPTION
Implicit linker scripts have different semantics compared to a linker script supplied with the '-T' command line option. Instead of replacing the default linker script / link options, the commands of an implicit linker script are combined with the default linker script [1].

[1] [https://sourceware.org/binutils/docs/ld/Scripts.html](https://sourceware.org/binutils/docs/ld/Scripts.html)