### PR TITLE
Replace tidy with superhtml as HTML validator

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,20 +32,17 @@ pub fn build(b: *std.Build) !void {
     const skip_install_langref = b.option(bool, "no-langref", "skip copying of langref to the installation prefix") orelse skip_install_lib_files;
     const std_docs = b.option(bool, "std-docs", "include standard library autodocs") orelse false;
     const no_bin = b.option(bool, "no-bin", "skip emitting compiler binary") orelse false;
-    const enable_tidy = b.option(bool, "enable-tidy", "Check langref output HTML validity") orelse false;
+    const enable_superhtml = b.option(bool, "enable-superhtml", "Check langref output HTML validity") orelse false;
 
     const langref_file = generateLangRef(b);
     const install_langref = b.addInstallFileWithDir(langref_file, .prefix, "doc/langref.html");
-    const check_langref = tidyCheck(b, langref_file);
-    if (enable_tidy) install_langref.step.dependOn(check_langref);
-    // Checking autodocs is disabled because tidy gives a false positive:
-    // line 304 column 9 - Warning: moved <style> tag to <head>! fix-style-tags: no to avoid.
-    // I noticed that `--show-warnings no` still incorrectly causes exit code 1.
-    // I was unable to find an alternative to tidy.
-    //const check_autodocs = tidyCheck(b, b.path("lib/docs/index.html"));
-    if (enable_tidy) {
+    const check_langref = superHtmlCheck(b, langref_file);
+    if (enable_superhtml) install_langref.step.dependOn(check_langref);
+
+    const check_autodocs = superHtmlCheck(b, b.path("lib/docs/index.html"));
+    if (enable_superhtml) {
         test_step.dependOn(check_langref);
-        //test_step.dependOn(check_autodocs);
+        test_step.dependOn(check_autodocs);
     }
     if (!skip_install_langref) {
         b.getInstallStep().dependOn(&install_langref.step);
@@ -1358,11 +1355,11 @@ fn generateLangRef(b: *std.Build) std.Build.LazyPath {
     return docgen_cmd.addOutputFileArg("langref.html");
 }
 
-fn tidyCheck(b: *std.Build, html_file: std.Build.LazyPath) *std.Build.Step {
-    const run_tidy = b.addSystemCommand(&.{
-        "tidy", "--drop-empty-elements", "no", "-qe",
+fn superHtmlCheck(b: *std.Build, html_file: std.Build.LazyPath) *std.Build.Step {
+    const run_superhtml = b.addSystemCommand(&.{
+        "superhtml", "check",
     });
-    run_tidy.addFileArg(html_file);
-    run_tidy.expectExitCode(0);
-    return &run_tidy.step;
+    run_superhtml.addFileArg(html_file);
+    run_superhtml.expectExitCode(0);
+    return &run_superhtml.step;
 }

--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -62,7 +62,7 @@ stage3-debug/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy
+  -Denable-superhtml
 
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-debug/bin/zig build update-zig1

--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -12,7 +12,7 @@ CACHE_BASENAME="zig+llvm+lld+clang-$TARGET-0.14.0-dev.1622+2ac543388"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"
 
-export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$PATH"
+export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/local/bin:$PATH"
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -62,7 +62,7 @@ stage3-release/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy
+  -Denable-superhtml
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -12,7 +12,7 @@ CACHE_BASENAME="zig+llvm+lld+clang-$TARGET-0.14.0-dev.1622+2ac543388"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"
 
-export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$PATH"
+export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/local/bin:$PATH"
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -12,7 +12,7 @@ CACHE_BASENAME="zig+llvm+lld+clang-$TARGET-0.14.0-dev.1622+2ac543388"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"
 
-export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64-8.2.1/bin:$PATH"
+export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64-8.2.1/bin:$HOME/local/bin:$PATH"
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.

--- a/ci/x86_64-linux-debug.sh
+++ b/ci/x86_64-linux-debug.sh
@@ -71,7 +71,7 @@ stage3-debug/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy
+  -Denable-superhtml
 
 # Ensure that updating the wasm binary from this commit will result in a viable build.
 stage3-debug/bin/zig build update-zig1

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -12,7 +12,7 @@ CACHE_BASENAME="zig+llvm+lld+clang-$TARGET-0.14.0-dev.1622+2ac543388"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"
 
-export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64-8.2.1/bin:$PATH"
+export PATH="$HOME/deps/wasmtime-v10.0.2-$ARCH-linux:$HOME/deps/qemu-linux-x86_64-8.2.1/bin:$HOME/local/bin:$PATH"
 
 # Make the `zig version` number consistent.
 # This will affect the cmake command below.

--- a/ci/x86_64-linux-release.sh
+++ b/ci/x86_64-linux-release.sh
@@ -71,7 +71,7 @@ stage3-release/bin/zig build test docs \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \
-  -Denable-tidy
+  -Denable-superhtml
 
 # Ensure that stage3 and stage4 are byte-for-byte identical.
 stage3-release/bin/zig build \


### PR DESCRIPTION
This PR requires the `superhtml` tool to be installed on the CI machine, I'm not sure how to approach that.