### PR TITLE
Audit isPowerOfTwo in Sema and LLVM

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -22052,7 +22052,7 @@ fn zirReify(
 
             const alignment_val_int = try alignment_val.toUnsignedIntSema(pt);
             if (alignment_val_int > 0 and !math.isPowerOfTwo(alignment_val_int)) {
-                return sema.fail(block, src, "alignment value '{d}' is not a power of two or zero", .{alignment_val_int});
+                return sema.fail(block, src, "alignment value '{d}' is not a power of two", .{alignment_val_int});
             }
             const abi_align = Alignment.fromByteUnits(alignment_val_int);
 
@@ -22731,7 +22731,7 @@ fn reifyUnion(
                 const byte_align = try (try field_info.fieldValue(pt, 2)).toUnsignedIntSema(pt);
                 if (byte_align > 0 and !math.isPowerOfTwo(byte_align)) {
                     // TODO: better source location
-                    return sema.fail(block, src, "alignment value '{d}' is not a power of two or zero", .{byte_align});
+                    return sema.fail(block, src, "alignment value '{d}' is not a power of two", .{byte_align});
                 }
                 field_aligns[field_idx] = Alignment.fromByteUnits(byte_align);
             }
@@ -22776,7 +22776,7 @@ fn reifyUnion(
                 const byte_align = try (try field_info.fieldValue(pt, 2)).toUnsignedIntSema(pt);
                 if (byte_align > 0 and !math.isPowerOfTwo(byte_align)) {
                     // TODO: better source location
-                    return sema.fail(block, src, "alignment value '{d}' is not a power of two or zero", .{byte_align});
+                    return sema.fail(block, src, "alignment value '{d}' is not a power of two", .{byte_align});
                 }
                 field_aligns[field_idx] = Alignment.fromByteUnits(byte_align);
             }
@@ -23013,7 +23013,7 @@ fn reifyStruct(
                 }
             } else {
                 if (layout == .@"packed") return sema.fail(block, src, "alignment in a packed struct field must be set to 0", .{});
-                if (!math.isPowerOfTwo(byte_align)) return sema.fail(block, src, "alignment value '{d}' is not a power of two or zero", .{byte_align});
+                if (!math.isPowerOfTwo(byte_align)) return sema.fail(block, src, "alignment value '{d}' is not a power of two", .{byte_align});
                 struct_type.field_aligns.get(ip)[field_idx] = Alignment.fromNonzeroByteUnits(byte_align);
             }
         }

--- a/test/cases/compile_errors/reify_type_with_invalid_field_alignment.zig
+++ b/test/cases/compile_errors/reify_type_with_invalid_field_alignment.zig
@@ -45,6 +45,6 @@ comptime {
 // backend=stage2
 // target=native
 //
-// :2:9: error: alignment value '3' is not a power of two or zero
-// :14:9: error: alignment value '5' is not a power of two or zero
-// :30:9: error: alignment value '7' is not a power of two or zero
+// :2:9: error: alignment value '3' is not a power of two
+// :14:9: error: alignment value '5' is not a power of two
+// :30:9: error: alignment value '7' is not a power of two


### PR DESCRIPTION
Part of #16021

All that's left now is this:
```
$ git grep isPowerOfTwo src/arch
src/arch/arm/CodeGen.zig:                            if (std.math.isPowerOfTwo(imm)) {
src/arch/arm/CodeGen.zig:                            if (std.math.isPowerOfTwo(imm)) {
src/arch/arm/CodeGen.zig:                            if (std.math.isPowerOfTwo(imm)) {
src/arch/riscv64/CodeGen.zig:                if (!math.isPowerOfTwo(size))
src/arch/riscv64/CodeGen.zig:                    if (!math.isPowerOfTwo(bit_size)) {
src/arch/riscv64/CodeGen.zig:                    if (!math.isPowerOfTwo(bit_size))
src/arch/riscv64/CodeGen.zig:                if (int_info.bits >= 8 and math.isPowerOfTwo(int_info.bits)) {
src/arch/riscv64/CodeGen.zig:        if (!math.isPowerOfTwo(int_info.bits) or int_info.bits < 8) {
src/arch/riscv64/CodeGen.zig:        if (!math.isPowerOfTwo(bit_size)) try func.truncateRegister(ty, src_reg);
src/arch/riscv64/CodeGen.zig:        if (!math.isPowerOfTwo(operand_bit_size))
src/arch/riscv64/CodeGen.zig:        if (!math.isPowerOfTwo(val_size))
src/arch/wasm/CodeGen.zig:    if ((!std.math.isPowerOfTwo(elem_size) or elem_size % 8 != 0) and vector_len > 1) {
src/arch/x86_64/CodeGen.zig:                if (int_info.bits >= 8 and math.isPowerOfTwo(int_info.bits)) {
src/arch/x86_64/CodeGen.zig:                if (int_info.bits >= 8 and math.isPowerOfTwo(int_info.bits)) {
src/arch/x86_64/CodeGen.zig:        if (math.isPowerOfTwo(src_bits)) {
src/arch/x86_64/CodeGen.zig:        if (src_bits <= 8 or !math.isPowerOfTwo(src_bits)) {
src/arch/x86_64/encoder.zig:            if (args.scale_index) |si| assert(std.math.isPowerOfTwo(si.scale));
```

As for the one issue I found in the LLVM parts of the compiler I filed #21401 