### PR TITLE
`libc`: Work around LLVM's misassembly of `j <reg>` on mips r6.

### DIFF
--- a/lib/libc/glibc/sysdeps/mips/mips32/crtn.S
+++ b/lib/libc/glibc/sysdeps/mips/mips32/crtn.S
@@ -42,7 +42,8 @@
 	lw $31,28($sp)
 	.set noreorder
 	.set nomacro
-	j $31
+	/* zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315 */
+	jr $31
 	addiu $sp,$sp,32
 	.set macro
 	.set reorder
@@ -51,7 +52,8 @@
 	lw $31,28($sp)
 	.set noreorder
 	.set nomacro
-	j $31
+	/* zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315 */
+	jr $31
 	addiu $sp,$sp,32
 	.set macro
 	.set reorder

--- a/lib/libc/glibc/sysdeps/mips/mips64/n32/crtn.S
+++ b/lib/libc/glibc/sysdeps/mips/mips64/n32/crtn.S
@@ -43,7 +43,8 @@
 	ld $28,0($sp)
 	.set noreorder
 	.set nomacro
-	j $31
+	/* zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315 */
+	jr $31
 	addiu $sp,$sp,16
 	.set macro
 	.set reorder
@@ -53,7 +54,8 @@
 	ld $28,0($sp)
 	.set noreorder
 	.set nomacro
-	j $31
+	/* zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315 */
+	jr $31
 	addiu $sp,$sp,16
 	.set macro
 	.set reorder

--- a/lib/libc/glibc/sysdeps/mips/mips64/n64/crtn.S
+++ b/lib/libc/glibc/sysdeps/mips/mips64/n64/crtn.S
@@ -43,7 +43,8 @@
 	ld $28,0($sp)
 	.set noreorder
 	.set nomacro
-	j $31
+	/* zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315 */
+	jr $31
 	daddiu $sp,$sp,16
 	.set macro
 	.set reorder
@@ -53,7 +54,8 @@
 	ld $28,0($sp)
 	.set noreorder
 	.set nomacro
-	j $31
+	/* zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315 */
+	jr $31
 	daddiu $sp,$sp,16
 	.set macro
 	.set reorder

--- a/lib/libc/glibc/sysdeps/unix/mips/sysdep.h
+++ b/lib/libc/glibc/sysdeps/unix/mips/sysdep.h
@@ -39,7 +39,8 @@
 		.end	function;		        \
 		.size	function,.-function
 
-#define ret	j ra ; nop
+// zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315
+#define ret	jr ra ; nop
 
 #undef PSEUDO_END
 #define PSEUDO_END(sym) cfi_endproc; .end sym; .size sym,.-sym

--- a/lib/libc/musl/crt/mips/crtn.s
+++ b/lib/libc/musl/crt/mips/crtn.s
@@ -3,11 +3,13 @@
 .section .init
 	lw $gp,24($sp)
 	lw $ra,28($sp)
-	j $ra
+	# zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315
+	jr $ra
 	addu $sp,$sp,32
 
 .section .fini
 	lw $gp,24($sp)
 	lw $ra,28($sp)
-	j $ra
+	# zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315
+	jr $ra
 	addu $sp,$sp,32

--- a/lib/libc/musl/crt/mips64/crtn.s
+++ b/lib/libc/musl/crt/mips64/crtn.s
@@ -3,11 +3,13 @@
 .section .init
 	ld $gp,16($sp)
 	ld $ra,24($sp)
-	j $ra
+	# zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315
+	jr $ra
 	daddu $sp,$sp,32
 
 .section .fini
 	ld $gp,16($sp)
 	ld $ra,24($sp)
-	j $ra
+	# zig patch: j <reg> -> jr <reg> for https://github.com/ziglang/zig/issues/21315
+	jr $ra
 	daddu $sp,$sp,32


### PR DESCRIPTION
See: https://github.com/ziglang/zig/issues/21315

I [sent the musl patch upstream](https://www.openwall.com/lists/musl/2024/09/18/2). I won't bother upstreaming the glibc parts because I seriously doubt they'll accept it. In any case, this can of course be reverted when the LLVM assembler bug is fixed.