### PR TITLE
Sema: add a few missing runtime value validations

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26193,6 +26193,8 @@ fn zirMemcpy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
     }
 
     try sema.requireRuntimeBlock(block, src, runtime_src);
+    try sema.validateRuntimeValue(block, dest_src, dest_ptr);
+    try sema.validateRuntimeValue(block, src_src, src_ptr);
 
     // Aliasing safety check.
     if (block.wantSafety()) {
@@ -26321,6 +26323,9 @@ fn zirMemset(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
     };
 
     try sema.requireRuntimeBlock(block, src, runtime_src);
+    try sema.validateRuntimeValue(block, dest_src, dest_ptr);
+    try sema.validateRuntimeValue(block, value_src, elem);
+
     _ = try block.addInst(.{
         .tag = if (block.wantSafety()) .memset_safe else .memset,
         .data = .{ .bin_op = .{

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2274,15 +2274,20 @@ pub fn resolveFinalDeclValue(
     src: LazySrcLoc,
     air_ref: Air.Inst.Ref,
 ) CompileError!Value {
+    const zcu = sema.pt.zcu;
+
     const val = try sema.resolveValueAllowVariables(air_ref) orelse {
         return sema.failWithNeededComptime(block, src, .{
             .needed_comptime_reason = "global variable initializer must be comptime-known",
         });
     };
     if (val.isGenericPoison()) return error.GenericPoison;
-    if (val.canMutateComptimeVarState(sema.pt.zcu)) {
+
+    const init_val: Value = if (val.getVariable(zcu)) |v| .fromInterned(v.init) else val;
+    if (init_val.canMutateComptimeVarState(zcu)) {
         return sema.fail(block, src, "global variable contains reference to comptime var", .{});
     }
+
     return val;
 }
 

--- a/test/cases/compile_errors/comptime_var_referenced_at_runtime.zig
+++ b/test/cases/compile_errors/comptime_var_referenced_at_runtime.zig
@@ -47,6 +47,22 @@ export fn qar() void {
     _ = y;
 }
 
+export fn bux() void {
+    comptime var x: [2]u32 = undefined;
+    x = .{ 1, 2 };
+
+    var rt: [2]u32 = undefined;
+    @memcpy(&rt, &x);
+}
+
+export fn far() void {
+    comptime var x: u32 = 123;
+
+    var rt: [2]*u32 = undefined;
+    const elem: *u32 = &x;
+    @memset(&rt, elem);
+}
+
 // error
 //
 // :5:19: error: runtime value contains reference to comptime var
@@ -63,3 +79,7 @@ export fn qar() void {
 // :41:12: note: comptime var pointers are not available at runtime
 // :46:39: error: runtime value contains reference to comptime var
 // :46:39: note: comptime var pointers are not available at runtime
+// :55:18: error: runtime value contains reference to comptime var
+// :55:18: note: comptime var pointers are not available at runtime
+// :63:18: error: runtime value contains reference to comptime var
+// :63:18: note: comptime var pointers are not available at runtime

--- a/test/cases/compile_errors/comptime_var_referenced_by_decl.zig
+++ b/test/cases/compile_errors/comptime_var_referenced_by_decl.zig
@@ -38,6 +38,12 @@ export const g: *const *const u32 = g: {
     break :g &aggregate[0];
 };
 
+// Mutable globals should have the same restrictions as const globals.
+export var h: *[1]u32 = h: {
+    var x: [1]u32 = .{123};
+    break :h &x;
+};
+
 // error
 //
 // :1:27: error: global variable contains reference to comptime var
@@ -47,3 +53,4 @@ export const g: *const *const u32 = g: {
 // :22:24: error: global variable contains reference to comptime var
 // :28:33: error: global variable contains reference to comptime var
 // :34:40: error: global variable contains reference to comptime var
+// :42:28: error: global variable contains reference to comptime var


### PR DESCRIPTION
Just a few missing calls to `validateRuntimeValue`, plus missing handling for the `variable` case when checking whether a declaration's resolved value references comptime-mutable memory.