### PR TITLE
link: consolidate diagnostics

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1679,6 +1679,7 @@ pub fn flushModule(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
+    const diags = &comp.link_diags;
 
     if (self.llvm_object) |llvm_object| {
         try self.base.emitLlvmObject(arena, llvm_object, prog_node);
@@ -1796,10 +1797,10 @@ pub fn flushModule(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
 
     if (self.entry_addr == null and comp.config.output_mode == .Exe) {
         log.debug("flushing. no_entry_point_found = true\n", .{});
-        comp.link_error_flags.no_entry_point_found = true;
+        diags.flags.no_entry_point_found = true;
     } else {
         log.debug("flushing. no_entry_point_found = false\n", .{});
-        comp.link_error_flags.no_entry_point_found = false;
+        diags.flags.no_entry_point_found = false;
         try self.writeHeader();
     }
 

--- a/src/link/Elf/eh_frame.zig
+++ b/src/link/Elf/eh_frame.zig
@@ -611,7 +611,8 @@ const riscv = struct {
 };
 
 fn reportInvalidReloc(rec: anytype, elf_file: *Elf, rel: elf.Elf64_Rela) !void {
-    var err = try elf_file.base.addErrorWithNotes(1);
+    const diags = &elf_file.base.comp.link_diags;
+    var err = try diags.addErrorWithNotes(1);
     try err.addMsg("invalid relocation type {} at offset 0x{x}", .{
         relocation.fmtRelocType(rel.r_type(), elf_file.getTarget().cpu.arch),
         rel.r_offset,

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -6,6 +6,7 @@ pub fn deinit(self: *Archive, allocator: Allocator) void {
 
 pub fn unpack(self: *Archive, macho_file: *MachO, path: Path, handle_index: File.HandleIndex, fat_arch: ?fat.Arch) !void {
     const gpa = macho_file.base.comp.gpa;
+    const diags = &macho_file.base.comp.link_diags;
 
     var arena = std.heap.ArenaAllocator.init(gpa);
     defer arena.deinit();
@@ -28,7 +29,7 @@ pub fn unpack(self: *Archive, macho_file: *MachO, path: Path, handle_index: File
         pos += @sizeOf(ar_hdr);
 
         if (!mem.eql(u8, &hdr.ar_fmag, ARFMAG)) {
-            try macho_file.reportParseError(path, "invalid header delimiter: expected '{s}', found '{s}'", .{
+            try diags.reportParseError(path, "invalid header delimiter: expected '{s}', found '{s}'", .{
                 std.fmt.fmtSliceEscapeLower(ARFMAG), std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag),
             });
             return error.MalformedArchive;

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -893,6 +893,7 @@ fn resolveRelocInner(
 const x86_64 = struct {
     fn relaxGotLoad(self: Atom, code: []u8, rel: Relocation, macho_file: *MachO) ResolveError!void {
         dev.check(.x86_64_backend);
+        const diags = &macho_file.base.comp.link_diags;
         const old_inst = disassemble(code) orelse return error.RelaxFail;
         switch (old_inst.encoding.mnemonic) {
             .mov => {
@@ -901,7 +902,7 @@ const x86_64 = struct {
                 encode(&.{inst}, code) catch return error.RelaxFail;
             },
             else => |x| {
-                var err = try macho_file.base.addErrorWithNotes(2);
+                var err = try diags.addErrorWithNotes(2);
                 try err.addMsg("{s}: 0x{x}: 0x{x}: failed to relax relocation of type {}", .{
                     self.getName(macho_file),
                     self.getAddress(macho_file),

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -649,6 +649,8 @@ fn parseInputFiles(wasm: *Wasm, files: []const []const u8) !void {
 /// file and parsed successfully. Returns false when file is not an object file.
 /// May return an error instead when parsing failed.
 fn parseObjectFile(wasm: *Wasm, path: []const u8) !bool {
+    const diags = &wasm.base.comp.link_diags;
+
     const obj_file = try fs.cwd().openFile(path, .{});
     errdefer obj_file.close();
 
@@ -656,7 +658,7 @@ fn parseObjectFile(wasm: *Wasm, path: []const u8) !bool {
     var object = Object.create(wasm, obj_file, path, null) catch |err| switch (err) {
         error.InvalidMagicByte, error.NotObjectFile => return false,
         else => |e| {
-            var err_note = try wasm.base.addErrorWithNotes(1);
+            var err_note = try diags.addErrorWithNotes(1);
             try err_note.addMsg("Failed parsing object file: {s}", .{@errorName(e)});
             try err_note.addNote("while parsing '{s}'", .{path});
             return error.FlushFailure;
@@ -698,6 +700,7 @@ pub inline fn getAtomPtr(wasm: *Wasm, index: Atom.Index) *Atom {
 /// are referenced by other object files or Zig code.
 fn parseArchive(wasm: *Wasm, path: []const u8, force_load: bool) !bool {
     const gpa = wasm.base.comp.gpa;
+    const diags = &wasm.base.comp.link_diags;
 
     const archive_file = try fs.cwd().openFile(path, .{});
     errdefer archive_file.close();
@@ -712,7 +715,7 @@ fn parseArchive(wasm: *Wasm, path: []const u8, force_load: bool) !bool {
             return false;
         },
         else => |e| {
-            var err_note = try wasm.base.addErrorWithNotes(1);
+            var err_note = try diags.addErrorWithNotes(1);
             try err_note.addMsg("Failed parsing archive: {s}", .{@errorName(e)});
             try err_note.addNote("while parsing archive {s}", .{path});
             return error.FlushFailure;
@@ -739,7 +742,7 @@ fn parseArchive(wasm: *Wasm, path: []const u8, force_load: bool) !bool {
 
     for (offsets.keys()) |file_offset| {
         var object = archive.parseObject(wasm, file_offset) catch |e| {
-            var err_note = try wasm.base.addErrorWithNotes(1);
+            var err_note = try diags.addErrorWithNotes(1);
             try err_note.addMsg("Failed parsing object: {s}", .{@errorName(e)});
             try err_note.addNote("while parsing object in archive {s}", .{path});
             return error.FlushFailure;
@@ -763,6 +766,7 @@ fn requiresTLSReloc(wasm: *const Wasm) bool {
 
 fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
     const gpa = wasm.base.comp.gpa;
+    const diags = &wasm.base.comp.link_diags;
     const obj_file = wasm.file(file_index).?;
     log.debug("Resolving symbols in object: '{s}'", .{obj_file.path()});
 
@@ -777,7 +781,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
 
         if (symbol.isLocal()) {
             if (symbol.isUndefined()) {
-                var err = try wasm.base.addErrorWithNotes(1);
+                var err = try diags.addErrorWithNotes(1);
                 try err.addMsg("Local symbols are not allowed to reference imports", .{});
                 try err.addNote("symbol '{s}' defined in '{s}'", .{ sym_name, obj_file.path() });
             }
@@ -814,7 +818,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
                     break :outer; // existing is weak, while new one isn't. Replace it.
                 }
                 // both are defined and weak, we have a symbol collision.
-                var err = try wasm.base.addErrorWithNotes(2);
+                var err = try diags.addErrorWithNotes(2);
                 try err.addMsg("symbol '{s}' defined multiple times", .{sym_name});
                 try err.addNote("first definition in '{s}'", .{existing_file_path});
                 try err.addNote("next definition in '{s}'", .{obj_file.path()});
@@ -825,7 +829,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
         }
 
         if (symbol.tag != existing_sym.tag) {
-            var err = try wasm.base.addErrorWithNotes(2);
+            var err = try diags.addErrorWithNotes(2);
             try err.addMsg("symbol '{s}' mismatching types '{s}' and '{s}'", .{ sym_name, @tagName(symbol.tag), @tagName(existing_sym.tag) });
             try err.addNote("first definition in '{s}'", .{existing_file_path});
             try err.addNote("next definition in '{s}'", .{obj_file.path()});
@@ -845,7 +849,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
                 const imp = obj_file.import(sym_index);
                 const module_name = obj_file.string(imp.module_name);
                 if (!mem.eql(u8, existing_name, module_name)) {
-                    var err = try wasm.base.addErrorWithNotes(2);
+                    var err = try diags.addErrorWithNotes(2);
                     try err.addMsg("symbol '{s}' module name mismatch. Expected '{s}', but found '{s}'", .{
                         sym_name,
                         existing_name,
@@ -865,7 +869,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
             const existing_ty = wasm.getGlobalType(existing_loc);
             const new_ty = wasm.getGlobalType(location);
             if (existing_ty.mutable != new_ty.mutable or existing_ty.valtype != new_ty.valtype) {
-                var err = try wasm.base.addErrorWithNotes(2);
+                var err = try diags.addErrorWithNotes(2);
                 try err.addMsg("symbol '{s}' mismatching global types", .{sym_name});
                 try err.addNote("first definition in '{s}'", .{existing_file_path});
                 try err.addNote("next definition in '{s}'", .{obj_file.path()});
@@ -876,7 +880,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
             const existing_ty = wasm.getFunctionSignature(existing_loc);
             const new_ty = wasm.getFunctionSignature(location);
             if (!existing_ty.eql(new_ty)) {
-                var err = try wasm.base.addErrorWithNotes(3);
+                var err = try diags.addErrorWithNotes(3);
                 try err.addMsg("symbol '{s}' mismatching function signatures.", .{sym_name});
                 try err.addNote("expected signature {}, but found signature {}", .{ existing_ty, new_ty });
                 try err.addNote("first definition in '{s}'", .{existing_file_path});
@@ -909,6 +913,7 @@ fn resolveSymbolsInObject(wasm: *Wasm, file_index: File.Index) !void {
 
 fn resolveSymbolsInArchives(wasm: *Wasm) !void {
     const gpa = wasm.base.comp.gpa;
+    const diags = &wasm.base.comp.link_diags;
     if (wasm.archives.items.len == 0) return;
 
     log.debug("Resolving symbols in archives", .{});
@@ -928,7 +933,7 @@ fn resolveSymbolsInArchives(wasm: *Wasm) !void {
             // Parse object and and resolve symbols again before we check remaining
             // undefined symbols.
             var object = archive.parseObject(wasm, offset.items[0]) catch |e| {
-                var err_note = try wasm.base.addErrorWithNotes(1);
+                var err_note = try diags.addErrorWithNotes(1);
                 try err_note.addMsg("Failed parsing object: {s}", .{@errorName(e)});
                 try err_note.addNote("while parsing object in archive {s}", .{archive.name});
                 return error.FlushFailure;
@@ -1172,6 +1177,7 @@ fn validateFeatures(
     emit_features_count: *u32,
 ) !void {
     const comp = wasm.base.comp;
+    const diags = &wasm.base.comp.link_diags;
     const target = comp.root_mod.resolved_target.result;
     const shared_memory = comp.config.shared_memory;
     const cpu_features = target.cpu.features;
@@ -1235,7 +1241,7 @@ fn validateFeatures(
             allowed[used_index] = is_enabled;
             emit_features_count.* += @intFromBool(is_enabled);
         } else if (is_enabled and !allowed[used_index]) {
-            var err = try wasm.base.addErrorWithNotes(1);
+            var err = try diags.addErrorWithNotes(1);
             try err.addMsg("feature '{}' not allowed, but used by linked object", .{@as(types.Feature.Tag, @enumFromInt(used_index))});
             try err.addNote("defined in '{s}'", .{wasm.files.items(.data)[used_set >> 1].object.path});
             valid_feature_set = false;
@@ -1249,7 +1255,7 @@ fn validateFeatures(
     if (shared_memory) {
         const disallowed_feature = disallowed[@intFromEnum(types.Feature.Tag.shared_mem)];
         if (@as(u1, @truncate(disallowed_feature)) != 0) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg(
                 "shared-memory is disallowed by '{s}' because it wasn't compiled with 'atomics' and 'bulk-memory' features enabled",
                 .{wasm.files.items(.data)[disallowed_feature >> 1].object.path},
@@ -1259,7 +1265,7 @@ fn validateFeatures(
 
         for ([_]types.Feature.Tag{ .atomics, .bulk_memory }) |feature| {
             if (!allowed[@intFromEnum(feature)]) {
-                var err = try wasm.base.addErrorWithNotes(0);
+                var err = try diags.addErrorWithNotes(0);
                 try err.addMsg("feature '{}' is not used but is required for shared-memory", .{feature});
             }
         }
@@ -1268,7 +1274,7 @@ fn validateFeatures(
     if (has_tls) {
         for ([_]types.Feature.Tag{ .atomics, .bulk_memory }) |feature| {
             if (!allowed[@intFromEnum(feature)]) {
-                var err = try wasm.base.addErrorWithNotes(0);
+                var err = try diags.addErrorWithNotes(0);
                 try err.addMsg("feature '{}' is not used but is required for thread-local storage", .{feature});
             }
         }
@@ -1282,7 +1288,7 @@ fn validateFeatures(
             // from here a feature is always used
             const disallowed_feature = disallowed[@intFromEnum(feature.tag)];
             if (@as(u1, @truncate(disallowed_feature)) != 0) {
-                var err = try wasm.base.addErrorWithNotes(2);
+                var err = try diags.addErrorWithNotes(2);
                 try err.addMsg("feature '{}' is disallowed, but used by linked object", .{feature.tag});
                 try err.addNote("disallowed by '{s}'", .{wasm.files.items(.data)[disallowed_feature >> 1].object.path});
                 try err.addNote("used in '{s}'", .{object.path});
@@ -1296,7 +1302,7 @@ fn validateFeatures(
         for (required, 0..) |required_feature, feature_index| {
             const is_required = @as(u1, @truncate(required_feature)) != 0;
             if (is_required and !object_used_features[feature_index]) {
-                var err = try wasm.base.addErrorWithNotes(2);
+                var err = try diags.addErrorWithNotes(2);
                 try err.addMsg("feature '{}' is required but not used in linked object", .{@as(types.Feature.Tag, @enumFromInt(feature_index))});
                 try err.addNote("required by '{s}'", .{wasm.files.items(.data)[required_feature >> 1].object.path});
                 try err.addNote("missing in '{s}'", .{object.path});
@@ -1364,6 +1370,7 @@ pub fn findGlobalSymbol(wasm: *Wasm, name: []const u8) ?SymbolLoc {
 
 fn checkUndefinedSymbols(wasm: *const Wasm) !void {
     const comp = wasm.base.comp;
+    const diags = &wasm.base.comp.link_diags;
     if (comp.config.output_mode == .Obj) return;
     if (wasm.import_symbols) return;
 
@@ -1377,7 +1384,7 @@ fn checkUndefinedSymbols(wasm: *const Wasm) !void {
             else
                 wasm.name;
             const symbol_name = undef.getName(wasm);
-            var err = try wasm.base.addErrorWithNotes(1);
+            var err = try diags.addErrorWithNotes(1);
             try err.addMsg("could not resolve undefined symbol '{s}'", .{symbol_name});
             try err.addNote("defined in '{s}'", .{file_name});
         }
@@ -1736,6 +1743,7 @@ fn sortDataSegments(wasm: *Wasm) !void {
 /// contain any parameters.
 fn setupInitFunctions(wasm: *Wasm) !void {
     const gpa = wasm.base.comp.gpa;
+    const diags = &wasm.base.comp.link_diags;
     // There's no constructors for Zig so we can simply search through linked object files only.
     for (wasm.objects.items) |file_index| {
         const object: Object = wasm.files.items(.data)[@intFromEnum(file_index)].object;
@@ -1751,7 +1759,7 @@ fn setupInitFunctions(wasm: *Wasm) !void {
                 break :ty object.func_types[func.type_index];
             };
             if (ty.params.len != 0) {
-                var err = try wasm.base.addErrorWithNotes(0);
+                var err = try diags.addErrorWithNotes(0);
                 try err.addMsg("constructor functions cannot take arguments: '{s}'", .{object.string_table.get(symbol.name)});
             }
             log.debug("appended init func '{s}'\n", .{object.string_table.get(symbol.name)});
@@ -2130,12 +2138,13 @@ fn mergeTypes(wasm: *Wasm) !void {
 
 fn checkExportNames(wasm: *Wasm) !void {
     const force_exp_names = wasm.export_symbol_names;
+    const diags = &wasm.base.comp.link_diags;
     if (force_exp_names.len > 0) {
         var failed_exports = false;
 
         for (force_exp_names) |exp_name| {
             const loc = wasm.findGlobalSymbol(exp_name) orelse {
-                var err = try wasm.base.addErrorWithNotes(0);
+                var err = try diags.addErrorWithNotes(0);
                 try err.addMsg("could not export '{s}', symbol not found", .{exp_name});
                 failed_exports = true;
                 continue;
@@ -2195,18 +2204,19 @@ fn setupExports(wasm: *Wasm) !void {
 
 fn setupStart(wasm: *Wasm) !void {
     const comp = wasm.base.comp;
+    const diags = &wasm.base.comp.link_diags;
     // do not export entry point if user set none or no default was set.
     const entry_name = wasm.entry_name orelse return;
 
     const symbol_loc = wasm.findGlobalSymbol(entry_name) orelse {
-        var err = try wasm.base.addErrorWithNotes(0);
+        var err = try diags.addErrorWithNotes(0);
         try err.addMsg("Entry symbol '{s}' missing, use '-fno-entry' to suppress", .{entry_name});
         return error.FlushFailure;
     };
 
     const symbol = symbol_loc.getSymbol(wasm);
     if (symbol.tag != .function) {
-        var err = try wasm.base.addErrorWithNotes(0);
+        var err = try diags.addErrorWithNotes(0);
         try err.addMsg("Entry symbol '{s}' is not a function", .{entry_name});
         return error.FlushFailure;
     }
@@ -2220,6 +2230,7 @@ fn setupStart(wasm: *Wasm) !void {
 /// Sets up the memory section of the wasm module, as well as the stack.
 fn setupMemory(wasm: *Wasm) !void {
     const comp = wasm.base.comp;
+    const diags = &wasm.base.comp.link_diags;
     const shared_memory = comp.config.shared_memory;
     log.debug("Setting up memory layout", .{});
     const page_size = std.wasm.page_size; // 64kb
@@ -2312,15 +2323,15 @@ fn setupMemory(wasm: *Wasm) !void {
 
     if (wasm.initial_memory) |initial_memory| {
         if (!std.mem.isAlignedGeneric(u64, initial_memory, page_size)) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg("Initial memory must be {d}-byte aligned", .{page_size});
         }
         if (memory_ptr > initial_memory) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg("Initial memory too small, must be at least {d} bytes", .{memory_ptr});
         }
         if (initial_memory > max_memory_allowed) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg("Initial memory exceeds maximum memory {d}", .{max_memory_allowed});
         }
         memory_ptr = initial_memory;
@@ -2338,15 +2349,15 @@ fn setupMemory(wasm: *Wasm) !void {
 
     if (wasm.max_memory) |max_memory| {
         if (!std.mem.isAlignedGeneric(u64, max_memory, page_size)) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg("Maximum memory must be {d}-byte aligned", .{page_size});
         }
         if (memory_ptr > max_memory) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg("Maximum memory too small, must be at least {d} bytes", .{memory_ptr});
         }
         if (max_memory > max_memory_allowed) {
-            var err = try wasm.base.addErrorWithNotes(0);
+            var err = try diags.addErrorWithNotes(0);
             try err.addMsg("Maximum memory exceeds maximum amount {d}", .{max_memory_allowed});
         }
         wasm.memories.limits.max = @as(u32, @intCast(max_memory / page_size));
@@ -2364,6 +2375,7 @@ fn setupMemory(wasm: *Wasm) !void {
 pub fn getMatchingSegment(wasm: *Wasm, file_index: File.Index, symbol_index: Symbol.Index) !u32 {
     const comp = wasm.base.comp;
     const gpa = comp.gpa;
+    const diags = &wasm.base.comp.link_diags;
     const obj_file = wasm.file(file_index).?;
     const symbol = obj_file.symbols()[@intFromEnum(symbol_index)];
     const index: u32 = @intCast(wasm.segments.items.len);
@@ -2450,7 +2462,7 @@ pub fn getMatchingSegment(wasm: *Wasm, file_index: File.Index, symbol_index: Sym
                     break :blk index;
                 };
             } else {
-                var err = try wasm.base.addErrorWithNotes(1);
+                var err = try diags.addErrorWithNotes(1);
                 try err.addMsg("found unknown section '{s}'", .{section_name});
                 try err.addNote("defined in '{s}'", .{obj_file.path()});
                 return error.UnexpectedValue;
@@ -2487,6 +2499,7 @@ pub fn flushModule(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
     defer tracy.end();
 
     const comp = wasm.base.comp;
+    const diags = &comp.link_diags;
     if (wasm.llvm_object) |llvm_object| {
         try wasm.base.emitLlvmObject(arena, llvm_object, prog_node);
         const use_lld = build_options.have_llvm and comp.config.use_lld;
@@ -2569,23 +2582,23 @@ pub fn flushModule(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
     if (wasm.zig_object_index != .null) {
         try wasm.resolveSymbolsInObject(wasm.zig_object_index);
     }
-    if (wasm.base.hasErrors()) return error.FlushFailure;
+    if (diags.hasErrors()) return error.FlushFailure;
     for (wasm.objects.items) |object_index| {
         try wasm.resolveSymbolsInObject(object_index);
     }
-    if (wasm.base.hasErrors()) return error.FlushFailure;
+    if (diags.hasErrors()) return error.FlushFailure;
 
     var emit_features_count: u32 = 0;
     var enabled_features: [@typeInfo(types.Feature.Tag).@"enum".fields.len]bool = undefined;
     try wasm.validateFeatures(&enabled_features, &emit_features_count);
     try wasm.resolveSymbolsInArchives();
-    if (wasm.base.hasErrors()) return error.FlushFailure;
+    if (diags.hasErrors()) return error.FlushFailure;
     try wasm.resolveLazySymbols();
     try wasm.checkUndefinedSymbols();
     try wasm.checkExportNames();
 
     try wasm.setupInitFunctions();
-    if (wasm.base.hasErrors()) return error.FlushFailure;
+    if (diags.hasErrors()) return error.FlushFailure;
     try wasm.setupStart();
 
     try wasm.markReferences();
@@ -2594,7 +2607,7 @@ pub fn flushModule(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
     try wasm.mergeTypes();
     try wasm.allocateAtoms();
     try wasm.setupMemory();
-    if (wasm.base.hasErrors()) return error.FlushFailure;
+    if (diags.hasErrors()) return error.FlushFailure;
     wasm.allocateVirtualAddresses();
     wasm.mapFunctionTable();
     try wasm.initializeCallCtorsFunction();
@@ -2604,7 +2617,7 @@ pub fn flushModule(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_no
     try wasm.setupStartSection();
     try wasm.setupExports();
     try wasm.writeToFile(enabled_features, emit_features_count, arena);
-    if (wasm.base.hasErrors()) return error.FlushFailure;
+    if (diags.hasErrors()) return error.FlushFailure;
 }
 
 /// Writes the WebAssembly in-memory module to the file
@@ -2615,6 +2628,7 @@ fn writeToFile(
     arena: Allocator,
 ) !void {
     const comp = wasm.base.comp;
+    const diags = &comp.link_diags;
     const gpa = comp.gpa;
     const use_llvm = comp.config.use_llvm;
     const use_lld = build_options.have_llvm and comp.config.use_lld;
@@ -3003,7 +3017,7 @@ fn writeToFile(
                 try emitBuildIdSection(&binary_bytes, str);
             },
             else => |mode| {
-                var err = try wasm.base.addErrorWithNotes(0);
+                var err = try diags.addErrorWithNotes(0);
                 try err.addMsg("build-id '{s}' is not supported for WebAssembly", .{@tagName(mode)});
             },
         }
@@ -3684,7 +3698,8 @@ fn linkWithLLD(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: 
                 switch (term) {
                     .Exited => |code| {
                         if (code != 0) {
-                            comp.lockAndParseLldStderr(linker_command, stderr);
+                            const diags = &comp.link_diags;
+                            diags.lockAndParseLldStderr(linker_command, stderr);
                             return error.LLDReportedFailure;
                         }
                     },


### PR DESCRIPTION
By organizing linker diagnostics into this struct, it becomes possible to share more code between linker backends, and more importantly it becomes possible to pass only the Diag struct to some functions, rather than passing the entire linker state object in. This makes data dependencies more obvious, making it easier to rearrange code and to multithread.

Also fix MachO code abusing an atomic variable. Not only was it using the wrong atomic operation, it is unnecessary additional state since the state is already being protected by a mutex.

This is only one commit, based on #21666.