### PR TITLE
link: fix false positive crtbegin/crtend detection

### DIFF
--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -398,10 +398,17 @@ pub const Manifest = struct {
         return gop.index;
     }
 
+    /// Deprecated, use `addOptionalFilePath`.
     pub fn addOptionalFile(self: *Manifest, optional_file_path: ?[]const u8) !void {
         self.hash.add(optional_file_path != null);
         const file_path = optional_file_path orelse return;
         _ = try self.addFile(file_path, null);
+    }
+
+    pub fn addOptionalFilePath(self: *Manifest, optional_file_path: ?Path) !void {
+        self.hash.add(optional_file_path != null);
+        const file_path = optional_file_path orelse return;
+        _ = try self.addFilePath(file_path, null);
     }
 
     pub fn addListOfFiles(self: *Manifest, list_of_files: []const []const u8) !void {

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -149,7 +149,7 @@ pub fn format(
         const stringEscape = std.zig.stringEscape;
         const f = switch (fmt_string[0]) {
             'q' => "",
-            '\'' => '\'',
+            '\'' => "\'",
             else => @compileError("unsupported format string: " ++ fmt_string),
         };
         if (self.root_dir.path) |p| {

--- a/lib/std/Build/Cache/Path.zig
+++ b/lib/std/Build/Cache/Path.zig
@@ -11,7 +11,11 @@ pub fn clone(p: Path, arena: Allocator) Allocator.Error!Path {
 }
 
 pub fn cwd() Path {
-    return .{ .root_dir = Cache.Directory.cwd() };
+    return initCwd("");
+}
+
+pub fn initCwd(sub_path: []const u8) Path {
+    return .{ .root_dir = Cache.Directory.cwd(), .sub_path = sub_path };
 }
 
 pub fn join(p: Path, arena: Allocator, sub_path: []const u8) Allocator.Error!Path {
@@ -126,6 +130,14 @@ pub fn makePath(p: Path, sub_path: []const u8) !void {
     return p.root_dir.handle.makePath(joined_path);
 }
 
+pub fn toString(p: Path, allocator: Allocator) Allocator.Error![]u8 {
+    return std.fmt.allocPrint(allocator, "{}", .{p});
+}
+
+pub fn toStringZ(p: Path, allocator: Allocator) Allocator.Error![:0]u8 {
+    return std.fmt.allocPrintZ(allocator, "{}", .{p});
+}
+
 pub fn format(
     self: Path,
     comptime fmt_string: []const u8,
@@ -180,6 +192,14 @@ pub fn subPathOpt(self: Path) ?[]const u8 {
 
 pub fn subPathOrDot(self: Path) []const u8 {
     return if (self.sub_path.len == 0) "." else self.sub_path;
+}
+
+pub fn stem(p: Path) []const u8 {
+    return fs.path.stem(p.sub_path);
+}
+
+pub fn basename(p: Path) []const u8 {
+    return fs.path.basename(p.sub_path);
 }
 
 /// Useful to make `Path` a key in `std.ArrayHashMap`.

--- a/lib/std/Build/Step/CheckObject.zig
+++ b/lib/std/Build/Step/CheckObject.zig
@@ -557,15 +557,15 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
     const check_object: *CheckObject = @fieldParentPtr("step", step);
     try step.singleUnchangingWatchInput(check_object.source);
 
-    const src_path = check_object.source.getPath2(b, step);
-    const contents = fs.cwd().readFileAllocOptions(
+    const src_path = check_object.source.getPath3(b, step);
+    const contents = src_path.root_dir.handle.readFileAllocOptions(
         gpa,
-        src_path,
+        src_path.sub_path,
         check_object.max_bytes,
         null,
         @alignOf(u64),
         null,
-    ) catch |err| return step.fail("unable to read '{s}': {s}", .{ src_path, @errorName(err) });
+    ) catch |err| return step.fail("unable to read '{'}': {s}", .{ src_path, @errorName(err) });
 
     var vars = std.StringHashMap(u64).init(gpa);
     for (check_object.checks.items) |chk| {
@@ -640,8 +640,13 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
                             \\{s}
                             \\========= but parsed file does not contain it: =======
                             \\{s}
-                            \\======================================================
-                        , .{ fmtMessageString(chk.kind, act.phrase.resolve(b, step)), fmtMessageString(chk.kind, output) });
+                            \\========= file path: =================================
+                            \\{}
+                        , .{
+                            fmtMessageString(chk.kind, act.phrase.resolve(b, step)),
+                            fmtMessageString(chk.kind, output),
+                            src_path,
+                        });
                     }
                 },
 
@@ -655,8 +660,13 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
                             \\*{s}*
                             \\========= but parsed file does not contain it: =======
                             \\{s}
-                            \\======================================================
-                        , .{ fmtMessageString(chk.kind, act.phrase.resolve(b, step)), fmtMessageString(chk.kind, output) });
+                            \\========= file path: =================================
+                            \\{}
+                        , .{
+                            fmtMessageString(chk.kind, act.phrase.resolve(b, step)),
+                            fmtMessageString(chk.kind, output),
+                            src_path,
+                        });
                     }
                 },
 
@@ -669,8 +679,13 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
                             \\{s}
                             \\========= but parsed file does contain it: ========
                             \\{s}
-                            \\===================================================
-                        , .{ fmtMessageString(chk.kind, act.phrase.resolve(b, step)), fmtMessageString(chk.kind, output) });
+                            \\========= file path: ==============================
+                            \\{}
+                        , .{
+                            fmtMessageString(chk.kind, act.phrase.resolve(b, step)),
+                            fmtMessageString(chk.kind, output),
+                            src_path,
+                        });
                     }
                 },
 
@@ -684,8 +699,13 @@ fn make(step: *Step, make_options: Step.MakeOptions) !void {
                             \\{s}
                             \\========= but parsed file does not contain it: =======
                             \\{s}
-                            \\======================================================
-                        , .{ act.phrase.resolve(b, step), fmtMessageString(chk.kind, output) });
+                            \\========= file path: ==============================
+                            \\{}
+                        , .{
+                            act.phrase.resolve(b, step),
+                            fmtMessageString(chk.kind, output),
+                            src_path,
+                        });
                     }
                 },
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -217,37 +217,37 @@ thread_pool: *ThreadPool,
 
 /// Populated when we build the libc++ static library. A Job to build this is placed in the queue
 /// and resolved before calling linker.flush().
-libcxx_static_lib: ?CRTFile = null,
+libcxx_static_lib: ?CrtFile = null,
 /// Populated when we build the libc++abi static library. A Job to build this is placed in the queue
 /// and resolved before calling linker.flush().
-libcxxabi_static_lib: ?CRTFile = null,
+libcxxabi_static_lib: ?CrtFile = null,
 /// Populated when we build the libunwind static library. A Job to build this is placed in the queue
 /// and resolved before calling linker.flush().
-libunwind_static_lib: ?CRTFile = null,
+libunwind_static_lib: ?CrtFile = null,
 /// Populated when we build the TSAN library. A Job to build this is placed in the queue
 /// and resolved before calling linker.flush().
-tsan_lib: ?CRTFile = null,
+tsan_lib: ?CrtFile = null,
 /// Populated when we build the libc static library. A Job to build this is placed in the queue
 /// and resolved before calling linker.flush().
-libc_static_lib: ?CRTFile = null,
+libc_static_lib: ?CrtFile = null,
 /// Populated when we build the libcompiler_rt static library. A Job to build this is indicated
 /// by setting `job_queued_compiler_rt_lib` and resolved before calling linker.flush().
-compiler_rt_lib: ?CRTFile = null,
+compiler_rt_lib: ?CrtFile = null,
 /// Populated when we build the compiler_rt_obj object. A Job to build this is indicated
 /// by setting `job_queued_compiler_rt_obj` and resolved before calling linker.flush().
-compiler_rt_obj: ?CRTFile = null,
+compiler_rt_obj: ?CrtFile = null,
 /// Populated when we build the libfuzzer static library. A Job to build this
 /// is indicated by setting `job_queued_fuzzer_lib` and resolved before
 /// calling linker.flush().
-fuzzer_lib: ?CRTFile = null,
+fuzzer_lib: ?CrtFile = null,
 
 glibc_so_files: ?glibc.BuiltSharedObjects = null,
-wasi_emulated_libs: []const wasi_libc.CRTFile,
+wasi_emulated_libs: []const wasi_libc.CrtFile,
 
 /// For example `Scrt1.o` and `libc_nonshared.a`. These are populated after building libc from source,
 /// The set of needed CRT (C runtime) files differs depending on the target and compilation settings.
 /// The key is the basename, and the value is the absolute path to the completed build artifact.
-crt_files: std.StringHashMapUnmanaged(CRTFile) = .empty,
+crt_files: std.StringHashMapUnmanaged(CrtFile) = .empty,
 
 /// How many lines of reference trace should be included per compile error.
 /// Null means only show snippet on first error.
@@ -276,20 +276,20 @@ digest: ?[Cache.bin_digest_len]u8 = null,
 pub const default_stack_protector_buffer_size = target_util.default_stack_protector_buffer_size;
 pub const SemaError = Zcu.SemaError;
 
-pub const CRTFile = struct {
+pub const CrtFile = struct {
     lock: Cache.Lock,
-    full_object_path: []const u8,
+    full_object_path: Path,
 
-    pub fn isObject(cf: CRTFile) bool {
-        return switch (classifyFileExt(cf.full_object_path)) {
+    pub fn isObject(cf: CrtFile) bool {
+        return switch (classifyFileExt(cf.full_object_path.sub_path)) {
             .object => true,
             else => false,
         };
     }
 
-    pub fn deinit(self: *CRTFile, gpa: Allocator) void {
+    pub fn deinit(self: *CrtFile, gpa: Allocator) void {
         self.lock.release();
-        gpa.free(self.full_object_path);
+        gpa.free(self.full_object_path.sub_path);
         self.* = undefined;
     }
 };
@@ -369,13 +369,13 @@ const Job = union(enum) {
     resolve_type_fully: InternPool.Index,
 
     /// one of the glibc static objects
-    glibc_crt_file: glibc.CRTFile,
+    glibc_crt_file: glibc.CrtFile,
     /// all of the glibc shared objects
     glibc_shared_objects,
     /// one of the musl static objects
-    musl_crt_file: musl.CRTFile,
+    musl_crt_file: musl.CrtFile,
     /// one of the mingw-w64 static objects
-    mingw_crt_file: mingw.CRTFile,
+    mingw_crt_file: mingw.CrtFile,
     /// libunwind.a, usually needed when linking libc
     libunwind: void,
     libcxx: void,
@@ -385,7 +385,7 @@ const Job = union(enum) {
     /// calls to, for example, memcpy and memset.
     zig_libc: void,
     /// one of WASI libc static objects
-    wasi_libc_crt_file: wasi_libc.CRTFile,
+    wasi_libc_crt_file: wasi_libc.CrtFile,
 
     /// The value is the index into `system_libs`.
     windows_import_lib: usize,
@@ -422,8 +422,8 @@ pub const CObject = struct {
     status: union(enum) {
         new,
         success: struct {
-            /// The outputted result. Owned by gpa.
-            object_path: []u8,
+            /// The outputted result. `sub_path` owned by gpa.
+            object_path: Path,
             /// This is a file system lock on the cache hash manifest representing this
             /// object. It prevents other invocations of the Zig compiler from interfering
             /// with this object until released.
@@ -719,7 +719,7 @@ pub const CObject = struct {
                 return true;
             },
             .success => |*success| {
-                gpa.free(success.object_path);
+                gpa.free(success.object_path.sub_path);
                 success.lock.release();
                 self.status = .new;
                 return false;
@@ -1018,7 +1018,7 @@ const CacheUse = union(CacheMode) {
 };
 
 pub const LinkObject = struct {
-    path: []const u8,
+    path: Path,
     must_link: bool = false,
     // When the library is passed via a positional argument, it will be
     // added as a full path. If it's `-l<lib>`, then just the basename.
@@ -1027,7 +1027,7 @@ pub const LinkObject = struct {
     loption: bool = false,
 
     pub fn isObject(lo: LinkObject) bool {
-        return switch (classifyFileExt(lo.path)) {
+        return switch (classifyFileExt(lo.path.sub_path)) {
             .object => true,
             else => false,
         };
@@ -1095,7 +1095,7 @@ pub const CreateOptions = struct {
     /// * getpid
     /// * mman
     /// * signal
-    wasi_emulated_libs: []const wasi_libc.CRTFile = &.{},
+    wasi_emulated_libs: []const wasi_libc.CrtFile = &.{},
     /// This means that if the output mode is an executable it will be a
     /// Position Independent Executable. If the output mode is not an
     /// executable this field is ignored.
@@ -2578,7 +2578,7 @@ fn addNonIncrementalStuffToCacheManifest(
     }
 
     for (comp.objects) |obj| {
-        _ = try man.addFile(obj.path, null);
+        _ = try man.addFilePath(obj.path, null);
         man.hash.add(obj.must_link);
         man.hash.add(obj.loption);
     }
@@ -2703,9 +2703,8 @@ fn emitOthers(comp: *Compilation) void {
         return;
     }
     const obj_path = comp.c_object_table.keys()[0].status.success.object_path;
-    const cwd = std.fs.cwd();
-    const ext = std.fs.path.extension(obj_path);
-    const basename = obj_path[0 .. obj_path.len - ext.len];
+    const ext = std.fs.path.extension(obj_path.sub_path);
+    const dirname = obj_path.sub_path[0 .. obj_path.sub_path.len - ext.len];
     // This obj path always ends with the object file extension, but if we change the
     // extension to .ll, .bc, or .s, then it will be the path to those things.
     const outs = [_]struct {
@@ -2720,13 +2719,13 @@ fn emitOthers(comp: *Compilation) void {
         if (out.emit) |loc| {
             if (loc.directory) |directory| {
                 const src_path = std.fmt.allocPrint(comp.gpa, "{s}{s}", .{
-                    basename, out.ext,
+                    dirname, out.ext,
                 }) catch |err| {
-                    log.err("unable to copy {s}{s}: {s}", .{ basename, out.ext, @errorName(err) });
+                    log.err("unable to copy {s}{s}: {s}", .{ dirname, out.ext, @errorName(err) });
                     continue;
                 };
                 defer comp.gpa.free(src_path);
-                cwd.copyFile(src_path, directory.handle, loc.basename, .{}) catch |err| {
+                obj_path.root_dir.handle.copyFile(src_path, directory.handle, loc.basename, .{}) catch |err| {
                     log.err("unable to copy {s}: {s}", .{ src_path, @errorName(err) });
                 };
             }
@@ -3774,7 +3773,7 @@ fn processOneJob(tid: usize, comp: *Compilation, job: Job, prog_node: std.Progre
             const named_frame = tracy.namedFrame("glibc_crt_file");
             defer named_frame.end();
 
-            glibc.buildCRTFile(comp, crt_file, prog_node) catch |err| {
+            glibc.buildCrtFile(comp, crt_file, prog_node) catch |err| {
                 // TODO Surface more error details.
                 comp.lockAndSetMiscFailure(.glibc_crt_file, "unable to build glibc CRT file: {s}", .{
                     @errorName(err),
@@ -3798,7 +3797,7 @@ fn processOneJob(tid: usize, comp: *Compilation, job: Job, prog_node: std.Progre
             const named_frame = tracy.namedFrame("musl_crt_file");
             defer named_frame.end();
 
-            musl.buildCRTFile(comp, crt_file, prog_node) catch |err| {
+            musl.buildCrtFile(comp, crt_file, prog_node) catch |err| {
                 // TODO Surface more error details.
                 comp.lockAndSetMiscFailure(
                     .musl_crt_file,
@@ -3811,7 +3810,7 @@ fn processOneJob(tid: usize, comp: *Compilation, job: Job, prog_node: std.Progre
             const named_frame = tracy.namedFrame("mingw_crt_file");
             defer named_frame.end();
 
-            mingw.buildCRTFile(comp, crt_file, prog_node) catch |err| {
+            mingw.buildCrtFile(comp, crt_file, prog_node) catch |err| {
                 // TODO Surface more error details.
                 comp.lockAndSetMiscFailure(
                     .mingw_crt_file,
@@ -3894,7 +3893,7 @@ fn processOneJob(tid: usize, comp: *Compilation, job: Job, prog_node: std.Progre
             const named_frame = tracy.namedFrame("wasi_libc_crt_file");
             defer named_frame.end();
 
-            wasi_libc.buildCRTFile(comp, crt_file, prog_node) catch |err| {
+            wasi_libc.buildCrtFile(comp, crt_file, prog_node) catch |err| {
                 // TODO Surface more error details.
                 comp.lockAndSetMiscFailure(
                     .wasi_libc_crt_file,
@@ -4602,7 +4601,7 @@ fn buildRt(
     root_source_name: []const u8,
     misc_task: MiscTask,
     output_mode: std.builtin.OutputMode,
-    out: *?CRTFile,
+    out: *?CrtFile,
     prog_node: std.Progress.Node,
 ) void {
     comp.buildOutputFromZig(
@@ -4703,7 +4702,9 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
 
     log.debug("updating C object: {s}", .{c_object.src.src_path});
 
-    if (c_object.clearStatus(comp.gpa)) {
+    const gpa = comp.gpa;
+
+    if (c_object.clearStatus(gpa)) {
         // There was previous failure.
         comp.mutex.lock();
         defer comp.mutex.unlock();
@@ -4722,7 +4723,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
 
     try cache_helpers.hashCSource(&man, c_object.src);
 
-    var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
+    var arena_allocator = std.heap.ArenaAllocator.init(gpa);
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
@@ -4744,7 +4745,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
     const target = comp.getTarget();
     const o_ext = target.ofmt.fileExt(target.cpu.arch);
     const digest = if (!comp.disable_c_depfile and try man.hit()) man.final() else blk: {
-        var argv = std.ArrayList([]const u8).init(comp.gpa);
+        var argv = std.ArrayList([]const u8).init(gpa);
         defer argv.deinit();
 
         // In case we are doing passthrough mode, we need to detect -S and -emit-llvm.
@@ -4908,7 +4909,7 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
 
                 switch (term) {
                     .Exited => |code| if (code != 0) if (out_diag_path) |diag_file_path| {
-                        const bundle = CObject.Diag.Bundle.parse(comp.gpa, diag_file_path) catch |err| {
+                        const bundle = CObject.Diag.Bundle.parse(gpa, diag_file_path) catch |err| {
                             log.err("{}: failed to parse clang diagnostics: {s}", .{ err, stderr });
                             return comp.failCObj(c_object, "clang exited with code {d}", .{code});
                         };
@@ -4982,9 +4983,10 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
 
     c_object.status = .{
         .success = .{
-            .object_path = try comp.local_cache_directory.join(comp.gpa, &[_][]const u8{
-                "o", &digest, o_basename,
-            }),
+            .object_path = .{
+                .root_dir = comp.local_cache_directory,
+                .sub_path = try std.fs.path.join(gpa, &.{ "o", &digest, o_basename }),
+            },
             .lock = man.toOwnedLock(),
         },
     };
@@ -6092,18 +6094,23 @@ test "classifyFileExt" {
     try std.testing.expectEqual(FileExt.zig, classifyFileExt("foo.zig"));
 }
 
-pub fn get_libc_crt_file(comp: *Compilation, arena: Allocator, basename: []const u8) ![]const u8 {
-    if (comp.wantBuildGLibCFromSource() or
-        comp.wantBuildMuslFromSource() or
-        comp.wantBuildMinGWFromSource() or
-        comp.wantBuildWasiLibcFromSource())
-    {
-        return comp.crt_files.get(basename).?.full_object_path;
-    }
-    const lci = comp.libc_installation orelse return error.LibCInstallationNotAvailable;
-    const crt_dir_path = lci.crt_dir orelse return error.LibCInstallationMissingCRTDir;
-    const full_path = try std.fs.path.join(arena, &[_][]const u8{ crt_dir_path, basename });
-    return full_path;
+pub fn get_libc_crt_file(comp: *Compilation, arena: Allocator, basename: []const u8) !Path {
+    return (try crtFilePath(comp, basename)) orelse {
+        const lci = comp.libc_installation orelse return error.LibCInstallationNotAvailable;
+        const crt_dir_path = lci.crt_dir orelse return error.LibCInstallationMissingCrtDir;
+        const full_path = try std.fs.path.join(arena, &[_][]const u8{ crt_dir_path, basename });
+        return Path.initCwd(full_path);
+    };
+}
+
+pub fn crtFileAsString(comp: *Compilation, arena: Allocator, basename: []const u8) ![]const u8 {
+    const path = try get_libc_crt_file(comp, arena, basename);
+    return path.toString(arena);
+}
+
+pub fn crtFilePath(comp: *Compilation, basename: []const u8) Allocator.Error!?Path {
+    const crt_file = comp.crt_files.get(basename) orelse return null;
+    return crt_file.full_object_path;
 }
 
 fn wantBuildLibCFromSource(comp: Compilation) bool {
@@ -6314,7 +6321,7 @@ fn buildOutputFromZig(
     comp: *Compilation,
     src_basename: []const u8,
     output_mode: std.builtin.OutputMode,
-    out: *?CRTFile,
+    out: *?CrtFile,
     misc_task_tag: MiscTask,
     prog_node: std.Progress.Node,
 ) !void {
@@ -6542,12 +6549,36 @@ pub fn build_crt_file(
     comp.crt_files.putAssumeCapacityNoClobber(basename, try sub_compilation.toCrtFile());
 }
 
-pub fn toCrtFile(comp: *Compilation) Allocator.Error!CRTFile {
+pub fn toCrtFile(comp: *Compilation) Allocator.Error!CrtFile {
     return .{
-        .full_object_path = try comp.local_cache_directory.join(comp.gpa, &.{
-            comp.cache_use.whole.bin_sub_path.?,
-        }),
+        .full_object_path = .{
+            .root_dir = comp.local_cache_directory,
+            .sub_path = try comp.gpa.dupe(u8, comp.cache_use.whole.bin_sub_path.?),
+        },
         .lock = comp.cache_use.whole.moveLock(),
+    };
+}
+
+pub fn getCrtPaths(
+    comp: *Compilation,
+    arena: Allocator,
+) error{ OutOfMemory, LibCInstallationMissingCrtDir }!LibCInstallation.CrtPaths {
+    const target = comp.root_mod.resolved_target.result;
+    const basenames = LibCInstallation.CrtBasenames.get(.{
+        .target = target,
+        .link_libc = comp.config.link_libc,
+        .output_mode = comp.config.output_mode,
+        .link_mode = comp.config.link_mode,
+        .pie = comp.config.pie,
+    });
+    if (comp.libc_installation) |lci| return lci.resolveCrtPaths(arena, basenames, target);
+
+    return .{
+        .crt0 = if (basenames.crt0) |basename| try comp.crtFilePath(basename) else null,
+        .crti = if (basenames.crti) |basename| try comp.crtFilePath(basename) else null,
+        .crtbegin = if (basenames.crtbegin) |basename| try comp.crtFilePath(basename) else null,
+        .crtend = if (basenames.crtend) |basename| try comp.crtFilePath(basename) else null,
+        .crtn = if (basenames.crtn) |basename| try comp.crtFilePath(basename) else null,
     };
 }
 

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -169,14 +169,14 @@ fn useElfInitFini(target: std.Target) bool {
     };
 }
 
-pub const CRTFile = enum {
+pub const CrtFile = enum {
     crti_o,
     crtn_o,
     scrt1_o,
     libc_nonshared_a,
 };
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
+pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
@@ -292,7 +292,8 @@ pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progre
                 .owner = undefined,
             };
             var files = [_]Compilation.CSourceFile{ start_o, abi_note_o, init_o };
-            return comp.build_crt_file("Scrt1", .Obj, .@"glibc Scrt1.o", prog_node, &files);
+            const basename = if (comp.config.output_mode == .Exe and !comp.config.pie) "crt1" else "Scrt1";
+            return comp.build_crt_file(basename, .Obj, .@"glibc Scrt1.o", prog_node, &files);
         },
         .libc_nonshared_a => {
             const s = path.sep_str;

--- a/src/link.zig
+++ b/src/link.zig
@@ -11,7 +11,7 @@ const wasi_libc = @import("wasi_libc.zig");
 const Air = @import("Air.zig");
 const Allocator = std.mem.Allocator;
 const Cache = std.Build.Cache;
-const Path = Cache.Path;
+const Path = std.Build.Cache.Path;
 const Compilation = @import("Compilation.zig");
 const LibCInstallation = std.zig.LibCInstallation;
 const Liveness = @import("Liveness.zig");
@@ -34,7 +34,7 @@ pub const SystemLib = struct {
     /// 1. Windows DLLs that zig ships such as advapi32.
     /// 2. extern "foo" fn declarations where we find out about libraries too late
     /// TODO: make this non-optional and resolve those two cases somehow.
-    path: ?[]const u8,
+    path: ?Path,
 };
 
 pub fn hashAddSystemLibs(
@@ -46,7 +46,7 @@ pub fn hashAddSystemLibs(
     for (hm.values()) |value| {
         man.hash.add(value.needed);
         man.hash.add(value.weak);
-        if (value.path) |p| _ = try man.addFile(p, null);
+        if (value.path) |p| _ = try man.addFilePath(p, null);
     }
 }
 
@@ -551,7 +551,7 @@ pub const File = struct {
         LLDCrashed,
         LLDReportedFailure,
         LLD_LinkingIsTODO_ForSpirV,
-        LibCInstallationMissingCRTDir,
+        LibCInstallationMissingCrtDir,
         LibCInstallationNotAvailable,
         LinkingWithoutZigSourceUnimplemented,
         MalformedArchive,
@@ -606,18 +606,15 @@ pub const File = struct {
         const comp = base.comp;
         if (comp.clang_preprocessor_mode == .yes or comp.clang_preprocessor_mode == .pch) {
             dev.check(.clang_command);
-            const gpa = comp.gpa;
             const emit = base.emit;
             // TODO: avoid extra link step when it's just 1 object file (the `zig cc -c` case)
             // Until then, we do `lld -r -o output.o input.o` even though the output is the same
             // as the input. For the preprocessing case (`zig cc -E -o foo`) we copy the file
             // to the final location. See also the corresponding TODO in Coff linking.
-            const full_out_path = try emit.root_dir.join(gpa, &[_][]const u8{emit.sub_path});
-            defer gpa.free(full_out_path);
             assert(comp.c_object_table.count() == 1);
             const the_key = comp.c_object_table.keys()[0];
             const cached_pp_file_path = the_key.status.success.object_path;
-            try fs.cwd().copyFile(cached_pp_file_path, fs.cwd(), full_out_path, .{});
+            try cached_pp_file_path.root_dir.handle.copyFile(cached_pp_file_path.sub_path, emit.root_dir.handle, emit.sub_path, .{});
             return;
         }
 
@@ -781,7 +778,7 @@ pub const File = struct {
 
         log.debug("zcu_obj_path={s}", .{if (zcu_obj_path) |s| s else "(null)"});
 
-        const compiler_rt_path: ?[]const u8 = if (comp.include_compiler_rt)
+        const compiler_rt_path: ?Path = if (comp.include_compiler_rt)
             comp.compiler_rt_obj.?.full_object_path
         else
             null;
@@ -806,18 +803,18 @@ pub const File = struct {
             base.releaseLock();
 
             for (objects) |obj| {
-                _ = try man.addFile(obj.path, null);
+                _ = try man.addFilePath(obj.path, null);
                 man.hash.add(obj.must_link);
                 man.hash.add(obj.loption);
             }
             for (comp.c_object_table.keys()) |key| {
-                _ = try man.addFile(key.status.success.object_path, null);
+                _ = try man.addFilePath(key.status.success.object_path, null);
             }
             for (comp.win32_resource_table.keys()) |key| {
                 _ = try man.addFile(key.status.success.res_path, null);
             }
             try man.addOptionalFile(zcu_obj_path);
-            try man.addOptionalFile(compiler_rt_path);
+            try man.addOptionalFilePath(compiler_rt_path);
 
             // We don't actually care whether it's a cache hit or miss; we just need the digest and the lock.
             _ = try man.hit();
@@ -851,10 +848,10 @@ pub const File = struct {
         defer object_files.deinit();
 
         for (objects) |obj| {
-            object_files.appendAssumeCapacity(try arena.dupeZ(u8, obj.path));
+            object_files.appendAssumeCapacity(try obj.path.toStringZ(arena));
         }
         for (comp.c_object_table.keys()) |key| {
-            object_files.appendAssumeCapacity(try arena.dupeZ(u8, key.status.success.object_path));
+            object_files.appendAssumeCapacity(try key.status.success.object_path.toStringZ(arena));
         }
         for (comp.win32_resource_table.keys()) |key| {
             object_files.appendAssumeCapacity(try arena.dupeZ(u8, key.status.success.res_path));
@@ -863,7 +860,7 @@ pub const File = struct {
             object_files.appendAssumeCapacity(try arena.dupeZ(u8, p));
         }
         if (compiler_rt_path) |p| {
-            object_files.appendAssumeCapacity(try arena.dupeZ(u8, p));
+            object_files.appendAssumeCapacity(try p.toStringZ(arena));
         }
 
         if (comp.verbose_link) {

--- a/src/link/Elf/LdScript.zig
+++ b/src/link/Elf/LdScript.zig
@@ -1,6 +1,11 @@
-path: []const u8,
+path: Path,
 cpu_arch: ?std.Target.Cpu.Arch = null,
-args: std.ArrayListUnmanaged(Elf.SystemLib) = .empty,
+args: std.ArrayListUnmanaged(Arg) = .empty,
+
+pub const Arg = struct {
+    needed: bool = false,
+    path: []const u8,
+};
 
 pub fn deinit(scr: *LdScript, allocator: Allocator) void {
     scr.args.deinit(allocator);
@@ -47,7 +52,7 @@ pub fn parse(scr: *LdScript, data: []const u8, elf_file: *Elf) Error!void {
 
     var it = TokenIterator{ .tokens = tokens.items };
     var parser = Parser{ .source = data, .it = &it };
-    var args = std.ArrayList(Elf.SystemLib).init(gpa);
+    var args = std.ArrayList(Arg).init(gpa);
     scr.doParse(.{
         .parser = &parser,
         .args = &args,
@@ -70,7 +75,7 @@ pub fn parse(scr: *LdScript, data: []const u8, elf_file: *Elf) Error!void {
 
 fn doParse(scr: *LdScript, ctx: struct {
     parser: *Parser,
-    args: *std.ArrayList(Elf.SystemLib),
+    args: *std.ArrayList(Arg),
 }) !void {
     while (true) {
         ctx.parser.skipAny(&.{ .comment, .new_line });
@@ -142,7 +147,7 @@ const Parser = struct {
         return error.UnknownCpuArch;
     }
 
-    fn group(p: *Parser, args: *std.ArrayList(Elf.SystemLib)) !void {
+    fn group(p: *Parser, args: *std.ArrayList(Arg)) !void {
         if (!p.skip(&.{.lparen})) return error.UnexpectedToken;
 
         while (true) {
@@ -162,7 +167,7 @@ const Parser = struct {
         _ = try p.require(.rparen);
     }
 
-    fn asNeeded(p: *Parser, args: *std.ArrayList(Elf.SystemLib)) !void {
+    fn asNeeded(p: *Parser, args: *std.ArrayList(Arg)) !void {
         if (!p.skip(&.{.lparen})) return error.UnexpectedToken;
 
         while (p.maybe(.literal)) |tok_id| {
@@ -239,7 +244,7 @@ const Token = struct {
 
     const Index = usize;
 
-    inline fn get(tok: Token, source: []const u8) []const u8 {
+    fn get(tok: Token, source: []const u8) []const u8 {
         return source[tok.start..tok.end];
     }
 };
@@ -399,11 +404,11 @@ const TokenIterator = struct {
         return it.tokens[it.pos];
     }
 
-    inline fn reset(it: *TokenIterator) void {
+    fn reset(it: *TokenIterator) void {
         it.pos = 0;
     }
 
-    inline fn seekTo(it: *TokenIterator, pos: Token.Index) void {
+    fn seekTo(it: *TokenIterator, pos: Token.Index) void {
         it.pos = pos;
     }
 
@@ -416,7 +421,7 @@ const TokenIterator = struct {
         }
     }
 
-    inline fn get(it: *TokenIterator, pos: Token.Index) Token {
+    fn get(it: *TokenIterator, pos: Token.Index) Token {
         assert(pos < it.tokens.len);
         return it.tokens[pos];
     }
@@ -426,6 +431,7 @@ const LdScript = @This();
 
 const std = @import("std");
 const assert = std.debug.assert;
+const Path = std.Build.Cache.Path;
 
 const Allocator = std.mem.Allocator;
 const Elf = @import("../Elf.zig");

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -5,7 +5,7 @@
 
 data: std.ArrayListUnmanaged(u8) = .empty,
 /// Externally owned memory.
-path: []const u8,
+basename: []const u8,
 index: File.Index,
 
 symtab: std.MultiArrayList(ElfSym) = .{},
@@ -88,7 +88,7 @@ pub fn init(self: *ZigObject, elf_file: *Elf, options: InitOptions) !void {
     try self.strtab.buffer.append(gpa, 0);
 
     {
-        const name_off = try self.strtab.insert(gpa, self.path);
+        const name_off = try self.strtab.insert(gpa, self.basename);
         const symbol_index = try self.newLocalSymbol(gpa, name_off);
         const sym = self.symbol(symbol_index);
         const esym = &self.symtab.items(.elf_sym)[sym.esym_index];
@@ -774,7 +774,7 @@ pub fn updateArSize(self: *ZigObject) void {
 }
 
 pub fn writeAr(self: ZigObject, writer: anytype) !void {
-    const name = self.path;
+    const name = self.basename;
     const hdr = Archive.setArHdr(.{
         .name = if (name.len <= Archive.max_member_name_len)
             .{ .name = name }
@@ -2384,9 +2384,9 @@ const relocation = @import("relocation.zig");
 const target_util = @import("../../target.zig");
 const trace = @import("../../tracy.zig").trace;
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 const Air = @import("../../Air.zig");
-const Allocator = std.mem.Allocator;
 const Archive = @import("Archive.zig");
 const Atom = @import("Atom.zig");
 const Dwarf = @import("../Dwarf.zig");

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -144,14 +144,14 @@ hot_state: if (is_hot_update_compatible) HotUpdateState else struct {} = .{},
 pub const Framework = struct {
     needed: bool = false,
     weak: bool = false,
-    path: []const u8,
+    path: Path,
 };
 
 pub fn hashAddFrameworks(man: *Cache.Manifest, hm: []const Framework) !void {
     for (hm) |value| {
         man.hash.add(value.needed);
         man.hash.add(value.weak);
-        _ = try man.addFile(value.path, null);
+        _ = try man.addFilePath(value.path, null);
     }
 }
 
@@ -239,9 +239,9 @@ pub fn createEmpty(
             const index: File.Index = @intCast(try self.files.addOne(gpa));
             self.files.set(index, .{ .zig_object = .{
                 .index = index,
-                .path = try std.fmt.allocPrint(arena, "{s}.o", .{fs.path.stem(
-                    zcu.main_mod.root_src_path,
-                )}),
+                .basename = try std.fmt.allocPrint(arena, "{s}.o", .{
+                    fs.path.stem(zcu.main_mod.root_src_path),
+                }),
             } });
             self.zig_object = index;
             const zo = self.getZigObject().?;
@@ -356,13 +356,12 @@ pub fn flushModule(self: *MachO, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
     defer sub_prog_node.end();
 
     const directory = self.base.emit.root_dir;
-    const full_out_path = try directory.join(arena, &[_][]const u8{self.base.emit.sub_path});
-    const module_obj_path: ?[]const u8 = if (self.base.zcu_object_sub_path) |path| blk: {
-        if (fs.path.dirname(full_out_path)) |dirname| {
-            break :blk try fs.path.join(arena, &.{ dirname, path });
-        } else {
-            break :blk path;
-        }
+    const module_obj_path: ?Path = if (self.base.zcu_object_sub_path) |path| .{
+        .root_dir = directory,
+        .sub_path = if (fs.path.dirname(self.base.emit.sub_path)) |dirname|
+            try fs.path.join(arena, &.{ dirname, path })
+        else
+            path,
     } else null;
 
     // --verbose-link
@@ -455,7 +454,7 @@ pub fn flushModule(self: *MachO, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
     }
 
     // Finally, link against compiler_rt.
-    const compiler_rt_path: ?[]const u8 = blk: {
+    const compiler_rt_path: ?Path = blk: {
         if (comp.compiler_rt_lib) |x| break :blk x.full_object_path;
         if (comp.compiler_rt_obj) |x| break :blk x.full_object_path;
         break :blk null;
@@ -567,7 +566,7 @@ pub fn flushModule(self: *MachO, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
         // The most important here is to have the correct vm and filesize of the __LINKEDIT segment
         // where the code signature goes into.
         var codesig = CodeSignature.init(self.getPageSize());
-        codesig.code_directory.ident = fs.path.basename(full_out_path);
+        codesig.code_directory.ident = fs.path.basename(self.base.emit.sub_path);
         if (self.entitlements) |path| try codesig.addEntitlements(gpa, path);
         try self.writeCodeSignaturePadding(&codesig);
         break :blk codesig;
@@ -625,11 +624,11 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
 
     if (self.base.isRelocatable()) {
         for (comp.objects) |obj| {
-            try argv.append(obj.path);
+            try argv.append(try obj.path.toString(arena));
         }
 
         for (comp.c_object_table.keys()) |key| {
-            try argv.append(key.status.success.object_path);
+            try argv.append(try key.status.success.object_path.toString(arena));
         }
 
         if (module_obj_path) |p| {
@@ -711,11 +710,11 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
             if (obj.must_link) {
                 try argv.append("-force_load");
             }
-            try argv.append(obj.path);
+            try argv.append(try obj.path.toString(arena));
         }
 
         for (comp.c_object_table.keys()) |key| {
-            try argv.append(key.status.success.object_path);
+            try argv.append(try key.status.success.object_path.toString(arena));
         }
 
         if (module_obj_path) |p| {
@@ -723,13 +722,12 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
         }
 
         if (comp.config.any_sanitize_thread) {
-            const path = comp.tsan_lib.?.full_object_path;
-            try argv.append(path);
-            try argv.appendSlice(&.{ "-rpath", std.fs.path.dirname(path) orelse "." });
+            const path = try comp.tsan_lib.?.full_object_path.toString(arena);
+            try argv.appendSlice(&.{ path, "-rpath", std.fs.path.dirname(path) orelse "." });
         }
 
         if (comp.config.any_fuzz) {
-            try argv.append(comp.fuzzer_lib.?.full_object_path);
+            try argv.append(try comp.fuzzer_lib.?.full_object_path.toString(arena));
         }
 
         for (self.lib_dirs) |lib_dir| {
@@ -754,7 +752,7 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
         }
 
         for (self.frameworks) |framework| {
-            const name = fs.path.stem(framework.path);
+            const name = framework.path.stem();
             const arg = if (framework.needed)
                 try std.fmt.allocPrint(arena, "-needed_framework {s}", .{name})
             else if (framework.weak)
@@ -765,14 +763,16 @@ fn dumpArgv(self: *MachO, comp: *Compilation) !void {
         }
 
         if (comp.config.link_libcpp) {
-            try argv.append(comp.libcxxabi_static_lib.?.full_object_path);
-            try argv.append(comp.libcxx_static_lib.?.full_object_path);
+            try argv.appendSlice(&.{
+                try comp.libcxxabi_static_lib.?.full_object_path.toString(arena),
+                try comp.libcxx_static_lib.?.full_object_path.toString(arena),
+            });
         }
 
         try argv.append("-lSystem");
 
-        if (comp.compiler_rt_lib) |lib| try argv.append(lib.full_object_path);
-        if (comp.compiler_rt_obj) |obj| try argv.append(obj.full_object_path);
+        if (comp.compiler_rt_lib) |lib| try argv.append(try lib.full_object_path.toString(arena));
+        if (comp.compiler_rt_obj) |obj| try argv.append(try obj.full_object_path.toString(arena));
     }
 
     Compilation.dump_argv(argv.items);
@@ -807,20 +807,20 @@ pub fn resolveLibSystem(
         return error.MissingLibSystem;
     }
 
-    const libsystem_path = try arena.dupe(u8, test_path.items);
+    const libsystem_path = Path.initCwd(try arena.dupe(u8, test_path.items));
     try out_libs.append(.{
         .needed = true,
         .path = libsystem_path,
     });
 }
 
-pub fn classifyInputFile(self: *MachO, path: []const u8, lib: SystemLib, must_link: bool) !void {
+pub fn classifyInputFile(self: *MachO, path: Path, lib: SystemLib, must_link: bool) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
-    log.debug("classifying input file {s}", .{path});
+    log.debug("classifying input file {}", .{path});
 
-    const file = try std.fs.cwd().openFile(path, .{});
+    const file = try path.root_dir.handle.openFile(path.sub_path, .{});
     const fh = try self.addFileHandle(file);
     var buffer: [Archive.SARMAG]u8 = undefined;
 
@@ -844,7 +844,7 @@ pub fn classifyInputFile(self: *MachO, path: []const u8, lib: SystemLib, must_li
     _ = try self.addTbd(lib, true, fh);
 }
 
-fn parseFatFile(self: *MachO, file: std.fs.File, path: []const u8) !?fat.Arch {
+fn parseFatFile(self: *MachO, file: std.fs.File, path: Path) !?fat.Arch {
     const fat_h = fat.readFatHeader(file) catch return null;
     if (fat_h.magic != macho.FAT_MAGIC and fat_h.magic != macho.FAT_MAGIC_64) return null;
     var fat_archs_buffer: [2]fat.Arch = undefined;
@@ -873,7 +873,7 @@ pub fn readArMagic(file: std.fs.File, offset: usize, buffer: *[Archive.SARMAG]u8
     return buffer[0..Archive.SARMAG];
 }
 
-fn addObject(self: *MachO, path: []const u8, handle: File.HandleIndex, offset: u64) !void {
+fn addObject(self: *MachO, path: Path, handle: File.HandleIndex, offset: u64) !void {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -886,7 +886,10 @@ fn addObject(self: *MachO, path: []const u8, handle: File.HandleIndex, offset: u
     const index = @as(File.Index, @intCast(try self.files.addOne(gpa)));
     self.files.set(index, .{ .object = .{
         .offset = offset,
-        .path = try gpa.dupe(u8, path),
+        .path = .{
+            .root_dir = path.root_dir,
+            .sub_path = try gpa.dupe(u8, path.sub_path),
+        },
         .file_handle = handle,
         .mtime = mtime,
         .index = index,
@@ -937,7 +940,7 @@ fn addArchive(self: *MachO, lib: SystemLib, must_link: bool, handle: File.Handle
 
     const gpa = self.base.comp.gpa;
 
-    var archive = Archive{};
+    var archive: Archive = .{};
     defer archive.deinit(gpa);
     try archive.unpack(self, lib.path, handle, fat_arch);
 
@@ -963,7 +966,10 @@ fn addDylib(self: *MachO, lib: SystemLib, explicit: bool, handle: File.HandleInd
         .offset = offset,
         .file_handle = handle,
         .tag = .dylib,
-        .path = try gpa.dupe(u8, lib.path),
+        .path = .{
+            .root_dir = lib.path.root_dir,
+            .sub_path = try gpa.dupe(u8, lib.path.sub_path),
+        },
         .index = index,
         .needed = lib.needed,
         .weak = lib.weak,
@@ -986,7 +992,10 @@ fn addTbd(self: *MachO, lib: SystemLib, explicit: bool, handle: File.HandleIndex
         .offset = 0,
         .file_handle = handle,
         .tag = .tbd,
-        .path = try gpa.dupe(u8, lib.path),
+        .path = .{
+            .root_dir = lib.path.root_dir,
+            .sub_path = try gpa.dupe(u8, lib.path.sub_path),
+        },
         .index = index,
         .needed = lib.needed,
         .weak = lib.weak,
@@ -1175,11 +1184,11 @@ fn parseDependentDylibs(self: *MachO) !void {
                     continue;
                 }
             };
-            const lib = SystemLib{
-                .path = full_path,
+            const lib: SystemLib = .{
+                .path = Path.initCwd(full_path),
                 .weak = is_weak,
             };
-            const file = try std.fs.cwd().openFile(lib.path, .{});
+            const file = try lib.path.root_dir.handle.openFile(lib.path.sub_path, .{});
             const fh = try self.addFileHandle(file);
             const fat_arch = try self.parseFatFile(file, lib.path);
             const offset = if (fat_arch) |fa| fa.offset else 0;
@@ -2865,7 +2874,8 @@ fn writeLoadCommands(self: *MachO) !struct { usize, usize, u64 } {
         ncmds += 1;
     }
     if (comp.config.any_sanitize_thread) {
-        const path = comp.tsan_lib.?.full_object_path;
+        const path = try comp.tsan_lib.?.full_object_path.toString(gpa);
+        defer gpa.free(path);
         const rpath = std.fs.path.dirname(path) orelse ".";
         try load_commands.writeRpathLC(rpath, writer);
         ncmds += 1;
@@ -3758,13 +3768,13 @@ pub fn eatPrefix(path: []const u8, prefix: []const u8) ?[]const u8 {
 
 pub fn reportParseError(
     self: *MachO,
-    path: []const u8,
+    path: Path,
     comptime format: []const u8,
     args: anytype,
 ) error{OutOfMemory}!void {
     var err = try self.base.addErrorWithNotes(1);
     try err.addMsg(format, args);
-    try err.addNote("while parsing {s}", .{path});
+    try err.addNote("while parsing {}", .{path});
 }
 
 pub fn reportParseError2(
@@ -3913,7 +3923,7 @@ fn fmtDumpState(
     _ = options;
     _ = unused_fmt_string;
     if (self.getZigObject()) |zo| {
-        try writer.print("zig_object({d}) : {s}\n", .{ zo.index, zo.path });
+        try writer.print("zig_object({d}) : {s}\n", .{ zo.index, zo.basename });
         try writer.print("{}{}\n", .{
             zo.fmtAtoms(self),
             zo.fmtSymtab(self),
@@ -3938,9 +3948,9 @@ fn fmtDumpState(
     }
     for (self.dylibs.items) |index| {
         const dylib = self.getFile(index).?.dylib;
-        try writer.print("dylib({d}) : {s} : needed({}) : weak({})", .{
+        try writer.print("dylib({d}) : {} : needed({}) : weak({})", .{
             index,
-            dylib.path,
+            @as(Path, dylib.path),
             dylib.needed,
             dylib.weak,
         });
@@ -4442,7 +4452,7 @@ pub const default_pagezero_size: u64 = 0x100000000;
 pub const default_headerpad_size: u32 = 0x1000;
 
 const SystemLib = struct {
-    path: []const u8,
+    path: Path,
     needed: bool = false,
     weak: bool = false,
     hidden: bool = false,

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -1,6 +1,6 @@
 /// Non-zero for fat dylibs
 offset: u64,
-path: []const u8,
+path: Path,
 index: File.Index,
 file_handle: File.HandleIndex,
 tag: enum { dylib, tbd },
@@ -28,7 +28,7 @@ referenced: bool = false,
 output_symtab_ctx: MachO.SymtabCtx = .{},
 
 pub fn deinit(self: *Dylib, allocator: Allocator) void {
-    allocator.free(self.path);
+    allocator.free(self.path.sub_path);
     self.exports.deinit(allocator);
     self.strtab.deinit(allocator);
     if (self.id) |*id| id.deinit(allocator);
@@ -61,7 +61,7 @@ fn parseBinary(self: *Dylib, macho_file: *MachO) !void {
     const file = macho_file.getFileHandle(self.file_handle);
     const offset = self.offset;
 
-    log.debug("parsing dylib from binary: {s}", .{self.path});
+    log.debug("parsing dylib from binary: {}", .{@as(Path, self.path)});
 
     var header_buffer: [@sizeOf(macho.mach_header_64)]u8 = undefined;
     {
@@ -267,7 +267,7 @@ fn parseTbd(self: *Dylib, macho_file: *MachO) !void {
 
     const gpa = macho_file.base.comp.gpa;
 
-    log.debug("parsing dylib from stub: {s}", .{self.path});
+    log.debug("parsing dylib from stub: {}", .{self.path});
 
     const file = macho_file.getFileHandle(self.file_handle);
     var lib_stub = LibStub.loadFromFile(gpa, file) catch |err| {
@@ -959,8 +959,9 @@ const mem = std.mem;
 const tapi = @import("../tapi.zig");
 const trace = @import("../../tracy.zig").trace;
 const std = @import("std");
-
 const Allocator = mem.Allocator;
+const Path = std.Build.Cache.Path;
+
 const Dylib = @This();
 const File = @import("file.zig").File;
 const LibStub = tapi.LibStub;

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -1,6 +1,8 @@
 /// Non-zero for fat object files or archives
 offset: u64,
-path: []const u8,
+/// Archive files cannot contain subdirectories, so only the basename is needed
+/// for output. However, the full path is kept for error reporting.
+path: Path,
 file_handle: File.HandleIndex,
 mtime: u64,
 index: File.Index,
@@ -39,8 +41,8 @@ output_symtab_ctx: MachO.SymtabCtx = .{},
 output_ar_state: Archive.ArState = .{},
 
 pub fn deinit(self: *Object, allocator: Allocator) void {
-    if (self.in_archive) |*ar| allocator.free(ar.path);
-    allocator.free(self.path);
+    if (self.in_archive) |*ar| allocator.free(ar.path.sub_path);
+    allocator.free(self.path.sub_path);
     for (self.sections.items(.relocs), self.sections.items(.subsections)) |*relocs, *sub| {
         relocs.deinit(allocator);
         sub.deinit(allocator);
@@ -1723,7 +1725,8 @@ pub fn updateArSize(self: *Object, macho_file: *MachO) !void {
 pub fn writeAr(self: Object, ar_format: Archive.Format, macho_file: *MachO, writer: anytype) !void {
     // Header
     const size = std.math.cast(usize, self.output_ar_state.size) orelse return error.Overflow;
-    try Archive.writeHeader(self.path, size, ar_format, writer);
+    const basename = std.fs.path.basename(self.path.sub_path);
+    try Archive.writeHeader(basename, size, ar_format, writer);
     // Data
     const file = macho_file.getFileHandle(self.file_handle);
     // TODO try using copyRangeAll
@@ -1774,6 +1777,11 @@ pub fn calcSymtabSize(self: *Object, macho_file: *MachO) void {
         self.calcStabsSize(macho_file);
 }
 
+fn pathLen(path: Path) usize {
+    // +1 for the path separator
+    return (if (path.root_dir.path) |p| p.len + @intFromBool(path.sub_path.len != 0) else 0) + path.sub_path.len;
+}
+
 pub fn calcStabsSize(self: *Object, macho_file: *MachO) void {
     if (self.compile_unit) |cu| {
         const comp_dir = cu.getCompDir(self.*);
@@ -1784,9 +1792,9 @@ pub fn calcStabsSize(self: *Object, macho_file: *MachO) void {
         self.output_symtab_ctx.strsize += @as(u32, @intCast(tu_name.len + 1)); // tu_name
 
         if (self.in_archive) |ar| {
-            self.output_symtab_ctx.strsize += @as(u32, @intCast(ar.path.len + 1 + self.path.len + 1 + 1));
+            self.output_symtab_ctx.strsize += @intCast(pathLen(ar.path) + 1 + self.path.basename().len + 1 + 1);
         } else {
-            self.output_symtab_ctx.strsize += @as(u32, @intCast(self.path.len + 1));
+            self.output_symtab_ctx.strsize += @intCast(pathLen(self.path) + 1);
         }
 
         for (self.symbols.items, 0..) |sym, i| {
@@ -2118,19 +2126,36 @@ pub fn writeStabs(self: Object, stroff: u32, macho_file: *MachO, ctx: anytype) v
         };
         index += 1;
         if (self.in_archive) |ar| {
-            @memcpy(ctx.strtab.items[n_strx..][0..ar.path.len], ar.path);
-            n_strx += @intCast(ar.path.len);
+            if (ar.path.root_dir.path) |p| {
+                @memcpy(ctx.strtab.items[n_strx..][0..p.len], p);
+                n_strx += @intCast(p.len);
+                if (ar.path.sub_path.len != 0) {
+                    ctx.strtab.items[n_strx] = '/';
+                    n_strx += 1;
+                }
+            }
+            @memcpy(ctx.strtab.items[n_strx..][0..ar.path.sub_path.len], ar.path.sub_path);
+            n_strx += @intCast(ar.path.sub_path.len);
             ctx.strtab.items[n_strx] = '(';
             n_strx += 1;
-            @memcpy(ctx.strtab.items[n_strx..][0..self.path.len], self.path);
-            n_strx += @intCast(self.path.len);
+            const basename = self.path.basename();
+            @memcpy(ctx.strtab.items[n_strx..][0..basename.len], basename);
+            n_strx += @intCast(basename.len);
             ctx.strtab.items[n_strx] = ')';
             n_strx += 1;
             ctx.strtab.items[n_strx] = 0;
             n_strx += 1;
         } else {
-            @memcpy(ctx.strtab.items[n_strx..][0..self.path.len], self.path);
-            n_strx += @intCast(self.path.len);
+            if (self.path.root_dir.path) |p| {
+                @memcpy(ctx.strtab.items[n_strx..][0..p.len], p);
+                n_strx += @intCast(p.len);
+                if (self.path.sub_path.len != 0) {
+                    ctx.strtab.items[n_strx] = '/';
+                    n_strx += 1;
+                }
+            }
+            @memcpy(ctx.strtab.items[n_strx..][0..self.path.sub_path.len], self.path.sub_path);
+            n_strx += @intCast(self.path.sub_path.len);
             ctx.strtab.items[n_strx] = 0;
             n_strx += 1;
         }
@@ -2666,11 +2691,12 @@ fn formatPath(
     _ = unused_fmt_string;
     _ = options;
     if (object.in_archive) |ar| {
-        try writer.writeAll(ar.path);
-        try writer.writeByte('(');
-        try writer.writeAll(object.path);
-        try writer.writeByte(')');
-    } else try writer.writeAll(object.path);
+        try writer.print("{}({s})", .{
+            @as(Path, ar.path), object.path.basename(),
+        });
+    } else {
+        try writer.print("{}", .{@as(Path, object.path)});
+    }
 }
 
 const Section = struct {
@@ -2777,7 +2803,7 @@ const CompileUnit = struct {
 };
 
 const InArchive = struct {
-    path: []const u8,
+    path: Path,
     size: u32,
 };
 
@@ -3170,6 +3196,7 @@ const math = std.math;
 const mem = std.mem;
 const trace = @import("../../tracy.zig").trace;
 const std = @import("std");
+const Path = std.Build.Cache.Path;
 
 const Allocator = mem.Allocator;
 const Archive = @import("Archive.zig");

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -1,6 +1,6 @@
 data: std.ArrayListUnmanaged(u8) = .empty,
 /// Externally owned memory.
-path: []const u8,
+basename: []const u8,
 index: File.Index,
 
 symtab: std.MultiArrayList(Nlist) = .{},
@@ -317,7 +317,7 @@ pub fn updateArSize(self: *ZigObject) void {
 pub fn writeAr(self: ZigObject, ar_format: Archive.Format, writer: anytype) !void {
     // Header
     const size = std.math.cast(usize, self.output_ar_state.size) orelse return error.Overflow;
-    try Archive.writeHeader(self.path, size, ar_format, writer);
+    try Archive.writeHeader(self.basename, size, ar_format, writer);
     // Data
     try writer.writeAll(self.data.items);
 }

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -23,10 +23,10 @@ pub const File = union(enum) {
         _ = unused_fmt_string;
         _ = options;
         switch (file) {
-            .zig_object => |x| try writer.writeAll(x.path),
+            .zig_object => |zo| try writer.writeAll(zo.basename),
             .internal => try writer.writeAll("internal"),
             .object => |x| try writer.print("{}", .{x.fmtPath()}),
-            .dylib => |x| try writer.writeAll(x.path),
+            .dylib => |dl| try writer.print("{}", .{@as(Path, dl.path)}),
         }
     }
 
@@ -373,13 +373,14 @@ pub const File = union(enum) {
     pub const HandleIndex = Index;
 };
 
+const std = @import("std");
 const assert = std.debug.assert;
 const log = std.log.scoped(.link);
 const macho = std.macho;
-const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
-
 const Allocator = std.mem.Allocator;
+const Path = std.Build.Cache.Path;
+
+const trace = @import("../../tracy.zig").trace;
 const Archive = @import("Archive.zig");
 const Atom = @import("Atom.zig");
 const InternalObject = @import("InternalObject.zig");

--- a/src/link/MachO/load_commands.zig
+++ b/src/link/MachO/load_commands.zig
@@ -72,7 +72,8 @@ pub fn calcLoadCommandsSize(macho_file: *MachO, assume_max_path_len: bool) !u32 
         }
 
         if (comp.config.any_sanitize_thread) {
-            const path = comp.tsan_lib.?.full_object_path;
+            const path = try comp.tsan_lib.?.full_object_path.toString(gpa);
+            defer gpa.free(path);
             const rpath = std.fs.path.dirname(path) orelse ".";
             sizeofcmds += calcInstallNameLen(
                 @sizeOf(macho.rpath_command),

--- a/src/link/StringTable.zig
+++ b/src/link/StringTable.zig
@@ -15,7 +15,7 @@ pub fn insert(self: *Self, gpa: Allocator, string: []const u8) !u32 {
     if (gop.found_existing) return gop.key_ptr.*;
 
     try self.buffer.ensureUnusedCapacity(gpa, string.len + 1);
-    const new_off = @as(u32, @intCast(self.buffer.items.len));
+    const new_off: u32 = @intCast(self.buffer.items.len);
 
     self.buffer.appendSliceAssumeCapacity(string);
     self.buffer.appendAssumeCapacity(0);

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,12 @@ const warn = std.log.warn;
 const ThreadPool = std.Thread.Pool;
 const cleanExit = std.process.cleanExit;
 const native_os = builtin.os.tag;
+const Cache = std.Build.Cache;
+const Path = std.Build.Cache.Path;
+const EnvVar = std.zig.EnvVar;
+const LibCInstallation = std.zig.LibCInstallation;
+const AstGen = std.zig.AstGen;
+const Server = std.zig.Server;
 
 const tracy = @import("tracy.zig");
 const Compilation = @import("Compilation.zig");
@@ -20,16 +26,11 @@ const link = @import("link.zig");
 const Package = @import("Package.zig");
 const build_options = @import("build_options");
 const introspect = @import("introspect.zig");
-const EnvVar = std.zig.EnvVar;
-const LibCInstallation = std.zig.LibCInstallation;
 const wasi_libc = @import("wasi_libc.zig");
-const Cache = std.Build.Cache;
 const target_util = @import("target.zig");
 const crash_report = @import("crash_report.zig");
 const Zcu = @import("Zcu.zig");
-const AstGen = std.zig.AstGen;
 const mingw = @import("mingw.zig");
-const Server = std.zig.Server;
 const dev = @import("dev.zig");
 
 pub const std_options = .{
@@ -1724,14 +1725,14 @@ fn buildOutputType(
                     }
                 } else switch (file_ext orelse Compilation.classifyFileExt(arg)) {
                     .shared_library => {
-                        try create_module.link_objects.append(arena, .{ .path = arg });
+                        try create_module.link_objects.append(arena, .{ .path = Path.initCwd(arg) });
                         create_module.opts.any_dyn_libs = true;
                     },
                     .object, .static_library => {
-                        try create_module.link_objects.append(arena, .{ .path = arg });
+                        try create_module.link_objects.append(arena, .{ .path = Path.initCwd(arg) });
                     },
                     .res => {
-                        try create_module.link_objects.append(arena, .{ .path = arg });
+                        try create_module.link_objects.append(arena, .{ .path = Path.initCwd(arg) });
                         contains_res_file = true;
                     },
                     .manifest => {
@@ -1845,20 +1846,20 @@ fn buildOutputType(
                         },
                         .shared_library => {
                             try create_module.link_objects.append(arena, .{
-                                .path = it.only_arg,
+                                .path = Path.initCwd(it.only_arg),
                                 .must_link = must_link,
                             });
                             create_module.opts.any_dyn_libs = true;
                         },
                         .unknown, .object, .static_library => {
                             try create_module.link_objects.append(arena, .{
-                                .path = it.only_arg,
+                                .path = Path.initCwd(it.only_arg),
                                 .must_link = must_link,
                             });
                         },
                         .res => {
                             try create_module.link_objects.append(arena, .{
-                                .path = it.only_arg,
+                                .path = Path.initCwd(it.only_arg),
                                 .must_link = must_link,
                             });
                             contains_res_file = true;
@@ -1894,7 +1895,7 @@ fn buildOutputType(
                             // binary: no extra rpaths and DSO filename exactly
                             // as provided. Hello, Go.
                             try create_module.link_objects.append(arena, .{
-                                .path = it.only_arg,
+                                .path = Path.initCwd(it.only_arg),
                                 .must_link = must_link,
                                 .loption = true,
                             });
@@ -2532,7 +2533,7 @@ fn buildOutputType(
                     install_name = linker_args_it.nextOrFatal();
                 } else if (mem.eql(u8, arg, "-force_load")) {
                     try create_module.link_objects.append(arena, .{
-                        .path = linker_args_it.nextOrFatal(),
+                        .path = Path.initCwd(linker_args_it.nextOrFatal()),
                         .must_link = true,
                     });
                 } else if (mem.eql(u8, arg, "-hash-style") or
@@ -2707,7 +2708,7 @@ fn buildOutputType(
                 break :b create_module.c_source_files.items[0].src_path;
 
             if (create_module.link_objects.items.len >= 1)
-                break :b create_module.link_objects.items[0].path;
+                break :b create_module.link_objects.items[0].path.sub_path;
 
             if (emit_bin == .yes)
                 break :b emit_bin.yes;
@@ -2963,7 +2964,7 @@ fn buildOutputType(
                     framework_dir_path,
                     framework_name,
                 )) {
-                    const path = try arena.dupe(u8, test_path.items);
+                    const path = Path.initCwd(try arena.dupe(u8, test_path.items));
                     try resolved_frameworks.append(.{
                         .needed = info.needed,
                         .weak = info.weak,
@@ -3635,7 +3636,7 @@ const CreateModule = struct {
         name: []const u8,
         lib: Compilation.SystemLib,
     }),
-    wasi_emulated_libs: std.ArrayListUnmanaged(wasi_libc.CRTFile),
+    wasi_emulated_libs: std.ArrayListUnmanaged(wasi_libc.CrtFile),
 
     c_source_files: std.ArrayListUnmanaged(Compilation.CSourceFile),
     rc_source_files: std.ArrayListUnmanaged(Compilation.RcSourceFile),
@@ -3808,7 +3809,7 @@ fn createModule(
             }
 
             if (target.os.tag == .wasi) {
-                if (wasi_libc.getEmulatedLibCRTFile(lib_name)) |crt_file| {
+                if (wasi_libc.getEmulatedLibCrtFile(lib_name)) |crt_file| {
                     try create_module.wasi_emulated_libs.append(arena, crt_file);
                     continue;
                 }
@@ -3929,7 +3930,7 @@ fn createModule(
                                 target,
                                 info.preferred_mode,
                             )) {
-                                const path = try arena.dupe(u8, test_path.items);
+                                const path = Path.initCwd(try arena.dupe(u8, test_path.items));
                                 switch (info.preferred_mode) {
                                     .static => try create_module.link_objects.append(arena, .{ .path = path }),
                                     .dynamic => try create_module.resolved_system_libs.append(arena, .{
@@ -3963,7 +3964,7 @@ fn createModule(
                                 target,
                                 info.fallbackMode(),
                             )) {
-                                const path = try arena.dupe(u8, test_path.items);
+                                const path = Path.initCwd(try arena.dupe(u8, test_path.items));
                                 switch (info.fallbackMode()) {
                                     .static => try create_module.link_objects.append(arena, .{ .path = path }),
                                     .dynamic => try create_module.resolved_system_libs.append(arena, .{
@@ -3997,7 +3998,7 @@ fn createModule(
                                 target,
                                 info.preferred_mode,
                             )) {
-                                const path = try arena.dupe(u8, test_path.items);
+                                const path = Path.initCwd(try arena.dupe(u8, test_path.items));
                                 switch (info.preferred_mode) {
                                     .static => try create_module.link_objects.append(arena, .{ .path = path }),
                                     .dynamic => try create_module.resolved_system_libs.append(arena, .{
@@ -4021,7 +4022,7 @@ fn createModule(
                                 target,
                                 info.fallbackMode(),
                             )) {
-                                const path = try arena.dupe(u8, test_path.items);
+                                const path = Path.initCwd(try arena.dupe(u8, test_path.items));
                                 switch (info.fallbackMode()) {
                                     .static => try create_module.link_objects.append(arena, .{ .path = path }),
                                     .dynamic => try create_module.resolved_system_libs.append(arena, .{
@@ -6163,7 +6164,7 @@ fn cmdAstCheck(
     }
 
     file.mod = try Package.Module.createLimited(arena, .{
-        .root = Cache.Path.cwd(),
+        .root = Path.cwd(),
         .root_src_path = file.sub_file_path,
         .fully_qualified_name = "root",
     });
@@ -6523,7 +6524,7 @@ fn cmdChangelist(
     };
 
     file.mod = try Package.Module.createLimited(arena, .{
-        .root = Cache.Path.cwd(),
+        .root = Path.cwd(),
         .root_src_path = file.sub_file_path,
         .fully_qualified_name = "root",
     });

--- a/src/musl.zig
+++ b/src/musl.zig
@@ -9,7 +9,7 @@ const archName = std.zig.target.muslArchName;
 const Compilation = @import("Compilation.zig");
 const build_options = @import("build_options");
 
-pub const CRTFile = enum {
+pub const CrtFile = enum {
     crti_o,
     crtn_o,
     crt1_o,
@@ -19,7 +19,7 @@ pub const CRTFile = enum {
     libc_so,
 };
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
+pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -6,7 +6,7 @@ const Allocator = std.mem.Allocator;
 const Compilation = @import("Compilation.zig");
 const build_options = @import("build_options");
 
-pub const CRTFile = enum {
+pub const CrtFile = enum {
     crt1_reactor_o,
     crt1_command_o,
     libc_a,
@@ -16,7 +16,7 @@ pub const CRTFile = enum {
     libwasi_emulated_signal_a,
 };
 
-pub fn getEmulatedLibCRTFile(lib_name: []const u8) ?CRTFile {
+pub fn getEmulatedLibCrtFile(lib_name: []const u8) ?CrtFile {
     if (mem.eql(u8, lib_name, "wasi-emulated-process-clocks")) {
         return .libwasi_emulated_process_clocks_a;
     }
@@ -32,7 +32,7 @@ pub fn getEmulatedLibCRTFile(lib_name: []const u8) ?CRTFile {
     return null;
 }
 
-pub fn emulatedLibCRFileLibName(crt_file: CRTFile) []const u8 {
+pub fn emulatedLibCRFileLibName(crt_file: CrtFile) []const u8 {
     return switch (crt_file) {
         .libwasi_emulated_process_clocks_a => "libwasi-emulated-process-clocks.a",
         .libwasi_emulated_getpid_a => "libwasi-emulated-getpid.a",
@@ -42,10 +42,10 @@ pub fn emulatedLibCRFileLibName(crt_file: CRTFile) []const u8 {
     };
 }
 
-pub fn execModelCrtFile(wasi_exec_model: std.builtin.WasiExecModel) CRTFile {
+pub fn execModelCrtFile(wasi_exec_model: std.builtin.WasiExecModel) CrtFile {
     return switch (wasi_exec_model) {
-        .reactor => CRTFile.crt1_reactor_o,
-        .command => CRTFile.crt1_command_o,
+        .reactor => CrtFile.crt1_reactor_o,
+        .command => CrtFile.crt1_command_o,
     };
 }
 
@@ -57,7 +57,7 @@ pub fn execModelCrtFileFullName(wasi_exec_model: std.builtin.WasiExecModel) []co
     };
 }
 
-pub fn buildCRTFile(comp: *Compilation, crt_file: CRTFile, prog_node: std.Progress.Node) !void {
+pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progress.Node) !void {
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -952,25 +952,25 @@ fn testEmitStaticLib(b: *Build, opts: Options) *Step {
 
     const check = lib.checkObject();
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj1.getEmittedBin());
+    check.checkExact("in object obj1.o");
     check.checkExact("foo");
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj1.getEmittedBin());
+    check.checkExact("in object obj1.o");
     check.checkExact("bar");
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj1.getEmittedBin());
+    check.checkExact("in object obj1.o");
     check.checkExact("fooBar");
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj2.getEmittedBin());
+    check.checkExact("in object obj2.o");
     check.checkExact("tentative");
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj3.getEmittedBin());
+    check.checkExact("in object a_very_long_file_name_so_that_it_ends_up_in_strtab.o");
     check.checkExact("weakFoo");
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj3.getEmittedBin());
+    check.checkExact("in object a_very_long_file_name_so_that_it_ends_up_in_strtab.o");
     check.checkExact("strongBar");
     check.checkInArchiveSymtab();
-    check.checkExactPath("in object", obj3.getEmittedBin());
+    check.checkExact("in object a_very_long_file_name_so_that_it_ends_up_in_strtab.o");
     check.checkExact("strongBarAlias");
     test_step.dependOn(&check.step);
 

--- a/test/link/link.zig
+++ b/test/link/link.zig
@@ -74,8 +74,8 @@ fn addCompileStep(
             .target = base.target,
             .optimize = base.optimize,
             .root_source_file = rsf: {
-                const name = b.fmt("{s}.zig", .{overlay.name});
                 const bytes = overlay.zig_source_bytes orelse break :rsf null;
+                const name = b.fmt("{s}.zig", .{overlay.name});
                 break :rsf b.addWriteFiles().add(name, bytes);
             },
             .pic = overlay.pic,


### PR DESCRIPTION
Embrace the Path abstraction, doing more operations based on directory handles rather than absolute file paths. Most of the diff noise here comes from this one.

Fix sorting of crtbegin/crtend atoms. Previously it would look at all path components for those strings.

Make the C runtime path detection partially a pure function, and move some logic to glibc.zig where it belongs.