### PR TITLE
Fix some RISC-V ABI issues and add ILP32/LP64 (soft float) to module tests

### DIFF
--- a/lib/compiler_rt/common.zig
+++ b/lib/compiler_rt/common.zig
@@ -103,7 +103,7 @@ pub fn F16T(comptime OtherType: type) type {
         else
             u16,
         .aarch64, .aarch64_be => f16,
-        .riscv64 => if (builtin.zig_backend == .stage1) u16 else f16,
+        .riscv32, .riscv64 => f16,
         .x86, .x86_64 => if (builtin.target.isDarwin()) switch (OtherType) {
             // Starting with LLVM 16, Darwin uses different abi for f16
             // depending on the type of the other return/argument..???

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -12419,7 +12419,8 @@ fn isScalar(zcu: *Zcu, ty: Type) bool {
 }
 
 /// This function returns true if we expect LLVM to lower x86_fp80 correctly
-/// and false if we expect LLVM to crash if it counters an x86_fp80 type.
+/// and false if we expect LLVM to crash if it encounters an x86_fp80 type,
+/// or if it produces miscompilations.
 fn backendSupportsF80(target: std.Target) bool {
     return switch (target.cpu.arch) {
         .x86_64, .x86 => !std.Target.x86.featureSetHas(target.cpu.features, .soft_float),
@@ -12428,8 +12429,8 @@ fn backendSupportsF80(target: std.Target) bool {
 }
 
 /// This function returns true if we expect LLVM to lower f16 correctly
-/// and false if we expect LLVM to crash if it counters an f16 type or
-/// if it produces miscompilations.
+/// and false if we expect LLVM to crash if it encounters an f16 type,
+/// or if it produces miscompilations.
 fn backendSupportsF16(target: std.Target) bool {
     return switch (target.cpu.arch) {
         .hexagon,
@@ -12443,7 +12444,6 @@ fn backendSupportsF16(target: std.Target) bool {
         .mipsel,
         .mips64,
         .mips64el,
-        .riscv32,
         .s390x,
         => false,
         .arm,
@@ -12459,7 +12459,7 @@ fn backendSupportsF16(target: std.Target) bool {
 }
 
 /// This function returns true if we expect LLVM to lower f128 correctly,
-/// and false if we expect LLVm to crash if it encounters and f128 type
+/// and false if we expect LLVM to crash if it encounters an f128 type,
 /// or if it produces miscompilations.
 fn backendSupportsF128(target: std.Target) bool {
     return switch (target.cpu.arch) {
@@ -12486,7 +12486,7 @@ fn backendSupportsF128(target: std.Target) bool {
 }
 
 /// LLVM does not support all relevant intrinsics for all targets, so we
-/// may need to manually generate a libc call
+/// may need to manually generate a compiler-rt call.
 fn intrinsicsAllowed(scalar_ty: Type, target: std.Target) bool {
     return switch (scalar_ty.toIntern()) {
         .f16_type => backendSupportsF16(target),

--- a/src/target.zig
+++ b/src/target.zig
@@ -427,17 +427,14 @@ pub fn llvmMachineAbi(target: std.Target) ?[:0]const u8 {
     // Once our self-hosted linker can handle both ABIs, this hack should go away.
     if (target.cpu.arch == .powerpc64) return "elfv2";
 
-    const have_float = switch (target.abi) {
-        .gnueabihf, .musleabihf, .eabihf => true,
-        else => false,
-    };
-
     switch (target.cpu.arch) {
         .riscv64 => {
             const featureSetHas = std.Target.riscv.featureSetHas;
-            if (featureSetHas(target.cpu.features, .d)) {
+            if (featureSetHas(target.cpu.features, .e)) {
+                return "lp64e";
+            } else if (featureSetHas(target.cpu.features, .d)) {
                 return "lp64d";
-            } else if (have_float) {
+            } else if (featureSetHas(target.cpu.features, .f)) {
                 return "lp64f";
             } else {
                 return "lp64";
@@ -445,12 +442,12 @@ pub fn llvmMachineAbi(target: std.Target) ?[:0]const u8 {
         },
         .riscv32 => {
             const featureSetHas = std.Target.riscv.featureSetHas;
-            if (featureSetHas(target.cpu.features, .d)) {
-                return "ilp32d";
-            } else if (have_float) {
-                return "ilp32f";
-            } else if (featureSetHas(target.cpu.features, .e)) {
+            if (featureSetHas(target.cpu.features, .e)) {
                 return "ilp32e";
+            } else if (featureSetHas(target.cpu.features, .d)) {
+                return "ilp32d";
+            } else if (featureSetHas(target.cpu.features, .f)) {
+                return "ilp32f";
             } else {
                 return "ilp32";
             }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -580,6 +580,20 @@ const test_targets = blk: {
         },
 
         .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "riscv32-linux-none",
+                .cpu_features = "baseline-d-f",
+            }) catch unreachable,
+        },
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "riscv32-linux-musl",
+                .cpu_features = "baseline-d-f",
+            }) catch unreachable,
+            .link_libc = true,
+        },
+
+        .{
             .target = .{
                 .cpu_arch = .riscv32,
                 .os_tag = .linux,
@@ -600,6 +614,20 @@ const test_targets = blk: {
                 .os_tag = .linux,
                 .abi = .gnu,
             },
+            .link_libc = true,
+        },
+
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "riscv64-linux-none",
+                .cpu_features = "baseline-d-f",
+            }) catch unreachable,
+        },
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "riscv64-linux-musl",
+                .cpu_features = "baseline-d-f",
+            }) catch unreachable,
             .link_libc = true,
         },
 
@@ -631,7 +659,7 @@ const test_targets = blk: {
             .target = std.Target.Query.parse(.{
                 .arch_os_abi = "riscv64-linux-musl",
                 .cpu_features = "baseline+v+zbb",
-            }) catch @panic("OOM"),
+            }) catch unreachable,
             .use_llvm = false,
             .use_lld = false,
         },


### PR DESCRIPTION
Note that I'm not adding ILP32F/LP64F (hard `f32`, soft `f64`) to the test matrix. They work, but they're used extremely rarely, so I don't think it's worth wasting valuable CI resources on them. For perspective, glibc doesn't support them, and musl [needs a patch](https://www.openwall.com/lists/musl/2024/06/29/1) for them to work, so I doubt anyone cares much.