### PR TITLE
Sema: give `try` operand `error{}` result type in non-errorable functions

### DIFF
--- a/test/behavior/try.zig
+++ b/test/behavior/try.zig
@@ -86,3 +86,40 @@ test "try forwards result location" {
     try expect((S.foo(false) catch return error.TestUnexpectedResult) == 123);
     try std.testing.expectError(error.Foo, S.foo(true));
 }
+
+test "'return try' of empty error set in function returning non-error" {
+    if (builtin.zig_backend == .stage2_x86) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn succeed0() error{}!u32 {
+            return 123;
+        }
+        fn succeed1() !u32 {
+            return 456;
+        }
+        fn tryNoError0() u32 {
+            return try succeed0();
+        }
+        fn tryNoError1() u32 {
+            return try succeed1();
+        }
+        fn tryNoError2() u32 {
+            const e: error{}!u32 = 789;
+            return try e;
+        }
+        fn doTheTest() !void {
+            const res0 = tryNoError0();
+            const res1 = tryNoError1();
+            const res2 = tryNoError2();
+            try expect(res0 == 123);
+            try expect(res1 == 456);
+            try expect(res2 == 789);
+        }
+    };
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}


### PR DESCRIPTION
Resolves: #21414