### PR TITLE
fix: support error set values with @errorCast

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -23603,7 +23603,7 @@ fn zirErrorCast(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData
         dest_ty.toIntern() != .adhoc_inferred_error_set_type and
         zcu.backendSupportsFeature(.error_set_has_value))
     {
-        if (dest_tag == .error_union) {
+        if (dest_tag == .error_union and base_operand_ty.zigTypeTag(zcu) == .error_union) {
             const err_code = try sema.analyzeErrUnionCode(block, operand_src, operand);
             const err_int = try block.addBitCast(err_int_ty, err_code);
             const zero_err = try pt.intRef(try pt.errorIntType(), 0);

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -23603,7 +23603,7 @@ fn zirErrorCast(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData
         dest_ty.toIntern() != .adhoc_inferred_error_set_type and
         zcu.backendSupportsFeature(.error_set_has_value))
     {
-        if (dest_tag == .error_union and base_operand_ty.zigTypeTag(zcu) == .error_union) {
+        if (dest_tag == .error_union and operand_tag == .error_union) {
             const err_code = try sema.analyzeErrUnionCode(block, operand_src, operand);
             const err_int = try block.addBitCast(err_int_ty, err_code);
             const zero_err = try pt.intRef(try pt.errorIntType(), 0);
@@ -23622,6 +23622,8 @@ fn zirErrorCast(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData
             const err_int_inst = try block.addBitCast(err_int_ty, operand);
             const ok = try block.addTyOp(.error_set_has_value, dest_ty, err_int_inst);
             try sema.addSafetyCheck(block, src, ok, .invalid_error_code);
+            if (dest_tag == .error_union and operand_tag == .error_set)
+                return block.addTyOp(.wrap_errunion_err, base_dest_ty, err_int_inst);
         }
     }
     return block.addBitCast(base_dest_ty, operand);

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1065,6 +1065,18 @@ test "errorCast from error sets to error unions" {
     try expectError(error.A, err_union);
 }
 
+test "errorCast return of error set to error union" {
+    const S = struct {
+        fn foo() error{Foo}!void {
+            return @This().bar() catch |err| @errorCast(err);
+        }
+        fn bar() error{ Foo, Bar }!void {
+            return error.Foo;
+        }
+    };
+    try std.testing.expect(S.foo() == error.Foo);
+}
+
 test "result location initialization of error union with OPV payload" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1065,12 +1065,24 @@ test "errorCast from error sets to error unions" {
     try expectError(error.A, err_union);
 }
 
-test "errorCast return of error set to error union" {
+test "errorCast return of error set to void payload error union" {
     const S = struct {
         fn foo() error{Foo}!void {
             return @This().bar() catch |err| @errorCast(err);
         }
         fn bar() error{ Foo, Bar }!void {
+            return error.Foo;
+        }
+    };
+    try std.testing.expect(S.foo() == error.Foo);
+}
+
+test "errorCast return of error set to non-void payload error union" {
+    const S = struct {
+        fn foo() error{Foo}!u32 {
+            return @This().bar() catch |err| @errorCast(err);
+        }
+        fn bar() error{ Foo, Bar }!u32 {
             return error.Foo;
         }
     };


### PR DESCRIPTION
It looks like `zirErrorCast` attempts to complete its cast if the destination operand is an error union, treating the source as an error union even if it's an error set value:

https://github.com/ziglang/zig/blob/d83a3f1746c81026d1cf0244156513c9b5a2a9f6/src/Sema.zig#L23606-L23607

Checking if the source type tag is also an error union avoids this, handling it instead in the check's `else` block:

https://github.com/ziglang/zig/blob/d83a3f1746c81026d1cf0244156513c9b5a2a9f6/src/Sema.zig#L23621-L23625

As far as I can tell, adding this additional `base_operand_ty.zigTypeTag(zcu) == .error_union` condition fixes the issue.

Running `zig build` on  the example from #20169 used to give the following error:

```shell
src/main.zig:21:41: error: expected error union type, found 'error{Foo,Bar}'
    return bar() catch |err| @errorCast(err);
                                        ^~~
```

but now compiles successfully.

Closes #20169 