### PR TITLE
elf: more incremental progress

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -393,12 +393,10 @@ pub const Section = struct {
             const needed_size = len;
             const min_alignment = sec.alignment.toByteUnits().?;
             try elf_file.growSection(shndx, needed_size, min_alignment);
-            const shdr = &elf_file.sections.items(.shdr)[shndx];
-            shdr.sh_size = needed_size;
-            elf_file.markDirty(shndx);
+            const shdr = elf_file.sections.items(.shdr)[shndx];
             atom.size = needed_size;
             atom.alignment = InternPool.Alignment.fromNonzeroByteUnits(shdr.sh_addralign);
-            sec.len = len;
+            sec.len = needed_size;
         } else if (dwarf.bin_file.cast(.macho)) |macho_file| {
             const header = if (macho_file.d_sym) |*d_sym| header: {
                 try d_sym.growSection(@intCast(sec.index), len, true, macho_file);

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -389,20 +389,10 @@ pub const Section = struct {
         if (dwarf.bin_file.cast(.elf)) |elf_file| {
             const zo = elf_file.zigObjectPtr().?;
             const atom = zo.symbol(sec.index).atom(elf_file).?;
-            const old_size = atom.size;
             atom.size = len;
             atom.alignment = sec.alignment;
             sec.len = len;
-            if (old_size > 0) {
-                if (!atom.alignment.check(@intCast(atom.value)) or atom.size > atom.fileCapacity(elf_file)) {
-                    try zo.allocateAtom(atom, false, elf_file);
-                } else {
-                    const shdr = &elf_file.sections.items(.shdr)[atom.output_section_index];
-                    shdr.sh_size = (shdr.sh_size - old_size) + atom.size;
-                }
-            } else {
-                try zo.allocateAtom(atom, false, elf_file);
-            }
+            try zo.allocateAtom(atom, false, elf_file);
         } else if (dwarf.bin_file.cast(.macho)) |macho_file| {
             const header = if (macho_file.d_sym) |*d_sym| header: {
                 try d_sym.growSection(@intCast(sec.index), len, true, macho_file);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3472,12 +3472,7 @@ fn resetShdrIndexes(self: *Elf, backlinks: []const u32) void {
         }
     }
 
-    if (self.zigObjectPtr()) |zo| {
-        for (zo.atoms_indexes.items) |atom_index| {
-            const atom_ptr = zo.atom(atom_index) orelse continue;
-            atom_ptr.output_section_index = backlinks[atom_ptr.output_section_index];
-        }
-    }
+    if (self.zigObjectPtr()) |zo| zo.resetShdrIndexes(backlinks);
 
     for (self.comdat_group_sections.items) |*cg| {
         cg.shndx = backlinks[cg.shndx];

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -809,8 +809,6 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
 
     const csu = try CsuObjects.init(arena, comp);
 
-    // Here we will parse object and library files (if referenced).
-
     // csu prelude
     if (csu.crt0) |path| try parseObjectReportingFailure(self, path);
     if (csu.crti) |path| try parseObjectReportingFailure(self, path);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4269,6 +4269,8 @@ fn writeSyntheticSections(self: *Elf) !void {
     }
 
     if (self.rela_dyn_section_index) |shndx| {
+        // TODO: would state tracking be more appropriate here? perhaps even custom relocation type?
+        self.rela_dyn.clearRetainingCapacity();
         const shdr = slice.items(.shdr)[shndx];
         try self.got.addRela(self);
         try self.copy_rel.addRela(self);
@@ -4301,6 +4303,8 @@ fn writeSyntheticSections(self: *Elf) !void {
     }
 
     if (self.rela_plt_section_index) |shndx| {
+        // TODO: would state tracking be more appropriate here? perhaps even custom relocation type?
+        self.rela_plt.clearRetainingCapacity();
         const shdr = slice.items(.shdr)[shndx];
         try self.plt.addRela(self);
         try self.base.file.?.pwriteAll(mem.sliceAsBytes(self.rela_plt.items), shdr.sh_offset);

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1801,7 +1801,6 @@ pub fn initOutputSection(self: *Elf, args: struct {
         .type = @"type",
         .flags = flags,
         .name = try self.insertShString(name),
-        .offset = std.math.maxInt(u64),
     });
     return out_shndx;
 }
@@ -2867,7 +2866,6 @@ fn initSyntheticSections(self: *Elf) !void {
                     elf.SHT_PROGBITS,
                 .flags = elf.SHF_ALLOC,
                 .addralign = ptr_size,
-                .offset = std.math.maxInt(u64),
             });
         }
         if (comp.link_eh_frame_hdr and self.eh_frame_hdr_section_index == null) {
@@ -2876,7 +2874,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .type = elf.SHT_PROGBITS,
                 .flags = elf.SHF_ALLOC,
                 .addralign = 4,
-                .offset = std.math.maxInt(u64),
             });
         }
     }
@@ -2887,7 +2884,6 @@ fn initSyntheticSections(self: *Elf) !void {
             .type = elf.SHT_PROGBITS,
             .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
             .addralign = ptr_size,
-            .offset = std.math.maxInt(u64),
         });
     }
 
@@ -2897,7 +2893,6 @@ fn initSyntheticSections(self: *Elf) !void {
             .type = elf.SHT_PROGBITS,
             .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
             .addralign = @alignOf(u64),
-            .offset = std.math.maxInt(u64),
         });
     }
 
@@ -2919,7 +2914,6 @@ fn initSyntheticSections(self: *Elf) !void {
             .flags = elf.SHF_ALLOC,
             .addralign = @alignOf(elf.Elf64_Rela),
             .entsize = @sizeOf(elf.Elf64_Rela),
-            .offset = std.math.maxInt(u64),
         });
     }
 
@@ -2930,7 +2924,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .type = elf.SHT_PROGBITS,
                 .flags = elf.SHF_ALLOC | elf.SHF_EXECINSTR,
                 .addralign = 16,
-                .offset = std.math.maxInt(u64),
             });
         }
         if (self.rela_plt_section_index == null) {
@@ -2940,7 +2933,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .flags = elf.SHF_ALLOC,
                 .addralign = @alignOf(elf.Elf64_Rela),
                 .entsize = @sizeOf(elf.Elf64_Rela),
-                .offset = std.math.maxInt(u64),
             });
         }
     }
@@ -2951,7 +2943,6 @@ fn initSyntheticSections(self: *Elf) !void {
             .type = elf.SHT_PROGBITS,
             .flags = elf.SHF_ALLOC | elf.SHF_EXECINSTR,
             .addralign = 16,
-            .offset = std.math.maxInt(u64),
         });
     }
 
@@ -2960,7 +2951,6 @@ fn initSyntheticSections(self: *Elf) !void {
             .name = try self.insertShString(".copyrel"),
             .type = elf.SHT_NOBITS,
             .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
-            .offset = std.math.maxInt(u64),
         });
     }
 
@@ -2979,7 +2969,6 @@ fn initSyntheticSections(self: *Elf) !void {
             .type = elf.SHT_PROGBITS,
             .flags = elf.SHF_ALLOC,
             .addralign = 1,
-            .offset = std.math.maxInt(u64),
         });
     }
 
@@ -2991,7 +2980,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .type = elf.SHT_STRTAB,
                 .entsize = 1,
                 .addralign = 1,
-                .offset = std.math.maxInt(u64),
             });
         }
         if (self.dynamic_section_index == null) {
@@ -3001,7 +2989,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .type = elf.SHT_DYNAMIC,
                 .entsize = @sizeOf(elf.Elf64_Dyn),
                 .addralign = @alignOf(elf.Elf64_Dyn),
-                .offset = std.math.maxInt(u64),
             });
         }
         if (self.dynsymtab_section_index == null) {
@@ -3012,7 +2999,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .addralign = @alignOf(elf.Elf64_Sym),
                 .entsize = @sizeOf(elf.Elf64_Sym),
                 .info = 1,
-                .offset = std.math.maxInt(u64),
             });
         }
         if (self.hash_section_index == null) {
@@ -3022,7 +3008,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .type = elf.SHT_HASH,
                 .addralign = 4,
                 .entsize = 4,
-                .offset = std.math.maxInt(u64),
             });
         }
         if (self.gnu_hash_section_index == null) {
@@ -3031,7 +3016,6 @@ fn initSyntheticSections(self: *Elf) !void {
                 .flags = elf.SHF_ALLOC,
                 .type = elf.SHT_GNU_HASH,
                 .addralign = 8,
-                .offset = std.math.maxInt(u64),
             });
         }
 
@@ -3047,7 +3031,6 @@ fn initSyntheticSections(self: *Elf) !void {
                     .type = elf.SHT_GNU_VERSYM,
                     .addralign = @alignOf(elf.Elf64_Versym),
                     .entsize = @sizeOf(elf.Elf64_Versym),
-                    .offset = std.math.maxInt(u64),
                 });
             }
             if (self.verneed_section_index == null) {
@@ -3056,7 +3039,6 @@ fn initSyntheticSections(self: *Elf) !void {
                     .flags = elf.SHF_ALLOC,
                     .type = elf.SHT_GNU_VERNEED,
                     .addralign = @alignOf(elf.Elf64_Verneed),
-                    .offset = std.math.maxInt(u64),
                 });
             }
         }
@@ -3077,7 +3059,6 @@ pub fn initSymtab(self: *Elf) !void {
             .type = elf.SHT_SYMTAB,
             .addralign = if (small_ptr) @alignOf(elf.Elf32_Sym) else @alignOf(elf.Elf64_Sym),
             .entsize = if (small_ptr) @sizeOf(elf.Elf32_Sym) else @sizeOf(elf.Elf64_Sym),
-            .offset = std.math.maxInt(u64),
         });
     }
     if (self.strtab_section_index == null) {
@@ -3086,7 +3067,6 @@ pub fn initSymtab(self: *Elf) !void {
             .type = elf.SHT_STRTAB,
             .entsize = 1,
             .addralign = 1,
-            .offset = std.math.maxInt(u64),
         });
     }
 }
@@ -3098,7 +3078,6 @@ pub fn initShStrtab(self: *Elf) !void {
             .type = elf.SHT_STRTAB,
             .entsize = 1,
             .addralign = 1,
-            .offset = std.math.maxInt(u64),
         });
     }
 }
@@ -4760,7 +4739,6 @@ pub fn addRelaShdr(self: *Elf, name: u32, shndx: u32) !u32 {
         .entsize = entsize,
         .info = shndx,
         .addralign = addralign,
-        .offset = std.math.maxInt(u64),
     });
 }
 
@@ -4772,7 +4750,6 @@ pub const AddSectionOpts = struct {
     info: u32 = 0,
     addralign: u64 = 0,
     entsize: u64 = 0,
-    offset: u64 = 0,
 };
 
 pub fn addSection(self: *Elf, opts: AddSectionOpts) !u32 {
@@ -4784,7 +4761,7 @@ pub fn addSection(self: *Elf, opts: AddSectionOpts) !u32 {
             .sh_type = opts.type,
             .sh_flags = opts.flags,
             .sh_addr = 0,
-            .sh_offset = opts.offset,
+            .sh_offset = 0,
             .sh_size = 0,
             .sh_link = opts.link,
             .sh_info = opts.info,

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -548,16 +548,6 @@ pub fn allocatedSize(self: *Elf, start: u64) u64 {
     return min_pos - start;
 }
 
-fn allocatedVirtualSize(self: *Elf, start: u64) u64 {
-    if (start == 0) return 0;
-    var min_pos: u64 = std.math.maxInt(u64);
-    for (self.phdrs.items) |phdr| {
-        if (phdr.p_vaddr <= start) continue;
-        if (phdr.p_vaddr < min_pos) min_pos = phdr.p_vaddr;
-    }
-    return min_pos - start;
-}
-
 pub fn findFreeSpace(self: *Elf, object_size: u64, min_alignment: u64) !u64 {
     var start: u64 = 0;
     while (try self.detectAllocCollision(start, object_size)) |item_end| {
@@ -566,59 +556,21 @@ pub fn findFreeSpace(self: *Elf, object_size: u64, min_alignment: u64) !u64 {
     return start;
 }
 
-pub fn growAllocSection(self: *Elf, shdr_index: u32, needed_size: u64, min_alignment: u64) !void {
-    const slice = self.sections.slice();
-    const shdr = &slice.items(.shdr)[shdr_index];
-    assert(shdr.sh_flags & elf.SHF_ALLOC != 0);
+pub fn growSection(self: *Elf, shdr_index: u32, needed_size: u64, min_alignment: u64) !void {
+    const shdr = &self.sections.items(.shdr)[shdr_index];
+    assert(shdr.sh_type != elf.SHT_NOBITS);
 
-    log.debug("allocated size {x} of {s}, needed size {x}", .{
-        self.allocatedSize(shdr.sh_offset),
+    const allocated_size = self.allocatedSize(shdr.sh_offset);
+    log.debug("allocated size {x} of '{s}', needed size {x}", .{
+        allocated_size,
         self.getShString(shdr.sh_name),
         needed_size,
     });
 
-    if (shdr.sh_type != elf.SHT_NOBITS) {
-        const allocated_size = self.allocatedSize(shdr.sh_offset);
-        if (needed_size > allocated_size) {
-            const existing_size = shdr.sh_size;
-            shdr.sh_size = 0;
-            // Must move the entire section.
-            const new_offset = try self.findFreeSpace(needed_size, min_alignment);
-
-            log.debug("new '{s}' file offset 0x{x} to 0x{x}", .{
-                self.getShString(shdr.sh_name),
-                new_offset,
-                new_offset + existing_size,
-            });
-
-            const amt = try self.base.file.?.copyRangeAll(shdr.sh_offset, self.base.file.?, new_offset, existing_size);
-            // TODO figure out what to about this error condition - how to communicate it up.
-            if (amt != existing_size) return error.InputOutput;
-
-            shdr.sh_offset = new_offset;
-        } else if (shdr.sh_offset + allocated_size == std.math.maxInt(u64)) {
-            try self.base.file.?.setEndPos(shdr.sh_offset + needed_size);
-        }
-    }
-    shdr.sh_size = needed_size;
-    self.markDirty(shdr_index);
-}
-
-pub fn growNonAllocSection(
-    self: *Elf,
-    shdr_index: u32,
-    needed_size: u64,
-    min_alignment: u64,
-    requires_file_copy: bool,
-) !void {
-    const shdr = &self.sections.items(.shdr)[shdr_index];
-    assert(shdr.sh_flags & elf.SHF_ALLOC == 0);
-
-    const allocated_size = self.allocatedSize(shdr.sh_offset);
     if (needed_size > allocated_size) {
         const existing_size = shdr.sh_size;
         shdr.sh_size = 0;
-        // Move all the symbols to a new file location.
+        // Must move the entire section.
         const new_offset = try self.findFreeSpace(needed_size, min_alignment);
 
         log.debug("new '{s}' file offset 0x{x} to 0x{x}", .{
@@ -627,22 +579,19 @@ pub fn growNonAllocSection(
             new_offset + existing_size,
         });
 
-        if (requires_file_copy) {
-            const amt = try self.base.file.?.copyRangeAll(
-                shdr.sh_offset,
-                self.base.file.?,
-                new_offset,
-                existing_size,
-            );
-            if (amt != existing_size) return error.InputOutput;
-        }
+        const amt = try self.base.file.?.copyRangeAll(
+            shdr.sh_offset,
+            self.base.file.?,
+            new_offset,
+            existing_size,
+        );
+        // TODO figure out what to about this error condition - how to communicate it up.
+        if (amt != existing_size) return error.InputOutput;
 
         shdr.sh_offset = new_offset;
     } else if (shdr.sh_offset + allocated_size == std.math.maxInt(u64)) {
         try self.base.file.?.setEndPos(shdr.sh_offset + needed_size);
     }
-    shdr.sh_size = needed_size;
-    self.markDirty(shdr_index);
 }
 
 pub fn markDirty(self: *Elf, shdr_index: u32) void {
@@ -751,10 +700,11 @@ pub fn allocateChunk(self: *Elf, args: struct {
         true;
     if (expand_section) {
         const needed_size = res.value + args.size;
-        if (shdr.sh_flags & elf.SHF_ALLOC != 0)
-            try self.growAllocSection(args.shndx, needed_size, args.alignment.toByteUnits().?)
-        else
-            try self.growNonAllocSection(args.shndx, needed_size, args.alignment.toByteUnits().?, true);
+        if (shdr.sh_type != elf.SHT_NOBITS) {
+            try self.growSection(args.shndx, needed_size, args.alignment.toByteUnits().?);
+        }
+        shdr.sh_size = needed_size;
+        self.markDirty(args.shndx);
     }
 
     return res;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4834,6 +4834,7 @@ const RelaDyn = struct {
     sym: u64 = 0,
     type: u32,
     addend: i64 = 0,
+    target: ?*const Symbol = null,
 };
 
 pub fn addRelaDyn(self: *Elf, opts: RelaDyn) !void {
@@ -4842,6 +4843,13 @@ pub fn addRelaDyn(self: *Elf, opts: RelaDyn) !void {
 }
 
 pub fn addRelaDynAssumeCapacity(self: *Elf, opts: RelaDyn) void {
+    relocs_log.debug("  {s}: [{x} => {d}({s})] + {x}", .{
+        relocation.fmtRelocType(opts.type, self.getTarget().cpu.arch),
+        opts.offset,
+        opts.sym,
+        if (opts.target) |sym| sym.name(self) else "",
+        opts.addend,
+    });
     self.rela_dyn.appendAssumeCapacity(.{
         .r_offset = opts.offset,
         .r_info = (opts.sym << 32) | opts.type,
@@ -5772,6 +5780,7 @@ const assert = std.debug.assert;
 const elf = std.elf;
 const fs = std.fs;
 const log = std.log.scoped(.link);
+const relocs_log = std.log.scoped(.link_relocs);
 const state_log = std.log.scoped(.link_state);
 const math = std.math;
 const mem = std.mem;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -987,6 +987,9 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
     for (self.objects.items) |index| {
         self.file(index).?.object.dirty = false;
     }
+    // TODO: would state tracking be more appropriate here? perhaps even custom relocation type?
+    self.rela_dyn.clearRetainingCapacity();
+    self.rela_plt.clearRetainingCapacity();
 
     if (self.zigObjectPtr()) |zo| {
         var has_reloc_errors = false;
@@ -1017,6 +1020,7 @@ pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_nod
     try self.writeShdrTable();
     try self.writeAtoms();
     try self.writeMergeSections();
+
     self.writeSyntheticSections() catch |err| switch (err) {
         error.RelocFailure => return error.FlushFailure,
         error.UnsupportedCpuArch => {
@@ -4236,8 +4240,6 @@ fn writeSyntheticSections(self: *Elf) !void {
     }
 
     if (self.rela_dyn_section_index) |shndx| {
-        // TODO: would state tracking be more appropriate here? perhaps even custom relocation type?
-        self.rela_dyn.clearRetainingCapacity();
         const shdr = slice.items(.shdr)[shndx];
         try self.got.addRela(self);
         try self.copy_rel.addRela(self);
@@ -4270,8 +4272,6 @@ fn writeSyntheticSections(self: *Elf) !void {
     }
 
     if (self.rela_plt_section_index) |shndx| {
-        // TODO: would state tracking be more appropriate here? perhaps even custom relocation type?
-        self.rela_plt.clearRetainingCapacity();
         const shdr = slice.items(.shdr)[shndx];
         try self.plt.addRela(self);
         try self.base.file.?.pwriteAll(mem.sliceAsBytes(self.rela_plt.items), shdr.sh_offset);

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -118,10 +118,19 @@ pub fn capacity(self: Atom, elf_file: *Elf) u64 {
     return @intCast(next_addr - self.address(elf_file));
 }
 
+pub fn fileCapacity(self: Atom, elf_file: *Elf) u64 {
+    const self_off = self.offset(elf_file);
+    const next_off = if (self.nextAtom(elf_file)) |next_atom|
+        next_atom.offset(elf_file)
+    else
+        self_off + elf_file.allocatedSize(self_off);
+    return @intCast(next_off - self_off);
+}
+
 pub fn freeListEligible(self: Atom, elf_file: *Elf) bool {
     // No need to keep a free list node for the last block.
     const next = self.nextAtom(elf_file) orelse return false;
-    const cap: u64 = @intCast(next.address(elf_file) - self.address(elf_file));
+    const cap: u64 = @intCast(next.value - self.value);
     const ideal_cap = Elf.padToIdeal(self.size);
     if (cap <= ideal_cap) return false;
     const surplus = cap - ideal_cap;

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -935,9 +935,10 @@ fn format2(
     _ = unused_fmt_string;
     const atom = ctx.atom;
     const elf_file = ctx.elf_file;
-    try writer.print("atom({d}) : {s} : @{x} : shdr({d}) : align({x}) : size({x})", .{
+    try writer.print("atom({d}) : {s} : @{x} : shdr({d}) : align({x}) : size({x}) : prev({}) : next({})", .{
         atom.atom_index,           atom.name(elf_file),                   atom.address(elf_file),
         atom.output_section_index, atom.alignment.toByteUnits() orelse 0, atom.size,
+        atom.prev_atom_ref,        atom.next_atom_ref,
     });
     if (atom.fdes(elf_file).len > 0) {
         try writer.writeAll(" : fdes{ ");

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -723,6 +723,7 @@ fn resolveDynAbsReloc(
                     .sym = target.extra(elf_file).dynamic,
                     .type = relocation.encode(.abs, cpu_arch),
                     .addend = A,
+                    .target = target,
                 });
                 try applyDynamicReloc(A, elf_file, writer);
             } else {
@@ -737,6 +738,7 @@ fn resolveDynAbsReloc(
                     .sym = target.extra(elf_file).dynamic,
                     .type = relocation.encode(.abs, cpu_arch),
                     .addend = A,
+                    .target = target,
                 });
                 try applyDynamicReloc(A, elf_file, writer);
             } else {
@@ -750,6 +752,7 @@ fn resolveDynAbsReloc(
                 .sym = target.extra(elf_file).dynamic,
                 .type = relocation.encode(.abs, cpu_arch),
                 .addend = A,
+                .target = target,
             });
             try applyDynamicReloc(A, elf_file, writer);
         },
@@ -759,6 +762,7 @@ fn resolveDynAbsReloc(
                 .offset = P,
                 .type = relocation.encode(.rel, cpu_arch),
                 .addend = S + A,
+                .target = target,
             });
             try applyDynamicReloc(S + A, elf_file, writer);
         },
@@ -769,6 +773,7 @@ fn resolveDynAbsReloc(
                 .offset = P,
                 .type = relocation.encode(.irel, cpu_arch),
                 .addend = S_ + A,
+                .target = target,
             });
             try applyDynamicReloc(S_ + A, elf_file, writer);
         },

--- a/src/link/Elf/AtomList.zig
+++ b/src/link/Elf/AtomList.zig
@@ -2,7 +2,8 @@ value: i64 = 0,
 size: u64 = 0,
 alignment: Atom.Alignment = .@"1",
 output_section_index: u32 = 0,
-atoms: std.ArrayListUnmanaged(Elf.Ref) = .empty,
+// atoms: std.ArrayListUnmanaged(Elf.Ref) = .empty,
+atoms: std.AutoArrayHashMapUnmanaged(Elf.Ref, void) = .empty,
 
 pub fn deinit(list: *AtomList, allocator: Allocator) void {
     list.atoms.deinit(allocator);
@@ -22,7 +23,7 @@ pub fn updateSize(list: *AtomList, elf_file: *Elf) void {
     // TODO perhaps a 'stale' flag would be better here?
     list.size = 0;
     list.alignment = .@"1";
-    for (list.atoms.items) |ref| {
+    for (list.atoms.keys()) |ref| {
         const atom_ptr = elf_file.atom(ref).?;
         assert(atom_ptr.alive);
         const off = atom_ptr.alignment.forward(list.size);
@@ -56,13 +57,13 @@ pub fn allocate(list: *AtomList, elf_file: *Elf) !void {
     // FIXME:JK this currently ignores Thunks as valid chunks.
     {
         var idx: usize = 0;
-        while (idx < list.atoms.items.len) : (idx += 1) {
-            const curr_atom_ptr = elf_file.atom(list.atoms.items[idx]).?;
+        while (idx < list.atoms.keys().len) : (idx += 1) {
+            const curr_atom_ptr = elf_file.atom(list.atoms.keys()[idx]).?;
             if (idx > 0) {
-                curr_atom_ptr.prev_atom_ref = list.atoms.items[idx - 1];
+                curr_atom_ptr.prev_atom_ref = list.atoms.keys()[idx - 1];
             }
-            if (idx + 1 < list.atoms.items.len) {
-                curr_atom_ptr.next_atom_ref = list.atoms.items[idx + 1];
+            if (idx + 1 < list.atoms.keys().len) {
+                curr_atom_ptr.next_atom_ref = list.atoms.keys()[idx + 1];
             }
         }
     }
@@ -74,7 +75,7 @@ pub fn allocate(list: *AtomList, elf_file: *Elf) !void {
     }
 
     // FIXME:JK if we had a link from Atom to parent AtomList we would not need to update Atom's value or osec index
-    for (list.atoms.items) |ref| {
+    for (list.atoms.keys()) |ref| {
         const atom_ptr = elf_file.atom(ref).?;
         atom_ptr.output_section_index = list.output_section_index;
         atom_ptr.value += list.value;
@@ -92,7 +93,7 @@ pub fn write(list: AtomList, buffer: *std.ArrayList(u8), undefs: anytype, elf_fi
     try buffer.ensureUnusedCapacity(list_size);
     buffer.appendNTimesAssumeCapacity(0, list_size);
 
-    for (list.atoms.items) |ref| {
+    for (list.atoms.keys()) |ref| {
         const atom_ptr = elf_file.atom(ref).?;
         assert(atom_ptr.alive);
 
@@ -128,7 +129,7 @@ pub fn writeRelocatable(list: AtomList, buffer: *std.ArrayList(u8), elf_file: *E
     try buffer.ensureUnusedCapacity(list_size);
     buffer.appendNTimesAssumeCapacity(0, list_size);
 
-    for (list.atoms.items) |ref| {
+    for (list.atoms.keys()) |ref| {
         const atom_ptr = elf_file.atom(ref).?;
         assert(atom_ptr.alive);
 
@@ -149,13 +150,13 @@ pub fn writeRelocatable(list: AtomList, buffer: *std.ArrayList(u8), elf_file: *E
 }
 
 pub fn firstAtom(list: AtomList, elf_file: *Elf) *Atom {
-    assert(list.atoms.items.len > 0);
-    return elf_file.atom(list.atoms.items[0]).?;
+    assert(list.atoms.keys().len > 0);
+    return elf_file.atom(list.atoms.keys()[0]).?;
 }
 
 pub fn lastAtom(list: AtomList, elf_file: *Elf) *Atom {
-    assert(list.atoms.items.len > 0);
-    return elf_file.atom(list.atoms.items[list.atoms.items.len - 1]).?;
+    assert(list.atoms.keys().len > 0);
+    return elf_file.atom(list.atoms.keys()[list.atoms.keys().len - 1]).?;
 }
 
 pub fn format(
@@ -191,9 +192,9 @@ fn format2(
         list.alignment.toByteUnits() orelse 0, list.size,
     });
     try writer.writeAll(" : atoms{ ");
-    for (list.atoms.items, 0..) |ref, i| {
+    for (list.atoms.keys(), 0..) |ref, i| {
         try writer.print("{}", .{ref});
-        if (i < list.atoms.items.len - 1) try writer.writeAll(", ");
+        if (i < list.atoms.keys().len - 1) try writer.writeAll(", ");
     }
     try writer.writeAll(" }");
 }

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -915,7 +915,7 @@ pub fn initOutputSections(self: *Object, elf_file: *Elf) !void {
         });
         const atom_list = &elf_file.sections.items(.atom_list_2)[osec];
         atom_list.output_section_index = osec;
-        try atom_list.atoms.append(elf_file.base.comp.gpa, atom_ptr.ref());
+        _ = try atom_list.atoms.getOrPut(elf_file.base.comp.gpa, atom_ptr.ref());
     }
 }
 

--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -29,6 +29,7 @@ cies: std.ArrayListUnmanaged(Cie) = .empty,
 eh_frame_data: std.ArrayListUnmanaged(u8) = .empty,
 
 alive: bool = true,
+dirty: bool = true,
 num_dynrelocs: u32 = 0,
 
 output_symtab_ctx: Elf.SymtabCtx = .{},

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -130,7 +130,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .entsize = 1,
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_str_section_dirty = true;
                 self.debug_str_index = try addSectionSymbolWithAtom(self, gpa, ".debug_str", .@"1", osec);
@@ -141,7 +140,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_info"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_info_section_dirty = true;
                 self.debug_info_index = try addSectionSymbolWithAtom(self, gpa, ".debug_info", .@"1", osec);
@@ -152,7 +150,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_abbrev"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_abbrev_section_dirty = true;
                 self.debug_abbrev_index = try addSectionSymbolWithAtom(self, gpa, ".debug_abbrev", .@"1", osec);
@@ -163,7 +160,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_aranges"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 16,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_aranges_section_dirty = true;
                 self.debug_aranges_index = try addSectionSymbolWithAtom(self, gpa, ".debug_aranges", .@"16", osec);
@@ -174,7 +170,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_line"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_line_section_dirty = true;
                 self.debug_line_index = try addSectionSymbolWithAtom(self, gpa, ".debug_line", .@"1", osec);
@@ -187,7 +182,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .entsize = 1,
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_line_str_section_dirty = true;
                 self.debug_line_str_index = try addSectionSymbolWithAtom(self, gpa, ".debug_line_str", .@"1", osec);
@@ -198,7 +192,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_loclists"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_loclists_section_dirty = true;
                 self.debug_loclists_index = try addSectionSymbolWithAtom(self, gpa, ".debug_loclists", .@"1", osec);
@@ -209,7 +202,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_rnglists"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_rnglists_section_dirty = true;
                 self.debug_rnglists_index = try addSectionSymbolWithAtom(self, gpa, ".debug_rnglists", .@"1", osec);
@@ -224,7 +216,6 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                         elf.SHT_PROGBITS,
                     .flags = elf.SHF_ALLOC,
                     .addralign = ptr_size,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.eh_frame_section_dirty = true;
                 self.eh_frame_index = try addSectionSymbolWithAtom(self, gpa, ".eh_frame", Atom.Alignment.fromNonzeroByteUnits(ptr_size), osec);
@@ -1026,7 +1017,6 @@ pub fn lowerUav(
             .type = elf.SHT_PROGBITS,
             .addralign = 1,
             .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
-            .offset = std.math.maxInt(u64),
         });
         self.data_relro_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".data.rel.ro"), osec);
         break :osec osec;
@@ -1166,7 +1156,6 @@ fn getNavShdrIndex(
             .flags = elf.SHF_ALLOC | elf.SHF_EXECINSTR,
             .name = try elf_file.insertShString(".text"),
             .addralign = 1,
-            .offset = std.math.maxInt(u64),
         });
         self.text_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".text"), osec);
         return osec;
@@ -1200,7 +1189,6 @@ fn getNavShdrIndex(
             .flags = elf.SHF_ALLOC | elf.SHF_WRITE | elf.SHF_TLS,
             .name = try elf_file.insertShString(".tdata"),
             .addralign = 1,
-            .offset = std.math.maxInt(u64),
         });
         self.tdata_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".tdata"), osec);
         return osec;
@@ -1213,7 +1201,6 @@ fn getNavShdrIndex(
             .type = elf.SHT_PROGBITS,
             .addralign = 1,
             .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
-            .offset = std.math.maxInt(u64),
         });
         self.data_relro_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".data.rel.ro"), osec);
         return osec;
@@ -1228,7 +1215,6 @@ fn getNavShdrIndex(
                     .type = elf.SHT_PROGBITS,
                     .addralign = ptr_size,
                     .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.data_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".data"), osec);
                 return osec;
@@ -1268,7 +1254,6 @@ fn getNavShdrIndex(
         .type = elf.SHT_PROGBITS,
         .addralign = ptr_size,
         .flags = elf.SHF_ALLOC | elf.SHF_WRITE,
-        .offset = std.math.maxInt(u64),
     });
     self.data_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".data"), osec);
     return osec;
@@ -1521,7 +1506,6 @@ pub fn updateFunc(
                     .flags = elf.SHF_ALLOC | elf.SHF_EXECINSTR,
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
-                    .offset = std.math.maxInt(u64),
                 });
                 self.text_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".text"), osec);
                 break :osec osec;
@@ -1697,7 +1681,6 @@ fn updateLazySymbol(
                 .type = elf.SHT_PROGBITS,
                 .addralign = 1,
                 .flags = elf.SHF_ALLOC | elf.SHF_EXECINSTR,
-                .offset = std.math.maxInt(u64),
             });
             self.text_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".text"), osec);
             break :osec osec;
@@ -1710,7 +1693,6 @@ fn updateLazySymbol(
                 .type = elf.SHT_PROGBITS,
                 .addralign = 1,
                 .flags = elf.SHF_ALLOC,
-                .offset = std.math.maxInt(u64),
             });
             self.rodata_index = try self.addSectionSymbol(gpa, try self.addString(gpa, ".rodata"), osec);
             break :osec osec;

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -130,10 +130,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .entsize = 1,
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_str_section_dirty = true;
                 self.debug_str_index = try addSectionSymbolWithAtom(self, gpa, ".debug_str", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_str_index.?).ref;
             }
 
             if (self.debug_info_index == null) {
@@ -141,10 +141,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_info"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_info_section_dirty = true;
                 self.debug_info_index = try addSectionSymbolWithAtom(self, gpa, ".debug_info", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_info_index.?).ref;
             }
 
             if (self.debug_abbrev_index == null) {
@@ -152,10 +152,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_abbrev"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_abbrev_section_dirty = true;
                 self.debug_abbrev_index = try addSectionSymbolWithAtom(self, gpa, ".debug_abbrev", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_abbrev_index.?).ref;
             }
 
             if (self.debug_aranges_index == null) {
@@ -163,10 +163,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_aranges"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 16,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_aranges_section_dirty = true;
                 self.debug_aranges_index = try addSectionSymbolWithAtom(self, gpa, ".debug_aranges", .@"16", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_aranges_index.?).ref;
             }
 
             if (self.debug_line_index == null) {
@@ -174,10 +174,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_line"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_line_section_dirty = true;
                 self.debug_line_index = try addSectionSymbolWithAtom(self, gpa, ".debug_line", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_line_index.?).ref;
             }
 
             if (self.debug_line_str_index == null) {
@@ -187,10 +187,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .entsize = 1,
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_line_str_section_dirty = true;
                 self.debug_line_str_index = try addSectionSymbolWithAtom(self, gpa, ".debug_line_str", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_line_str_index.?).ref;
             }
 
             if (self.debug_loclists_index == null) {
@@ -198,10 +198,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_loclists"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_loclists_section_dirty = true;
                 self.debug_loclists_index = try addSectionSymbolWithAtom(self, gpa, ".debug_loclists", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_loclists_index.?).ref;
             }
 
             if (self.debug_rnglists_index == null) {
@@ -209,10 +209,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                     .name = try elf_file.insertShString(".debug_rnglists"),
                     .type = elf.SHT_PROGBITS,
                     .addralign = 1,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.debug_rnglists_section_dirty = true;
                 self.debug_rnglists_index = try addSectionSymbolWithAtom(self, gpa, ".debug_rnglists", .@"1", osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.debug_rnglists_index.?).ref;
             }
 
             if (self.eh_frame_index == null) {
@@ -224,10 +224,10 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
                         elf.SHT_PROGBITS,
                     .flags = elf.SHF_ALLOC,
                     .addralign = ptr_size,
+                    .offset = std.math.maxInt(u64),
                 });
                 self.eh_frame_section_dirty = true;
                 self.eh_frame_index = try addSectionSymbolWithAtom(self, gpa, ".eh_frame", Atom.Alignment.fromNonzeroByteUnits(ptr_size), osec);
-                elf_file.sections.items(.last_atom)[osec] = self.symbol(self.eh_frame_index.?).ref;
             }
 
             try dwarf.initMetadata();
@@ -1318,7 +1318,7 @@ fn updateNavCode(
         const capacity = atom_ptr.capacity(elf_file);
         const need_realloc = code.len > capacity or !required_alignment.check(@intCast(atom_ptr.value));
         if (need_realloc) {
-            try self.growAtom(atom_ptr, elf_file);
+            try self.allocateAtom(atom_ptr, true, elf_file);
             log.debug("growing {} from 0x{x} to 0x{x}", .{ nav.fqn.fmt(ip), old_vaddr, atom_ptr.value });
             if (old_vaddr != atom_ptr.value) {
                 sym.value = 0;
@@ -1328,7 +1328,7 @@ fn updateNavCode(
             // TODO shrink section size
         }
     } else {
-        try self.allocateAtom(atom_ptr, elf_file);
+        try self.allocateAtom(atom_ptr, true, elf_file);
         errdefer self.freeNavMetadata(elf_file, sym_index);
         sym.value = 0;
         esym.st_value = 0;
@@ -1403,7 +1403,7 @@ fn updateTlv(
     const gop = try self.tls_variables.getOrPut(gpa, atom_ptr.atom_index);
     assert(!gop.found_existing); // TODO incremental updates
 
-    try self.allocateAtom(atom_ptr, elf_file);
+    try self.allocateAtom(atom_ptr, true, elf_file);
     sym.value = 0;
     esym.st_value = 0;
 
@@ -1729,7 +1729,7 @@ fn updateLazySymbol(
     atom_ptr.size = code.len;
     atom_ptr.output_section_index = output_section_index;
 
-    try self.allocateAtom(atom_ptr, elf_file);
+    try self.allocateAtom(atom_ptr, true, elf_file);
     errdefer self.freeNavMetadata(elf_file, symbol_index);
 
     local_sym.value = 0;
@@ -1784,7 +1784,7 @@ fn lowerConst(
     atom_ptr.size = code.len;
     atom_ptr.output_section_index = output_section_index;
 
-    try self.allocateAtom(atom_ptr, elf_file);
+    try self.allocateAtom(atom_ptr, true, elf_file);
     errdefer self.freeNavMetadata(elf_file, sym_index);
 
     try elf_file.base.file.?.pwriteAll(code, atom_ptr.offset(elf_file));
@@ -1981,17 +1981,27 @@ fn writeTrampoline(tr_sym: Symbol, target: Symbol, elf_file: *Elf) !void {
     }
 }
 
-fn allocateAtom(self: *ZigObject, atom_ptr: *Atom, elf_file: *Elf) !void {
+pub fn allocateAtom(self: *ZigObject, atom_ptr: *Atom, requires_padding: bool, elf_file: *Elf) !void {
+    const slice = elf_file.sections.slice();
+    const shdr = &slice.items(.shdr)[atom_ptr.output_section_index];
+    const last_atom_ref = &slice.items(.last_atom)[atom_ptr.output_section_index];
+
+    // FIXME:JK this only works if this atom is the only atom in the output section
+    // In every other case, we need to redo the prev/next links
+    if (last_atom_ref.eql(atom_ptr.ref())) last_atom_ref.* = .{};
+
     const alloc_res = try elf_file.allocateChunk(.{
         .shndx = atom_ptr.output_section_index,
         .size = atom_ptr.size,
         .alignment = atom_ptr.alignment,
+        .requires_padding = requires_padding,
     });
     atom_ptr.value = @intCast(alloc_res.value);
-
-    const slice = elf_file.sections.slice();
-    const shdr = &slice.items(.shdr)[atom_ptr.output_section_index];
-    const last_atom_ref = &slice.items(.last_atom)[atom_ptr.output_section_index];
+    log.debug("allocated {s} at {x}\n  placement {?}", .{
+        atom_ptr.name(elf_file),
+        atom_ptr.offset(elf_file),
+        alloc_res.placement,
+    });
 
     const expand_section = if (elf_file.atom(alloc_res.placement)) |placement_atom|
         placement_atom.nextAtom(elf_file) == null
@@ -2013,12 +2023,6 @@ fn allocateAtom(self: *ZigObject, atom_ptr: *Atom, elf_file: *Elf) !void {
     }
     shdr.sh_addralign = @max(shdr.sh_addralign, atom_ptr.alignment.toByteUnits().?);
 
-    if (self.sectionSymbol(atom_ptr.output_section_index, elf_file)) |sym| {
-        assert(sym.atom(elf_file) == null and sym.mergeSubsection(elf_file) == null);
-        const esym = &self.symtab.items(.elf_sym)[sym.esym_index];
-        esym.st_size += atom_ptr.size + Elf.padToIdeal(atom_ptr.size);
-    }
-
     // This function can also reallocate an atom.
     // In this case we need to "unplug" it from its previous location before
     // plugging it in to its new location.
@@ -2037,12 +2041,8 @@ fn allocateAtom(self: *ZigObject, atom_ptr: *Atom, elf_file: *Elf) !void {
         atom_ptr.prev_atom_ref = .{ .index = 0, .file = 0 };
         atom_ptr.next_atom_ref = .{ .index = 0, .file = 0 };
     }
-}
 
-fn growAtom(self: *ZigObject, atom_ptr: *Atom, elf_file: *Elf) !void {
-    if (!atom_ptr.alignment.check(@intCast(atom_ptr.value)) or atom_ptr.size > atom_ptr.capacity(elf_file)) {
-        try self.allocateAtom(atom_ptr, elf_file);
-    }
+    log.debug("  prev {?}, next {?}", .{ atom_ptr.prev_atom_ref, atom_ptr.next_atom_ref });
 }
 
 pub fn resetShdrIndexes(self: *ZigObject, backlinks: anytype) void {

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -336,8 +336,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
             const atom_ptr = self.atom(sym.ref.index).?;
             if (!atom_ptr.alive) continue;
 
-            log.debug("parsing relocs in {s}", .{sym.name(elf_file)});
-
             const relocs = &self.relocs.items[atom_ptr.relocsShndx().?];
             for (sect.units.items) |*unit| {
                 try relocs.ensureUnusedCapacity(gpa, unit.cross_unit_relocs.items.len +
@@ -350,12 +348,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
                     else
                         0));
                     const r_type = relocation.dwarf.crossSectionRelocType(dwarf.format, cpu_arch);
-                    log.debug("  {s} <- r_off={x}, r_add={x}, r_type={}", .{
-                        self.symbol(sym_index).name(elf_file),
-                        r_offset,
-                        r_addend,
-                        relocation.fmtRelocType(r_type, cpu_arch),
-                    });
                     atom_ptr.addRelocAssumeCapacity(.{
                         .r_offset = r_offset,
                         .r_addend = r_addend,
@@ -384,12 +376,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
                     else
                         0));
                     const r_type = relocation.dwarf.crossSectionRelocType(dwarf.format, cpu_arch);
-                    log.debug("  {s} <- r_off={x}, r_add={x}, r_type={}", .{
-                        self.symbol(target_sym_index).name(elf_file),
-                        r_offset,
-                        r_addend,
-                        relocation.fmtRelocType(r_type, cpu_arch),
-                    });
                     atom_ptr.addRelocAssumeCapacity(.{
                         .r_offset = r_offset,
                         .r_addend = r_addend,
@@ -410,12 +396,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
                         else
                             0));
                         const r_type = relocation.dwarf.crossSectionRelocType(dwarf.format, cpu_arch);
-                        log.debug("  {s} <- r_off={x}, r_add={x}, r_type={}", .{
-                            self.symbol(sym_index).name(elf_file),
-                            r_offset,
-                            r_addend,
-                            relocation.fmtRelocType(r_type, cpu_arch),
-                        });
                         atom_ptr.addRelocAssumeCapacity(.{
                             .r_offset = r_offset,
                             .r_addend = r_addend,
@@ -430,12 +410,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
                         else
                             0));
                         const r_type = relocation.dwarf.crossSectionRelocType(dwarf.format, cpu_arch);
-                        log.debug("  {s} <- r_off={x}, r_add={x}, r_type={}", .{
-                            self.symbol(sym_index).name(elf_file),
-                            r_offset,
-                            r_addend,
-                            relocation.fmtRelocType(r_type, cpu_arch),
-                        });
                         atom_ptr.addRelocAssumeCapacity(.{
                             .r_offset = r_offset,
                             .r_addend = r_addend,
@@ -464,12 +438,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
                         else
                             0));
                         const r_type = relocation.dwarf.crossSectionRelocType(dwarf.format, cpu_arch);
-                        log.debug("  {s} <- r_off={x}, r_add={x}, r_type={}", .{
-                            self.symbol(target_sym_index).name(elf_file),
-                            r_offset,
-                            r_addend,
-                            relocation.fmtRelocType(r_type, cpu_arch),
-                        });
                         atom_ptr.addRelocAssumeCapacity(.{
                             .r_offset = r_offset,
                             .r_addend = r_addend,
@@ -481,12 +449,6 @@ pub fn flushModule(self: *ZigObject, elf_file: *Elf, tid: Zcu.PerThread.Id) !voi
                         const r_offset = entry_off + reloc.source_off;
                         const r_addend: i64 = @intCast(reloc.target_off);
                         const r_type = relocation.dwarf.externalRelocType(target_sym.*, sect_index, dwarf.address_size, cpu_arch);
-                        log.debug("  {s} <- r_off={x}, r_add={x}, r_type={}", .{
-                            target_sym.name(elf_file),
-                            r_offset,
-                            r_addend,
-                            relocation.fmtRelocType(r_type, cpu_arch),
-                        });
                         atom_ptr.addRelocAssumeCapacity(.{
                             .r_offset = r_offset,
                             .r_addend = r_addend,

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -95,16 +95,16 @@ pub const File = union(enum) {
                     log.debug("'{s}' is non-local", .{sym.name(ef)});
                     try ef.dynsym.addSymbol(ref, ef);
                 }
-                if (sym.flags.needs_got) {
+                if (sym.flags.needs_got and !sym.flags.has_got) {
                     log.debug("'{s}' needs GOT", .{sym.name(ef)});
                     _ = try ef.got.addGotSymbol(ref, ef);
                 }
-                if (sym.flags.needs_plt) {
+                if (sym.flags.needs_plt and !sym.flags.has_plt) {
                     if (sym.flags.is_canonical) {
                         log.debug("'{s}' needs CPLT", .{sym.name(ef)});
                         sym.flags.@"export" = true;
                         try ef.plt.addSymbol(ref, ef);
-                    } else if (sym.flags.needs_got) {
+                    } else if (sym.flags.needs_got and !sym.flags.has_got) {
                         log.debug("'{s}' needs PLTGOT", .{sym.name(ef)});
                         try ef.plt_got.addSymbol(ref, ef);
                     } else {
@@ -116,15 +116,15 @@ pub const File = union(enum) {
                     log.debug("'{s}' needs COPYREL", .{sym.name(ef)});
                     try ef.copy_rel.addSymbol(ref, ef);
                 }
-                if (sym.flags.needs_tlsgd) {
+                if (sym.flags.needs_tlsgd and !sym.flags.has_tlsgd) {
                     log.debug("'{s}' needs TLSGD", .{sym.name(ef)});
                     try ef.got.addTlsGdSymbol(ref, ef);
                 }
-                if (sym.flags.needs_gottp) {
+                if (sym.flags.needs_gottp and !sym.flags.has_gottp) {
                     log.debug("'{s}' needs GOTTP", .{sym.name(ef)});
                     try ef.got.addGotTpSymbol(ref, ef);
                 }
-                if (sym.flags.needs_tlsdesc) {
+                if (sym.flags.needs_tlsdesc and !sym.flags.has_tlsdesc) {
                     log.debug("'{s}' needs TLSDESC", .{sym.name(ef)});
                     try ef.got.addTlsDescSymbol(ref, ef);
                 }

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -99,18 +99,18 @@ pub const File = union(enum) {
                     log.debug("'{s}' needs GOT", .{sym.name(ef)});
                     _ = try ef.got.addGotSymbol(ref, ef);
                 }
-                if (sym.flags.needs_plt and !sym.flags.has_plt) {
-                    if (sym.flags.is_canonical) {
+                if (sym.flags.needs_plt) {
+                    if (sym.flags.is_canonical and !sym.flags.has_plt) {
                         log.debug("'{s}' needs CPLT", .{sym.name(ef)});
                         sym.flags.@"export" = true;
                         try ef.plt.addSymbol(ref, ef);
-                    } else if (sym.flags.needs_got and !sym.flags.has_got) {
+                    } else if (sym.flags.needs_got and !sym.flags.has_pltgot) {
                         log.debug("'{s}' needs PLTGOT", .{sym.name(ef)});
                         try ef.plt_got.addSymbol(ref, ef);
-                    } else {
+                    } else if (!sym.flags.has_plt) {
                         log.debug("'{s}' needs PLT", .{sym.name(ef)});
                         try ef.plt.addSymbol(ref, ef);
-                    }
+                    } else unreachable;
                 }
                 if (sym.flags.needs_copy_rel and !sym.flags.has_copy_rel) {
                     log.debug("'{s}' needs COPYREL", .{sym.name(ef)});

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -110,7 +110,7 @@ pub const File = union(enum) {
                     } else if (!sym.flags.has_plt) {
                         log.debug("'{s}' needs PLT", .{sym.name(ef)});
                         try ef.plt.addSymbol(ref, ef);
-                    } else unreachable;
+                    }
                 }
                 if (sym.flags.needs_copy_rel and !sym.flags.has_copy_rel) {
                     log.debug("'{s}' needs COPYREL", .{sym.name(ef)});

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -336,8 +336,10 @@ fn updateSectionSizes(elf_file: *Elf) !void {
     const slice = elf_file.sections.slice();
     for (slice.items(.atom_list_2)) |*atom_list| {
         if (atom_list.atoms.keys().len == 0) continue;
+        if (!atom_list.dirty) continue;
         atom_list.updateSize(elf_file);
         try atom_list.allocate(elf_file);
+        atom_list.dirty = false;
     }
 
     for (slice.items(.shdr), 0..) |*shdr, shndx| {

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -335,7 +335,7 @@ fn initComdatGroups(elf_file: *Elf) !void {
 fn updateSectionSizes(elf_file: *Elf) !void {
     const slice = elf_file.sections.slice();
     for (slice.items(.atom_list_2)) |*atom_list| {
-        if (atom_list.atoms.items.len == 0) continue;
+        if (atom_list.atoms.keys().len == 0) continue;
         atom_list.updateSize(elf_file);
         try atom_list.allocate(elf_file);
     }
@@ -434,7 +434,7 @@ fn writeAtoms(elf_file: *Elf) !void {
     const slice = elf_file.sections.slice();
     for (slice.items(.shdr), slice.items(.atom_list_2)) |shdr, atom_list| {
         if (shdr.sh_type == elf.SHT_NOBITS) continue;
-        if (atom_list.atoms.items.len == 0) continue;
+        if (atom_list.atoms.keys().len == 0) continue;
         try atom_list.writeRelocatable(&buffer, elf_file);
     }
 }

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -394,24 +394,14 @@ fn allocateAllocSections(elf_file: *Elf) !void {
             shdr.sh_size = 0;
             const new_offset = try elf_file.findFreeSpace(needed_size, shdr.sh_addralign);
 
-            if (elf_file.zigObjectPtr()) |zo| blk: {
-                const existing_size = for ([_]?Symbol.Index{
-                    zo.text_index,
-                    zo.rodata_index,
-                    zo.data_relro_index,
-                    zo.data_index,
-                    zo.tdata_index,
-                    zo.eh_frame_index,
-                }) |maybe_sym_index| {
-                    const sect_sym_index = maybe_sym_index orelse continue;
-                    const sect_atom_ptr = zo.symbol(sect_sym_index).atom(elf_file).?;
-                    if (sect_atom_ptr.output_section_index == shndx) break sect_atom_ptr.size;
-                } else break :blk;
-                log.debug("moving {s} from 0x{x} to 0x{x}", .{
-                    elf_file.getShString(shdr.sh_name),
-                    shdr.sh_offset,
-                    new_offset,
-                });
+            log.debug("moving {s} from 0x{x} to 0x{x}", .{
+                elf_file.getShString(shdr.sh_name),
+                shdr.sh_offset,
+                new_offset,
+            });
+
+            if (shdr.sh_offset > 0) {
+                const existing_size = elf_file.sectionSize(@intCast(shndx));
                 const amt = try elf_file.base.file.?.copyRangeAll(
                     shdr.sh_offset,
                     elf_file.base.file.?,

--- a/src/link/Elf/relocatable.zig
+++ b/src/link/Elf/relocatable.zig
@@ -295,7 +295,6 @@ fn initSections(elf_file: *Elf) !void {
                     elf.SHT_PROGBITS,
                 .flags = elf.SHF_ALLOC,
                 .addralign = elf_file.ptrWidthBytes(),
-                .offset = std.math.maxInt(u64),
             });
         }
         elf_file.eh_frame_rela_section_index = elf_file.sectionByName(".rela.eh_frame") orelse
@@ -324,7 +323,6 @@ fn initComdatGroups(elf_file: *Elf) !void {
                     .type = elf.SHT_GROUP,
                     .entsize = @sizeOf(u32),
                     .addralign = @alignOf(u32),
-                    .offset = std.math.maxInt(u64),
                 }),
                 .cg_ref = .{ .index = @intCast(cg_index), .file = index },
             };

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -895,8 +895,7 @@ pub const PltGotSection = struct {
         const gpa = comp.gpa;
         const index = @as(u32, @intCast(plt_got.symbols.items.len));
         const symbol = elf_file.symbol(ref).?;
-        symbol.flags.has_plt = true;
-        symbol.flags.has_got = true;
+        symbol.flags.has_pltgot = true;
         symbol.addExtra(.{ .plt_got = index }, elf_file);
         try plt_got.symbols.append(gpa, ref);
     }

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -435,6 +435,8 @@ pub const GotSection = struct {
         const cpu_arch = elf_file.getTarget().cpu.arch;
         try elf_file.rela_dyn.ensureUnusedCapacity(gpa, got.numRela(elf_file));
 
+        relocs_log.debug(".got", .{});
+
         for (got.entries.items) |entry| {
             const symbol = elf_file.symbol(entry.ref);
             const extra = if (symbol) |s| s.extra(elf_file) else null;
@@ -447,6 +449,7 @@ pub const GotSection = struct {
                             .offset = offset,
                             .sym = extra.?.dynamic,
                             .type = relocation.encode(.glob_dat, cpu_arch),
+                            .target = symbol,
                         });
                         continue;
                     }
@@ -455,6 +458,7 @@ pub const GotSection = struct {
                             .offset = offset,
                             .type = relocation.encode(.irel, cpu_arch),
                             .addend = symbol.?.address(.{ .plt = false }, elf_file),
+                            .target = symbol,
                         });
                         continue;
                     }
@@ -465,6 +469,7 @@ pub const GotSection = struct {
                             .offset = offset,
                             .type = relocation.encode(.rel, cpu_arch),
                             .addend = symbol.?.address(.{ .plt = false }, elf_file),
+                            .target = symbol,
                         });
                     }
                 },
@@ -486,17 +491,20 @@ pub const GotSection = struct {
                             .offset = offset,
                             .sym = extra.?.dynamic,
                             .type = relocation.encode(.dtpmod, cpu_arch),
+                            .target = symbol,
                         });
                         elf_file.addRelaDynAssumeCapacity(.{
                             .offset = offset + 8,
                             .sym = extra.?.dynamic,
                             .type = relocation.encode(.dtpoff, cpu_arch),
+                            .target = symbol,
                         });
                     } else if (is_dyn_lib) {
                         elf_file.addRelaDynAssumeCapacity(.{
                             .offset = offset,
                             .sym = extra.?.dynamic,
                             .type = relocation.encode(.dtpmod, cpu_arch),
+                            .target = symbol,
                         });
                     }
                 },
@@ -508,12 +516,14 @@ pub const GotSection = struct {
                             .offset = offset,
                             .sym = extra.?.dynamic,
                             .type = relocation.encode(.tpoff, cpu_arch),
+                            .target = symbol,
                         });
                     } else if (is_dyn_lib) {
                         elf_file.addRelaDynAssumeCapacity(.{
                             .offset = offset,
                             .type = relocation.encode(.tpoff, cpu_arch),
                             .addend = symbol.?.address(.{}, elf_file) - elf_file.tlsAddress(),
+                            .target = symbol,
                         });
                     }
                 },
@@ -525,6 +535,7 @@ pub const GotSection = struct {
                         .sym = if (symbol.?.flags.import) extra.?.dynamic else 0,
                         .type = relocation.encode(.tlsdesc, cpu_arch),
                         .addend = if (symbol.?.flags.import) 0 else symbol.?.address(.{}, elf_file) - elf_file.tlsAddress(),
+                        .target = symbol,
                     });
                 },
             }
@@ -681,6 +692,9 @@ pub const PltSection = struct {
         const gpa = comp.gpa;
         const cpu_arch = elf_file.getTarget().cpu.arch;
         try elf_file.rela_plt.ensureUnusedCapacity(gpa, plt.numRela());
+
+        relocs_log.debug(".plt", .{});
+
         for (plt.symbols.items) |ref| {
             const sym = elf_file.symbol(ref).?;
             assert(sym.flags.import);
@@ -688,6 +702,14 @@ pub const PltSection = struct {
             const r_offset: u64 = @intCast(sym.gotPltAddress(elf_file));
             const r_sym: u64 = extra.dynamic;
             const r_type = relocation.encode(.jump_slot, cpu_arch);
+
+            relocs_log.debug("  {s}: [{x} => {d}({s})] + 0", .{
+                relocation.fmtRelocType(r_type, cpu_arch),
+                r_offset,
+                r_sym,
+                sym.name(elf_file),
+            });
+
             elf_file.rela_plt.appendAssumeCapacity(.{
                 .r_offset = r_offset,
                 .r_info = (r_sym << 32) | r_type,
@@ -1053,6 +1075,9 @@ pub const CopyRelSection = struct {
         const gpa = comp.gpa;
         const cpu_arch = elf_file.getTarget().cpu.arch;
         try elf_file.rela_dyn.ensureUnusedCapacity(gpa, copy_rel.numRela());
+
+        relocs_log.debug(".copy.rel", .{});
+
         for (copy_rel.symbols.items) |ref| {
             const sym = elf_file.symbol(ref).?;
             assert(sym.flags.import and sym.flags.has_copy_rel);
@@ -1525,6 +1550,7 @@ const elf = std.elf;
 const math = std.math;
 const mem = std.mem;
 const log = std.log.scoped(.link);
+const relocs_log = std.log.scoped(.link_relocs);
 const relocation = @import("relocation.zig");
 const std = @import("std");
 


### PR DESCRIPTION
In order to track if we need to reparse paths and objects (including relocatables, archives and shared objects) I've decided to add the paths, files, and some flags to local cache but I haven't used the frontend mechanism to achieve this, well not yet anyhow since I wasn't sure how to best go about it. I would appreciate input on this especially from @andrewrk and @mlugg. Next in order to detect if we are running the link from scratch (i.e., if we should invalidate the cache) I'm committing a random uuid-like value for the linker run. Again, this is very much a PoC so any feedback and suggestions are more than welcome.

Now onto progress report. I hear from @mlugg that apparently with this patch incremental works enough to do some basic incremental updates on Andrew's tetris clone. I have also managed to get a simplistic update to building zig itself working too. Now, we are from incremental being actually usable but it's (some) progress.