### PR TITLE
std.PriorityQueue: Convert to an 'unmanaged'-style API

### DIFF
--- a/lib/std/priority_dequeue.zig
+++ b/lib/std/priority_dequeue.zig
@@ -34,9 +34,7 @@ pub fn PriorityDequeue(comptime T: type, comptime Context: type, comptime compar
 
         /// Free memory used by the dequeue.
         pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
-            if (self.items.len > 0) {
-                allocator.free(self.items);
-            }
+            allocator.free(self.items);
         }
 
         /// Insert a new element, maintaining priority.

--- a/lib/std/priority_dequeue.zig
+++ b/lib/std/priority_dequeue.zig
@@ -34,7 +34,9 @@ pub fn PriorityDequeue(comptime T: type, comptime Context: type, comptime compar
 
         /// Free memory used by the dequeue.
         pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
-            allocator.free(self.items);
+            if (self.items.len > 0) {
+                allocator.free(self.items);
+            }
         }
 
         /// Insert a new element, maintaining priority.

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -19,23 +19,25 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         const Self = @This();
 
         items: []T,
-        /// The capacity of the queue. This may be read directly, but must not
+        /// The current size of the queue. This may be read directly, but must not
         /// be modified directly.
-        capacity: usize,
+        len: usize,
         context: Context,
 
         /// Initialize and return an empty PriorityQueue.
         pub fn init(context: Context) Self {
             return .{
                 .items = &[_]T{},
-                .capacity = 0,
+                .len = 0,
                 .context = context,
             };
         }
 
         /// Free memory used by the queue.
         pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
-            allocator.free(self.allocatedSlice());
+            if (self.items.len > 0) {
+                allocator.free(self.items);
+            }
         }
 
         /// Insert a new element, maintaining priority.
@@ -47,9 +49,13 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         /// Insert a new element, maintaining priority. Assumes there is enough
         /// capacity in the queue for the additional item.
         pub fn addAssumeCapacity(self: *Self, elem: T) void {
-            self.items.len += 1;
-            self.items[self.items.len - 1] = elem;
-            siftUp(self, self.items.len - 1);
+            self.items[self.len] = elem;
+
+            if (self.len > 0) {
+                self.siftUp(self.len);
+            }
+
+            self.len += 1;
         }
 
         fn siftUp(self: *Self, start_index: usize) void {
@@ -82,13 +88,13 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         /// Look at the highest priority element in the queue. Returns
         /// `null` if empty.
         pub fn peek(self: *Self) ?T {
-            return if (self.items.len > 0) self.items[0] else null;
+            return if (self.len > 0) self.items[0] else null;
         }
 
         /// Pop the highest priority element from the queue. Returns
         /// `null` if empty.
         pub fn removeOrNull(self: *Self) ?T {
-            return if (self.items.len > 0) self.remove() else null;
+            return if (self.len > 0) self.remove() else null;
         }
 
         /// Remove and return the highest priority element from the
@@ -101,23 +107,23 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         /// same order as iterator, which is not necessarily priority
         /// order.
         pub fn removeIndex(self: *Self, index: usize) T {
-            assert(self.items.len > index);
-            const last = self.items[self.items.len - 1];
+            assert(self.len > index);
+            const last = self.items[self.len - 1];
             const item = self.items[index];
             self.items[index] = last;
-            self.items.len -= 1;
+            self.len -= 1;
 
-            if (index == self.items.len) {
+            if (index == self.len) {
                 // Last element removed, nothing more to do.
             } else if (index == 0) {
-                siftDown(self, index);
+                self.siftDown(index);
             } else {
                 const parent_index = ((index - 1) >> 1);
                 const parent = self.items[parent_index];
                 if (compareFn(self.context, last, parent) == .gt) {
-                    siftDown(self, index);
+                    self.siftDown(index);
                 } else {
-                    siftUp(self, index);
+                    self.siftUp(index);
                 }
             }
 
@@ -127,14 +133,7 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         /// Return the number of elements remaining in the priority
         /// queue.
         pub fn count(self: Self) usize {
-            return self.items.len;
-        }
-
-        /// Returns a slice of all the items plus the extra capacity, whose memory
-        /// contents are `undefined`.
-        fn allocatedSlice(self: Self) []T {
-            // `items.len` is the length, not the capacity.
-            return self.items.ptr[0..self.capacity];
+            return self.len;
         }
 
         fn siftDown(self: *Self, target_index: usize) void {
@@ -142,10 +141,10 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
             var index = target_index;
             while (true) {
                 var lesser_child_i = (std.math.mul(usize, index, 2) catch break) | 1;
-                if (!(lesser_child_i < self.items.len)) break;
+                if (!(lesser_child_i < self.len)) break;
 
                 const next_child_i = lesser_child_i + 1;
-                if (next_child_i < self.items.len and compareFn(self.context, self.items[next_child_i], self.items[lesser_child_i]) == .lt) {
+                if (next_child_i < self.len and compareFn(self.context, self.items[next_child_i], self.items[lesser_child_i]) == .lt) {
                     lesser_child_i = next_child_i;
                 }
 
@@ -164,11 +163,11 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         pub fn fromOwnedSlice(items: []T, context: Context) Self {
             var self = Self{
                 .items = items,
-                .capacity = items.len,
+                .len = items.len,
                 .context = context,
             };
 
-            var i = self.items.len >> 1;
+            var i = self.len >> 1;
             while (i > 0) {
                 i -= 1;
                 self.siftDown(i);
@@ -182,48 +181,41 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
             allocator: std.mem.Allocator,
             new_capacity: usize,
         ) !void {
-            var better_capacity = self.capacity;
+            var better_capacity = self.items.len;
             if (better_capacity >= new_capacity) return;
             while (true) {
                 better_capacity += better_capacity / 2 + 8;
                 if (better_capacity >= new_capacity) break;
             }
-            const old_memory = self.allocatedSlice();
-            const new_memory = try allocator.realloc(old_memory, better_capacity);
-            self.items.ptr = new_memory.ptr;
-            self.capacity = new_memory.len;
+            self.items = try allocator.realloc(self.items, better_capacity);
         }
 
         /// Ensure that the queue can fit at least `additional_count` **more** item.
         pub fn ensureUnusedCapacity(self: *Self, allocator: std.mem.Allocator, additional_count: usize) !void {
             return self.ensureTotalCapacity(
                 allocator,
-                self.items.len + additional_count,
+                self.len + additional_count,
             );
         }
 
         /// Reduce allocated capacity to `new_capacity`.
         pub fn shrinkAndFree(self: *Self, allocator: std.mem.Allocator, new_capacity: usize) void {
-            assert(new_capacity <= self.capacity);
+            assert(new_capacity <= self.items.len);
 
             // Cannot shrink to smaller than the current queue size without invalidating the heap property
-            assert(new_capacity >= self.items.len);
+            assert(new_capacity >= self.len);
 
-            const old_memory = self.allocatedSlice();
-            const new_memory = allocator.realloc(old_memory, new_capacity) catch |e| switch (e) {
+            self.items = allocator.realloc(self.items, new_capacity) catch |e| switch (e) {
                 error.OutOfMemory => { // no problem, capacity is still correct then.
                     return;
                 },
             };
-
-            self.items.ptr = new_memory.ptr;
-            self.capacity = new_memory.len;
         }
 
         pub fn update(self: *Self, elem: T, new_elem: T) !void {
             const update_index = blk: {
                 var idx: usize = 0;
-                while (idx < self.items.len) : (idx += 1) {
+                while (idx < self.len) : (idx += 1) {
                     const item = self.items[idx];
                     if (compareFn(self.context, item, elem) == .eq) break :blk idx;
                 }
@@ -243,7 +235,7 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
             count: usize,
 
             pub fn next(it: *Iterator) ?T {
-                if (it.count >= it.queue.items.len) return null;
+                if (it.count >= it.queue.len) return null;
                 const out = it.count;
                 it.count += 1;
                 return it.queue.items[out];
@@ -275,8 +267,8 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
             for (self.items) |e| {
                 print("{}, ", .{e});
             }
-            print("len: {} ", .{self.items.len});
-            print("capacity: {}", .{self.capacity});
+            print("len: {} ", .{self.len});
+            print("capacity: {}", .{self.items.len});
             print(" }}\n", .{});
         }
     };
@@ -530,16 +522,16 @@ test "shrinkAndFree" {
     defer queue.deinit(allocator);
 
     try queue.ensureTotalCapacity(allocator, 4);
-    try expect(queue.capacity >= 4);
+    try expect(queue.items.len >= 4);
 
     try queue.add(allocator, 1);
     try queue.add(allocator, 2);
     try queue.add(allocator, 3);
-    try expect(queue.capacity >= 4);
+    try expect(queue.items.len >= 4);
     try expectEqual(@as(usize, 3), queue.count());
 
     queue.shrinkAndFree(allocator, 3);
-    try expectEqual(@as(usize, 3), queue.capacity);
+    try expectEqual(@as(usize, 3), queue.items.len);
     try expectEqual(@as(usize, 3), queue.count());
 
     try expectEqual(@as(u32, 1), queue.remove());

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -19,8 +19,7 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         const Self = @This();
 
         items: []T,
-        /// The capacity of the queue. This may be read directly, but must not
-        /// be modified directly.
+        /// Tracks the allocated slice of memory when combined with `items.ptr`.
         capacity: usize,
         context: Context,
 

--- a/lib/std/priority_queue.zig
+++ b/lib/std/priority_queue.zig
@@ -18,11 +18,20 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
     return struct {
         const Self = @This();
 
-        items: []T = undefined,
+        items: []T,
         /// The capacity of the queue. This may be read directly, but must not
         /// be modified directly.
-        capacity: usize = 0,
+        capacity: usize,
         context: Context,
+
+        /// Initialize and return an empty PriorityQueue.
+        pub fn init(context: Context) Self {
+            return .{
+                .items = &[_]T{},
+                .capacity = 0,
+                .context = context,
+            };
+        }
 
         /// Free memory used by the queue.
         pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
@@ -168,7 +177,11 @@ pub fn PriorityQueue(comptime T: type, comptime Context: type, comptime compareF
         }
 
         /// Ensure that the queue can fit at least `new_capacity` items.
-        pub fn ensureTotalCapacity(self: *Self, allocator: std.mem.Allocator, new_capacity: usize) !void {
+        pub fn ensureTotalCapacity(
+            self: *Self,
+            allocator: std.mem.Allocator,
+            new_capacity: usize,
+        ) !void {
             var better_capacity = self.capacity;
             if (better_capacity >= new_capacity) return;
             while (true) {
@@ -283,7 +296,7 @@ const PQgt = PriorityQueue(u32, void, greaterThan);
 
 test "add and remove min heap" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 54);
@@ -302,7 +315,7 @@ test "add and remove min heap" {
 
 test "add and remove same min heap" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 1);
@@ -321,7 +334,7 @@ test "add and remove same min heap" {
 
 test "removeOrNull on empty" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try expect(queue.removeOrNull() == null);
@@ -329,7 +342,7 @@ test "removeOrNull on empty" {
 
 test "edge case 3 elements" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 9);
@@ -342,7 +355,7 @@ test "edge case 3 elements" {
 
 test "peek" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try expect(queue.peek() == null);
@@ -355,7 +368,7 @@ test "peek" {
 
 test "sift up with odd indices" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     const items = [_]u32{ 15, 7, 21, 14, 13, 22, 12, 6, 7, 25, 5, 24, 11, 16, 15, 24, 2, 1 };
@@ -369,7 +382,7 @@ test "sift up with odd indices" {
 
 test "addSlice" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     const items = [_]u32{ 15, 7, 21, 14, 13, 22, 12, 6, 7, 25, 5, 24, 11, 16, 15, 24, 2, 1 };
@@ -418,7 +431,7 @@ test "fromOwnedSlice" {
 
 test "add and remove max heap" {
     const allocator = testing.allocator;
-    var queue: PQgt = .{ .context = {} };
+    var queue = PQgt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 54);
@@ -437,7 +450,7 @@ test "add and remove max heap" {
 
 test "add and remove same max heap" {
     const allocator = testing.allocator;
-    var queue: PQgt = .{ .context = {} };
+    var queue = PQgt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 1);
@@ -456,7 +469,7 @@ test "add and remove same max heap" {
 
 test "iterator" {
     const allocator = testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     var map = std.AutoHashMap(u32, void).init(allocator);
@@ -478,7 +491,7 @@ test "iterator" {
 
 test "remove at index" {
     const allocator = testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     const items = [_]u32{ 2, 1, 8, 9, 3, 4, 5 };
@@ -503,7 +516,7 @@ test "remove at index" {
 
 test "iterator while empty" {
     const allocator = testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     var it = queue.iterator();
@@ -513,7 +526,7 @@ test "iterator while empty" {
 
 test "shrinkAndFree" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.ensureTotalCapacity(allocator, 4);
@@ -537,7 +550,7 @@ test "shrinkAndFree" {
 
 test "update min heap" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 55);
@@ -553,7 +566,7 @@ test "update min heap" {
 
 test "update same min heap" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 1);
@@ -570,7 +583,7 @@ test "update same min heap" {
 
 test "update max heap" {
     const allocator = std.testing.allocator;
-    var queue: PQgt = .{ .context = {} };
+    var queue = PQgt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 55);
@@ -586,7 +599,7 @@ test "update max heap" {
 
 test "update same max heap" {
     const allocator = std.testing.allocator;
-    var queue: PQgt = .{ .context = {} };
+    var queue = PQgt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 1);
@@ -603,7 +616,7 @@ test "update same max heap" {
 
 test "update after remove" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 1);
@@ -613,7 +626,7 @@ test "update after remove" {
 
 test "siftUp in remove" {
     const allocator = std.testing.allocator;
-    var queue: PQlt = .{ .context = {} };
+    var queue = PQlt.init({});
     defer queue.deinit(allocator);
 
     try queue.addSlice(
@@ -637,9 +650,8 @@ const CPQlt = PriorityQueue(usize, []const u32, contextLessThan);
 
 test "add and remove min heap with context comparator" {
     const allocator = std.testing.allocator;
-    var queue: CPQlt = .{
-        .context = &[_]u32{ 5, 3, 4, 2, 2, 8, 0 },
-    };
+    const context = [_]u32{ 5, 3, 4, 2, 2, 8, 0 };
+    var queue = CPQlt.init(&context);
     defer queue.deinit(allocator);
 
     try queue.add(allocator, 0);


### PR DESCRIPTION
Resolves: #21432.

Removed the allocator field from the PriorityQueue struct and adapted functions to take an allocator where needed.

Updated tests accordingly.

If these changes look good, I'll make corresponding changes to PriorityDequeue and include them in a follow-up patch.