### PR TITLE
doc: Bump LLVM version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ensure you have the required dependencies:
 
  * CMake >= 3.15
  * System C/C++ Toolchain
- * LLVM, Clang, LLD development libraries == 18.x
+ * LLVM, Clang, LLD development libraries == 19.x
 
 Then it is the standard CMake build process:
 


### PR DESCRIPTION
Quick one-liner to bump README LLVM version now that llvm19 branch is merged.