### PR TITLE
std.testing.expectEqual: {any} in print and move tests

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -125,7 +125,7 @@ fn expectEqualInner(comptime T: type, expected: T, actual: T) !void {
             var i: usize = 0;
             while (i < info.len) : (i += 1) {
                 if (!std.meta.eql(expected[i], actual[i])) {
-                    print("index {} incorrect. expected {}, found {}\n", .{
+                    print("index {d} incorrect. expected {any}, found {any}\n", .{
                         i, expected[i], actual[i],
                     });
                     return error.TestExpectedEqual;
@@ -212,6 +212,34 @@ test "expectEqual union with comptime-only field" {
     };
 
     try expectEqual(U{ .a = {} }, .a);
+}
+
+test "expectEqual nested array" {
+    const a = [2][2]f32{
+        [_]f32{ 1.0, 0.0 },
+        [_]f32{ 0.0, 1.0 },
+    };
+
+    const b = [2][2]f32{
+        [_]f32{ 1.0, 0.0 },
+        [_]f32{ 0.0, 1.0 },
+    };
+
+    try expectEqual(a, b);
+}
+
+test "expectEqual vector" {
+    const a: @Vector(4, u32) = @splat(4);
+    const b: @Vector(4, u32) = @splat(4);
+
+    try expectEqual(a, b);
+}
+
+test "expectEqual null" {
+    const a = .{null};
+    const b = @Vector(1, ?*u8){null};
+
+    try expectEqual(a, b);
 }
 
 /// This function is intended to be used only in tests. When the formatted result of the template
@@ -582,27 +610,6 @@ pub fn tmpDir(opts: std.fs.Dir.OpenOptions) TmpDir {
         .parent_dir = parent_dir,
         .sub_path = sub_path,
     };
-}
-
-test "expectEqual nested array" {
-    const a = [2][2]f32{
-        [_]f32{ 1.0, 0.0 },
-        [_]f32{ 0.0, 1.0 },
-    };
-
-    const b = [2][2]f32{
-        [_]f32{ 1.0, 0.0 },
-        [_]f32{ 0.0, 1.0 },
-    };
-
-    try expectEqual(a, b);
-}
-
-test "expectEqual vector" {
-    const a: @Vector(4, u32) = @splat(4);
-    const b: @Vector(4, u32) = @splat(4);
-
-    try expectEqual(a, b);
 }
 
 pub fn expectEqualStrings(expected: []const u8, actual: []const u8) !void {


### PR DESCRIPTION
Fixes: #19454

In L128 of testing.zig, patterned to others like it (e.g., L755). Also added the original test from issue (as "expectEqual null").

Also moved 2 tests because those are also `expectEqual` tests.