### PR TITLE
Package.Fetch: add another non-standard Content-Type

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1068,7 +1068,8 @@ fn unpackResource(
             if (ascii.eqlIgnoreCase(mime_type, "application/gzip") or
                 ascii.eqlIgnoreCase(mime_type, "application/x-gzip") or
                 ascii.eqlIgnoreCase(mime_type, "application/tar+gzip") or
-                ascii.eqlIgnoreCase(mime_type, "application/x-tar-gz"))
+                ascii.eqlIgnoreCase(mime_type, "application/x-tar-gz") or
+                ascii.eqlIgnoreCase(mime_type, "application/x-gtar-compressed"))
             {
                 break :ft .@"tar.gz";
             }


### PR DESCRIPTION
For instance, the official download site for libvterm uses this MIME type for tar.gz tarballs.