### PR TITLE
`std.Target`: Introduce `Abi.androideabi` to distinguish the soft float case.

### DIFF
--- a/lib/compiler/aro/aro/Compilation.zig
+++ b/lib/compiler/aro/aro/Compilation.zig
@@ -308,7 +308,7 @@ fn generateSystemDefines(comp: *Compilation, w: anytype) !void {
         ),
         else => {},
     }
-    if (comp.target.abi == .android) {
+    if (comp.target.isAndroid()) {
         try w.writeAll("#define __ANDROID__ 1\n");
     }
 

--- a/lib/compiler/aro/aro/target.zig
+++ b/lib/compiler/aro/aro/target.zig
@@ -690,6 +690,7 @@ pub fn toLLVMTriple(target: std.Target, buf: []u8) []const u8 {
         .eabi => "eabi",
         .eabihf => "eabihf",
         .android => "android",
+        .androideabi => "androideabi",
         .musl => "musl",
         .musleabi => "musleabi",
         .musleabihf => "musleabihf",

--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -22,6 +22,7 @@ pub const want_aeabi = switch (builtin.abi) {
     .gnueabi,
     .gnueabihf,
     .android,
+    .androideabi,
     => switch (builtin.cpu.arch) {
         .arm, .armeb, .thumb, .thumbeb => true,
         else => false,

--- a/lib/compiler_rt/emutls.zig
+++ b/lib/compiler_rt/emutls.zig
@@ -18,7 +18,7 @@ const gcc_word = usize;
 pub const panic = common.panic;
 
 comptime {
-    if (builtin.link_libc and (builtin.abi == .android or builtin.os.tag == .openbsd)) {
+    if (builtin.link_libc and (builtin.abi.isAndroid() or builtin.os.tag == .openbsd)) {
         @export(&__emutls_get_address, .{ .name = "__emutls_get_address", .linkage = common.linkage, .visibility = common.visibility });
     }
 }

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -664,6 +664,7 @@ pub const Abi = enum {
     eabihf,
     ilp32,
     android,
+    androideabi,
     musl,
     musleabi,
     musleabihf,
@@ -770,8 +771,16 @@ pub const Abi = enum {
         };
     }
 
+    pub inline fn isAndroid(abi: Abi) bool {
+        return switch (abi) {
+            .android, .androideabi => true,
+            else => false,
+        };
+    }
+
     pub inline fn floatAbi(abi: Abi) FloatAbi {
         return switch (abi) {
+            .androideabi,
             .eabi,
             .gnueabi,
             .musleabi,
@@ -1617,7 +1626,7 @@ pub inline fn isMusl(target: Target) bool {
 }
 
 pub inline fn isAndroid(target: Target) bool {
-    return target.abi == .android;
+    return target.abi.isAndroid();
 }
 
 pub inline fn isWasm(target: Target) bool {
@@ -1724,7 +1733,7 @@ pub const DynamicLinker = struct {
     }
 
     pub fn standard(cpu: Cpu, os_tag: Os.Tag, abi: Abi) DynamicLinker {
-        return if (abi == .android) initFmt("/system/bin/linker{s}", .{
+        return if (abi.isAndroid()) initFmt("/system/bin/linker{s}", .{
             if (ptrBitWidth_cpu_abi(cpu, abi) == 64) "64" else "",
         }) catch unreachable else if (abi.isMusl()) return initFmt("/lib/ld-musl-{s}{s}.so.1", .{
             @tagName(switch (cpu.arch) {
@@ -2391,6 +2400,7 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
                     .eabi,
                     .eabihf,
                     .android,
+                    .androideabi,
                     .musleabi,
                     .musleabihf,
                     => 8,
@@ -2463,6 +2473,7 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
                 .eabi,
                 .eabihf,
                 .android,
+                .androideabi,
                 .musleabi,
                 .musleabihf,
                 => {},

--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -374,7 +374,7 @@ pub fn canDetectLibC(self: Query) bool {
     if (self.isNativeOs()) return true;
     if (self.os_tag) |os| {
         if (builtin.os.tag == .macos and os.isDarwin()) return true;
-        if (os == .linux and self.abi == .android) return true;
+        if (os == .linux and self.abi.isAndroid()) return true;
     }
     return false;
 }

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -5946,7 +5946,7 @@ pub const PR = switch (native_os) {
 };
 pub const _errno = switch (native_os) {
     .linux => switch (native_abi) {
-        .android => private.__errno,
+        .android, .androideabi => private.__errno,
         else => private.__errno_location,
     },
     .emscripten => private.__errno_location,
@@ -6754,7 +6754,7 @@ pub const pthread_mutex_t = switch (native_os) {
                 .mips64, .powerpc64, .powerpc64le, .sparc64 => 40,
                 else => if (@sizeOf(usize) == 8) 40 else 24,
             },
-            .android => if (@sizeOf(usize) == 8) 40 else 4,
+            .android, .androideabi => if (@sizeOf(usize) == 8) 40 else 4,
             else => @compileError("unsupported ABI"),
         };
     },
@@ -6848,7 +6848,7 @@ pub const pthread_cond_t = switch (native_os) {
 
 pub const pthread_rwlock_t = switch (native_os) {
     .linux => switch (native_abi) {
-        .android => switch (@sizeOf(usize)) {
+        .android, .androideabi => switch (@sizeOf(usize)) {
             4 => extern struct {
                 data: [40]u8 align(@alignOf(usize)) = [_]u8{0} ** 40,
             },

--- a/lib/std/zig/LibCDirs.zig
+++ b/lib/std/zig/LibCDirs.zig
@@ -248,6 +248,7 @@ fn libCGenericName(target: std.Target) [:0]const u8 {
         .eabihf,
         .ilp32,
         .android,
+        .androideabi,
         .msvc,
         .itanium,
         .cygnus,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -172,6 +172,7 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .eabi => "eabi",
         .eabihf => "eabihf",
         .android => "android",
+        .androideabi => "androideabi",
         .musl => "musl",
         .musleabi => "musleabi",
         .musleabihf => "musleabihf",

--- a/src/target.zig
+++ b/src/target.zig
@@ -304,20 +304,17 @@ pub fn libcFullLinkFlags(target: std.Target) []const []const u8 {
             "-lc",
             "-lnetwork",
         },
-        else => switch (target.abi) {
-            .android => &[_][]const u8{
-                "-lm",
-                "-lc",
-                "-ldl",
-            },
-            else => &[_][]const u8{
-                "-lm",
-                "-lpthread",
-                "-lc",
-                "-ldl",
-                "-lrt",
-                "-lutil",
-            },
+        else => if (target.isAndroid()) &[_][]const u8{
+            "-lm",
+            "-lc",
+            "-ldl",
+        } else &[_][]const u8{
+            "-lm",
+            "-lpthread",
+            "-lc",
+            "-ldl",
+            "-lrt",
+            "-lutil",
         },
     };
 }


### PR DESCRIPTION
`Abi.android` on its own is not enough to know whether soft float or hard float should be used. In the C world, `androideabi` is typically used for the soft float case, so let's go with that.

Note that Android doesn't have a hard float ABI for 32-bit Arm, so no `androideabihf`.

Closes #21488.