### PR TITLE
`objcopy`: Use `p_paddr` from `PT_LOAD` even if zero.

### DIFF
--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -392,7 +392,7 @@ const BinaryElfOutput = struct {
             if (phdr.p_type == elf.PT_LOAD) {
                 const newSegment = try allocator.create(BinaryElfSegment);
 
-                newSegment.physicalAddress = if (phdr.p_paddr != 0) phdr.p_paddr else phdr.p_vaddr;
+                newSegment.physicalAddress = phdr.p_paddr;
                 newSegment.virtualAddress = phdr.p_vaddr;
                 newSegment.fileSize = @intCast(phdr.p_filesz);
                 newSegment.elfOffset = phdr.p_offset;


### PR DESCRIPTION
Fix suggested by @cclin0816. I couldn't see any obvious reason why this would be wrong.

Closes #20019.