### PR TITLE
Faster Ast.zig

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1194,7 +1194,7 @@ pub fn HashMapUnmanaged(
         /// fuse the basic blocks after the branch to the basic blocks
         /// from this function.  To encourage that, this function is
         /// marked as inline.
-        inline fn getIndex(self: Self, key: anytype, ctx: anytype) ?usize {
+        fn getIndex(self: Self, key: anytype, ctx: anytype) ?usize {
             comptime verifyContext(@TypeOf(ctx), @TypeOf(key), K, Hash, false);
 
             if (self.size == 0) {

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1194,7 +1194,7 @@ pub fn HashMapUnmanaged(
         /// fuse the basic blocks after the branch to the basic blocks
         /// from this function.  To encourage that, this function is
         /// marked as inline.
-        fn getIndex(self: Self, key: anytype, ctx: anytype) ?usize {
+        inline fn getIndex(self: Self, key: anytype, ctx: anytype) ?usize {
             comptime verifyContext(@TypeOf(ctx), @TypeOf(key), K, Hash, false);
 
             if (self.size == 0) {


### PR DESCRIPTION
I managed to eek a little more speed out of ast-check:
![image](https://github.com/user-attachments/assets/8955a51a-8b7d-4abe-b741-44bf5813f713)
("old-zig" in this is master as of [b817823](https://github.com/ziglang/zig/commit/b81782366bcdaf18ad0066e029cfdb2ed028bddd), "new-zig" is this PR)

While I haven't tested it, this should also reduce a little memory usage after generating the AST.