### PR TITLE
`std.ascii`: make `toLower` `toUpper` branchless

### DIFF
--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -182,12 +182,12 @@ pub const isASCII = isAscii;
 
 /// Uppercases the character and returns it as-is if already uppercase or not a letter.
 pub fn toUpper(c: u8) u8 {
-    return c ^ (@as(u8, @intFromBool(isLower(c))) * 0b00100000);
+    return c ^ (@as(u8, @intFromBool(isLower(c))) *% 0b00100000);
 }
 
 /// Lowercases the character and returns it as-is if already lowercase or not a letter.
 pub fn toLower(c: u8) u8 {
-    return c | (@as(u8, @intFromBool(isUpper(c))) * 0b00100000);
+    return c | (@as(u8, @intFromBool(isUpper(c))) *% 0b00100000);
 }
 
 test "ASCII character classes" {

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -182,20 +182,12 @@ pub const isASCII = isAscii;
 
 /// Uppercases the character and returns it as-is if already uppercase or not a letter.
 pub fn toUpper(c: u8) u8 {
-    if (isLower(c)) {
-        return c & 0b11011111;
-    } else {
-        return c;
-    }
+    return c ^ (@as(u8, @intFromBool(isLower(c))) * 0b00100000);
 }
 
 /// Lowercases the character and returns it as-is if already lowercase or not a letter.
 pub fn toLower(c: u8) u8 {
-    if (isUpper(c)) {
-        return c | 0b00100000;
-    } else {
-        return c;
-    }
+    return c | (@as(u8, @intFromBool(isUpper(c))) * 0b00100000);
 }
 
 test "ASCII character classes" {

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -182,12 +182,14 @@ pub const isASCII = isAscii;
 
 /// Uppercases the character and returns it as-is if already uppercase or not a letter.
 pub fn toUpper(c: u8) u8 {
-    return c ^ (@as(u8, @intFromBool(isLower(c))) *% 0b00100000);
+    const mask = @as(u8, @intFromBool(isLower(c))) << 5;
+    return c ^ mask;
 }
 
 /// Lowercases the character and returns it as-is if already lowercase or not a letter.
 pub fn toLower(c: u8) u8 {
-    return c | (@as(u8, @intFromBool(isUpper(c))) *% 0b00100000);
+    const mask = @as(u8, @intFromBool(isUpper(c))) << 5;
+    return c | mask;
 }
 
 test "ASCII character classes" {


### PR DESCRIPTION
[Godbolt link](https://godbolt.org/z/sET64sr1Y)
Remove some extended instructions.