### PR TITLE
std.start: dont query stack limit for wanted stack size 0

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -537,31 +537,35 @@ fn posixCallMainAndExit(argc_argv_ptr: [*]usize) callconv(.C) noreturn {
 
 fn expandStackSize(phdrs: []elf.Phdr) void {
     for (phdrs) |*phdr| {
-        if ((phdr.p_type == elf.PT_GNU_STACK) and (phdr.p_memsz > 0)) {
-            assert(phdr.p_memsz % std.mem.page_size == 0);
+        switch (phdr.p_type) {
+            elf.PT_GNU_STACK => {
+                if (phdr.p_memsz == 0) break;
+                assert(phdr.p_memsz % std.mem.page_size == 0);
 
-            // Silently fail if we are unable to get limits.
-            const limits = std.posix.getrlimit(.STACK) catch break;
+                // Silently fail if we are unable to get limits.
+                const limits = std.posix.getrlimit(.STACK) catch break;
 
-            // Clamp to limits.max .
-            const wanted_stack_size = @min(phdr.p_memsz, limits.max);
+                // Clamp to limits.max .
+                const wanted_stack_size = @min(phdr.p_memsz, limits.max);
 
-            if (wanted_stack_size > limits.cur) {
-                std.posix.setrlimit(.STACK, .{
-                    .cur = wanted_stack_size,
-                    .max = limits.max,
-                }) catch {
-                    // Because we could not increase the stack size to the upper bound,
-                    // depending on what happens at runtime, a stack overflow may occur.
-                    // However it would cause a segmentation fault, thanks to stack probing,
-                    // so we do not have a memory safety issue here.
-                    // This is intentional silent failure.
-                    // This logic should be revisited when the following issues are addressed:
-                    // https://github.com/ziglang/zig/issues/157
-                    // https://github.com/ziglang/zig/issues/1006
-                };
-            }
-            break;
+                if (wanted_stack_size > limits.cur) {
+                    std.posix.setrlimit(.STACK, .{
+                        .cur = wanted_stack_size,
+                        .max = limits.max,
+                    }) catch {
+                        // Because we could not increase the stack size to the upper bound,
+                        // depending on what happens at runtime, a stack overflow may occur.
+                        // However it would cause a segmentation fault, thanks to stack probing,
+                        // so we do not have a memory safety issue here.
+                        // This is intentional silent failure.
+                        // This logic should be revisited when the following issues are addressed:
+                        // https://github.com/ziglang/zig/issues/157
+                        // https://github.com/ziglang/zig/issues/1006
+                    };
+                }
+                break;
+            },
+            else => {},
         }
     }
 }


### PR DESCRIPTION
If wanted stack size is `0` (effectively asking the system to use some sane default), the following `if` wont be true:
https://github.com/ziglang/zig/blob/085cc54aadb327b9910be2c72b31ea046e7e8f52/lib/std/start.zig#L550
so we wont `setrlimit()` and therefore dont need to `getrlimit()`

For the following test, the wanted stack size is set via `--stack 0`

Before:

```
$ zig build-exe hello.zig -O ReleaseFast -fsingle-threaded --stack 0

$ strace ./hello
execve("./hello", ["./hello"], 0x7ffe9784a320 /* 34 vars */) = 0
prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
rt_sigaction(SIGPIPE, {sa_handler=0x1001550, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x1001560}, NULL, 8) = 0
write(1, "Hello, World!\n", 14Hello, World!
)         = 14
exit(0)                                 = ?
+++ exited with 0 +++
```

After:

```
$ zig build-exe hello.zig -O ReleaseFast -fsingle-threaded --stack 0

$ strace ./hello
execve("./hello", ["./hello"], 0x7ffd3a872c70 /* 34 vars */) = 0
rt_sigaction(SIGPIPE, {sa_handler=0x1001560, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x1001570}, NULL, 8) = 0
write(1, "Hello, World!\n", 14Hello, World!
)         = 14
exit(0)                                 = ?
+++ exited with 0 +++
```

Would be better if wanted stack size were comptime so the whole `expandStackSize()` could be optimized out.
Maye someone can help out and enhance this PR?
Is there something like `build.options.stack_size` we could check instead of the elf-header-field?