### PR TITLE
`std.c`: Fix `Stat` struct layout for mips/mipsel with glibc.

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -6389,14 +6389,14 @@ pub const Stat = switch (native_os) {
                 return self.ctim;
             }
         } else extern struct {
-            dev: dev_t,
+            dev: u32,
             __pad0: [3]u32,
             ino: ino_t,
             mode: mode_t,
             nlink: nlink_t,
             uid: uid_t,
             gid: gid_t,
-            rdev: dev_t,
+            rdev: u32,
             __pad1: [3]u32,
             size: off_t,
             atim: timespec,


### PR DESCRIPTION
`std.os.linux.dev_t` for mips32 is `u64`, but glibc uses `u32`. The C header also doesn't actually use `dev_t` for these fields anyway.

Long term, I want to pull these basic types out of `std.os.linux`; they're a libc concept and are not always the same between glibc and musl.

Closes #21276.