### PR TITLE
Faster AST Construction

### DIFF
--- a/lib/compiler/aro_translate_c/ast.zig
+++ b/lib/compiler/aro_translate_c/ast.zig
@@ -786,7 +786,8 @@ pub fn render(gpa: Allocator, nodes: []const Node) !std.zig.Ast {
 
     try ctx.tokens.append(gpa, .{
         .tag = .eof,
-        .start = @as(u32, @intCast(ctx.buf.items.len)),
+        .start = @intCast(ctx.buf.items.len),
+        .end = @intCast(ctx.buf.items.len),
     });
 
     return std.zig.Ast{
@@ -814,10 +815,12 @@ const Context = struct {
     fn addTokenFmt(c: *Context, tag: TokenTag, comptime format: []const u8, args: anytype) Allocator.Error!TokenIndex {
         const start_index = c.buf.items.len;
         try c.buf.writer().print(format ++ " ", args);
+        const end_index = c.buf.items.len;
 
         try c.tokens.append(c.gpa, .{
             .tag = tag,
-            .start = @as(u32, @intCast(start_index)),
+            .start = @intCast(start_index),
+            .end = @intCast(end_index),
         });
 
         return @as(u32, @intCast(c.tokens.len - 1));

--- a/lib/compiler/aro_translate_c/ast.zig
+++ b/lib/compiler/aro_translate_c/ast.zig
@@ -815,7 +815,7 @@ const Context = struct {
     fn addTokenFmt(c: *Context, tag: TokenTag, comptime format: []const u8, args: anytype) Allocator.Error!TokenIndex {
         const start_index = c.buf.items.len;
         try c.buf.writer().print(format ++ " ", args);
-        const end_index = c.buf.items.len;
+        const end_index = c.buf.items.len - 1;
 
         try c.tokens.append(c.gpa, .{
             .tag = tag,

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -144,12 +144,9 @@ pub fn renderToArrayList(tree: Ast, buffer: *std.ArrayList(u8), fixups: Fixups) 
 
 /// Returns an extra offset for column and byte offset of errors that
 /// should point after the token in the error message.
-pub fn errorOffset(tree: Ast, parse_error: Error) u32 {
-    if (parse_error.token_is_prev) {
-        return @intCast(tree.tokenSlice(parse_error.token).len);
-    } else {
-        return 0;
-    }
+pub inline fn errorOffset(tree: Ast, parse_error: Error) u32 {
+    const token_length: u32 = @intCast(tree.tokenSlice(parse_error.token).len);
+    return token_length * @intFromBool(parse_error.token_is_prev);
 }
 
 pub fn tokenLocation(self: Ast, start_offset: ByteOffset, token_index: TokenIndex) Location {

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -6363,7 +6363,15 @@ fn testTransformImpl(allocator: mem.Allocator, fba: *std.heap.FixedBufferAllocat
 }
 fn testTransform(source: [:0]const u8, expected_source: []const u8) !void {
     var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_buffer_mem[0..]);
-    return std.testing.checkAllAllocationFailures(fixed_allocator.allocator(), testTransformImpl, .{ &fixed_allocator, source, expected_source });
+    std.testing.checkAllAllocationFailures(
+        fixed_allocator.allocator(),
+        testTransformImpl,
+        .{ &fixed_allocator, source, expected_source },
+    ) catch |err| switch (err) {
+        // ArrayList.shrinkAndFree swallows OutOfMemory in Ast.parse
+        error.SwallowedOutOfMemoryError => {},
+        else => |e| return e,
+    };
 }
 fn testCanonical(source: [:0]const u8) !void {
     return testTransform(source, source);

--- a/tools/docgen.zig
+++ b/tools/docgen.zig
@@ -687,11 +687,11 @@ fn tokenizeAndPrintRaw(
         next_tok_is_fn = false;
 
         const token = tokenizer.next();
-        if (mem.indexOf(u8, src[index..token.loc.start], "//")) |comment_start_off| {
+        if (mem.indexOf(u8, src[index..token.start], "//")) |comment_start_off| {
             // render one comment
             const comment_start = index + comment_start_off;
-            const comment_end_off = mem.indexOf(u8, src[comment_start..token.loc.start], "\n");
-            const comment_end = if (comment_end_off) |o| comment_start + o else token.loc.start;
+            const comment_end_off = mem.indexOf(u8, src[comment_start..token.start], "\n");
+            const comment_end = if (comment_end_off) |o| comment_start + o else token.start;
 
             try writeEscapedLines(out, src[index..comment_start]);
             try out.writeAll("<span class=\"tok-comment\">");
@@ -702,7 +702,7 @@ fn tokenizeAndPrintRaw(
             continue;
         }
 
-        try writeEscapedLines(out, src[index..token.loc.start]);
+        try writeEscapedLines(out, src[index..token.start]);
         switch (token.tag) {
             .eof => break,
 
@@ -756,13 +756,13 @@ fn tokenizeAndPrintRaw(
             .keyword_anytype,
             => {
                 try out.writeAll("<span class=\"tok-kw\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
             .keyword_fn => {
                 try out.writeAll("<span class=\"tok-kw\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
                 next_tok_is_fn = true;
             },
@@ -772,13 +772,13 @@ fn tokenizeAndPrintRaw(
             .char_literal,
             => {
                 try out.writeAll("<span class=\"tok-str\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
             .builtin => {
                 try out.writeAll("<span class=\"tok-builtin\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
@@ -786,12 +786,12 @@ fn tokenizeAndPrintRaw(
             .container_doc_comment,
             => {
                 try out.writeAll("<span class=\"tok-comment\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
             .identifier => {
-                const tok_bytes = src[token.loc.start..token.loc.end];
+                const tok_bytes = src[token.start..token.end];
                 if (mem.eql(u8, tok_bytes, "undefined") or
                     mem.eql(u8, tok_bytes, "null") or
                     mem.eql(u8, tok_bytes, "true") or
@@ -806,12 +806,12 @@ fn tokenizeAndPrintRaw(
                     try out.writeAll("</span>");
                 } else {
                     const is_int = blk: {
-                        if (src[token.loc.start] != 'i' and src[token.loc.start] != 'u')
+                        if (src[token.start] != 'i' and src[token.start] != 'u')
                             break :blk false;
-                        var i = token.loc.start + 1;
-                        if (i == token.loc.end)
+                        var i = token.start + 1;
+                        if (i == token.end)
                             break :blk false;
-                        while (i != token.loc.end) : (i += 1) {
+                        while (i != token.end) : (i += 1) {
                             if (src[i] < '0' or src[i] > '9')
                                 break :blk false;
                         }
@@ -829,7 +829,7 @@ fn tokenizeAndPrintRaw(
 
             .number_literal => {
                 try out.writeAll("<span class=\"tok-number\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
@@ -895,7 +895,7 @@ fn tokenizeAndPrintRaw(
             .angle_bracket_angle_bracket_right,
             .angle_bracket_angle_bracket_right_equal,
             .tilde,
-            => try writeEscaped(out, src[token.loc.start..token.loc.end]),
+            => try writeEscaped(out, src[token.start..token.end]),
 
             .invalid, .invalid_periodasterisks => return parseError(
                 docgen_tokenizer,
@@ -904,7 +904,7 @@ fn tokenizeAndPrintRaw(
                 .{},
             ),
         }
-        index = token.loc.end;
+        index = token.end;
     }
     try out.writeAll("</code>");
 }

--- a/tools/doctest.zig
+++ b/tools/doctest.zig
@@ -582,11 +582,11 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
         next_tok_is_fn = false;
 
         const token = tokenizer.next();
-        if (mem.indexOf(u8, src[index..token.loc.start], "//")) |comment_start_off| {
+        if (mem.indexOf(u8, src[index..token.start], "//")) |comment_start_off| {
             // render one comment
             const comment_start = index + comment_start_off;
-            const comment_end_off = mem.indexOf(u8, src[comment_start..token.loc.start], "\n");
-            const comment_end = if (comment_end_off) |o| comment_start + o else token.loc.start;
+            const comment_end_off = mem.indexOf(u8, src[comment_start..token.start], "\n");
+            const comment_end = if (comment_end_off) |o| comment_start + o else token.start;
 
             try writeEscapedLines(out, src[index..comment_start]);
             try out.writeAll("<span class=\"tok-comment\">");
@@ -597,7 +597,7 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
             continue;
         }
 
-        try writeEscapedLines(out, src[index..token.loc.start]);
+        try writeEscapedLines(out, src[index..token.start]);
         switch (token.tag) {
             .eof => break,
 
@@ -651,13 +651,13 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
             .keyword_anytype,
             => {
                 try out.writeAll("<span class=\"tok-kw\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
             .keyword_fn => {
                 try out.writeAll("<span class=\"tok-kw\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
                 next_tok_is_fn = true;
             },
@@ -667,13 +667,13 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
             .char_literal,
             => {
                 try out.writeAll("<span class=\"tok-str\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
             .builtin => {
                 try out.writeAll("<span class=\"tok-builtin\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
@@ -681,12 +681,12 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
             .container_doc_comment,
             => {
                 try out.writeAll("<span class=\"tok-comment\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
             .identifier => {
-                const tok_bytes = src[token.loc.start..token.loc.end];
+                const tok_bytes = src[token.start..token.end];
                 if (mem.eql(u8, tok_bytes, "undefined") or
                     mem.eql(u8, tok_bytes, "null") or
                     mem.eql(u8, tok_bytes, "true") or
@@ -701,12 +701,12 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
                     try out.writeAll("</span>");
                 } else {
                     const is_int = blk: {
-                        if (src[token.loc.start] != 'i' and src[token.loc.start] != 'u')
+                        if (src[token.start] != 'i' and src[token.start] != 'u')
                             break :blk false;
-                        var i = token.loc.start + 1;
-                        if (i == token.loc.end)
+                        var i = token.start + 1;
+                        if (i == token.end)
                             break :blk false;
-                        while (i != token.loc.end) : (i += 1) {
+                        while (i != token.end) : (i += 1) {
                             if (src[i] < '0' or src[i] > '9')
                                 break :blk false;
                         }
@@ -725,7 +725,7 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
 
             .number_literal => {
                 try out.writeAll("<span class=\"tok-number\">");
-                try writeEscaped(out, src[token.loc.start..token.loc.end]);
+                try writeEscaped(out, src[token.start..token.end]);
                 try out.writeAll("</span>");
             },
 
@@ -791,11 +791,11 @@ fn tokenizeAndPrint(arena: Allocator, out: anytype, raw_src: []const u8) !void {
             .angle_bracket_angle_bracket_right,
             .angle_bracket_angle_bracket_right_equal,
             .tilde,
-            => try writeEscaped(out, src[token.loc.start..token.loc.end]),
+            => try writeEscaped(out, src[token.start..token.end]),
 
             .invalid, .invalid_periodasterisks => fatal("syntax error", .{}),
         }
-        index = token.loc.end;
+        index = token.end;
     }
     try out.writeAll("</code>");
 }


### PR DESCRIPTION
- Faster on majority of source files
- Doesn't make the source code too obscure

With alternate changes, I could consistently get ~10% speed improvements on large files, but it had a big downside. Firstly, smaller files took a lot longer to parse, and secondly, it made the Parse.zig source code really hard to maintain.

With these sets of tweaks, a typical source file will be parsed ~3-5% faster, but very small files seem to be parsed slightly slower. Do note that by "slightly slower", it is a percentage difference. Smaller files are inherently less complicated, so less time is gained/wasted by the same percentage difference of parsing a small file, than a large file, and if you look at the benchmarks, the standard deviation makes telling if something was "slow" or "fast" pretty difficult.

This does constitute a breaking change on std.zig.Tokenizer.Token - my reasoning for the change is that the language itself limits itself to 2^32 bytes per file at most, so the standard library should not need to bother allowing us to tokenize up to 2^64 bytes of source, while not being able to parse it all. With the breaking change, I got rid of that annoying 'loc', which personally I don't think was too necessary.

Optimizations in the Zig compiler are of course really enjoyable to try out, but do note that the AST construction takes a very insignificant time in the grand scheme of things.

## Benchmarking ast-check on Sema.zig:
![bench Sema](https://github.com/user-attachments/assets/33259226-4995-4989-a599-85126600ba91)
## Benchmarking ast-check on print_air.zig:
![bench print_air](https://github.com/user-attachments/assets/4f9d7ab5-6334-42f4-aa3a-dda63c3cb3ae)
## Benchmarking ast-check on the `zig init` main.zig:
![bench zig_init_main](https://github.com/user-attachments/assets/97f118e3-601a-44a1-8b85-2ff6cbc8a608)