### PR TITLE
`compiler-rt`: Export extra soft float libcall names for `thumb-windows-gnu`.

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -28,6 +28,8 @@ pub const want_aeabi = switch (builtin.abi) {
     },
     else => false,
 };
+pub const want_mingw_arm_abi = builtin.cpu.arch.isArmOrThumb() and builtin.target.isMinGW();
+
 pub const want_ppc_abi = builtin.cpu.arch.isPowerPC();
 
 pub const want_float_exceptions = !builtin.cpu.arch.isWasm();

--- a/lib/compiler_rt/fixdfdi.zig
+++ b/lib/compiler_rt/fixdfdi.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const intFromFloat = @import("./int_from_float.zig").intFromFloat;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_d2lz, .{ .name = "__aeabi_d2lz", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__fixdfdi, .{ .name = "__fixdfdi", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__fixdfdi, .{ .name = "__dtoi64", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixsfdi.zig
+++ b/lib/compiler_rt/fixsfdi.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const intFromFloat = @import("./int_from_float.zig").intFromFloat;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_f2lz, .{ .name = "__aeabi_f2lz", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__fixsfdi, .{ .name = "__fixsfdi", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__fixsfdi, .{ .name = "__stoi64", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixunsdfdi.zig
+++ b/lib/compiler_rt/fixunsdfdi.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const intFromFloat = @import("./int_from_float.zig").intFromFloat;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_d2ulz, .{ .name = "__aeabi_d2ulz", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__fixunsdfdi, .{ .name = "__fixunsdfdi", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__fixunsdfdi, .{ .name = "__dtou64", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/fixunssfdi.zig
+++ b/lib/compiler_rt/fixunssfdi.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const intFromFloat = @import("./int_from_float.zig").intFromFloat;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_f2ulz, .{ .name = "__aeabi_f2ulz", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__fixunssfdi, .{ .name = "__fixunssfdi", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__fixunssfdi, .{ .name = "__stou64", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatdidf.zig
+++ b/lib/compiler_rt/floatdidf.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const floatFromInt = @import("./float_from_int.zig").floatFromInt;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_l2d, .{ .name = "__aeabi_l2d", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__floatdidf, .{ .name = "__floatdidf", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__floatdidf, .{ .name = "__i64tod", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatdisf.zig
+++ b/lib/compiler_rt/floatdisf.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const floatFromInt = @import("./float_from_int.zig").floatFromInt;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_l2f, .{ .name = "__aeabi_l2f", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__floatdisf, .{ .name = "__floatdisf", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__floatdisf, .{ .name = "__i64tos", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatundidf.zig
+++ b/lib/compiler_rt/floatundidf.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const floatFromInt = @import("./float_from_int.zig").floatFromInt;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_ul2d, .{ .name = "__aeabi_ul2d", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__floatundidf, .{ .name = "__floatundidf", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__floatundidf, .{ .name = "__u64tod", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 

--- a/lib/compiler_rt/floatundisf.zig
+++ b/lib/compiler_rt/floatundisf.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const common = @import("./common.zig");
 const floatFromInt = @import("./float_from_int.zig").floatFromInt;
 
@@ -8,6 +9,10 @@ comptime {
         @export(&__aeabi_ul2f, .{ .name = "__aeabi_ul2f", .linkage = common.linkage, .visibility = common.visibility });
     } else {
         @export(&__floatundisf, .{ .name = "__floatundisf", .linkage = common.linkage, .visibility = common.visibility });
+
+        if (common.want_mingw_arm_abi) {
+            @export(&__floatundisf, .{ .name = "__u64tos", .linkage = common.linkage, .visibility = common.visibility });
+        }
     }
 }
 


### PR DESCRIPTION
These are necessary in addition to the usual ones. LLVM emits calls to both sets, for whatever reason.

With this and #21472, we can bootstrap for `thumb-windows-gnu`. (Whether the resulting binary works is a whole other question though...)