### PR TITLE
`start`: Rewrite arm code to work for thumb1 too.

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -280,12 +280,14 @@ fn _start() callconv(.Naked) noreturn {
             \\ b %[posixCallMainAndExit]
             ,
             .arm, .armeb, .thumb, .thumbeb =>
-            \\ mov fp, #0
-            \\ mov lr, #0
+            // Note that this code must work for Thumb-1.
+            \\ movs v1, #0
+            \\ mov fp, v1
+            \\ mov lr, v1
             \\ mov a1, sp
-            \\ mov ip, sp
-            \\ and ip, ip, #-16
-            \\ mov sp, ip
+            \\ subs v1, #16
+            \\ ands v1, a1
+            \\ mov sp, v1
             \\ b %[posixCallMainAndExit]
             ,
             .csky =>


### PR DESCRIPTION
0ecc6332b4eb1ced547ffa38f57471134aaa4d13 improved things for thumb2, but thumb1 has a much smaller permissible instruction set. This commit makes that work.