### PR TITLE
Proposal: add assertLocked to std.debug.SafetyLock

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1527,9 +1527,9 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
 }
 
 pub const SafetyLock = struct {
-    state: State = .unlocked,
+    state: State = if (runtime_safety) .unlocked else .unknown,
 
-    pub const State = if (runtime_safety) enum { unlocked, locked } else enum { unlocked };
+    pub const State = if (runtime_safety) enum { unlocked, locked } else enum { unknown };
 
     pub fn lock(l: *SafetyLock) void {
         if (!runtime_safety) return;
@@ -1547,7 +1547,21 @@ pub const SafetyLock = struct {
         if (!runtime_safety) return;
         assert(l.state == .unlocked);
     }
+
+    pub fn assertLocked(l: SafetyLock) void {
+        if (!runtime_safety) return;
+        assert(l.state == .locked);
+    }
 };
+
+test SafetyLock {
+    var safety_lock: SafetyLock = .{};
+    safety_lock.assertUnlocked();
+    safety_lock.lock();
+    safety_lock.assertLocked();
+    safety_lock.unlock();
+    safety_lock.assertUnlocked();
+}
 
 /// Detect whether the program is being executed in the Valgrind virtual machine.
 ///

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1692,7 +1692,7 @@ pub fn HashMapUnmanaged(
             }
 
             self.size = 0;
-            self.pointer_stability = .{ .state = .unlocked };
+            self.pointer_stability = .{};
             std.mem.swap(Self, self, &map);
             map.deinit(allocator);
         }


### PR DESCRIPTION
- Adds a function which asserts that a SatetyLock's state is locked when runtime_safety is on.
- Changes the state enum when runtime_safety is off to be `unknown`.
- Add a simple usage test.

In my code, I have several constructs with methods that are, roughly:
- Begin
- Add item
- End

Where begin reserves resources, add item adds a pending value, and end sends the queued items.  As adding items is only valid between begin and end calls, I want an assert construct in my code.  I started writing my own, realized there's probably one in the standard library, and found SafetyLock.  However SafetyLock is currently only used in cases where a special state makes some calls invalid, and is not used anywhere that a special state makes calls valid.  Therefor, I propose adding a method `assertLocked`.

In performing this change, I noticed that when runtime_safety is off then the only state is `unlocked`.  This obviously clashes with a method called `assertLocked`.  So I've changed the state in that case to be named `unknown`.  As a side benefit, I think this better reflects the state.  It'll have a better chance of correctness with any code inspecting the state, since outside code can't look at the SafetyLock and see that it's `unlocked` in runtime_safety=false code when, in the same overall program state, it would be locked in runtime_safety=true code.

There was one place where unlocked was mentioned outside of the definition.  I've switched to using a default field value, though I could see adding `SafetlyLock.unlocked` instead.  Which to do is up to reviewers style choice.  A corresponding `SafetyLock.locked` would conflict with https://github.com/ziglang/zig/issues/19328