### PR TITLE
incr-check enhancements, and CI for incremental test cases

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -577,6 +577,10 @@ pub fn build(b: *std.Build) !void {
     } else {
         update_mingw_step.dependOn(&b.addFail("The -Dmingw-src=... option is required for this step").step);
     }
+
+    const test_incremental_step = b.step("test-incremental", "Run the incremental compilation test cases");
+    try tests.addIncrementalTests(b, test_incremental_step);
+    test_step.dependOn(test_incremental_step);
 }
 
 fn addWasiUpdateStep(b: *std.Build, version: [:0]const u8) !void {

--- a/test/incremental/add_decl
+++ b/test/incremental/add_decl
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const std = @import("std");

--- a/test/incremental/add_decl_namespaced
+++ b/test/incremental/add_decl_namespaced
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const std = @import("std");

--- a/test/incremental/delete_comptime_decls
+++ b/test/incremental/delete_comptime_decls
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 pub fn main() void {}

--- a/test/incremental/hello
+++ b/test/incremental/hello
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const std = @import("std");

--- a/test/incremental/modify_inline_fn
+++ b/test/incremental/modify_inline_fn
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const std = @import("std");

--- a/test/incremental/move_src
+++ b/test/incremental/move_src
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const std = @import("std");

--- a/test/incremental/remove_enum_field
+++ b/test/incremental/remove_enum_field
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const MyEnum = enum(u8) {

--- a/test/incremental/type_becomes_comptime_only
+++ b/test/incremental/type_becomes_comptime_only
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const SomeType = u32;

--- a/test/incremental/unreferenced_error
+++ b/test/incremental/unreferenced_error
@@ -1,5 +1,6 @@
 #target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
 #update=initial version
 #file=main.zig
 const std = @import("std");

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1509,3 +1509,31 @@ pub fn addDebuggerTests(b: *std.Build, options: DebuggerContext.Options) ?*Step 
     });
     return step;
 }
+
+pub fn addIncrementalTests(b: *std.Build, test_step: *Step) !void {
+    const incr_check = b.addExecutable(.{
+        .name = "incr-check",
+        .root_source_file = b.path("tools/incr-check.zig"),
+        .target = b.graph.host,
+        .optimize = .Debug,
+    });
+
+    var dir = try b.build_root.handle.openDir("test/incremental", .{ .iterate = true });
+    defer dir.close();
+
+    var it = try dir.walk(b.graph.arena);
+    while (try it.next()) |entry| {
+        if (entry.kind != .file) continue;
+
+        const run = b.addRunArtifact(incr_check);
+        run.setName(b.fmt("incr-check '{s}'", .{entry.basename}));
+
+        run.addArg(b.graph.zig_exe);
+        run.addFileArg(b.path("test/incremental/").path(b, entry.path));
+        run.addArgs(&.{ "--zig-lib-dir", b.fmt("{}", .{b.graph.zig_lib_directory}) });
+
+        run.addCheck(.{ .expect_term = .{ .Exited = 0 } });
+
+        test_step.dependOn(&run.step);
+    }
+}

--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -68,7 +68,9 @@ pub fn main() !void {
     const debug_log_verbose = debug_zcu or debug_link;
 
     for (case.targets) |target| {
-        std.log.scoped(.status).info("target: '{s}-{s}'", .{ target.query, @tagName(target.backend) });
+        if (debug_log_verbose) {
+            std.log.scoped(.status).info("target: '{s}-{s}'", .{ target.query, @tagName(target.backend) });
+        }
 
         var child_args: std.ArrayListUnmanaged([]const u8) = .empty;
         try child_args.appendSlice(arena, &.{


### PR DESCRIPTION
This does exactly what the title says. `zig build test` now includes `zig build test-incremental`, which runs `incr-check` over every case in `test/incremental/` (we expect exit code 0 from `incr-check`). In addition, `incr-check` undergoes several enhancements:
* Progress output now includes the target being tested
* External executors are used for emitted binaries which cannot be executed natively
  * (If no executor exists, execution of the binary is silently skipped)
* The temporary directory created by `incr-check` is removed by default (both on success and on error); it can be retained for debugging purposes with the `--preserve-tmp` flag

All of the incremental test cases now include the `x86_64-windows-cbe` target too, just for a little more coverage -- see the corresponding commit message.