### PR TITLE
Sema: don't emit instruction when casting `@min`/`@max` result to OPV type

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26205,6 +26205,10 @@ fn analyzeMinMax(
         .child = refined_scalar_ty.toIntern(),
     }) else refined_scalar_ty;
 
+    if (try sema.typeHasOnePossibleValue(refined_ty)) |opv| {
+        return Air.internedToRef(opv.toIntern());
+    }
+
     if (!refined_ty.eql(unrefined_ty, zcu)) {
         // We've reduced the type - cast the result down
         return block.addTyOp(.intcast, refined_ty, cur_minmax.?);

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -336,3 +336,17 @@ test "@min/@max of signed and unsigned runtime integers" {
     try expectEqual(x, @min(x, y));
     try expectEqual(y, @max(x, y));
 }
+
+test "@min resulting in u0" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        fn min(a: u0, b: u8) u8 {
+            return @min(a, b);
+        }
+    };
+    const x = S.min(0, 1);
+    try expect(x == 0);
+}


### PR DESCRIPTION
Resolves: #21408