### PR TITLE
ppc64: get further along into system bootstrap

### DIFF
--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -48,7 +48,7 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         : [number] "{r0}" (@intFromEnum(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -63,7 +63,7 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -79,7 +79,7 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -96,7 +96,7 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -122,7 +122,7 @@ pub fn syscall6(
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
           [arg6] "{r8}" (arg6),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r9", "r10", "r11", "r12"
     );
 }
 

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -391,6 +391,7 @@ fn _start() callconv(.Naked) noreturn {
             \\ stdu 0, -32(1)
             \\ mtlr 0
             \\ b %[posixCallMainAndExit]
+            \\ nop
             ,
             .s390x =>
             // Set up the stack frame (register save area and cleared back-chain slot).


### PR DESCRIPTION
With this PR **and** a few steps not included in this PR, stage3 compiler builds on an alpine ppc64le VM with system tools (gcc compiler and binutils linker).

---

1. The following extra patch is required to get to stage3 but is **not** part of this PR.
    1. build stage2 with `-Os` option because apparently system assembler cannot handle a larger unoptimized object. Not part of PR because this is a hack to get around a system limitation. Possibly in the future our c-backend will be able to split .c output and that would be one way to solve this issue.
    2. need a `update-stage1` for some zig master commits that have accumulated since last update
    3. hack zig to understand page size is 64K. Not part of PR because #20511 will fix it.
<details>
<summary>diff</summary>

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index ebdce53228..2ef97ec9b7 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -821,7 +821,7 @@ if(MSVC)
 else()
   set(ZIG_WASM2C_COMPILE_FLAGS "-std=c99 -O2")
   set(ZIG1_COMPILE_FLAGS "-std=c99 -Os")
-  set(ZIG2_COMPILE_FLAGS "-std=c99 -O0 -fno-stack-protector")
+  set(ZIG2_COMPILE_FLAGS "-std=c99 -Os -fno-stack-protector")
   if(APPLE)
     set(ZIG2_LINK_FLAGS "-Wl,-stack_size,0x10000000")
   elseif(MINGW)
diff --git a/lib/std/mem.zig b/lib/std/mem.zig
index d458e26989..1033e3ef7a 100644
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -25,6 +25,10 @@ pub const page_size = switch (builtin.cpu.arch) {
         // as Linux for now.
         else => 16 * 1024,
     },
+    .powerpc, .powerpcle, .powerpc64, .powerpc64le => switch (builtin.os.tag) {
+        .linux => 64 * 1024,
+        else => 4 * 1024,
+    },
     else => 4 * 1024,
 };
```
</details>

2. In case anyone is curious, the stage3 compiler is unable to create a test exe or main exe and fails with:
<details>
<summary>panic</summary>

```
thread 6473 panic: attempt to cast negative value to unsigned integer
/home/mike/project/zig/work/ppc64/lib/std/start.zig:596:40: 0x4c4b0bb in main (zig)
    return callMainWithArgs(@as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp);
                                       ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12361:46: 0x73300b3 in hash (zig)
                hasher.update(std.mem.asBytes(&@field(key.value, field.name)));
                                             ^
/home/mike/project/zig/work/ppc64/lib/std/array_hash_map.zig:1891:28: 0x721ffcf in checkedHash__anon_1116373 (zig)
            return ctx.hash(key);
                           ^
/home/mike/project/zig/work/ppc64/lib/std/array_hash_map.zig:1709:34: 0x72201d7 in getOrPutInternal__anon_1116377 (zig)
            const h = checkedHash(ctx, key);
                                 ^
/home/mike/project/zig/work/ppc64/lib/std/array_hash_map.zig:841:52: 0x70308d7 in getOrPutAssumeCapacityAdapted__anon_1077325 (zig)
                .u8 => return self.getOrPutInternal(key, ctx, header, u8),
                                                   ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12374:64: 0x6caea87 in metadataSimpleAssumeCapacity__anon_806453 (zig)
    const gop = self.metadata_map.getOrPutAssumeCapacityAdapted(
                                                               ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12507:45: 0x693c9eb in debugLocationAssumeCapacity (zig)
    return self.metadataSimpleAssumeCapacity(.location, Metadata.Location{
                                            ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12018:44: 0x652148b in debugLocation (zig)
    return self.debugLocationAssumeCapacity(line, column, scope, inlined_at);
                                           ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:5094:62: 0x60f4b2b in toMetadata (zig)
            .location => |location| try builder.debugLocation(
                                                             ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:5407:79: 0x60bed73 in genBodyDebugScope (zig)
            const inlined_at_location = try self.wip.debug_location.toMetadata(&o.builder);
                                                                              ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:6160:35: 0x6103ff3 in lowerBlock (zig)
        try self.genBodyDebugScope(maybe_inline_func, body, .none);
                                  ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:7328:31: 0x610500f in airDbgInlineBlock (zig)
        return self.lowerBlock(inst, extra.data.func, @ptrCast(self.air.extra[extra.end..][0..extra.data.body_len]));
                              ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:5320:59: 0x5b9a17b in genBody (zig)
                    const res = try self.airDbgInlineBlock(inst);
                                                          ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:1812:19: 0x5b942df in updateFunc (zig)
        fg.genBody(air.getMainBody(), .poi) catch |err| switch (err) {
                  ^
/home/mike/project/zig/work/ppc64/src/link/Elf.zig:2716:70: 0x608174b in updateFunc (zig)
    if (self.llvm_object) |llvm_object| return llvm_object.updateFunc(pt, func_index, air, liveness);
                                                                     ^
/home/mike/project/zig/work/ppc64/src/link.zig:431:82: 0x5b9f9d3 in updateFunc (zig)
                return @as(*tag.Type(), @fieldParentPtr("base", base)).updateFunc(pt, func_index, air, liveness);
                                                                                 ^
/home/mike/project/zig/work/ppc64/src/Zcu/PerThread.zig:902:22: 0x57eb307 in linkerUpdateFunc (zig)
        lf.updateFunc(pt, func_index, air, liveness) catch |err| switch (err) {
                     ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3965:36: 0x536609f in processOneCodegenJob (zig)
            try pt.linkerUpdateFunc(func.func, func.air);
                                   ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3918:36: 0x5365c23 in queueCodegenJob (zig)
        return processOneCodegenJob(tid, comp, codegen_job);
                                   ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3672:37: 0x50f5a2b in processOneJob (zig)
            try comp.queueCodegenJob(tid, .{ .func = .{
                                    ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3628:30: 0x4ec8cb3 in performAllTheWorkInner (zig)
            try processOneJob(@intFromEnum(Zcu.PerThread.Id.main), comp, job, main_progress_node);
                             ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3499:36: 0x4d70d57 in performAllTheWork (zig)
    try comp.performAllTheWorkInner(main_progress_node);
                                   ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:2261:31: 0x4d6c6df in update (zig)
    try comp.performAllTheWork(main_progress_node);
                              ^
/home/mike/project/zig/work/ppc64/src/main.zig:4501:20: 0x4d73aeb in updateModule (zig)
    try comp.update(prog_node);
                   ^
/home/mike/project/zig/work/ppc64/src/main.zig:3548:21: 0x4dd7673 in buildOutputType (zig)
        updateModule(comp, color, root_prog_node) catch |err| switch (err) {
                    ^
/home/mike/project/zig/work/ppc64/src/main.zig:257:31: 0x4c4e7bf in mainArgs (zig)
        return buildOutputType(gpa, arena, args, .{ .build = .Exe });
                              ^
/home/mike/project/zig/work/ppc64/src/main.zig:198:20: 0x4c4b6db in main (zig)
    return mainArgs(gpa, arena, args);
                   ^
/home/mike/project/zig/work/ppc64/lib/std/start.zig:621:37: 0x4c4b157 in main (zig)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x7fffa7c0f323 in ??? (ld-musl-powerpc64le.so.1)
???:?:?: 0x7fffa7c0f39b in ??? (ld-musl-powerpc64le.so.1)
crt/crt1.c:18:2: 0x4c466ab in _start_c (crt/crt1.c)
???:?:?: 0x4c46667 in ??? (???)
thread 6479 panic: attempt to cast negative value to unsigned integer
/home/mike/project/zig/work/ppc64/lib/std/start.zig:596:40: 0x4c4b0bb in main (zig)
    return callMainWithArgs(@as(usize, @intCast(c_argc)), @as([*][*:0]u8, @ptrCast(c_argv)), envp);
                                       ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12361:46: 0x721bbe3 in hash (zig)
                hasher.update(std.mem.asBytes(&@field(key.value, field.name)));
                                             ^
/home/mike/project/zig/work/ppc64/lib/std/array_hash_map.zig:1891:28: 0x702c37f in checkedHash__anon_1076920 (zig)
            return ctx.hash(key);
                           ^
/home/mike/project/zig/work/ppc64/lib/std/array_hash_map.zig:1709:34: 0x702c587 in getOrPutInternal__anon_1076924 (zig)
            const h = checkedHash(ctx, key);
                                 ^
/home/mike/project/zig/work/ppc64/lib/std/array_hash_map.zig:841:52: 0x6cab857 in getOrPutAssumeCapacityAdapted__anon_806220 (zig)
                .u8 => return self.getOrPutInternal(key, ctx, header, u8),
                                                   ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12374:64: 0x69345bf in metadataSimpleAssumeCapacity__anon_726276 (zig)
    const gop = self.metadata_map.getOrPutAssumeCapacityAdapted(
                                                               ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:13045:45: 0x65151e7 in debugParameterAssumeCapacity (zig)
    return self.metadataSimpleAssumeCapacity(.parameter, Metadata.Parameter{
                                            ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm/Builder.zig:12301:45: 0x60b97cf in debugParameter (zig)
    return self.debugParameterAssumeCapacity(name, file, scope, line, ty, arg_no);
                                            ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:9496:61: 0x60b8e1f in airArg (zig)
        const debug_parameter = try o.builder.debugParameter(
                                                            ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:5179:51: 0x5b9892b in genBody (zig)
                .arg            => try self.airArg(inst),
                                                  ^
/home/mike/project/zig/work/ppc64/src/codegen/llvm.zig:1812:19: 0x5b942df in updateFunc (zig)
        fg.genBody(air.getMainBody(), .poi) catch |err| switch (err) {
                  ^
/home/mike/project/zig/work/ppc64/src/link/Elf.zig:2716:70: 0x608174b in updateFunc (zig)
    if (self.llvm_object) |llvm_object| return llvm_object.updateFunc(pt, func_index, air, liveness);
                                                                     ^
/home/mike/project/zig/work/ppc64/src/link.zig:431:82: 0x5b9f9d3 in updateFunc (zig)
                return @as(*tag.Type(), @fieldParentPtr("base", base)).updateFunc(pt, func_index, air, liveness);
                                                                                 ^
/home/mike/project/zig/work/ppc64/src/Zcu/PerThread.zig:902:22: 0x57eb307 in linkerUpdateFunc (zig)
        lf.updateFunc(pt, func_index, air, liveness) catch |err| switch (err) {
                     ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3965:36: 0x536609f in processOneCodegenJob (zig)
            try pt.linkerUpdateFunc(func.func, func.air);
                                   ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3918:36: 0x5365c23 in queueCodegenJob (zig)
        return processOneCodegenJob(tid, comp, codegen_job);
                                   ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3672:37: 0x50f5a2b in processOneJob (zig)
            try comp.queueCodegenJob(tid, .{ .func = .{
                                    ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3628:30: 0x4ec8cb3 in performAllTheWorkInner (zig)
            try processOneJob(@intFromEnum(Zcu.PerThread.Id.main), comp, job, main_progress_node);
                             ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:3499:36: 0x4d70d57 in performAllTheWork (zig)
    try comp.performAllTheWorkInner(main_progress_node);
                                   ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:2261:31: 0x4d6c6df in update (zig)
    try comp.performAllTheWork(main_progress_node);
                              ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:6277:28: 0x536800b in updateSubCompilation (zig)
        try sub_comp.update(sub_node);
                           ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:6416:34: 0x53a1c57 in buildOutputFromZig (zig)
    try comp.updateSubCompilation(sub_compilation, misc_task_tag, prog_node);
                                 ^
/home/mike/project/zig/work/ppc64/src/Compilation.zig:4594:28: 0x57dff17 in buildRt (zig)
    comp.buildOutputFromZig(
                           ^
/home/mike/project/zig/work/ppc64/lib/std/Thread/WaitGroup.zig:61:13: 0x5355227 in run (zig)
            @call(.auto, func, args_inner);
            ^
/home/mike/project/zig/work/ppc64/lib/std/Thread.zig:486:13: 0x5b8836f in callFn__anon_392777 (zig)
            @call(.auto, f, args);
            ^
/home/mike/project/zig/work/ppc64/lib/std/Thread.zig:755:30: 0x57dfe27 in entryFn (zig)
                return callFn(f, args_ptr.*);
                             ^
???:?:?: 0x7fffa7c66e63 in ??? (ld-musl-powerpc64le.so.1)
???:?:?: 0x7fffa7c77d5b in ??? (ld-musl-powerpc64le.so.1)
zsh: abort      zig build-exe z0.zig
```
</details>