### PR TITLE
std: fix typo in darwin segset_t

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -10,7 +10,7 @@ const mode_t = std.c.mode_t;
 const off_t = std.c.off_t;
 const pid_t = std.c.pid_t;
 const pthread_attr_t = std.c.pthread_attr_t;
-const sigset_t = std.c.segset_t;
+const sigset_t = std.c.sigset_t;
 const timespec = std.c.timespec;
 const sf_hdtr = std.c.sf_hdtr;
 


### PR DESCRIPTION
Fixes the typo in `lib/std/c/darwin.zig`.

Part of https://github.com/ziglang/zig/issues/21094