### PR TITLE
std.posix: Added error message 'ProcessNotFound' for reading and writing in a Linux process

### DIFF
--- a/lib/compiler/fmt.zig
+++ b/lib/compiler/fmt.zig
@@ -207,6 +207,7 @@ const FmtError = error{
     LockViolation,
     NetNameDeleted,
     InvalidArgument,
+    ProcessNotFound,
 } || fs.File.OpenError;
 
 fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool, dir: fs.Dir, sub_path: []const u8) FmtError!void {

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -799,8 +799,8 @@ pub const ReadError = error{
     /// not hold the required rights to read from it.
     AccessDenied,
 
-    // This error occurs in Linux if the process to be read from
-    // no longer exists.
+    /// This error occurs in Linux if the process to be read from
+    /// no longer exists.
     ProcessNotFound,
 } || UnexpectedError;
 
@@ -1185,8 +1185,8 @@ pub const WriteError = error{
     /// Connection reset by peer.
     ConnectionResetByPeer,
 
-    // This error occurs in Linux if the process being written to
-    // no longer exists.
+    /// This error occurs in Linux if the process being written to
+    /// no longer exists.
     ProcessNotFound,
 } || UnexpectedError;
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -798,6 +798,11 @@ pub const ReadError = error{
     /// In WASI, this error occurs when the file descriptor does
     /// not hold the required rights to read from it.
     AccessDenied,
+
+    // This error occurs in Linux if the process to be read from
+    // no longer exists.
+    ProcessNotFound,
+
 } || UnexpectedError;
 
 /// Returns the number of bytes that were read, which can be less than
@@ -854,6 +859,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .INTR => continue,
             .INVAL => unreachable,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .CANCELED => return error.Canceled,
             .BADF => return error.NotOpenForReading, // Can be a race condition.
@@ -917,6 +923,7 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
             .INTR => continue,
             .INVAL => unreachable,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForReading, // can be a race condition
             .IO => return error.InputOutput,
@@ -996,6 +1003,7 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .INTR => continue,
             .INVAL => unreachable,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForReading, // Can be a race condition.
             .IO => return error.InputOutput,
@@ -1133,6 +1141,7 @@ pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
             .INTR => continue,
             .INVAL => unreachable,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForReading, // can be a race condition
             .IO => return error.InputOutput,
@@ -1176,6 +1185,11 @@ pub const WriteError = error{
 
     /// Connection reset by peer.
     ConnectionResetByPeer,
+
+    // This error occurs in Linux if the process being written to
+    // no longer exists.
+    ProcessNotFound,
+
 } || UnexpectedError;
 
 /// Write to a file descriptor.
@@ -1243,6 +1257,7 @@ pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
             .INTR => continue,
             .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // can be a race condition.
             .DESTADDRREQ => unreachable, // `connect` was never called.
@@ -1315,6 +1330,7 @@ pub fn writev(fd: fd_t, iov: []const iovec_const) WriteError!usize {
             .INTR => continue,
             .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // Can be a race condition.
             .DESTADDRREQ => unreachable, // `connect` was never called.
@@ -1404,6 +1420,7 @@ pub fn pwrite(fd: fd_t, bytes: []const u8, offset: u64) PWriteError!usize {
             .INTR => continue,
             .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // Can be a race condition.
             .DESTADDRREQ => unreachable, // `connect` was never called.
@@ -1488,6 +1505,7 @@ pub fn pwritev(fd: fd_t, iov: []const iovec_const, offset: u64) PWriteError!usiz
             .INTR => continue,
             .INVAL => return error.InvalidArgument,
             .FAULT => unreachable,
+            .NOENT => return error.ProcessNotFound,
             .AGAIN => return error.WouldBlock,
             .BADF => return error.NotOpenForWriting, // Can be a race condition.
             .DESTADDRREQ => unreachable, // `connect` was never called.

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -802,7 +802,6 @@ pub const ReadError = error{
     // This error occurs in Linux if the process to be read from
     // no longer exists.
     ProcessNotFound,
-
 } || UnexpectedError;
 
 /// Returns the number of bytes that were read, which can be less than
@@ -1189,7 +1188,6 @@ pub const WriteError = error{
     // This error occurs in Linux if the process being written to
     // no longer exists.
     ProcessNotFound,
-
 } || UnexpectedError;
 
 /// Write to a file descriptor.

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -832,6 +832,7 @@ fn glibcVerFromRPath(rpath: []const u8) !std.SemanticVersion {
         error.UnableToReadElfFile,
         error.Unexpected,
         error.FileSystem,
+        error.ProcessNotFound,
         => |e| return e,
     };
 }
@@ -1122,6 +1123,7 @@ fn detectAbiAndDynamicLinker(
         error.SymLinkLoop,
         error.ProcessFdQuotaExceeded,
         error.SystemFdQuotaExceeded,
+        error.ProcessNotFound,
         => |e| return e,
 
         error.UnableToReadElfFile,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1078,6 +1078,7 @@ fn detectAbiAndDynamicLinker(
             const len = preadAtLeast(file, &buffer, 0, min_len) catch |err| switch (err) {
                 error.UnexpectedEndOfFile,
                 error.UnableToReadElfFile,
+                error.ProcessNotFound,
                 => return defaultAbiAndDynamicLinker(cpu, os, query),
 
                 else => |e| return e,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -172,6 +172,7 @@ pub const DetectError = error{
     DeviceBusy,
     OSVersionDetectionFail,
     Unexpected,
+    ProcessNotFound,
 };
 
 /// Given a `Target.Query`, which specifies in detail which parts of the

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -443,6 +443,7 @@ pub const AbiAndDynamicLinkerFromFileError = error{
     Unexpected,
     UnexpectedEndOfFile,
     NameTooLong,
+    ProcessNotFound,
 };
 
 pub fn abiAndDynamicLinkerFromFile(
@@ -1176,6 +1177,7 @@ fn preadAtLeast(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usi
             error.Unexpected => return error.Unexpected,
             error.InputOutput => return error.FileSystem,
             error.AccessDenied => return error.Unexpected,
+            error.ProcessNotFound => return error.ProcessNotFound,
         };
         if (len == 0) return error.UnexpectedEndOfFile;
         i += len;


### PR DESCRIPTION
This error occurs if the process to be read from or written to no longer exists.

Fixes #19875