### PR TITLE
disallow readStruct for packed structs

### DIFF
--- a/lib/std/io/Reader.zig
+++ b/lib/std/io/Reader.zig
@@ -326,7 +326,9 @@ pub fn isBytes(self: Self, slice: []const u8) anyerror!bool {
 
 pub fn readStruct(self: Self, comptime T: type) anyerror!T {
     // Only extern and packed structs have defined in-memory layout.
-    comptime assert(@typeInfo(T).@"struct".layout != .auto);
+    // Packed structs may have padding due to alignment of the backing integer.
+    // Therefore, only extern structs are allowed.
+    comptime assert(@typeInfo(T).@"struct".layout == .@"extern");
     var res: [1]T = undefined;
     try self.readNoEof(mem.sliceAsBytes(res[0..]));
     return res[0];


### PR DESCRIPTION
Intended to close https://github.com/ziglang/zig/issues/12960

I did a quick grep of this entire repo and every usage of `readStruct` is using an `extern` struct.

Warning: I think this is considered a "breaking" change?