### PR TITLE
build: protect from depending on the same step multiple times

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2353,7 +2353,7 @@ pub const LazyPath = union(enum) {
     pub fn addStepDependencies(lazy_path: LazyPath, other_step: *Step) void {
         switch (lazy_path) {
             .src_path, .cwd_relative, .dependency => {},
-            .generated => |gen| other_step.dependOn(gen.file.step),
+            .generated => |gen| _ = other_step.dependOnIfNotAlready(gen.file.step),
         }
     }
 

--- a/test/standalone/cmakedefine/build.zig
+++ b/test/standalone/cmakedefine/build.zig
@@ -85,7 +85,7 @@ fn compare_headers(step: *std.Build.Step, options: std.Build.Step.MakeOptions) !
     const allocator = step.owner.allocator;
     const expected_fmt = "expected_{s}";
 
-    for (step.dependencies.items) |config_header_step| {
+    for (step.dependencies.keys()) |config_header_step| {
         const config_header: *ConfigHeader = @fieldParentPtr("step", config_header_step);
 
         const zig_header_path = config_header.output_file.path orelse @panic("Could not locate header file");

--- a/test/standalone/emit_asm_no_bin/build.zig
+++ b/test/standalone/emit_asm_no_bin/build.zig
@@ -13,7 +13,6 @@ pub fn build(b: *std.Build) void {
         .target = b.graph.host,
     });
     _ = obj.getEmittedAsm();
-    b.default_step.dependOn(&obj.step);
 
     test_step.dependOn(&obj.step);
 }

--- a/test/standalone/emit_llvm_no_bin/build.zig
+++ b/test/standalone/emit_llvm_no_bin/build.zig
@@ -14,7 +14,6 @@ pub fn build(b: *std.Build) void {
     });
     _ = obj.getEmittedLlvmIr();
     _ = obj.getEmittedLlvmBc();
-    b.default_step.dependOn(&obj.step);
 
     test_step.dependOn(&obj.step);
 }

--- a/test/standalone/run_output_caching/build.zig
+++ b/test/standalone/run_output_caching/build.zig
@@ -90,7 +90,7 @@ const CheckOutputCaching = struct {
     fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
         const check: *CheckOutputCaching = @fieldParentPtr("step", step);
 
-        for (step.dependencies.items) |dependency| {
+        for (step.dependencies.keys()) |dependency| {
             if (check.expect_caching) {
                 if (dependency.result_cached) continue;
                 return step.fail("expected '{s}' step to be cached, but it was not", .{dependency.name});

--- a/test/standalone/self_exe_symlink/build.zig
+++ b/test/standalone/self_exe_symlink/build.zig
@@ -37,7 +37,6 @@ pub fn build(b: *std.Build) void {
     run_from_symlink.addFileArg(symlink_path);
     run_from_symlink.expectExitCode(0);
     run_from_symlink.skip_foreign_checks = true;
-    run_from_symlink.step.dependOn(&run_create_symlink.step);
 
     test_step.dependOn(&run_from_symlink.step);
 }


### PR DESCRIPTION
In experimenting with the build system I discovered there were some places where the same step was being added as a dependency multiple times. The implementation currently uses an ArrayList and doesn't prevent the same entry from being added. For the same reason that Zig makes unused variables an error, I've made a change that makes duplicate dependencies an error by default. `Step.dependOn` will now panic if the same dependency is added multiple times. In cases where its unclear if a dependency may have already been added, like `LazyPath.addStepDependencies`, build code can call `Step.dependOnIfNotAlready` to avoid this panic.