### PR TITLE
std.fs.Dir: Make Dir.close not take a pointer

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -785,9 +785,8 @@ pub const OpenError = error{
     NetworkNotFound,
 } || posix.UnexpectedError;
 
-pub fn close(self: *Dir) void {
+pub fn close(self: Dir) void {
     posix.close(self.fd);
-    self.* = undefined;
 }
 
 /// Opens a file for reading or writing, without attempting to create a new file.


### PR DESCRIPTION
This is the only Dir function that requires a pointer and it is not necessary. This is also in line with File.close.