### PR TITLE
std.Build: allow packages to expose arbitrary LazyPaths by name

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -89,6 +89,7 @@ dep_prefix: []const u8 = "",
 modules: std.StringArrayHashMap(*Module),
 
 named_writefiles: std.StringArrayHashMap(*Step.WriteFile),
+named_lazy_paths: std.StringArrayHashMap(LazyPath),
 /// A map from build root dirs to the corresponding `*Dependency`. This is shared with all child
 /// `Build`s.
 initialized_deps: *InitializedDepMap,
@@ -300,8 +301,9 @@ pub fn create(
         .install_path = undefined,
         .args = null,
         .host = graph.host,
-        .modules = std.StringArrayHashMap(*Module).init(arena),
-        .named_writefiles = std.StringArrayHashMap(*Step.WriteFile).init(arena),
+        .modules = .init(arena),
+        .named_writefiles = .init(arena),
+        .named_lazy_paths = .init(arena),
         .initialized_deps = initialized_deps,
         .pkg_hash = "",
         .available_deps = available_deps,
@@ -393,8 +395,9 @@ fn createChildOnly(
         .glibc_runtimes_dir = parent.glibc_runtimes_dir,
         .host = parent.host,
         .dep_prefix = parent.fmt("{s}{s}.", .{ parent.dep_prefix, dep_name }),
-        .modules = std.StringArrayHashMap(*Module).init(allocator),
-        .named_writefiles = std.StringArrayHashMap(*Step.WriteFile).init(allocator),
+        .modules = .init(allocator),
+        .named_writefiles = .init(allocator),
+        .named_lazy_paths = .init(allocator),
         .initialized_deps = parent.initialized_deps,
         .pkg_hash = pkg_hash,
         .available_deps = pkg_deps,
@@ -1058,6 +1061,10 @@ pub fn addNamedWriteFiles(b: *Build, name: []const u8) *Step.WriteFile {
     const wf = Step.WriteFile.create(b);
     b.named_writefiles.put(b.dupe(name), wf) catch @panic("OOM");
     return wf;
+}
+
+pub fn addNamedLazyPath(b: *Build, name: []const u8, lp: LazyPath) void {
+    b.named_lazy_paths.put(b.dupe(name), lp.dupe(b)) catch @panic("OOM");
 }
 
 pub fn addWriteFiles(b: *Build) *Step.WriteFile {
@@ -1899,6 +1906,12 @@ pub const Dependency = struct {
     pub fn namedWriteFiles(d: *Dependency, name: []const u8) *Step.WriteFile {
         return d.builder.named_writefiles.get(name) orelse {
             panic("unable to find named writefiles '{s}'", .{name});
+        };
+    }
+
+    pub fn namedLazyPath(d: *Dependency, name: []const u8) LazyPath {
+        return d.builder.named_lazy_paths.get(name) orelse {
+            panic("unable to find named lazypath '{s}'", .{name});
         };
     }
 


### PR DESCRIPTION
This is an enhancement to the build system. There's no corresponding issue -- @andrewrk, I'll therefore wait for your approval on this one.

It seems reasonable and useful for packages to be allowed to expose arbitrary `LazyPath`s to dependants; for instance, an output file/dir from a `Step.Run`. I ran into this when helping @sphaerophoria make a package which exposes a bunch of Qt stuff by calling into CMake rather than porting the build system to Zig. You can also imagine situations in pure-Zig-land where this would be helpful; for instance, perhaps a package wants to expose a file containing some kind of generated JSON/ZON data (generated by a Zig program).

(Also, use decl literals for a couple of inits :D)