### PR TITLE
link.Elf: reduce flush logic (rpaths, isObject fs reads)

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -235,6 +235,7 @@ sanitize_coverage_trace_pc_guard: ?bool = null,
 pub const ExpectedCompileErrors = union(enum) {
     contains: []const u8,
     exact: []const []const u8,
+    starts_with: []const u8,
 };
 
 pub const Entry = union(enum) {
@@ -1958,6 +1959,17 @@ fn checkCompileErrors(compile: *Compile) !void {
 
     // TODO merge this with the testing.expectEqualStrings logic, and also CheckFile
     switch (expect_errors) {
+        .starts_with => |expect_starts_with| {
+            if (std.mem.startsWith(u8, actual_stderr, expect_starts_with)) return;
+            return compile.step.fail(
+                \\
+                \\========= should start with: ============
+                \\{s}
+                \\========= but not found: ================
+                \\{s}
+                \\=========================================
+            , .{ expect_starts_with, actual_stderr });
+        },
         .contains => |expect_line| {
             while (actual_line_it.next()) |actual_line| {
                 if (!matchCompileError(actual_line, expect_line)) continue;

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -280,6 +280,13 @@ pub const CRTFile = struct {
     lock: Cache.Lock,
     full_object_path: []const u8,
 
+    pub fn isObject(cf: CRTFile) bool {
+        return switch (classifyFileExt(cf.full_object_path)) {
+            .object => true,
+            else => false,
+        };
+    }
+
     pub fn deinit(self: *CRTFile, gpa: Allocator) void {
         self.lock.release();
         gpa.free(self.full_object_path);
@@ -1018,6 +1025,13 @@ pub const LinkObject = struct {
     //
     // Consistent with `withLOption` variable name in lld ELF driver.
     loption: bool = false,
+
+    pub fn isObject(lo: LinkObject) bool {
+        return switch (classifyFileExt(lo.path)) {
+            .object => true,
+            else => false,
+        };
+    }
 };
 
 pub const CreateOptions = struct {
@@ -2433,7 +2447,7 @@ fn flush(
     if (comp.bin_file) |lf| {
         // This is needed before reading the error flags.
         lf.flush(arena, tid, prog_node) catch |err| switch (err) {
-            error.FlushFailure => {}, // error reported through link_error_flags
+            error.FlushFailure, error.LinkFailure => {}, // error reported through link_error_flags
             error.LLDReportedFailure => {}, // error reported via lockAndParseLldStderr
             else => |e| return e,
         };

--- a/src/link.zig
+++ b/src/link.zig
@@ -67,7 +67,6 @@ pub const File = struct {
     gc_sections: bool,
     print_gc_sections: bool,
     build_id: std.zig.BuildId,
-    rpath_list: []const []const u8,
     allow_shlib_undefined: bool,
     stack_size: u64,
 

--- a/src/link.zig
+++ b/src/link.zig
@@ -533,7 +533,10 @@ pub const File = struct {
         FailedToEmit,
         FileSystem,
         FilesOpenedWithWrongFlags,
+        /// Indicates an error will be present in `Compilation.link_errors`.
         FlushFailure,
+        /// Indicates an error will be present in `Compilation.link_errors`.
+        LinkFailure,
         FunctionSignatureMismatch,
         GlobalTypeMismatch,
         HotSwapUnavailableOnHostOperatingSystem,

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -148,7 +148,6 @@ pub fn createEmpty(
             .file = file,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
     };
 

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -263,7 +263,6 @@ pub fn createEmpty(
             .file = null,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
         .ptr_width = ptr_width,
         .page_size = page_size,

--- a/src/link/Elf/Archive.zig
+++ b/src/link/Elf/Archive.zig
@@ -35,10 +35,9 @@ pub fn parse(self: *Archive, elf_file: *Elf, path: []const u8, handle_index: Fil
         pos += @sizeOf(elf.ar_hdr);
 
         if (!mem.eql(u8, &hdr.ar_fmag, elf.ARFMAG)) {
-            try elf_file.reportParseError(path, "invalid archive header delimiter: {s}", .{
+            return elf_file.failParse(path, "invalid archive header delimiter: {s}", .{
                 std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag),
             });
-            return error.MalformedArchive;
         }
 
         const obj_size = try hdr.size();

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -1,5 +1,7 @@
 base: link.File,
 
+rpath_list: []const []const u8,
+
 /// If this is not null, an object file is created by LLVM and emitted to zcu_object_sub_path.
 llvm_object: ?LlvmObject.Ptr = null,
 
@@ -192,8 +194,8 @@ pub fn createEmpty(
             .file = null,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
+        .rpath_list = options.rpath_list,
         .pagezero_size = options.pagezero_size,
         .headerpad_size = options.headerpad_size,
         .headerpad_max_install_names = options.headerpad_max_install_names,
@@ -662,9 +664,8 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
             try argv.append(syslibroot);
         }
 
-        for (self.base.rpath_list) |rpath| {
-            try argv.append("-rpath");
-            try argv.append(rpath);
+        for (self.rpath_list) |rpath| {
+            try argv.appendSlice(&.{ "-rpath", rpath });
         }
 
         if (self.pagezero_size) |size| {
@@ -2842,7 +2843,7 @@ fn writeLoadCommands(self: *MachO) !struct { usize, usize, u64 } {
         ncmds += 1;
     }
 
-    for (self.base.rpath_list) |rpath| {
+    for (self.rpath_list) |rpath| {
         try load_commands.writeRpathLC(rpath, writer);
         ncmds += 1;
     }

--- a/src/link/MachO/load_commands.zig
+++ b/src/link/MachO/load_commands.zig
@@ -63,7 +63,7 @@ pub fn calcLoadCommandsSize(macho_file: *MachO, assume_max_path_len: bool) !u32 
     }
     // LC_RPATH
     {
-        for (macho_file.base.rpath_list) |rpath| {
+        for (macho_file.rpath_list) |rpath| {
             sizeofcmds += calcInstallNameLen(
                 @sizeOf(macho.rpath_command),
                 rpath,

--- a/src/link/NvPtx.zig
+++ b/src/link/NvPtx.zig
@@ -60,7 +60,6 @@ pub fn createEmpty(
             .file = null,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
         .llvm_object = llvm_object,
     };

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -304,7 +304,6 @@ pub fn createEmpty(
             .file = null,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
         .sixtyfour_bit = sixtyfour_bit,
         .bases = undefined,

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -74,7 +74,6 @@ pub fn createEmpty(
             .file = null,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
         .object = codegen.Object.init(gpa),
     };

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -398,7 +398,6 @@ pub fn createEmpty(
             .file = null,
             .disable_lld_caching = options.disable_lld_caching,
             .build_id = options.build_id,
-            .rpath_list = options.rpath_list,
         },
         .name = undefined,
         .import_table = options.import_table,

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -3916,7 +3916,7 @@ fn testUnknownFileTypeError(b: *Build, opts: Options) *Step {
     //     "note: while parsing /?/liba.dylib",
     // } });
     expectLinkErrors(exe, test_step, .{
-        .contains = "error: invalid token in LD script: '\\x00\\x00\\x00\\x0c\\x00\\x00\\x00/usr/lib/dyld\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d' (0:1069)",
+        .starts_with = "error: invalid token in LD script: '\\x00\\x00\\x00\\x0c\\x00\\x00\\x00/usr/lib/dyld\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d' (",
     });
 
     return test_step;

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -3916,7 +3916,7 @@ fn testUnknownFileTypeError(b: *Build, opts: Options) *Step {
     //     "note: while parsing /?/liba.dylib",
     // } });
     expectLinkErrors(exe, test_step, .{
-        .contains = "error: unexpected error: parsing input file failed with error InvalidLdScript",
+        .contains = "error: invalid token in LD script: '\\x00\\x00\\x00\\x0c\\x00\\x00\\x00/usr/lib/dyld\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d' (0:1069)",
     });
 
     return test_step;


### PR DESCRIPTION
The goal is to minimize as much as possible how much logic is inside flush(). So let's start by moving out obvious stuff.
* No longer create 2 unnecessary tables for rpaths
* No longer create unnecessary array list for positionals
* No longer make unnecessary file system reads for object files