### PR TITLE
Sema: add missing coercion to `bool` for `condbr_inline`

### DIFF
--- a/test/cases/compile_errors/if_condition_is_bool_not_int.zig
+++ b/test/cases/compile_errors/if_condition_is_bool_not_int.zig
@@ -1,5 +1,9 @@
-export fn f() void {
+export fn foo() void {
     if (0) {}
+}
+
+export fn bar() void {
+    comptime if (0) {};
 }
 
 // error
@@ -7,3 +11,4 @@ export fn f() void {
 // target=native
 //
 // :2:9: error: expected type 'bool', found 'comptime_int'
+// :6:18: error: expected type 'bool', found 'comptime_int'


### PR DESCRIPTION
Also, start using labeled switch statements when dispatching maybe-runtime instructions like condbr to comptime-only variants like condbr_inline.

This can't be merged until we get a zig1.wasm update due to #21385.

Resolves: #21405