### PR TITLE
fix: Add error note when attempt is made to destructure error union

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5428,6 +5428,9 @@ fn zirValidateDestructure(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Comp
             const msg = try sema.errMsg(src, "type '{}' cannot be destructured", .{operand_ty.fmt(pt)});
             errdefer msg.destroy(sema.gpa);
             try sema.errNote(destructure_src, msg, "result destructured here", .{});
+            if (operand_ty.zigTypeTag(pt.zcu) == .error_union) {
+                try sema.errNote(src, msg, "consider using 'try', 'catch', or 'if'", .{});
+            }
             break :msg msg;
         });
     }

--- a/test/cases/compile_errors/destructure_error_union.zig
+++ b/test/cases/compile_errors/destructure_error_union.zig
@@ -1,9 +1,7 @@
-fn foo() !struct { u8, u8 } {
-    return error.Failure;
-}
-
 pub export fn entry() void {
-    const bar, const baz = foo();
+    const Foo = struct { u8, u8 };
+    const foo: anyerror!Foo = error.Failure;
+    const bar, const baz = foo;
     _ = bar;
     _ = baz;
 }
@@ -12,6 +10,6 @@ pub export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :6:31: error: type '@typeInfo(@typeInfo(@TypeOf(tmp.foo)).@"fn".return_type.?).error_union.error_set!tmp.foo__struct_1306' cannot be destructured
-// :6:26: note: result destructured here
-// :6:31: note: consider using 'try', 'catch', or 'if'
+// :4:28: error: type 'anyerror!tmp.entry.Foo' cannot be destructured
+// :4:26: note: result destructured here
+// :4:28: note: consider using 'try', 'catch', or 'if'

--- a/test/cases/compile_errors/destructure_error_union.zig
+++ b/test/cases/compile_errors/destructure_error_union.zig
@@ -1,0 +1,17 @@
+fn foo() !struct { u8, u8 } {
+    return error.Failure;
+}
+
+pub export fn entry() void {
+    const bar, const baz = foo();
+    _ = bar;
+    _ = baz;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :6:31: error: type '@typeInfo(@typeInfo(@TypeOf(tmp.foo)).@"fn".return_type.?).error_union.error_set!tmp.foo__struct_1306' cannot be destructured
+// :6:26: note: result destructured here
+// :6:31: note: consider using 'try', 'catch', or 'if'


### PR DESCRIPTION
Adds a helpful error note when an attempt is made to destructure an error union.

Before:

```shell
src/main.zig:6:31: error: type '@typeInfo(@typeInfo(@TypeOf(main.foo)).@"fn".return_type.?).error_union.error_set!main.foo__struct_1598' cannot be destructured
    const bar, const baz = foo();
                           ~~~^~
src/main.zig:6:26: note: result destructured here
    const bar, const baz = foo();
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```

After:

```shell
src/main.zig:6:31: error: type '@typeInfo(@typeInfo(@TypeOf(main.foo)).@"fn".return_type.?).error_union.error_set!main.foo__struct_1598' cannot be destructured
    const bar, const baz = foo();
                           ~~~^~
src/main.zig:6:26: note: result destructured here
    const bar, const baz = foo();
    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
src/main.zig:6:31: note: consider using 'try', 'catch', or 'if'
```

Closes #21417 