### PR TITLE
:memo: Comment (and docs) did not correspond to the actual code

### DIFF
--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -1043,10 +1043,7 @@ pub const DynamicBitSet = struct {
     /// The integer type used to shift a mask in this bit set
     pub const ShiftInt = std.math.Log2Int(MaskInt);
 
-    /// The allocator used by this bit set
     allocator: Allocator,
-
-    /// Underlying data structure
     unmanaged: DynamicBitSetUnmanaged = .{},
 
     /// Creates a bit set with no elements present.

--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -1046,7 +1046,7 @@ pub const DynamicBitSet = struct {
     /// The allocator used by this bit set
     allocator: Allocator,
 
-    /// The number of valid items in this bit set
+    /// Underlying data structure
     unmanaged: DynamicBitSetUnmanaged = .{},
 
     /// Creates a bit set with no elements present.


### PR DESCRIPTION
Which resulted in a confusing statement [in the documentation](https://ziglang.org/documentation/master/std/#std.bit_set.DynamicBitSet)