### PR TITLE
zig objcopy: support --add-section

### DIFF
--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -865,7 +865,7 @@ fn ElfFile(comptime is_64: bool) type {
             // program header: list of segments
             const program_segments = blk: {
                 if (@sizeOf(Elf_Phdr) != header.phentsize)
-                    fatal("zig objcopy: unsuported ELF file, unexpected phentsize ({d})", .{header.phentsize});
+                    fatal("zig objcopy: unsupported ELF file, unexpected phentsize ({d})", .{header.phentsize});
 
                 const program_header = try allocator.alloc(Elf_Phdr, header.phnum);
                 const bytes_read = try in_file.preadAll(std.mem.sliceAsBytes(program_header), header.phoff);
@@ -877,7 +877,7 @@ fn ElfFile(comptime is_64: bool) type {
             // section header
             const sections = blk: {
                 if (@sizeOf(Elf_Shdr) != header.shentsize)
-                    fatal("zig objcopy: unsuported ELF file, unexpected shentsize ({d})", .{header.shentsize});
+                    fatal("zig objcopy: unsupported ELF file, unexpected shentsize ({d})", .{header.shentsize});
 
                 const section_header = try allocator.alloc(Section, header.shnum);
 
@@ -1126,7 +1126,7 @@ fn ElfFile(comptime is_64: bool) type {
                         if (section.section.sh_type == elf.SHT_NOBITS)
                             continue;
                         if (section.section.sh_offset < offset) {
-                            fatal("zig objcopy: unsuported ELF file", .{});
+                            fatal("zig objcopy: unsupported ELF file", .{});
                         }
                         offset = section.section.sh_offset;
                     }

--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -40,9 +40,9 @@ fn cmdObjCopy(
     var only_keep_debug: bool = false;
     var compress_debug_sections: bool = false;
     var listen = false;
-    var add_section: ?AddSectionOptions = null;
-    var set_section_alignment: ?SetSectionAlignmentOptions = null;
-    var set_section_flags: ?SetSectionFlagsOptions = null;
+    var add_section: ?AddSection = null;
+    var set_section_alignment: ?SetSectionAlignment = null;
+    var set_section_flags: ?SetSectionFlags = null;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
         if (!mem.startsWith(u8, arg, "-")) {
@@ -279,23 +279,22 @@ pub const EmitRawElfOptions = struct {
     ofmt: std.Target.ObjectFormat,
     only_section: ?[]const u8 = null,
     pad_to: ?u64 = null,
-    add_section: ?AddSectionOptions,
-    set_section_alignment: ?SetSectionAlignmentOptions,
-    set_section_flags: ?SetSectionFlagsOptions,
+    add_section: ?AddSection,
+    set_section_alignment: ?SetSectionAlignment,
+    set_section_flags: ?SetSectionFlags,
 };
 
-const AddSectionOptions = struct {
+const AddSection = struct {
     section_name: []const u8,
-    // file to store in new section
     file_path: []const u8,
 };
 
-const SetSectionAlignmentOptions = struct {
+const SetSectionAlignment = struct {
     section_name: []const u8,
     alignment: u32,
 };
 
-const SetSectionFlagsOptions = struct {
+const SetSectionFlags = struct {
     section_name: []const u8,
     flags: SectionFlags,
 };
@@ -740,9 +739,9 @@ const StripElfOptions = struct {
     strip_debug: bool = false,
     only_keep_debug: bool = false,
     compress_debug: bool = false,
-    add_section: ?AddSectionOptions,
-    set_section_alignment: ?SetSectionAlignmentOptions,
-    set_section_flags: ?SetSectionFlagsOptions,
+    add_section: ?AddSection,
+    set_section_alignment: ?SetSectionAlignment,
+    set_section_flags: ?SetSectionFlags,
 };
 
 fn stripElf(
@@ -976,9 +975,9 @@ fn ElfFile(comptime is_64: bool) type {
             section_filter: Filter = .all,
             debuglink: ?DebugLink = null,
             compress_debug: bool = false,
-            add_section: ?AddSectionOptions = null,
-            set_section_alignment: ?SetSectionAlignmentOptions = null,
-            set_section_flags: ?SetSectionFlagsOptions = null,
+            add_section: ?AddSection = null,
+            set_section_alignment: ?SetSectionAlignment = null,
+            set_section_flags: ?SetSectionFlags = null,
         };
         fn emit(self: *const Self, gpa: Allocator, out_file: File, in_file: File, options: EmitElfOptions) !void {
             var arena = std.heap.ArenaAllocator.init(gpa);

--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -274,7 +274,7 @@ const usage =
     \\  --compress-debug-sections               Compress DWARF debug sections with zlib
     \\  --set-section-alignment <name>=<align>  Set alignment of section <name> to <align> bytes. Must be a power of two.
     \\  --set-section-flags <name>=<file>       Set flags of section <name> to <flags> represented as a comma separated set of flags.
-    \\  --add-section <name>=<file>             Add file content from <file> with the section name <name>.
+    \\  --add-section <name>=<file>             Add file content from <file> with the a new section named <name>.
     \\
 ;
 
@@ -1251,21 +1251,18 @@ fn ElfFile(comptime is_64: bool) type {
                         fatal("unable to open '{s}': {s}", .{ add_section.file_path, @errorName(err) });
                     defer section_file.close();
 
-                    const max_size = std.math.maxInt(usize);
-                    const payload = try section_file.readToEndAlloc(arena.allocator(), max_size);
-                    const flags = 0;
-                    const alignment = 4;
+                    const payload = try section_file.readToEndAlloc(arena.allocator(), std.math.maxInt(usize));
 
                     dest_sections[dest_section_idx] = Elf_Shdr{
                         .sh_name = user_section_name,
                         .sh_type = elf.SHT_PROGBITS,
-                        .sh_flags = flags,
+                        .sh_flags = 0,
                         .sh_addr = 0,
                         .sh_offset = eof_offset,
                         .sh_size = @intCast(payload.len),
                         .sh_link = elf.SHN_UNDEF,
                         .sh_info = elf.SHN_UNDEF,
-                        .sh_addralign = alignment,
+                        .sh_addralign = 4,
                         .sh_entsize = 0,
                     };
                     dest_section_idx += 1;

--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -185,14 +185,17 @@ fn cmdObjCopy(
                 fatal("zig objcopy: ELF to RAW or HEX copying does not support --strip", .{});
             if (opt_extract != null)
                 fatal("zig objcopy: ELF to RAW or HEX copying does not support --extract-to", .{});
+            if (add_section != null)
+                fatal("zig objcopy: ELF to RAW or HEX copying does not support --add-section", .{});
+            if (set_section_alignment != null)
+                fatal("zig objcopy: ELF to RAW or HEX copying does not support --set_section_alignment", .{});
+            if (set_section_flags != null)
+                fatal("zig objcopy: ELF to RAW or HEX copying does not support --set_section_flags", .{});
 
             try emitElf(arena, in_file, out_file, elf_hdr, .{
                 .ofmt = out_fmt,
                 .only_section = only_section,
                 .pad_to = pad_to,
-                .add_section = add_section,
-                .set_section_alignment = set_section_alignment,
-                .set_section_flags = set_section_flags,
             });
         },
         .elf => {
@@ -279,9 +282,9 @@ pub const EmitRawElfOptions = struct {
     ofmt: std.Target.ObjectFormat,
     only_section: ?[]const u8 = null,
     pad_to: ?u64 = null,
-    add_section: ?AddSection,
-    set_section_alignment: ?SetSectionAlignment,
-    set_section_flags: ?SetSectionFlags,
+    add_section: ?AddSection = null,
+    set_section_alignment: ?SetSectionAlignment = null,
+    set_section_flags: ?SetSectionFlags = null,
 };
 
 const AddSection = struct {


### PR DESCRIPTION
Adds support for --add-section, --set-section-alignment and --set-section-flags to both the zig objcopy CLI and std.Build.Step.ObjCopy.

Example usage to make a copy of ls with a copy of itself inside a the new section ".abc":
`zig objcopy ./ls ./ls_out --add-section ".abc=./ls" --set-section-alignment ".abc=256" --set-section-flags ".abc=data,readonly"`

Closes #19009