### PR TITLE
fix: print correct number of provided arguments in `@min`/ `@max` error message

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -9142,7 +9142,7 @@ fn minMax(
 ) InnerError!Zir.Inst.Ref {
     const astgen = gz.astgen;
     if (args.len < 2) {
-        return astgen.failNode(node, "expected at least 2 arguments, found 0", .{});
+        return astgen.failNode(node, "expected at least 2 arguments, found {}", .{args.len});
     }
     if (args.len == 2) {
         const tag: Zir.Inst.Tag = switch (op) {

--- a/test/cases/compile_errors/minmax_missing_args.zig
+++ b/test/cases/compile_errors/minmax_missing_args.zig
@@ -1,0 +1,9 @@
+comptime { _ = @min(1); }
+comptime { _ = @max(1); }
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:16: error: expected at least 2 arguments, found 1
+// :2:16: error: expected at least 2 arguments, found 1


### PR DESCRIPTION
The error message for too-few arguments provided to the builtin `@min` and `@max` functions currently has a hardcoded 0 as the provided number of arguments.

Using the example from #21549 

```zig
comptime { _ = @min(1); }
comptime { _ = @max(1); }
```

Before:

```shell
src/main.zig:1:16: error: expected at least 2 arguments, found 0
comptime { _ = @min(1); }
               ^~~~~~~
src/main.zig:2:16: error: expected at least 2 arguments, found 0
comptime { _ = @max(1); }
               ^~~~~~~
```

After:

```shell
src/main.zig:1:16: error: expected at least 2 arguments, found 1
comptime { _ = @min(1); }
               ^~~~~~~
src/main.zig:2:16: error: expected at least 2 arguments, found 1
comptime { _ = @max(1); }
               ^~~~~~~
```

Closes #21549 