### PR TITLE
Add post-quantum key agreement X25519MLKEM768

### DIFF
--- a/lib/std/crypto/tls.zig
+++ b/lib/std/crypto/tls.zig
@@ -279,8 +279,8 @@ pub const NamedGroup = enum(u16) {
     ffdhe8192 = 0x0104,
 
     // Hybrid post-quantum key agreements
-    x25519_kyber512d00 = 0xFE30,
-    x25519_kyber768d00 = 0x6399,
+    secp256r1_ml_kem256 = 0x11EB,
+    x25519_ml_kem768 = 0x11EC,
 
     _,
 };


### PR DESCRIPTION
X25519MLKEM768 replaces X25519Kyber768Draft00 now that NIST has released ML-KEM.

IANA has assigned the codepoint 0x11ec:
https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8

Chrome and Firefox are planning to enable this in October.