### PR TITLE
Remove old deprecated symbols in std

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6242,7 +6242,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
           <li>Are you linking libc? In this case, {#syntax#}std.heap.c_allocator{#endsyntax#} is likely
               the right choice, at least for your main allocator.</li>
           <li>
-              Need to use the same allocator in multiple threads? use one of your choice
+              Need to use the same allocator in multiple threads? Use one of your choice
               wrapped around {#syntax#}std.heap.ThreadSafeAllocator{#endsyntax#}
           </li>
           <li>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4766,10 +4766,10 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       Converts an integer into an {#link|enum#} value. The return type is the inferred result type.
       </p>
       <p>
-      Attempting to convert an integer with no corresponding value in the enum invokes 
+      Attempting to convert an integer with no corresponding value in the enum invokes
       safety-checked {#link|Undefined Behavior#}.
       Note that a {#link|non-exhaustive enum|Non-exhaustive enum#} has corresponding values for all
-      integers in the enum's integer tag type: the {#syntax#}_{#endsyntax#} value represents all 
+      integers in the enum's integer tag type: the {#syntax#}_{#endsyntax#} value represents all
       the remaining unnamed integers in the enum's tag type.
       </p>
       {#see_also|@intFromEnum#}
@@ -6242,10 +6242,12 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
           <li>Are you linking libc? In this case, {#syntax#}std.heap.c_allocator{#endsyntax#} is likely
               the right choice, at least for your main allocator.</li>
           <li>
+              Need to use the same allocator in multiple threads? use one of your choice
+              wrapped around {#syntax#}std.heap.ThreadSafeAllocator{#endsyntax#}
+          </li>
+          <li>
               Is the maximum number of bytes that you will need bounded by a number known at
-              {#link|comptime#}? In this case, use {#syntax#}std.heap.FixedBufferAllocator{#endsyntax#} or
-              {#syntax#}std.heap.ThreadSafeFixedBufferAllocator{#endsyntax#} depending on whether you need
-              thread-safety or not.
+              {#link|comptime#}? In this case, use {#syntax#}std.heap.FixedBufferAllocator{#endsyntax#}.
           </li>
           <li>
               Is your program a command line application which runs from start to end without any fundamental

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -501,8 +501,6 @@ pub const FixedBufferAllocator = struct {
     }
 };
 
-pub const ThreadSafeFixedBufferAllocator = @compileError("ThreadSafeFixedBufferAllocator has been replaced with `threadSafeAllocator` on FixedBufferAllocator");
-
 /// Returns a `StackFallbackAllocator` allocating using either a
 /// `FixedBufferAllocator` on an array of size `size` and falling back to
 /// `fallback_allocator` if that fails.

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -4334,8 +4334,6 @@ pub fn alignForwardLog2(addr: usize, log2_alignment: u8) usize {
     return alignForward(usize, addr, alignment);
 }
 
-pub const alignForwardGeneric = @compileError("renamed to alignForward");
-
 /// Force an evaluation of the expression; this tries to prevent
 /// the compiler from optimizing the computation away even if the
 /// result eventually gets discarded.
@@ -4458,8 +4456,6 @@ pub fn alignBackward(comptime T: type, addr: T, alignment: T) T {
     // 111110000 // binary not
     return addr & ~(alignment - 1);
 }
-
-pub const alignBackwardGeneric = @compileError("renamed to alignBackward");
 
 /// Returns whether `alignment` is a valid alignment, meaning it is
 /// a positive power of 2.

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -240,8 +240,6 @@ pub fn Sentinel(comptime T: type, comptime sentinel_val: Elem(T)) type {
     @compileError("Unable to derive a sentinel pointer type from " ++ @typeName(T));
 }
 
-pub const assumeSentinel = @compileError("This function has been removed, consider using std.mem.sliceTo() or if needed a @ptrCast()");
-
 pub fn containerLayout(comptime T: type) Type.ContainerLayout {
     return switch (@typeInfo(T)) {
         .@"struct" => |info| info.layout,
@@ -930,8 +928,6 @@ pub fn fieldIndex(comptime T: type, comptime name: []const u8) ?comptime_int {
     return null;
 }
 
-pub const refAllDecls = @compileError("refAllDecls has been moved from std.meta to std.testing");
-
 /// Returns a slice of pointers to public declarations of a namespace.
 pub fn declList(comptime Namespace: type, comptime Decl: type) []const *const Decl {
     const S = struct {
@@ -950,8 +946,6 @@ pub fn declList(comptime Namespace: type, comptime Decl: type) []const *const De
         return &array;
     }
 }
-
-pub const IntType = @compileError("replaced by std.meta.Int");
 
 pub fn Int(comptime signedness: std.builtin.Signedness, comptime bit_count: u16) type {
     return @Type(.{

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -848,6 +848,7 @@ test PaxIterator {
 
 test {
     _ = @import("tar/test.zig");
+    _ = @import("tar/writer.zig");
     _ = Diagnostics;
 }
 

--- a/lib/std/tar/writer.zig
+++ b/lib/std/tar/writer.zig
@@ -84,7 +84,7 @@ pub fn Writer(comptime WriterType: type) type {
 
         /// Writes fs.Dir.WalkerEntry. Uses `mtime` from file system entry and
         /// default for entry mode .
-        pub fn writeEntry(self: *Self, entry: std.fs.Dir.Walker.WalkerEntry) !void {
+        pub fn writeEntry(self: *Self, entry: std.fs.Dir.Walker.Entry) !void {
             switch (entry.kind) {
                 .directory => {
                     try self.writeDir(entry.path, .{ .mtime = try entryMtime(entry) });
@@ -95,7 +95,7 @@ pub fn Writer(comptime WriterType: type) type {
                     try self.writeFile(entry.path, file);
                 },
                 .sym_link => {
-                    var link_name_buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+                    var link_name_buffer: [std.fs.max_path_bytes]u8 = undefined;
                     const link_name = try entry.dir.readLink(entry.basename, &link_name_buffer);
                     try self.writeLink(entry.path, link_name, .{ .mtime = try entryMtime(entry) });
                 },
@@ -133,7 +133,7 @@ pub fn Writer(comptime WriterType: type) type {
             return self.mtime_now;
         }
 
-        fn entryMtime(entry: std.fs.Dir.Walker.WalkerEntry) !u64 {
+        fn entryMtime(entry: std.fs.Dir.Walker.Entry) !u64 {
             const stat = try entry.dir.statFile(entry.basename);
             return @intCast(@divFloor(stat.mtime, std.time.ns_per_s));
         }
@@ -424,8 +424,8 @@ test "write files" {
         .{ .path = "e123456789" ** 11, .content = "e" },
     };
 
-    var file_name_buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-    var link_name_buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var file_name_buffer: [std.fs.max_path_bytes]u8 = undefined;
+    var link_name_buffer: [std.fs.max_path_bytes]u8 = undefined;
 
     // with root
     {


### PR DESCRIPTION
All have been deprecated for over a year, so 0.10 release and older.

|deprecate date|Symbol                                  |
|-------------:|:---------------------------------------|
|oct 2020      |std.meta.refAllDecls                    |
|nov 2020      |std.meta.IntType                        |
|nov 2021      |std.heap.ThreadSafeFixedBufferAllocator |
|jan 2023      |std.meta.assumeSentinel                 |
|jun 2023      |std.mem.alignForwardGeneric             |
|jun 2023      |std.mem.alignBackwardGeneric            |