### PR TITLE
mips: use byval for all integer types

### DIFF
--- a/src/arch/mips/abi.zig
+++ b/src/arch/mips/abi.zig
@@ -41,8 +41,6 @@ pub fn classifyType(ty: Type, zcu: *Zcu, ctx: Context) Class {
         .bool => return .byval,
         .float => return .byval,
         .int, .@"enum", .error_set => {
-            const bit_size = ty.bitSize(zcu);
-            if (bit_size > max_direct_size) return .memory;
             return .byval;
         },
         .vector => {


### PR DESCRIPTION
This fixes crashing std and compiler_rt tests.
ABI tests cannot be enabled for this because clang doesn't support `__int128` on mips(el).