### PR TITLE
remove explicit ComplexTypeTag from switch

### DIFF
--- a/doc/langref/test_tagged_union.zig
+++ b/doc/langref/test_tagged_union.zig
@@ -15,8 +15,8 @@ test "switch on tagged union" {
     try expect(@as(ComplexTypeTag, c) == ComplexTypeTag.ok);
 
     switch (c) {
-        ComplexTypeTag.ok => |value| try expect(value == 42),
-        ComplexTypeTag.not_ok => unreachable,
+        .ok => |value| try expect(value == 42),
+        .not_ok => unreachable,
     }
 }
 


### PR DESCRIPTION
Going through the reference, I wonder if it's better to leave off the explicit type since we can use literals and the example is calling out coercing. I think this is more like what a programmer would do in real code, and it looks better. Tested.