### PR TITLE
`std.Target`: Fix `cTypePreferredAlignment()` to always return 1 for avr.

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -2626,7 +2626,6 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
             },
 
             .msp430,
-            .avr,
             => 2,
 
             .arc,
@@ -2675,6 +2674,9 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
             .wasm32,
             .wasm64,
             => 16,
+
+            .avr,
+            => unreachable, // Handled above.
         }),
     );
 }
@@ -2709,12 +2711,7 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
             .longdouble => return 4,
             else => {},
         },
-        .avr => switch (c_type) {
-            .char, .int, .uint, .long, .ulong, .float, .longdouble => return 1,
-            .short, .ushort => return 2,
-            .double => return 4,
-            .longlong, .ulonglong => return 8,
-        },
+        .avr => return 1,
         .x86 => switch (target.os.tag) {
             .windows, .uefi => switch (c_type) {
                 .longdouble => switch (target.abi) {
@@ -2750,7 +2747,6 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
             .arc,
             .arm,
             .armeb,
-            .avr,
             .thumb,
             .thumbeb,
             .amdgcn,
@@ -2788,6 +2784,9 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
             .wasm32,
             .wasm64,
             => 16,
+
+            .avr,
+            => unreachable, // Handled above.
         }),
     );
 }


### PR DESCRIPTION
This matches avr-gcc's ABI.

Note that this makes us diverge from Clang 19's AVR ABI. But we already did that in other ways for AVR, so I don't consider that a significant issue. (Right now, we're in a weird middle-ground where we don't fully match Clang *or* avr-gcc.) I'm [working on](https://github.com/llvm/llvm-project/pull/111290) getting Clang to match avr-gcc as well, which should hopefully make it into Clang 20.

Also worth noting:

https://github.com/ziglang/zig/blob/d5c9d8529534745c9feae6b67cdc01d53f11a0d9/src/Type.zig#L1639-L1641