### PR TITLE
Fix memcpy alias bug in std.compress.lzma

### DIFF
--- a/lib/std/compress/lzma.zig
+++ b/lib/std/compress/lzma.zig
@@ -77,7 +77,7 @@ pub fn Decompress(comptime ReaderType: type) type {
             const input = self.to_read.items;
             const n = @min(input.len, output.len);
             @memcpy(output[0..n], input[0..n]);
-            @memcpy(input[0 .. input.len - n], input[n..]);
+            std.mem.copyForwards(u8, input[0 .. input.len - n], input[n..]);
             self.to_read.shrinkRetainingCapacity(input.len - n);
             return n;
         }

--- a/lib/std/compress/lzma/test.zig
+++ b/lib/std/compress/lzma/test.zig
@@ -87,3 +87,13 @@ test "too small uncompressed size in header" {
         @embedFile("testdata/bad-too_small_size-without_eopm-3.lzma"),
     );
 }
+
+test "reading one byte" {
+    const compressed = @embedFile("testdata/good-known_size-with_eopm.lzma");
+    var stream = std.io.fixedBufferStream(compressed);
+    var decompressor = try lzma.decompress(std.testing.allocator, stream.reader());
+    defer decompressor.deinit();
+
+    var buffer = [1]u8{0};
+    _ = try decompressor.read(buffer[0..]);
+}


### PR DESCRIPTION
Replaces memcpy with mem.copyForwards to prevent overlap panic.

```zig
thread 18216 panic: @memcpy arguments alias
C:\Program Files\Zig\lib\std\compress\lzma.zig:80:53: 0x18c72d in read (lzma.exe.obj)
            @memcpy(input[0 .. input.len - n], input[n..]);
```

The lzma tests never triggered the bug, I assume the inputs are too small so readAllAlloc never calls .read() for less than half of the buffer length, so if needed I attach some compressed input that does (let me know if I should get a minimal input that reproduces the issue and add a test).

```zig
test "lzma big file" {
    const allocator = std.testing.allocator;
    
    const compressed_file = try std.fs.cwd().openFile("compressed.txt", .{});
    defer compressed_file.close();

    var decompressor = try std.compress.lzma.decompress(allocator, compressed_file.reader());
    defer decompressor.deinit();
    
    var buffer = [1]u8{0};
    _ = try decompressor.read(buffer[0..]);
}
```

[compressed.txt](https://github.com/user-attachments/files/17041326/compressed.txt)
[expected.txt](https://github.com/user-attachments/files/17041328/expected.txt)