### PR TITLE
fix IB in fifoToOwnedArrayList

### DIFF
--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -316,9 +316,7 @@ pub const RunResult = struct {
 };
 
 fn fifoToOwnedArrayList(fifo: *std.io.PollFifo) std.ArrayList(u8) {
-    if (fifo.head > 0) {
-        @memcpy(fifo.buf[0..fifo.count], fifo.buf[fifo.head..][0..fifo.count]);
-    }
+    if (fifo.head != 0) fifo.realign();
     const result = std.ArrayList(u8){
         .items = fifo.buf[0..fifo.count],
         .capacity = fifo.buf.len,


### PR DESCRIPTION
memcpy requires non-overlapping arguments.

fifo.realign() handles this case correctly and tries to provide an optimized implementation.

This probably wasn't hit in practice, as, in a typical usage, fifo's head is not advanced.