### PR TITLE
fetch: support specifying hash on the CLI

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -6968,10 +6968,10 @@ fn parseRcIncludes(arg: []const u8) Compilation.RcIncludes {
 }
 
 const usage_fetch =
-    \\Usage: zig fetch [options] <url>
-    \\Usage: zig fetch [options] <path>
+    \\Usage: zig fetch [options] <url> [hash]
+    \\Usage: zig fetch [options] <path> [hash]
     \\
-    \\    Copy a package into the global cache and print its hash.
+    \\    Copy a package into the global cache, print, and optionally verify its hash.
     \\
     \\Options:
     \\  -h, --help                    Print this help and exit
@@ -6995,6 +6995,7 @@ fn cmdFetch(
     const work_around_btrfs_bug = native_os == .linux and
         EnvVar.ZIG_BTRFS_WORKAROUND.isSet();
     var opt_path_or_url: ?[]const u8 = null;
+    var opt_hash: ?Package.Manifest.MultiHashHexDigest = null;
     var override_global_cache_dir: ?[]const u8 = try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(arena);
     var debug_hash: bool = false;
     var save: union(enum) {
@@ -7029,11 +7030,16 @@ fn cmdFetch(
                 } else {
                     fatal("unrecognized parameter: '{s}'", .{arg});
                 }
-            } else if (opt_path_or_url != null) {
-                fatal("unexpected extra parameter: '{s}'", .{arg});
-            } else {
+            } else if (opt_path_or_url == null) {
                 opt_path_or_url = arg;
-            }
+            } else if (opt_hash == null) {
+                if (arg.len != Package.Manifest.multihash_hex_digest_len) {
+                    fatal("wrong hash size. expected: {d}, found: {d}", .{
+                        Package.Manifest.multihash_hex_digest_len, arg,
+                    });
+                }
+                opt_hash = arg[0..Package.Manifest.multihash_hex_digest_len].*;
+            } else fatal("unexpected extra parameter: '{s}'", .{arg});
         }
     }
 
@@ -7075,7 +7081,10 @@ fn cmdFetch(
 
     var fetch: Package.Fetch = .{
         .arena = std.heap.ArenaAllocator.init(gpa),
-        .location = .{ .path_or_url = path_or_url },
+        .location = .{ .local_or_remote = .{
+            .url = path_or_url,
+            .hash = opt_hash,
+        } },
         .location_tok = 0,
         .hash_tok = 0,
         .name_tok = 0,
@@ -7112,7 +7121,7 @@ fn cmdFetch(
         process.exit(1);
     }
 
-    const hex_digest = Package.Manifest.hexDigest(fetch.actual_hash);
+    const hex_digest = opt_hash orelse Package.Manifest.hexDigest(fetch.actual_hash);
 
     root_prog_node.end();
     root_prog_node = .{ .index = .none };


### PR DESCRIPTION
If you use `zig fetch` as a `curl`, you might want to provide it with the expected hash up-front, to skip the download work if the resource is already cached, and to otherwise verify the resource integrity.

Example usage:

```
λ /usr/bin/time zig-out/bin/zig fetch https://github.com/tigerbeetle/tigerbeetle/releases/download/0.16.5/tigerbeetle-universal-macos.zip
12209a8b1468572b678c8949f114633b2e25fe08132d19d9edcf6263e081fd550217
        3.01 real         1.41 user         0.08 sys
matklad@ahab ~/p/zig (master)
λ /usr/bin/time zig-out/bin/zig fetch https://github.com/tigerbeetle/tigerbeetle/releases/download/0.16.5/tigerbeetle-universal-macos.zip 12209a8b1468572b678c8949f114633b2e25fe08132d19d9edcf6263e081fd550217
12209a8b1468572b678c8949f114633b2e25fe08132d19d9edcf6263e081fd550217
        0.00 real         0.00 user         0.00 sys
matklad@ahab ~/p/zig (master)
λ /usr/bin/time zig-out/bin/zig fetch https://github.com/tigerbeetle/tigerbeetle/releases/download/0.16.5/tigerbeetle-universal-macos.zip 12209a8b1468572b678c8949f114633b2e25fe08132d19d9edcf6263e081fd550218
error: hash mismatch: manifest declares 12209a8b1468572b678c8949f114633b2e25fe08132d19d9edcf6263e081fd550218 but the fetched package has 12209a8b1468572b678c8949f114633b2e25fe08132d19d9edcf6263e081fd550217
        2.39 real         1.39 user         0.09 sys
matklad@ahab ~/p/zig (master) [1]
λ
```