### PR TITLE
fix typo in @typeName langref

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2257,7 +2257,7 @@ or
           that variable.</li>
           <li>If the struct is in the {#syntax#}return{#endsyntax#} expression, it gets named after
           the function it is returning from, with the parameter values serialized.</li>
-          <li>Otherwise, the struct gets a name such as <code>(filename.funcname.__struct_ID)</code>.</li>
+          <li>Otherwise, the struct gets a name such as <code>(filename.funcname__struct_ID)</code>.</li>
           <li>If the struct is declared inside another struct, it gets named after both the parent
           struct and the name inferred by the previous rules, separated by a dot.</li>
       </ul>


### PR DESCRIPTION
My second attempted contribution! Feedback welcome.

Intended to resolve https://github.com/ziglang/zig/issues/21535

I traced the relevant lines to: 

https://github.com/ziglang/zig/blob/085cc54aadb327b9910be2c72b31ea046e7e8f52/src/Sema.zig#L2978

```zig
    return ip.getOrPutStringFmt(gpa, pt.tid, "{}__{s}_{d}", .{
        block.type_name_ctx.fmt(ip), anon_prefix, @intFromEnum(type_index),
    }, .no_embedded_nulls);

```

and the relevant lines in the langref (changed in this PR).

I figured a change to Sema like that would be pretty breaking so I assumed y'all would want the change in the langref and not a change to Sema, if the change is desired in Sema, I could put the dot in the format string, otherwise I woudn't know what to do since that block name comes from deep inside intern pool stuff.

Should I be running any pre-commit formatter or other tooling before opening PR's for changes to the langref?


**Verification Evidence:**

To test this change I ran `zig build langref` and inspected the area in `Struct Naming`. It looks normal and has the change:

![image](https://github.com/user-attachments/assets/71de4999-cfd5-4da9-a48f-cecc5c7a6885)

