### PR TITLE
fix: Only suggest try on destructure of error union if payload type can be destructured

### DIFF
--- a/test/cases/compile_errors/invalid_destructure_error_union.zig
+++ b/test/cases/compile_errors/invalid_destructure_error_union.zig
@@ -1,0 +1,13 @@
+pub export fn entry() void {
+    const foo: anyerror!u32 = error.Failure;
+    const bar, const baz = foo;
+    _ = bar;
+    _ = baz;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:28: error: type 'anyerror!u32' cannot be destructured
+// :3:26: note: result destructured here


### PR DESCRIPTION
Followup to #21491, based on [this comment ](https://github.com/ziglang/zig/pull/21491#issuecomment-2371768955).

Previously, the following note was added whenever an attempt was made to destructure an error union:

`note: consider using 'try', 'catch', or 'if'`

With these changes, the note is added only if the underlying payload type can be destructured.