### PR TITLE
`std.io.Reader`: Fix test erroneously using `undefined`.

### DIFF
--- a/lib/std/io/Reader/test.zig
+++ b/lib/std/io/Reader/test.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const std = @import("../../std.zig");
 const testing = std.testing;
 
@@ -11,7 +12,7 @@ test "Reader" {
         b = 99,
         c = 2,
         d = 3,
-    }, undefined)) == .c);
+    }, builtin.cpu.arch.endian())) == .c);
     try testing.expectError(error.EndOfStream, reader.readByte());
 }
 


### PR DESCRIPTION
The `endian` argument ends up being read here:

https://github.com/ziglang/zig/blob/085cc54aadb327b9910be2c72b31ea046e7e8f52/lib/std/mem.zig#L1722-L1725

So this seems obviously broken.

For whatever reason, this only manifested on `powerpc-linux-*` with `-O ReleaseSafe`.