### PR TITLE
build: detect and abort build when getPath is called outside of any make

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -169,23 +169,22 @@ pub const IncludeDir = union(enum) {
         include_dir: IncludeDir,
         b: *std.Build,
         zig_args: *std.ArrayList([]const u8),
-        asking_step: ?*Step,
     ) !void {
         switch (include_dir) {
             .path => |include_path| {
-                try zig_args.appendSlice(&.{ "-I", include_path.getPath2(b, asking_step) });
+                try zig_args.appendSlice(&.{ "-I", include_path.getPath(b) });
             },
             .path_system => |include_path| {
-                try zig_args.appendSlice(&.{ "-isystem", include_path.getPath2(b, asking_step) });
+                try zig_args.appendSlice(&.{ "-isystem", include_path.getPath(b) });
             },
             .path_after => |include_path| {
-                try zig_args.appendSlice(&.{ "-idirafter", include_path.getPath2(b, asking_step) });
+                try zig_args.appendSlice(&.{ "-idirafter", include_path.getPath(b) });
             },
             .framework_path => |include_path| {
-                try zig_args.appendSlice(&.{ "-F", include_path.getPath2(b, asking_step) });
+                try zig_args.appendSlice(&.{ "-F", include_path.getPath(b) });
             },
             .framework_path_system => |include_path| {
-                try zig_args.appendSlice(&.{ "-iframework", include_path.getPath2(b, asking_step) });
+                try zig_args.appendSlice(&.{ "-iframework", include_path.getPath(b) });
             },
             .other_step => |other| {
                 if (other.generated_h) |header| {
@@ -540,7 +539,6 @@ pub fn addCMacro(m: *Module, name: []const u8, value: []const u8) void {
 pub fn appendZigProcessFlags(
     m: *Module,
     zig_args: *std.ArrayList([]const u8),
-    asking_step: ?*Step,
 ) !void {
     const b = m.owner;
 
@@ -605,7 +603,7 @@ pub fn appendZigProcessFlags(
     }
 
     for (m.include_dirs.items) |include_dir| {
-        try include_dir.appendZigProcessFlags(b, zig_args, asking_step);
+        try include_dir.appendZigProcessFlags(b, zig_args);
     }
 
     try zig_args.appendSlice(m.c_macros.items);
@@ -613,14 +611,14 @@ pub fn appendZigProcessFlags(
     try zig_args.ensureUnusedCapacity(2 * m.lib_paths.items.len);
     for (m.lib_paths.items) |lib_path| {
         zig_args.appendAssumeCapacity("-L");
-        zig_args.appendAssumeCapacity(lib_path.getPath2(b, asking_step));
+        zig_args.appendAssumeCapacity(lib_path.getPath(b));
     }
 
     try zig_args.ensureUnusedCapacity(2 * m.rpaths.items.len);
     for (m.rpaths.items) |rpath| switch (rpath) {
         .lazy_path => |lp| {
             zig_args.appendAssumeCapacity("-rpath");
-            zig_args.appendAssumeCapacity(lp.getPath2(b, asking_step));
+            zig_args.appendAssumeCapacity(lp.getPath(b));
         },
         .special => |bytes| {
             zig_args.appendAssumeCapacity("-rpath");

--- a/lib/std/Build/Step/CheckFile.zig
+++ b/lib/std/Build/Step/CheckFile.zig
@@ -52,7 +52,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     const check_file: *CheckFile = @fieldParentPtr("step", step);
     try step.singleUnchangingWatchInput(check_file.source);
 
-    const src_path = check_file.source.getPath2(b, step);
+    const src_path = check_file.source.getPath(b);
     const contents = fs.cwd().readFileAlloc(b.allocator, src_path, check_file.max_bytes) catch |err| {
         return step.fail("unable to read '{s}': {s}", .{
             src_path, @errorName(err),

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -193,7 +193,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     switch (config_header.style) {
         .autoconf => |file_source| {
             try output.appendSlice(c_generated_line);
-            const src_path = file_source.getPath2(b, step);
+            const src_path = file_source.getPath(b);
             const contents = std.fs.cwd().readFileAlloc(arena, src_path, config_header.max_bytes) catch |err| {
                 return step.fail("unable to read autoconf input file '{s}': {s}", .{
                     src_path, @errorName(err),
@@ -203,7 +203,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
         },
         .cmake => |file_source| {
             try output.appendSlice(c_generated_line);
-            const src_path = file_source.getPath2(b, step);
+            const src_path = file_source.getPath(b);
             const contents = std.fs.cwd().readFileAlloc(arena, src_path, config_header.max_bytes) catch |err| {
                 return step.fail("unable to read cmake input file '{s}': {s}", .{
                     src_path, @errorName(err),

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -125,7 +125,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
 
     if (install_artifact.dest_dir) |dest_dir| {
         const full_dest_path = b.getInstallPath(dest_dir, install_artifact.dest_sub_path);
-        const src_path = install_artifact.emitted_bin.?.getPath3(b, step);
+        const src_path = install_artifact.emitted_bin.?.getPath3(b);
         const p = fs.Dir.updateFile(src_path.root_dir.handle, src_path.sub_path, cwd, full_dest_path, .{}) catch |err| {
             return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
                 src_path.sub_path, full_dest_path, @errorName(err),
@@ -141,7 +141,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     }
 
     if (install_artifact.implib_dir) |implib_dir| {
-        const src_path = install_artifact.emitted_implib.?.getPath3(b, step);
+        const src_path = install_artifact.emitted_implib.?.getPath3(b);
         const full_implib_path = b.getInstallPath(implib_dir, fs.path.basename(src_path.sub_path));
         const p = fs.Dir.updateFile(src_path.root_dir.handle, src_path.sub_path, cwd, full_implib_path, .{}) catch |err| {
             return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
@@ -152,7 +152,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     }
 
     if (install_artifact.pdb_dir) |pdb_dir| {
-        const src_path = install_artifact.emitted_pdb.?.getPath3(b, step);
+        const src_path = install_artifact.emitted_pdb.?.getPath3(b);
         const full_pdb_path = b.getInstallPath(pdb_dir, fs.path.basename(src_path.sub_path));
         const p = fs.Dir.updateFile(src_path.root_dir.handle, src_path.sub_path, cwd, full_pdb_path, .{}) catch |err| {
             return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
@@ -164,7 +164,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
 
     if (install_artifact.h_dir) |h_dir| {
         if (install_artifact.emitted_h) |emitted_h| {
-            const src_path = emitted_h.getPath3(b, step);
+            const src_path = emitted_h.getPath3(b);
             const full_h_path = b.getInstallPath(h_dir, fs.path.basename(src_path.sub_path));
             const p = fs.Dir.updateFile(src_path.root_dir.handle, src_path.sub_path, cwd, full_h_path, .{}) catch |err| {
                 return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
@@ -176,7 +176,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
 
         for (install_artifact.artifact.installed_headers.items) |installation| switch (installation) {
             .file => |file| {
-                const src_path = file.source.getPath3(b, step);
+                const src_path = file.source.getPath3(b);
                 const full_h_path = b.getInstallPath(h_dir, file.dest_rel_path);
                 const p = fs.Dir.updateFile(src_path.root_dir.handle, src_path.sub_path, cwd, full_h_path, .{}) catch |err| {
                     return step.fail("unable to update file from '{s}' to '{s}': {s}", .{
@@ -186,7 +186,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                 all_cached = all_cached and p == .fresh;
             },
             .directory => |dir| {
-                const src_dir_path = dir.source.getPath3(b, step);
+                const src_dir_path = dir.source.getPath3(b);
                 const full_h_prefix = b.getInstallPath(h_dir, dir.dest_rel_path);
 
                 var src_dir = src_dir_path.root_dir.handle.openDir(src_dir_path.sub_path, .{ .iterate = true }) catch |err| {

--- a/lib/std/Build/Step/InstallDir.zig
+++ b/lib/std/Build/Step/InstallDir.zig
@@ -62,7 +62,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     step.clearWatchInputs();
     const arena = b.allocator;
     const dest_prefix = b.getInstallPath(install_dir.options.install_dir, install_dir.options.install_subdir);
-    const src_dir_path = install_dir.options.source_dir.getPath3(b, step);
+    const src_dir_path = install_dir.options.source_dir.getPath3(b);
     const need_derived_inputs = try step.addDirectoryWatchInput(install_dir.options.source_dir);
     var src_dir = src_dir_path.root_dir.handle.openDir(src_dir_path.subPathOrDot(), .{ .iterate = true }) catch |err| {
         return step.fail("unable to open source directory '{}': {s}", .{

--- a/lib/std/Build/Step/InstallFile.zig
+++ b/lib/std/Build/Step/InstallFile.zig
@@ -41,7 +41,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     const install_file: *InstallFile = @fieldParentPtr("step", step);
     try step.singleUnchangingWatchInput(install_file.source);
 
-    const full_src_path = install_file.source.getPath2(b, step);
+    const full_src_path = install_file.source.getPath(b);
     const full_dest_path = b.getInstallPath(install_file.dir, install_file.dest_rel_path);
     const cwd = std.fs.cwd();
     const prev = std.fs.Dir.updateFile(cwd, full_src_path, cwd, full_dest_path, .{}) catch |err| {

--- a/lib/std/Build/Step/ObjCopy.zig
+++ b/lib/std/Build/Step/ObjCopy.zig
@@ -151,7 +151,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     var man = b.graph.cache.obtain();
     defer man.deinit();
 
-    const full_src_path = objcopy.input_file.getPath2(b, step);
+    const full_src_path = objcopy.input_file.getPath(b);
     _ = try man.addFile(full_src_path, null);
     man.hash.addOptionalBytes(objcopy.only_section);
     man.hash.addOptional(objcopy.pad_to);

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -411,7 +411,7 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
         options.addOption(
             []const u8,
             item.name,
-            item.path.getPath2(b, step),
+            item.path.getPath(b),
         );
     }
     if (!step.inputs.populated()) for (options.args.items) |item| {

--- a/lib/std/Build/Step/RemoveDir.zig
+++ b/lib/std/Build/Step/RemoveDir.zig
@@ -20,6 +20,7 @@ pub fn create(owner: *std.Build, doomed_path: LazyPath) *RemoveDir {
         }),
         .doomed_path = doomed_path.dupe(owner),
     };
+    doomed_path.addStepDependencies(&remove_dir.step);
     return remove_dir;
 }
 
@@ -32,7 +33,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     step.clearWatchInputs();
     try step.addWatchInput(remove_dir.doomed_path);
 
-    const full_doomed_path = remove_dir.doomed_path.getPath2(b, step);
+    const full_doomed_path = remove_dir.doomed_path.getPath(b);
 
     b.build_root.handle.deleteTree(full_doomed_path) catch |err| {
         if (b.build_root.path) |base| {

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -627,13 +627,13 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                 man.hash.addBytes(bytes);
             },
             .lazy_path => |file| {
-                const file_path = file.lazy_path.getPath2(b, step);
+                const file_path = file.lazy_path.getPath(b);
                 try argv_list.append(b.fmt("{s}{s}", .{ file.prefix, file_path }));
                 man.hash.addBytes(file.prefix);
                 _ = try man.addFile(file_path, null);
             },
             .directory_source => |file| {
-                const file_path = file.lazy_path.getPath2(b, step);
+                const file_path = file.lazy_path.getPath(b);
                 try argv_list.append(b.fmt("{s}{s}", .{ file.prefix, file_path }));
                 man.hash.addBytes(file.prefix);
                 man.hash.addBytes(file_path);
@@ -672,7 +672,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
             man.hash.addBytes(bytes);
         },
         .lazy_path => |lazy_path| {
-            const file_path = lazy_path.getPath2(b, step);
+            const file_path = lazy_path.getPath(b);
             _ = try man.addFile(file_path, null);
         },
         .none => {},
@@ -689,7 +689,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     hashStdIo(&man.hash, run.stdio);
 
     for (run.file_inputs.items) |lazy_path| {
-        _ = try man.addFile(lazy_path.getPath2(b, step), null);
+        _ = try man.addFile(lazy_path.getPath(b), null);
     }
 
     if (!has_side_effects and try step.cacheHitAndWatch(&man)) {
@@ -850,11 +850,11 @@ pub fn rerunInFuzzMode(
                 try argv_list.append(arena, bytes);
             },
             .lazy_path => |file| {
-                const file_path = file.lazy_path.getPath2(b, step);
+                const file_path = file.lazy_path.getPath(b);
                 try argv_list.append(arena, b.fmt("{s}{s}", .{ file.prefix, file_path }));
             },
             .directory_source => |file| {
-                const file_path = file.lazy_path.getPath2(b, step);
+                const file_path = file.lazy_path.getPath(b);
                 try argv_list.append(arena, b.fmt("{s}{s}", .{ file.prefix, file_path }));
             },
             .artifact => |pa| {
@@ -966,7 +966,7 @@ fn runCommand(
     const b = step.owner;
     const arena = b.allocator;
 
-    const cwd: ?[]const u8 = if (run.cwd) |lazy_cwd| lazy_cwd.getPath2(b, step) else null;
+    const cwd: ?[]const u8 = if (run.cwd) |lazy_cwd| lazy_cwd.getPath(b) else null;
 
     try step.handleChildProcUnsupported(cwd, argv);
     try Step.handleVerbose2(step.owner, cwd, run.env_map, argv);
@@ -1306,7 +1306,7 @@ fn spawnChildAndCollect(
 
     var child = std.process.Child.init(argv, arena);
     if (run.cwd) |lazy_cwd| {
-        child.cwd = lazy_cwd.getPath2(b, &run.step);
+        child.cwd = lazy_cwd.getPath(b);
     } else {
         child.cwd = b.build_root.path;
         child.cwd_dir = b.build_root.handle;
@@ -1660,7 +1660,7 @@ fn evalGeneric(run: *Run, child: *std.process.Child) !StdIoResult {
             child.stdin = null;
         },
         .lazy_path => |lazy_path| {
-            const path = lazy_path.getPath2(b, &run.step);
+            const path = lazy_path.getPath(b);
             const file = b.build_root.handle.openFile(path, .{}) catch |err| {
                 return run.step.fail("unable to open stdin file: {s}", .{@errorName(err)});
             };
@@ -1727,7 +1727,7 @@ fn addPathForDynLibs(run: *Run, artifact: *Step.Compile) void {
         if (compile.root_module.resolved_target.?.result.os.tag == .windows and
             compile.isDynamicLibrary())
         {
-            addPathDir(run, fs.path.dirname(compile.getEmittedBin().getPath2(b, &run.step)).?);
+            addPathDir(run, fs.path.dirname(compile.getEmittedBin().getPath(b)).?);
         }
     }
 }

--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -189,7 +189,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     }
 
     for (translate_c.include_dirs.items) |include_dir| {
-        try include_dir.appendZigProcessFlags(b, &argv_list, step);
+        try include_dir.appendZigProcessFlags(b, &argv_list);
     }
 
     for (translate_c.c_macros.items) |c_macro| {
@@ -197,7 +197,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
         try argv_list.append(c_macro);
     }
 
-    const c_source_path = translate_c.source.getPath2(b, step);
+    const c_source_path = translate_c.source.getPath(b);
     try argv_list.append(c_source_path);
 
     const output_dir = try step.evalZigProcess(argv_list.items, prog_node, false);

--- a/lib/std/Build/Step/UpdateSourceFiles.zig
+++ b/lib/std/Build/Step/UpdateSourceFiles.zig
@@ -93,7 +93,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
             .copy => |file_source| {
                 if (!step.inputs.populated()) try step.addWatchInput(file_source);
 
-                const source_path = file_source.getPath2(b, step);
+                const source_path = file_source.getPath(b);
                 const prev_status = fs.Dir.updateFile(
                     fs.cwd(),
                     source_path,

--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -197,7 +197,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                 man.hash.addBytes(bytes);
             },
             .copy => |lazy_path| {
-                const path = lazy_path.getPath3(b, step);
+                const path = lazy_path.getPath3(b);
                 _ = try man.addFilePath(path, null);
                 try step.addWatchInput(lazy_path);
             },
@@ -214,7 +214,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
         if (dir.options.include_extensions) |incs| for (incs) |inc| man.hash.addBytes(inc);
 
         const need_derived_inputs = try step.addDirectoryWatchInput(dir.source);
-        const src_dir_path = dir.source.getPath3(b, step);
+        const src_dir_path = dir.source.getPath3(b);
 
         var src_dir = src_dir_path.root_dir.handle.openDir(src_dir_path.subPathOrDot(), .{ .iterate = true }) catch |err| {
             return step.fail("unable to open source directory '{}': {s}", .{
@@ -283,7 +283,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                 };
             },
             .copy => |file_source| {
-                const source_path = file_source.getPath2(b, step);
+                const source_path = file_source.getPath(b);
                 const prev_status = fs.Dir.updateFile(
                     cwd,
                     source_path,
@@ -310,7 +310,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     }
 
     for (write_file.directories.items, open_dir_cache) |dir, already_open_dir| {
-        const src_dir_path = dir.source.getPath3(b, step);
+        const src_dir_path = dir.source.getPath3(b);
         const dest_dirname = dir.sub_path;
 
         if (dest_dirname.len != 0) {

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -69,6 +69,9 @@
         .@"extern" = .{
             .path = "extern",
         },
+        .lazypath = .{
+            .path = "lazypath",
+        },
         .dep_diamond = .{
             .path = "dep_diamond",
         },

--- a/test/standalone/lazypath/build.zig
+++ b/test/standalone/lazypath/build.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    {
+        const zig_build = addZigBuild(b);
+        zig_build.addArg("-Dresolve-path-during-config");
+        zig_build.addCheck(.{ .expect_stderr_match = "getPath called on LazyPath outside of any step's make function" });
+        test_step.dependOn(&zig_build.step);
+    }
+
+    inline for (&.{
+        // TODO: we should be able to assert an error regardless of the LazyPath kind
+        //       but this requires more changes
+        //"dangling_src_path",
+        "dangling_generated",
+        //"dangling_cwd_relative",
+        //"dangling_dependency",
+    }) |step_name| {
+        const zig_build = addZigBuild(b);
+        zig_build.addArg(step_name);
+        const e = "getPath() was called on a GeneratedFile that wasn't built yet.";
+        zig_build.addCheck(.{ .expect_stderr_match = e });
+        test_step.dependOn(&zig_build.step);
+    }
+}
+
+fn addZigBuild(b: *std.Build) *std.Build.Step.Run {
+    return b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "build",
+        "--build-file",
+        b.pathFromRoot("example/build.zig"),
+    });
+}

--- a/test/standalone/lazypath/example/build.zig
+++ b/test/standalone/lazypath/example/build.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    if (b.option(bool, "resolve-path-during-config", "") orelse false) {
+        const path = b.path("foo");
+        _ = path.getPath(b);
+        @panic("getPath didn't panic like it should have");
+    }
+
+    b.step("dangling_src_path", "").dependOn(
+        &DanglingLazyPath.create(b, b.path("dangling")).step,
+    );
+    const write_files = b.addWriteFiles();
+    const generated = write_files.add("generated", "foo");
+    b.step("dangling_generated", "").dependOn(
+        &DanglingLazyPath.create(b, generated).step,
+    );
+    b.step("dangling_cwd_relative", "").dependOn(
+        &DanglingLazyPath.create(b, .{ .cwd_relative = "dangling" }).step,
+    );
+    //b.step("dangling_dependency", "").dependOn(
+    //    &DanglingLazyPath.create(b, b.dependency("d").path("dangling") ).step,
+    //);
+}
+
+const DanglingLazyPath = struct {
+    step: std.Build.Step,
+    lazy_path: std.Build.LazyPath,
+    pub fn create(b: *std.Build, lazy_path: std.Build.LazyPath) *DanglingLazyPath {
+        const d = b.allocator.create(DanglingLazyPath) catch @panic("OOM");
+        d.* = .{
+            .step = std.Build.Step.init(.{
+                .id = .custom,
+                .name = "dangling lazy path",
+                .owner = b,
+                .makeFn = make,
+            }),
+            .lazy_path = lazy_path,
+        };
+        // leave dangling by not calling lazy_path.addStepDependencies(d.step);
+        return d;
+    }
+    fn make(step: *std.Build.Step, options: std.Build.Step.MakeOptions) !void {
+        _ = options;
+        const d: *DanglingLazyPath = @fieldParentPtr("step", step);
+        _ = d.lazy_path.getPath(step.owner); // should panic
+        @panic("getPath didn't panic like it should have");
+    }
+};


### PR DESCRIPTION
zig's build system now detects when any LazyPath.getPath function is called outside of any make function.  This is done by saving the currently running step to a threadlocal global variable.  An added benefit of this change is we can use this thread local variable to provide better error messages without having to manage/propagate the currently running step throughout the build.

I also have a follow up change in the works that will be able to detect whenever any step tries to use a lazy path without having dependend on it first, but this requires more changes to the API that I'd rather defer to its own PR. With that branch I had found a few errors and included one of the fixes in this commit (see `RemoveDir.zig`).  Also, with this PR and the follow up, we'll have everything we need to be able to implement https://github.com/ziglang/zig/issues/21525 (the ability to only fetch lazy dependencies if they are required by the current set of steps/targets).