### PR TITLE
`musl`: Align `_init`/`_fini` symbols correctly on arm.

### DIFF
--- a/lib/libc/musl/crt/arm/crti.s
+++ b/lib/libc/musl/crt/arm/crti.s
@@ -3,11 +3,13 @@
 .section .init
 .global _init
 .type _init,%function
+.align 2
 _init:
 	push {r0,lr}
 
 .section .fini
 .global _fini
 .type _fini,%function
+.align 2
 _fini:
 	push {r0,lr}


### PR DESCRIPTION
See upstream patch: https://www.openwall.com/lists/musl/2024/10/10/4