### PR TITLE
uefi: erroneous alignment check in pool_allocator

### DIFF
--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -48,11 +48,9 @@ const UefiPoolAllocator = struct {
         ret_addr: usize,
     ) bool {
         _ = ret_addr;
+        _ = log2_old_ptr_align;
 
         if (new_len > buf.len) return false;
-
-        _ = mem.alignAllocLen(buf.len, new_len, log2_old_ptr_align);
-
         return true;
     }
 
@@ -121,9 +119,6 @@ fn uefi_resize(
     std.debug.assert(log2_old_ptr_align <= 3);
 
     if (new_len > buf.len) return false;
-
-    _ = mem.alignAllocLen(buf.len, new_len, 8);
-
     return true;
 }
 


### PR DESCRIPTION
Fixes #21446

Both UefiPoolAllocator and UefiRawPoolAllocator were passing the value of `log2_ptr_align` directly to
`mem.alignAllocLen` which expects a alignment value.

I have removed these calls entirely because the value was thrown away regardless, and the alignment given is always valid (not that either resize could do anything about it).