### PR TITLE
std.os.linux: extend rtattr.type to support IFA_*

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -8064,9 +8064,31 @@ pub const rtattr = extern struct {
     len: c_ushort,
 
     /// Type of option
-    type: IFLA,
+    type: extern union {
+        /// IFLA_* from linux/if_link.h
+        link: IFLA,
+        /// IFA_* from linux/if_addr.h
+        addr: IFA,
+    },
 
     pub const ALIGNTO = 4;
+};
+
+pub const IFA = enum(c_ushort) {
+    UNSPEC,
+    ADDRESS,
+    LOCAL,
+    LABEL,
+    BROADCAST,
+    ANYCAST,
+    CACHEINFO,
+    MULTICAST,
+    FLAGS,
+    RT_PRIORITY,
+    TARGET_NETNSID,
+    PROTO,
+
+    _,
 };
 
 pub const IFLA = enum(c_ushort) {


### PR DESCRIPTION
This is a breaking change which updates the `rtattr.type` from `IFLA` to `union { IFLA, IFA }`. `IFLA` is for the `RTM_*LINK` messages and `IFA` is for the `RTM_*ADDR` messages.

The declaration of IFA is based on linux-6.11(actually no updates after 5.18).

I am recently exploring the linux netlink api, and find that current definition of `std.os.linux.rtattr`  declares the `type` as `IFLA`, but actually it can also be `IFA`. For more, please refer to `man 7 rtnetlink`.

When the message type is `RTM_GETLINK` for instance, the `rtattr.type` is `IFLA`, when it is `RTM_GETADDR`, the `rtattr.type` should he `IFA` instead.

Part of my side project code here:
```zig
var msg_iter = try req.get(.RTM_GETADDR);
defer msg_iter.deinit();
while (try msg_iter.next()) |msg| {
    if (msg.header.type != .RTM_NEWADDR)
        continue;
    const addrmsg = msg.as(netlink.ifaddrmsg);
    log.debug("addr: {}", .{addrmsg});

    var attr_iter = msg.attributes();
    while (attr_iter.next()) |attr| {
        log.debug("attr: {*},{}", .{ attr, attr.header });
        if (addrmsg.family != os.AF.INET)
            continue;

        switch (attr.type(netlink.IFA)) {
            .LABEL => {
                const zname = attr.asSlice(u8, 0);
                log.info("name: {s}", .{zname});
            },
            .LOCAL => {
                const addr = std.net.Ip4Address.init(attr.as([4]u8).*, 0);
                log.info("addr: {}/{}", .{ addr, addrmsg.prefixlen });
            },
            .BROADCAST => {
                const addr = std.net.Ip4Address.init(attr.as([4]u8).*, 0);
                log.info("brd: {any}", .{addr});
            },
            else => {},
        }
    }
}
```