### PR TITLE
fix: Correct error message for invalid bytes in multiline strings and comments

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -13981,6 +13981,39 @@ fn lowerAstErrors(astgen: *AstGen) !void {
     var notes: std.ArrayListUnmanaged(u32) = .empty;
     defer notes.deinit(gpa);
 
+    const token_starts = tree.tokens.items(.start);
+    const token_tags = tree.tokens.items(.tag);
+    const parse_err = tree.errors[0];
+    const tok = parse_err.token + @intFromBool(parse_err.token_is_prev);
+    const tok_start = token_starts[tok];
+    const start_char = tree.source[tok_start];
+
+    if (token_tags[tok] == .invalid and
+        (start_char == '\"' or start_char == '\'' or start_char == '/' or mem.startsWith(u8, tree.source[tok_start..], "\\\\")))
+    {
+        const tok_len: u32 = @intCast(tree.tokenSlice(tok).len);
+        const tok_end = tok_start + tok_len;
+        const bad_off = blk: {
+            var idx = tok_start;
+            while (idx < tok_end) : (idx += 1) {
+                switch (tree.source[idx]) {
+                    0x00...0x09, 0x0b...0x1f, 0x7f => break,
+                    else => {},
+                }
+            }
+            break :blk idx - tok_start;
+        };
+
+        const err: Ast.Error = .{
+            .tag = Ast.Error.Tag.invalid_byte,
+            .token = tok,
+            .extra = .{ .offset = bad_off },
+        };
+        msg.clearRetainingCapacity();
+        try tree.renderError(err, msg.writer(gpa));
+        return try astgen.appendErrorTokNotesOff(tok, bad_off, "{s}", .{msg.items}, notes.items);
+    }
+
     var cur_err = tree.errors[0];
     for (tree.errors[1..]) |err| {
         if (err.is_note) {

--- a/test/cases/compile_errors/normal_string_with_newline.zig
+++ b/test/cases/compile_errors/normal_string_with_newline.zig
@@ -5,4 +5,4 @@ b";
 // backend=stage2
 // target=native
 //
-// :1:13: error: expected expression, found 'invalid token'
+// :1:15: error: string literal contains invalid byte: '\n'

--- a/test/cases/compile_errors/tab_inside_comment.zig
+++ b/test/cases/compile_errors/tab_inside_comment.zig
@@ -1,0 +1,8 @@
+// Some		comment
+export fn entry() void {}
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:8: error: comment contains invalid byte: '\t'

--- a/test/cases/compile_errors/tab_inside_doc_comment.zig
+++ b/test/cases/compile_errors/tab_inside_doc_comment.zig
@@ -1,0 +1,8 @@
+/// Some doc		comment
+export fn entry() void {}
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:13: error: comment contains invalid byte: '\t'

--- a/test/cases/compile_errors/tab_inside_multiline_string.zig
+++ b/test/cases/compile_errors/tab_inside_multiline_string.zig
@@ -1,0 +1,13 @@
+export fn entry() void {
+    const foo =
+        \\const S = struct {
+        \\	// hello
+        \\}
+    ;
+    _ = foo;
+}
+// error
+// backend=stage2
+// target=native
+//
+// :4:11: error: string literal contains invalid byte: '\t'

--- a/test/cases/compile_errors/tab_inside_string.zig
+++ b/test/cases/compile_errors/tab_inside_string.zig
@@ -1,0 +1,10 @@
+export fn entry() void {
+    const foo = "	hello";
+    _ = foo;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:18: error: string literal contains invalid byte: '\t'

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -217,7 +217,7 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
         const case = ctx.obj("invalid byte in string", b.graph.host);
 
         case.addError("_ = \"\x01Q\";", &[_][]const u8{
-            ":1:5: error: expected expression, found 'invalid token'",
+            ":1:6: error: string literal contains invalid byte: '\\x01'",
         });
     }
 
@@ -225,7 +225,7 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
         const case = ctx.obj("invalid byte in comment", b.graph.host);
 
         case.addError("//\x01Q", &[_][]const u8{
-            ":1:1: error: expected type expression, found 'invalid token'",
+            ":1:3: error: comment contains invalid byte: '\\x01'",
         });
     }
 
@@ -233,7 +233,7 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
         const case = ctx.obj("control character in character literal", b.graph.host);
 
         case.addError("const c = '\x01';", &[_][]const u8{
-            ":1:11: error: expected expression, found 'invalid token'",
+            ":1:12: error: character literal contains invalid byte: '\\x01'",
         });
     }
 


### PR DESCRIPTION
This change provides a correct error message when an invalid byte is found inside of a multiline string line, comments, and doc comments. 

<Details>
<Summary>Inside multiline strings</Summary>
Taking the example from #20900:

```zig

const foo =
    \\const S = struct {
    \\<TAB>// hello
    \\}
;
```

Before:

```shell
src/main.zig:4:1: error: expected ';' after statement
    \\ // hello
^
```

After:

```shell
src/main.zig:4:5: error: expected 'a string literal', found invalid bytes
    \\ // hello
    ^~~~~~~~~~~
src/main.zig:4:7: note: invalid byte: '\t'
    \\ // hello
      ^~~~~~~~~~~
```
</Details>

<Details>
<Summary>Doc comments</Summary>

```zig
/// Some <TAB>comment
```

Before:

```shell
src/main.zig:1:1: error: expected type expression, found 'invalid token'
/// Some  comment
^~~~~~~~~~~~~~~~~
```

After:

```shell
src/main.zig:1:1: error: expected 'a document comment', found invalid bytes
/// Some  comment
^~~~~~~~~~~~~~~~~
src/main.zig:1:10: note: invalid byte: '\t'
/// Some  comment
         ^~~~~~~~~~~~~~~~~
```
</Details>

<Details>
<Summary>Comments</Summary>

```zig
// Some <TAB>comment
```

Before:

```shell
src/main.zig:1:1: error: expected type expression, found 'invalid token'
// Some  comment
^~~~~~~~~~~~~~~~~
```

After:

```shell
src/main.zig:1:1: error: expected 'a comment', found invalid bytes
// Some  comment
^~~~~~~~~~~~~~~~~
src/main.zig:1:9: note: invalid byte: '\t'
// Some  comment
        ^~~~~~~~~~~~~~~~~
```
</Details>

I'm not 100% confident in the set of invalid bytes I added in `lowerAstErrors`, as it's just based off of those listed in the [`multiline_string_literal_line` case](https://github.com/ziglang/zig/blob/8b82a0e0fc5cac9a5376f06955ca4419b9a9923f/lib/std/zig/tokenizer.zig#L765-L778) of `Tokenizer.next()`. I think this part of the PR in particular could benefit from a close second check. :)

~~I initially thought that the similar problem with invalid bytes inside comments (mentioned [here](https://github.com/ziglang/zig/issues/20900#issuecomment-2316464047)), but there isn't a `.comment` variant (only `.doc_comment` and `.container_doc_comment`) of `Token.Tag` to report the expected token as. Another variant to `Ast.Error.Tag` could be added to handle this case, but I wanted to check before doing so.~~ See followup comment.

One minor nit/ bikeshed question: The rendered error message for this case reads `error: expected 'a string literal', found invalid bytes`. Since this error is triggered by the first *single* invalid byte encountered by the tokenizer, should this message use "byte" instead?

- Closes #20900
- Closes #22160