### PR TITLE
std.sort.PartitionPoint: Improve performance

### DIFF
--- a/lib/std/sort.zig
+++ b/lib/std/sort.zig
@@ -678,18 +678,23 @@ pub fn partitionPoint(
     context: anytype,
     comptime predicate: fn (@TypeOf(context), T) bool,
 ) usize {
-    var low: usize = 0;
-    var high: usize = items.len;
+    var it: usize = 0;
+    var len: usize = items.len;
 
-    while (low < high) {
-        const mid = low + (high - low) / 2;
-        if (predicate(context, items[mid])) {
-            low = mid + 1;
-        } else {
-            high = mid;
+    while (len > 1) {
+        const half: usize = len / 2;
+        len -= half;
+        if (predicate(context, items[it + half - 1])) {
+            @branchHint(.unpredictable);
+            it += half;
         }
     }
-    return low;
+
+    if (it < items.len) {
+        it += @intFromBool(predicate(context, items[it]));
+    }
+
+    return it;
 }
 
 test partitionPoint {


### PR DESCRIPTION
fairly large speedup for small sizes compared to the old implementation on my machine, basically the same for large arrays, more benchmarking is needed though and any feedback is welcome

@Rexicon226 could you take a look? (sorry for the ping but you were greatly helpful last time i made a PR)

plot of performance for u32s at time of writing on my machine
![image](https://github.com/user-attachments/assets/bdbeccc3-8b57-40f2-bb28-b2a03a1ed6f3)
