### PR TITLE
Re-enable some tests that were disabled due to #14366

### DIFF
--- a/lib/std/math/float.zig
+++ b/lib/std/math/float.zig
@@ -172,9 +172,6 @@ test nan {
 }
 
 test snan {
-    // TODO: https://github.com/ziglang/zig/issues/14366
-    if (builtin.zig_backend == .stage2_llvm and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
-
     const snan_u16: u16 = 0x7D00;
     const snan_u32: u32 = 0x7FA00000;
     const snan_u64: u64 = 0x7FF4000000000000;

--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -32,7 +32,13 @@ test isSignalNan {
         // TODO: Signalling NaN values get converted to quiet NaN values in
         //       some cases where they shouldn't such that this can fail.
         //       See https://github.com/ziglang/zig/issues/14366
-        // try expect(isSignalNan(math.snan(T)));
+        if (!builtin.cpu.arch.isArmOrThumb() and
+            !builtin.cpu.arch.isAARCH64() and
+            !builtin.cpu.arch.isPowerPC() and
+            builtin.zig_backend != .stage2_c)
+        {
+            try expect(isSignalNan(math.snan(T)));
+        }
         try expect(!isSignalNan(math.nan(T)));
         try expect(!isSignalNan(@as(T, 1.0)));
         try expect(!isSignalNan(math.inf(T)));

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -429,9 +429,6 @@ test "bitcast nan float does not modify signaling bit" {
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    // TODO: https://github.com/ziglang/zig/issues/14366
-    if (builtin.zig_backend == .stage2_llvm and comptime builtin.cpu.arch.isArmOrThumb()) return error.SkipZigTest;
-
     const snan_u16: u16 = 0x7D00;
     const snan_u32: u32 = 0x7FA00000;
     const snan_u64: u64 = 0x7FF4000000000000;


### PR DESCRIPTION
This still leaves the `isSignalNan` test disabled for arm, aarch64, and powerpc, as well as the C backend, so #14366 should remain open.