### PR TITLE
Clarify the multidimensional array docs example

### DIFF
--- a/doc/langref/test_multidimensional_arrays.zig
+++ b/doc/langref/test_multidimensional_arrays.zig
@@ -1,18 +1,22 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const expectEqual = std.testing.expectEqual;
 
-const mat4x4 = [4][4]f32{
-    [_]f32{ 1.0, 0.0, 0.0, 0.0 },
-    [_]f32{ 0.0, 1.0, 0.0, 1.0 },
-    [_]f32{ 0.0, 0.0, 1.0, 0.0 },
-    [_]f32{ 0.0, 0.0, 0.0, 1.0 },
+const mat4x5 = [4][5]f32{
+    [_]f32{ 1.0, 0.0, 0.0, 0.0, 0.0 },
+    [_]f32{ 0.0, 1.0, 0.0, 1.0, 0.0 },
+    [_]f32{ 0.0, 0.0, 1.0, 0.0, 0.0 },
+    [_]f32{ 0.0, 0.0, 0.0, 1.0, 9.9 },
 };
 test "multidimensional arrays" {
+    // mat4x5 itself is a one-dimensional array of arrays.
+    try expectEqual(mat4x5[1], [_]f32{ 0.0, 1.0, 0.0, 1.0, 0.0 });
+
     // Access the 2D array by indexing the outer array, and then the inner array.
-    try expect(mat4x4[1][1] == 1.0);
+    try expect(mat4x5[3][4] == 9.9);
 
     // Here we iterate with for loops.
-    for (mat4x4, 0..) |row, row_index| {
+    for (mat4x5, 0..) |row, row_index| {
         for (row, 0..) |cell, column_index| {
             if (row_index == column_index) {
                 try expect(cell == 1.0);
@@ -20,8 +24,8 @@ test "multidimensional arrays" {
         }
     }
 
-    // initialize a multidimensional array to zeros
-    const all_zero: [4][4]f32 = .{.{0} ** 4} ** 4;
+    // Initialize a multidimensional array to zeros.
+    const all_zero: [4][5]f32 = .{.{0} ** 5} ** 4;
     try expect(all_zero[0][0] == 0);
 }
 


### PR DESCRIPTION
Use a rectangular matrix instead of a square one to distinguish rows and
columns more clearly. Extend the example with row access.

Closes #9690
