### PR TITLE
link.Elf: eliminate an O(N^2) algorithm in flush()

### DIFF
--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -1179,13 +1179,10 @@ fn ElfFile(comptime is_64: bool) type {
                                     @memcpy(data, src_data);
 
                                     const defs = @as([*]elf.Verdef, @ptrCast(data))[0 .. @as(usize, @intCast(src.sh_size)) / @sizeOf(elf.Verdef)];
-                                    for (defs) |*def| {
-                                        // Original author of this next line had elf.SHN_UNDEF
-                                        // here which does not make sense given that this field
-                                        // is elf.VER_NDX
-                                        if (def.ndx != .LOCAL)
-                                            def.ndx = @enumFromInt(sections_update[src.sh_info].remap_idx);
-                                    }
+                                    for (defs) |*def| switch (def.ndx) {
+                                        .LOCAL, .GLOBAL => {},
+                                        else => def.ndx = @enumFromInt(sections_update[src.sh_info].remap_idx),
+                                    };
 
                                     break :dst_data data;
                                 },

--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -832,7 +832,6 @@ fn ElfFile(comptime is_64: bool) type {
     const Elf_Shdr = if (is_64) elf.Elf64_Shdr else elf.Elf32_Shdr;
     const Elf_Chdr = if (is_64) elf.Elf64_Chdr else elf.Elf32_Chdr;
     const Elf_Sym = if (is_64) elf.Elf64_Sym else elf.Elf32_Sym;
-    const Elf_Verdef = if (is_64) elf.Elf64_Verdef else elf.Elf32_Verdef;
     const Elf_OffSize = if (is_64) elf.Elf64_Off else elf.Elf32_Off;
 
     return struct {
@@ -1179,10 +1178,13 @@ fn ElfFile(comptime is_64: bool) type {
                                     const data = try allocator.alignedAlloc(u8, section_memory_align, src_data.len);
                                     @memcpy(data, src_data);
 
-                                    const defs = @as([*]Elf_Verdef, @ptrCast(data))[0 .. @as(usize, @intCast(src.sh_size)) / @sizeOf(Elf_Verdef)];
+                                    const defs = @as([*]elf.Verdef, @ptrCast(data))[0 .. @as(usize, @intCast(src.sh_size)) / @sizeOf(elf.Verdef)];
                                     for (defs) |*def| {
-                                        if (def.vd_ndx != elf.SHN_UNDEF)
-                                            def.vd_ndx = sections_update[src.sh_info].remap_idx;
+                                        // Original author of this next line had elf.SHN_UNDEF
+                                        // here which does not make sense given that this field
+                                        // is elf.VER_NDX
+                                        if (def.ndx != .LOCAL)
+                                            def.ndx = @enumFromInt(sections_update[src.sh_info].remap_idx);
                                     }
 
                                     break :dst_data data;

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -150,6 +150,14 @@ pub const File = struct {
         inode: fs.File.INode,
         size: u64,
         mtime: i128,
+
+        pub fn fromFs(fs_stat: fs.File.Stat) Stat {
+            return .{
+                .inode = fs_stat.inode,
+                .size = fs_stat.size,
+                .mtime = fs_stat.mtime,
+            };
+        }
     };
 
     pub fn deinit(self: *File, gpa: Allocator) void {

--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -141,7 +141,7 @@ pub const ElfDynLib = struct {
     strings: [*:0]u8,
     syms: [*]elf.Sym,
     hashtab: [*]posix.Elf_Symndx,
-    versym: ?[*]u16,
+    versym: ?[*]elf.Versym,
     verdef: ?*elf.Verdef,
     memory: []align(mem.page_size) u8,
 
@@ -319,7 +319,7 @@ pub const ElfDynLib = struct {
         var maybe_strings: ?[*:0]u8 = null;
         var maybe_syms: ?[*]elf.Sym = null;
         var maybe_hashtab: ?[*]posix.Elf_Symndx = null;
-        var maybe_versym: ?[*]u16 = null;
+        var maybe_versym: ?[*]elf.Versym = null;
         var maybe_verdef: ?*elf.Verdef = null;
 
         {
@@ -327,11 +327,11 @@ pub const ElfDynLib = struct {
             while (dynv[i] != 0) : (i += 2) {
                 const p = base + dynv[i + 1];
                 switch (dynv[i]) {
-                    elf.DT_STRTAB => maybe_strings = @as([*:0]u8, @ptrFromInt(p)),
-                    elf.DT_SYMTAB => maybe_syms = @as([*]elf.Sym, @ptrFromInt(p)),
-                    elf.DT_HASH => maybe_hashtab = @as([*]posix.Elf_Symndx, @ptrFromInt(p)),
-                    elf.DT_VERSYM => maybe_versym = @as([*]u16, @ptrFromInt(p)),
-                    elf.DT_VERDEF => maybe_verdef = @as(*elf.Verdef, @ptrFromInt(p)),
+                    elf.DT_STRTAB => maybe_strings = @ptrFromInt(p),
+                    elf.DT_SYMTAB => maybe_syms = @ptrFromInt(p),
+                    elf.DT_HASH => maybe_hashtab = @ptrFromInt(p),
+                    elf.DT_VERSYM => maybe_versym = @ptrFromInt(p),
+                    elf.DT_VERDEF => maybe_verdef = @ptrFromInt(p),
                     else => {},
                 }
             }
@@ -399,18 +399,16 @@ pub const ElfDynLib = struct {
     }
 };
 
-fn checkver(def_arg: *elf.Verdef, vsym_arg: i32, vername: []const u8, strings: [*:0]u8) bool {
+fn checkver(def_arg: *elf.Verdef, vsym_arg: elf.Versym, vername: []const u8, strings: [*:0]u8) bool {
     var def = def_arg;
-    const vsym = @as(u32, @bitCast(vsym_arg)) & 0x7fff;
+    const vsym_index = vsym_arg.VERSION;
     while (true) {
-        if (0 == (def.vd_flags & elf.VER_FLG_BASE) and (def.vd_ndx & 0x7fff) == vsym)
-            break;
-        if (def.vd_next == 0)
-            return false;
-        def = @as(*elf.Verdef, @ptrFromInt(@intFromPtr(def) + def.vd_next));
+        if (0 == (def.flags & elf.VER_FLG_BASE) and @intFromEnum(def.ndx) == vsym_index) break;
+        if (def.next == 0) return false;
+        def = @ptrFromInt(@intFromPtr(def) + def.next);
     }
-    const aux = @as(*elf.Verdaux, @ptrFromInt(@intFromPtr(def) + def.vd_aux));
-    return mem.eql(u8, vername, mem.sliceTo(strings + aux.vda_name, 0));
+    const aux: *elf.Verdaux = @ptrFromInt(@intFromPtr(def) + def.aux);
+    return mem.eql(u8, vername, mem.sliceTo(strings + aux.name, 0));
 }
 
 test "ElfDynLib" {

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -258,17 +258,26 @@ pub const DF_1_SINGLETON = 0x02000000;
 pub const DF_1_STUB = 0x04000000;
 pub const DF_1_PIE = 0x08000000;
 
-pub const VERSYM_HIDDEN = 0x8000;
-pub const VERSYM_VERSION = 0x7fff;
+pub const Versym = packed struct(u16) {
+    VERSION: u15,
+    HIDDEN: bool,
 
-/// Symbol is local
-pub const VER_NDX_LOCAL = 0;
-/// Symbol is global
-pub const VER_NDX_GLOBAL = 1;
-/// Beginning of reserved entries
-pub const VER_NDX_LORESERVE = 0xff00;
-/// Symbol is to be eliminated
-pub const VER_NDX_ELIMINATE = 0xff01;
+    pub const LOCAL: Versym = @bitCast(@intFromEnum(VER_NDX.LOCAL));
+    pub const GLOBAL: Versym = @bitCast(@intFromEnum(VER_NDX.GLOBAL));
+};
+
+pub const VER_NDX = enum(u16) {
+    /// Symbol is local
+    LOCAL = 0,
+    /// Symbol is global
+    GLOBAL = 1,
+    /// Beginning of reserved entries
+    LORESERVE = 0xff00,
+    /// Symbol is to be eliminated
+    ELIMINATE = 0xff01,
+    UNSPECIFIED = 0xffff,
+    _,
+};
 
 /// Version definition of the file itself
 pub const VER_FLG_BASE = 1;
@@ -698,12 +707,9 @@ pub const EI_PAD = 9;
 
 pub const EI_NIDENT = 16;
 
-pub const Elf32_Half = u16;
-pub const Elf64_Half = u16;
-pub const Elf32_Word = u32;
-pub const Elf32_Sword = i32;
-pub const Elf64_Word = u32;
-pub const Elf64_Sword = i32;
+pub const Half = u16;
+pub const Word = u32;
+pub const Sword = i32;
 pub const Elf32_Xword = u64;
 pub const Elf32_Sxword = i64;
 pub const Elf64_Xword = u64;
@@ -714,53 +720,51 @@ pub const Elf32_Off = u32;
 pub const Elf64_Off = u64;
 pub const Elf32_Section = u16;
 pub const Elf64_Section = u16;
-pub const Elf32_Versym = Elf32_Half;
-pub const Elf64_Versym = Elf64_Half;
 pub const Elf32_Ehdr = extern struct {
     e_ident: [EI_NIDENT]u8,
     e_type: ET,
     e_machine: EM,
-    e_version: Elf32_Word,
+    e_version: Word,
     e_entry: Elf32_Addr,
     e_phoff: Elf32_Off,
     e_shoff: Elf32_Off,
-    e_flags: Elf32_Word,
-    e_ehsize: Elf32_Half,
-    e_phentsize: Elf32_Half,
-    e_phnum: Elf32_Half,
-    e_shentsize: Elf32_Half,
-    e_shnum: Elf32_Half,
-    e_shstrndx: Elf32_Half,
+    e_flags: Word,
+    e_ehsize: Half,
+    e_phentsize: Half,
+    e_phnum: Half,
+    e_shentsize: Half,
+    e_shnum: Half,
+    e_shstrndx: Half,
 };
 pub const Elf64_Ehdr = extern struct {
     e_ident: [EI_NIDENT]u8,
     e_type: ET,
     e_machine: EM,
-    e_version: Elf64_Word,
+    e_version: Word,
     e_entry: Elf64_Addr,
     e_phoff: Elf64_Off,
     e_shoff: Elf64_Off,
-    e_flags: Elf64_Word,
-    e_ehsize: Elf64_Half,
-    e_phentsize: Elf64_Half,
-    e_phnum: Elf64_Half,
-    e_shentsize: Elf64_Half,
-    e_shnum: Elf64_Half,
-    e_shstrndx: Elf64_Half,
+    e_flags: Word,
+    e_ehsize: Half,
+    e_phentsize: Half,
+    e_phnum: Half,
+    e_shentsize: Half,
+    e_shnum: Half,
+    e_shstrndx: Half,
 };
 pub const Elf32_Phdr = extern struct {
-    p_type: Elf32_Word,
+    p_type: Word,
     p_offset: Elf32_Off,
     p_vaddr: Elf32_Addr,
     p_paddr: Elf32_Addr,
-    p_filesz: Elf32_Word,
-    p_memsz: Elf32_Word,
-    p_flags: Elf32_Word,
-    p_align: Elf32_Word,
+    p_filesz: Word,
+    p_memsz: Word,
+    p_flags: Word,
+    p_align: Word,
 };
 pub const Elf64_Phdr = extern struct {
-    p_type: Elf64_Word,
-    p_flags: Elf64_Word,
+    p_type: Word,
+    p_flags: Word,
     p_offset: Elf64_Off,
     p_vaddr: Elf64_Addr,
     p_paddr: Elf64_Addr,
@@ -769,44 +773,44 @@ pub const Elf64_Phdr = extern struct {
     p_align: Elf64_Xword,
 };
 pub const Elf32_Shdr = extern struct {
-    sh_name: Elf32_Word,
-    sh_type: Elf32_Word,
-    sh_flags: Elf32_Word,
+    sh_name: Word,
+    sh_type: Word,
+    sh_flags: Word,
     sh_addr: Elf32_Addr,
     sh_offset: Elf32_Off,
-    sh_size: Elf32_Word,
-    sh_link: Elf32_Word,
-    sh_info: Elf32_Word,
-    sh_addralign: Elf32_Word,
-    sh_entsize: Elf32_Word,
+    sh_size: Word,
+    sh_link: Word,
+    sh_info: Word,
+    sh_addralign: Word,
+    sh_entsize: Word,
 };
 pub const Elf64_Shdr = extern struct {
-    sh_name: Elf64_Word,
-    sh_type: Elf64_Word,
+    sh_name: Word,
+    sh_type: Word,
     sh_flags: Elf64_Xword,
     sh_addr: Elf64_Addr,
     sh_offset: Elf64_Off,
     sh_size: Elf64_Xword,
-    sh_link: Elf64_Word,
-    sh_info: Elf64_Word,
+    sh_link: Word,
+    sh_info: Word,
     sh_addralign: Elf64_Xword,
     sh_entsize: Elf64_Xword,
 };
 pub const Elf32_Chdr = extern struct {
     ch_type: COMPRESS,
-    ch_size: Elf32_Word,
-    ch_addralign: Elf32_Word,
+    ch_size: Word,
+    ch_addralign: Word,
 };
 pub const Elf64_Chdr = extern struct {
     ch_type: COMPRESS,
-    ch_reserved: Elf64_Word = 0,
+    ch_reserved: Word = 0,
     ch_size: Elf64_Xword,
     ch_addralign: Elf64_Xword,
 };
 pub const Elf32_Sym = extern struct {
-    st_name: Elf32_Word,
+    st_name: Word,
     st_value: Elf32_Addr,
-    st_size: Elf32_Word,
+    st_size: Word,
     st_info: u8,
     st_other: u8,
     st_shndx: Elf32_Section,
@@ -819,7 +823,7 @@ pub const Elf32_Sym = extern struct {
     }
 };
 pub const Elf64_Sym = extern struct {
-    st_name: Elf64_Word,
+    st_name: Word,
     st_info: u8,
     st_other: u8,
     st_shndx: Elf64_Section,
@@ -834,16 +838,16 @@ pub const Elf64_Sym = extern struct {
     }
 };
 pub const Elf32_Syminfo = extern struct {
-    si_boundto: Elf32_Half,
-    si_flags: Elf32_Half,
+    si_boundto: Half,
+    si_flags: Half,
 };
 pub const Elf64_Syminfo = extern struct {
-    si_boundto: Elf64_Half,
-    si_flags: Elf64_Half,
+    si_boundto: Half,
+    si_flags: Half,
 };
 pub const Elf32_Rel = extern struct {
     r_offset: Elf32_Addr,
-    r_info: Elf32_Word,
+    r_info: Word,
 
     pub inline fn r_sym(self: @This()) u24 {
         return @truncate(self.r_info >> 8);
@@ -865,8 +869,8 @@ pub const Elf64_Rel = extern struct {
 };
 pub const Elf32_Rela = extern struct {
     r_offset: Elf32_Addr,
-    r_info: Elf32_Word,
-    r_addend: Elf32_Sword,
+    r_info: Word,
+    r_addend: Sword,
 
     pub inline fn r_sym(self: @This()) u24 {
         return @truncate(self.r_info >> 8);
@@ -887,69 +891,49 @@ pub const Elf64_Rela = extern struct {
         return @truncate(self.r_info);
     }
 };
-pub const Elf32_Relr = Elf32_Word;
+pub const Elf32_Relr = Word;
 pub const Elf64_Relr = Elf64_Xword;
 pub const Elf32_Dyn = extern struct {
-    d_tag: Elf32_Sword,
+    d_tag: Sword,
     d_val: Elf32_Addr,
 };
 pub const Elf64_Dyn = extern struct {
     d_tag: Elf64_Sxword,
     d_val: Elf64_Addr,
 };
-pub const Elf32_Verdef = extern struct {
-    vd_version: Elf32_Half,
-    vd_flags: Elf32_Half,
-    vd_ndx: Elf32_Half,
-    vd_cnt: Elf32_Half,
-    vd_hash: Elf32_Word,
-    vd_aux: Elf32_Word,
-    vd_next: Elf32_Word,
+pub const Verdef = extern struct {
+    version: Half,
+    flags: Half,
+    ndx: VER_NDX,
+    cnt: Half,
+    hash: Word,
+    aux: Word,
+    next: Word,
 };
-pub const Elf64_Verdef = extern struct {
-    vd_version: Elf64_Half,
-    vd_flags: Elf64_Half,
-    vd_ndx: Elf64_Half,
-    vd_cnt: Elf64_Half,
-    vd_hash: Elf64_Word,
-    vd_aux: Elf64_Word,
-    vd_next: Elf64_Word,
-};
-pub const Elf32_Verdaux = extern struct {
-    vda_name: Elf32_Word,
-    vda_next: Elf32_Word,
-};
-pub const Elf64_Verdaux = extern struct {
-    vda_name: Elf64_Word,
-    vda_next: Elf64_Word,
+pub const Verdaux = extern struct {
+    name: Word,
+    next: Word,
 };
 pub const Elf32_Verneed = extern struct {
-    vn_version: Elf32_Half,
-    vn_cnt: Elf32_Half,
-    vn_file: Elf32_Word,
-    vn_aux: Elf32_Word,
-    vn_next: Elf32_Word,
+    vn_version: Half,
+    vn_cnt: Half,
+    vn_file: Word,
+    vn_aux: Word,
+    vn_next: Word,
 };
 pub const Elf64_Verneed = extern struct {
-    vn_version: Elf64_Half,
-    vn_cnt: Elf64_Half,
-    vn_file: Elf64_Word,
-    vn_aux: Elf64_Word,
-    vn_next: Elf64_Word,
+    vn_version: Half,
+    vn_cnt: Half,
+    vn_file: Word,
+    vn_aux: Word,
+    vn_next: Word,
 };
-pub const Elf32_Vernaux = extern struct {
-    vna_hash: Elf32_Word,
-    vna_flags: Elf32_Half,
-    vna_other: Elf32_Half,
-    vna_name: Elf32_Word,
-    vna_next: Elf32_Word,
-};
-pub const Elf64_Vernaux = extern struct {
-    vna_hash: Elf64_Word,
-    vna_flags: Elf64_Half,
-    vna_other: Elf64_Half,
-    vna_name: Elf64_Word,
-    vna_next: Elf64_Word,
+pub const Vernaux = extern struct {
+    hash: Word,
+    flags: Half,
+    other: Half,
+    name: Word,
+    next: Word,
 };
 pub const Elf32_auxv_t = extern struct {
     a_type: u32,
@@ -964,81 +948,81 @@ pub const Elf64_auxv_t = extern struct {
     },
 };
 pub const Elf32_Nhdr = extern struct {
-    n_namesz: Elf32_Word,
-    n_descsz: Elf32_Word,
-    n_type: Elf32_Word,
+    n_namesz: Word,
+    n_descsz: Word,
+    n_type: Word,
 };
 pub const Elf64_Nhdr = extern struct {
-    n_namesz: Elf64_Word,
-    n_descsz: Elf64_Word,
-    n_type: Elf64_Word,
+    n_namesz: Word,
+    n_descsz: Word,
+    n_type: Word,
 };
 pub const Elf32_Move = extern struct {
     m_value: Elf32_Xword,
-    m_info: Elf32_Word,
-    m_poffset: Elf32_Word,
-    m_repeat: Elf32_Half,
-    m_stride: Elf32_Half,
+    m_info: Word,
+    m_poffset: Word,
+    m_repeat: Half,
+    m_stride: Half,
 };
 pub const Elf64_Move = extern struct {
     m_value: Elf64_Xword,
     m_info: Elf64_Xword,
     m_poffset: Elf64_Xword,
-    m_repeat: Elf64_Half,
-    m_stride: Elf64_Half,
+    m_repeat: Half,
+    m_stride: Half,
 };
 pub const Elf32_gptab = extern union {
     gt_header: extern struct {
-        gt_current_g_value: Elf32_Word,
-        gt_unused: Elf32_Word,
+        gt_current_g_value: Word,
+        gt_unused: Word,
     },
     gt_entry: extern struct {
-        gt_g_value: Elf32_Word,
-        gt_bytes: Elf32_Word,
+        gt_g_value: Word,
+        gt_bytes: Word,
     },
 };
 pub const Elf32_RegInfo = extern struct {
-    ri_gprmask: Elf32_Word,
-    ri_cprmask: [4]Elf32_Word,
-    ri_gp_value: Elf32_Sword,
+    ri_gprmask: Word,
+    ri_cprmask: [4]Word,
+    ri_gp_value: Sword,
 };
 pub const Elf_Options = extern struct {
     kind: u8,
     size: u8,
     section: Elf32_Section,
-    info: Elf32_Word,
+    info: Word,
 };
 pub const Elf_Options_Hw = extern struct {
-    hwp_flags1: Elf32_Word,
-    hwp_flags2: Elf32_Word,
+    hwp_flags1: Word,
+    hwp_flags2: Word,
 };
 pub const Elf32_Lib = extern struct {
-    l_name: Elf32_Word,
-    l_time_stamp: Elf32_Word,
-    l_checksum: Elf32_Word,
-    l_version: Elf32_Word,
-    l_flags: Elf32_Word,
+    l_name: Word,
+    l_time_stamp: Word,
+    l_checksum: Word,
+    l_version: Word,
+    l_flags: Word,
 };
 pub const Elf64_Lib = extern struct {
-    l_name: Elf64_Word,
-    l_time_stamp: Elf64_Word,
-    l_checksum: Elf64_Word,
-    l_version: Elf64_Word,
-    l_flags: Elf64_Word,
+    l_name: Word,
+    l_time_stamp: Word,
+    l_checksum: Word,
+    l_version: Word,
+    l_flags: Word,
 };
 pub const Elf32_Conflict = Elf32_Addr;
 pub const Elf_MIPS_ABIFlags_v0 = extern struct {
-    version: Elf32_Half,
+    version: Half,
     isa_level: u8,
     isa_rev: u8,
     gpr_size: u8,
     cpr1_size: u8,
     cpr2_size: u8,
     fp_abi: u8,
-    isa_ext: Elf32_Word,
-    ases: Elf32_Word,
-    flags1: Elf32_Word,
-    flags2: Elf32_Word,
+    isa_ext: Word,
+    ases: Word,
+    flags1: Word,
+    flags2: Word,
 };
 
 comptime {
@@ -1102,22 +1086,11 @@ pub const Sym = switch (@sizeOf(usize)) {
     8 => Elf64_Sym,
     else => @compileError("expected pointer size of 32 or 64"),
 };
-pub const Verdef = switch (@sizeOf(usize)) {
-    4 => Elf32_Verdef,
-    8 => Elf64_Verdef,
-    else => @compileError("expected pointer size of 32 or 64"),
-};
-pub const Verdaux = switch (@sizeOf(usize)) {
-    4 => Elf32_Verdaux,
-    8 => Elf64_Verdaux,
-    else => @compileError("expected pointer size of 32 or 64"),
-};
 pub const Addr = switch (@sizeOf(usize)) {
     4 => Elf32_Addr,
     8 => Elf64_Addr,
     else => @compileError("expected pointer size of 32 or 64"),
 };
-pub const Half = u16;
 
 pub const OSABI = enum(u8) {
     /// UNIX System V ABI

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1002,6 +1002,7 @@ const CacheUse = union(CacheMode) {
 pub const LinkObject = struct {
     path: Path,
     must_link: bool = false,
+    needed: bool = false,
     // When the library is passed via a positional argument, it will be
     // added as a full path. If it's `-l<lib>`, then just the basename.
     //
@@ -2561,6 +2562,7 @@ fn addNonIncrementalStuffToCacheManifest(
     for (comp.objects) |obj| {
         _ = try man.addFilePath(obj.path, null);
         man.hash.add(obj.must_link);
+        man.hash.add(obj.needed);
         man.hash.add(obj.loption);
     }
 

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -592,6 +592,7 @@ fn reportUndefined(
     const file_ptr = self.file(elf_file).?;
     const rel_esym = switch (file_ptr) {
         .zig_object => |x| x.symbol(rel.r_sym()).elfSym(elf_file),
+        .shared_object => |so| so.parsed.symtab[rel.r_sym()],
         inline else => |x| x.symtab.items[rel.r_sym()],
     };
     const esym = sym.elfSym(elf_file);

--- a/src/link/Elf/SharedObject.zig
+++ b/src/link/Elf/SharedObject.zig
@@ -1,236 +1,316 @@
 path: Path,
 index: File.Index,
 
-header: ?elf.Elf64_Ehdr = null,
-shdrs: std.ArrayListUnmanaged(elf.Elf64_Shdr) = .empty,
+parsed: Parsed,
 
-symtab: std.ArrayListUnmanaged(elf.Elf64_Sym) = .empty,
-strtab: std.ArrayListUnmanaged(u8) = .empty,
-/// Version symtab contains version strings of the symbols if present.
-versyms: std.ArrayListUnmanaged(elf.Elf64_Versym) = .empty,
-verstrings: std.ArrayListUnmanaged(u32) = .empty,
+symbols: std.ArrayListUnmanaged(Symbol),
+symbols_extra: std.ArrayListUnmanaged(u32),
+symbols_resolver: std.ArrayListUnmanaged(Elf.SymbolResolver.Index),
 
-symbols: std.ArrayListUnmanaged(Symbol) = .empty,
-symbols_extra: std.ArrayListUnmanaged(u32) = .empty,
-symbols_resolver: std.ArrayListUnmanaged(Elf.SymbolResolver.Index) = .empty,
-
-aliases: ?std.ArrayListUnmanaged(u32) = null,
-dynamic_table: std.ArrayListUnmanaged(elf.Elf64_Dyn) = .empty,
+aliases: ?std.ArrayListUnmanaged(u32),
 
 needed: bool,
 alive: bool,
 
-output_symtab_ctx: Elf.SymtabCtx = .{},
+output_symtab_ctx: Elf.SymtabCtx,
 
-pub fn isSharedObject(path: Path) !bool {
-    const file = try path.root_dir.handle.openFile(path.sub_path, .{});
-    defer file.close();
-    const reader = file.reader();
-    const header = reader.readStruct(elf.Elf64_Ehdr) catch return false;
-    if (!mem.eql(u8, header.e_ident[0..4], "\x7fELF")) return false;
-    if (header.e_ident[elf.EI_VERSION] != 1) return false;
-    if (header.e_type != elf.ET.DYN) return false;
-    return true;
+pub fn deinit(so: *SharedObject, gpa: Allocator) void {
+    gpa.free(so.path.sub_path);
+    so.parsed.deinit(gpa);
+    so.symbols.deinit(gpa);
+    so.symbols_extra.deinit(gpa);
+    so.symbols_resolver.deinit(gpa);
+    if (so.aliases) |*aliases| aliases.deinit(gpa);
+    so.* = undefined;
 }
 
-pub fn deinit(self: *SharedObject, allocator: Allocator) void {
-    allocator.free(self.path.sub_path);
-    self.shdrs.deinit(allocator);
-    self.symtab.deinit(allocator);
-    self.strtab.deinit(allocator);
-    self.versyms.deinit(allocator);
-    self.verstrings.deinit(allocator);
-    self.symbols.deinit(allocator);
-    self.symbols_extra.deinit(allocator);
-    self.symbols_resolver.deinit(allocator);
-    if (self.aliases) |*aliases| aliases.deinit(allocator);
-    self.dynamic_table.deinit(allocator);
-}
+pub const Header = struct {
+    dynamic_table: []const elf.Elf64_Dyn,
+    soname_index: ?u32,
+    verdefnum: ?u32,
 
-pub fn parse(self: *SharedObject, elf_file: *Elf, handle: std.fs.File) !void {
-    const comp = elf_file.base.comp;
-    const gpa = comp.gpa;
-    const file_size = (try handle.stat()).size;
+    sections: []const elf.Elf64_Shdr,
+    dynsym_sect_index: ?u32,
+    versym_sect_index: ?u32,
+    verdef_sect_index: ?u32,
 
-    const header_buffer = try Elf.preadAllAlloc(gpa, handle, 0, @sizeOf(elf.Elf64_Ehdr));
-    defer gpa.free(header_buffer);
-    self.header = @as(*align(1) const elf.Elf64_Ehdr, @ptrCast(header_buffer)).*;
+    stat: Stat,
+    strtab: std.ArrayListUnmanaged(u8),
 
-    const em = elf_file.base.comp.root_mod.resolved_target.result.toElfMachine();
-    if (em != self.header.?.e_machine) {
-        return elf_file.failFile(self.index, "invalid ELF machine type: {s}", .{
-            @tagName(self.header.?.e_machine),
-        });
+    pub fn deinit(header: *Header, gpa: Allocator) void {
+        gpa.free(header.sections);
+        gpa.free(header.dynamic_table);
+        header.strtab.deinit(gpa);
+        header.* = undefined;
     }
 
-    const shoff = std.math.cast(usize, self.header.?.e_shoff) orelse return error.Overflow;
-    const shnum = std.math.cast(usize, self.header.?.e_shnum) orelse return error.Overflow;
-    const shsize = shnum * @sizeOf(elf.Elf64_Shdr);
-    if (file_size < shoff or file_size < shoff + shsize) {
-        return elf_file.failFile(self.index, "corrupted header: section header table extends past the end of file", .{});
+    pub fn soname(header: Header) ?[]const u8 {
+        const i = header.soname_index orelse return null;
+        return Elf.stringTableLookup(header.strtab.items, i);
+    }
+};
+
+pub const Parsed = struct {
+    stat: Stat,
+    strtab: []const u8,
+    soname_index: ?u32,
+    sections: []const elf.Elf64_Shdr,
+
+    /// Nonlocal symbols only.
+    symtab: []const elf.Elf64_Sym,
+    /// Version symtab contains version strings of the symbols if present.
+    /// Nonlocal symbols only.
+    versyms: []const elf.Versym,
+    /// Nonlocal symbols only.
+    symbols: []const Parsed.Symbol,
+
+    verstrings: []const u32,
+
+    const Symbol = struct {
+        mangled_name: u32,
+    };
+
+    pub fn deinit(p: *Parsed, gpa: Allocator) void {
+        gpa.free(p.strtab);
+        gpa.free(p.symtab);
+        gpa.free(p.versyms);
+        gpa.free(p.symbols);
+        gpa.free(p.verstrings);
+        p.* = undefined;
     }
 
-    const shdrs_buffer = try Elf.preadAllAlloc(gpa, handle, shoff, shsize);
-    defer gpa.free(shdrs_buffer);
-    const shdrs = @as([*]align(1) const elf.Elf64_Shdr, @ptrCast(shdrs_buffer.ptr))[0..shnum];
-    try self.shdrs.appendUnalignedSlice(gpa, shdrs);
+    pub fn versionString(p: Parsed, index: elf.Versym) [:0]const u8 {
+        return versionStringLookup(p.strtab, p.verstrings, index);
+    }
+
+    pub fn soname(p: Parsed) ?[]const u8 {
+        const i = p.soname_index orelse return null;
+        return Elf.stringTableLookup(p.strtab, i);
+    }
+};
+
+pub fn parseHeader(
+    gpa: Allocator,
+    diags: *Diags,
+    file_path: Path,
+    fs_file: std.fs.File,
+    stat: Stat,
+    target: std.Target,
+) !Header {
+    var ehdr: elf.Elf64_Ehdr = undefined;
+    {
+        const buf = mem.asBytes(&ehdr);
+        const amt = try fs_file.preadAll(buf, 0);
+        if (amt != buf.len) return error.UnexpectedEndOfFile;
+    }
+    if (!mem.eql(u8, ehdr.e_ident[0..4], "\x7fELF")) return error.BadMagic;
+    if (ehdr.e_ident[elf.EI_VERSION] != 1) return error.BadElfVersion;
+    if (ehdr.e_type != elf.ET.DYN) return error.NotSharedObject;
+
+    if (target.toElfMachine() != ehdr.e_machine)
+        return diags.failParse(file_path, "invalid ELF machine type: {s}", .{@tagName(ehdr.e_machine)});
+
+    const shoff = std.math.cast(usize, ehdr.e_shoff) orelse return error.Overflow;
+    const shnum = std.math.cast(u32, ehdr.e_shnum) orelse return error.Overflow;
+
+    const sections = try gpa.alloc(elf.Elf64_Shdr, shnum);
+    errdefer gpa.free(sections);
+    {
+        const buf = mem.sliceAsBytes(sections);
+        const amt = try fs_file.preadAll(buf, shoff);
+        if (amt != buf.len) return error.UnexpectedEndOfFile;
+    }
 
     var dynsym_sect_index: ?u32 = null;
     var dynamic_sect_index: ?u32 = null;
     var versym_sect_index: ?u32 = null;
     var verdef_sect_index: ?u32 = null;
-    for (self.shdrs.items, 0..) |shdr, i| {
-        if (shdr.sh_type != elf.SHT_NOBITS) {
-            if (file_size < shdr.sh_offset or file_size < shdr.sh_offset + shdr.sh_size) {
-                return elf_file.failFile(self.index, "corrupted section header", .{});
-            }
-        }
+    for (sections, 0..) |shdr, i_usize| {
+        const i: u32 = @intCast(i_usize);
         switch (shdr.sh_type) {
-            elf.SHT_DYNSYM => dynsym_sect_index = @intCast(i),
-            elf.SHT_DYNAMIC => dynamic_sect_index = @intCast(i),
-            elf.SHT_GNU_VERSYM => versym_sect_index = @intCast(i),
-            elf.SHT_GNU_VERDEF => verdef_sect_index = @intCast(i),
-            else => {},
+            elf.SHT_DYNSYM => dynsym_sect_index = i,
+            elf.SHT_DYNAMIC => dynamic_sect_index = i,
+            elf.SHT_GNU_VERSYM => versym_sect_index = i,
+            elf.SHT_GNU_VERDEF => verdef_sect_index = i,
+            else => continue,
         }
     }
 
-    if (dynamic_sect_index) |index| {
-        const shdr = self.shdrs.items[index];
-        const raw = try Elf.preadAllAlloc(gpa, handle, shdr.sh_offset, shdr.sh_size);
-        defer gpa.free(raw);
-        const num = @divExact(raw.len, @sizeOf(elf.Elf64_Dyn));
-        const dyntab = @as([*]align(1) const elf.Elf64_Dyn, @ptrCast(raw.ptr))[0..num];
-        try self.dynamic_table.appendUnalignedSlice(gpa, dyntab);
+    const dynamic_table: []elf.Elf64_Dyn = if (dynamic_sect_index) |index| dt: {
+        const shdr = sections[index];
+        const n = shdr.sh_size / @sizeOf(elf.Elf64_Dyn);
+        const dynamic_table = try gpa.alloc(elf.Elf64_Dyn, n);
+        errdefer gpa.free(dynamic_table);
+        const buf = mem.sliceAsBytes(dynamic_table);
+        const amt = try fs_file.preadAll(buf, shdr.sh_offset);
+        if (amt != buf.len) return error.UnexpectedEndOfFile;
+        break :dt dynamic_table;
+    } else &.{};
+    errdefer gpa.free(dynamic_table);
+
+    var strtab: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer strtab.deinit(gpa);
+
+    if (dynsym_sect_index) |index| {
+        const dynsym_shdr = sections[index];
+        if (dynsym_shdr.sh_link >= sections.len) return error.BadStringTableIndex;
+        const strtab_shdr = sections[dynsym_shdr.sh_link];
+        const buf = try strtab.addManyAsSlice(gpa, strtab_shdr.sh_size);
+        const amt = try fs_file.preadAll(buf, strtab_shdr.sh_offset);
+        if (amt != buf.len) return error.UnexpectedEndOfFile;
     }
 
-    const symtab = if (dynsym_sect_index) |index| blk: {
-        const shdr = self.shdrs.items[index];
-        const buffer = try Elf.preadAllAlloc(gpa, handle, shdr.sh_offset, shdr.sh_size);
-        const nsyms = @divExact(buffer.len, @sizeOf(elf.Elf64_Sym));
-        break :blk @as([*]align(1) const elf.Elf64_Sym, @ptrCast(buffer.ptr))[0..nsyms];
-    } else &[0]elf.Elf64_Sym{};
+    var soname_index: ?u32 = null;
+    var verdefnum: ?u32 = null;
+    for (dynamic_table) |entry| switch (entry.d_tag) {
+        elf.DT_SONAME => {
+            if (entry.d_val >= strtab.items.len) return error.BadSonameIndex;
+            soname_index = @intCast(entry.d_val);
+        },
+        elf.DT_VERDEFNUM => {
+            verdefnum = @intCast(entry.d_val);
+        },
+        else => continue,
+    };
+
+    return .{
+        .dynamic_table = dynamic_table,
+        .soname_index = soname_index,
+        .verdefnum = verdefnum,
+        .sections = sections,
+        .dynsym_sect_index = dynsym_sect_index,
+        .versym_sect_index = versym_sect_index,
+        .verdef_sect_index = verdef_sect_index,
+        .strtab = strtab,
+        .stat = stat,
+    };
+}
+
+pub fn parse(
+    gpa: Allocator,
+    /// Moves resources from header. Caller may unconditionally deinit.
+    header: *Header,
+    fs_file: std.fs.File,
+) !Parsed {
+    const symtab = if (header.dynsym_sect_index) |index| st: {
+        const shdr = header.sections[index];
+        const n = shdr.sh_size / @sizeOf(elf.Elf64_Sym);
+        const symtab = try gpa.alloc(elf.Elf64_Sym, n);
+        errdefer gpa.free(symtab);
+        const buf = mem.sliceAsBytes(symtab);
+        const amt = try fs_file.preadAll(buf, shdr.sh_offset);
+        if (amt != buf.len) return error.UnexpectedEndOfFile;
+        break :st symtab;
+    } else &.{};
     defer gpa.free(symtab);
 
-    const strtab = if (dynsym_sect_index) |index| blk: {
-        const symtab_shdr = self.shdrs.items[index];
-        const shdr = self.shdrs.items[symtab_shdr.sh_link];
-        const buffer = try Elf.preadAllAlloc(gpa, handle, shdr.sh_offset, shdr.sh_size);
-        break :blk buffer;
-    } else &[0]u8{};
-    defer gpa.free(strtab);
+    var verstrings: std.ArrayListUnmanaged(u32) = .empty;
+    defer verstrings.deinit(gpa);
 
-    try self.parseVersions(elf_file, handle, .{
-        .symtab = symtab,
-        .verdef_sect_index = verdef_sect_index,
-        .versym_sect_index = versym_sect_index,
-    });
-
-    try self.initSymbols(elf_file, .{
-        .symtab = symtab,
-        .strtab = strtab,
-    });
-}
-
-fn parseVersions(self: *SharedObject, elf_file: *Elf, handle: std.fs.File, opts: struct {
-    symtab: []align(1) const elf.Elf64_Sym,
-    verdef_sect_index: ?u32,
-    versym_sect_index: ?u32,
-}) !void {
-    const comp = elf_file.base.comp;
-    const gpa = comp.gpa;
-
-    try self.verstrings.resize(gpa, 2);
-    self.verstrings.items[elf.VER_NDX_LOCAL] = 0;
-    self.verstrings.items[elf.VER_NDX_GLOBAL] = 0;
-
-    if (opts.verdef_sect_index) |shndx| {
-        const shdr = self.shdrs.items[shndx];
-        const verdefs = try Elf.preadAllAlloc(gpa, handle, shdr.sh_offset, shdr.sh_size);
+    if (header.verdef_sect_index) |shndx| {
+        const shdr = header.sections[shndx];
+        const verdefs = try Elf.preadAllAlloc(gpa, fs_file, shdr.sh_offset, shdr.sh_size);
         defer gpa.free(verdefs);
-        const nverdefs = self.verdefNum();
-        try self.verstrings.resize(gpa, self.verstrings.items.len + nverdefs);
 
-        var i: u32 = 0;
         var offset: u32 = 0;
-        while (i < nverdefs) : (i += 1) {
-            const verdef = @as(*align(1) const elf.Elf64_Verdef, @ptrCast(verdefs.ptr + offset)).*;
-            defer offset += verdef.vd_next;
-            if (verdef.vd_flags == elf.VER_FLG_BASE) continue; // Skip BASE entry
-            const vda_name = if (verdef.vd_cnt > 0)
-                @as(*align(1) const elf.Elf64_Verdaux, @ptrCast(verdefs.ptr + offset + verdef.vd_aux)).vda_name
-            else
-                0;
-            self.verstrings.items[verdef.vd_ndx] = vda_name;
+        while (true) {
+            const verdef = mem.bytesAsValue(elf.Verdef, verdefs[offset..][0..@sizeOf(elf.Verdef)]);
+            if (verdef.ndx == .UNSPECIFIED) return error.VerDefSymbolTooLarge;
+
+            if (verstrings.items.len <= @intFromEnum(verdef.ndx))
+                try verstrings.appendNTimes(gpa, 0, @intFromEnum(verdef.ndx) + 1 - verstrings.items.len);
+
+            const aux = mem.bytesAsValue(elf.Verdaux, verdefs[offset + verdef.aux ..][0..@sizeOf(elf.Verdaux)]);
+            verstrings.items[@intFromEnum(verdef.ndx)] = aux.name;
+
+            if (verdef.next == 0) break;
+            offset += verdef.next;
         }
     }
 
-    try self.versyms.ensureTotalCapacityPrecise(gpa, opts.symtab.len);
+    const versyms = if (header.versym_sect_index) |versym_sect_index| vs: {
+        const shdr = header.sections[versym_sect_index];
+        if (shdr.sh_size != symtab.len * @sizeOf(elf.Versym)) return error.BadVerSymSectionSize;
 
-    if (opts.versym_sect_index) |shndx| {
-        const shdr = self.shdrs.items[shndx];
-        const versyms_raw = try Elf.preadAllAlloc(gpa, handle, shdr.sh_offset, shdr.sh_size);
-        defer gpa.free(versyms_raw);
-        const nversyms = @divExact(versyms_raw.len, @sizeOf(elf.Elf64_Versym));
-        const versyms = @as([*]align(1) const elf.Elf64_Versym, @ptrCast(versyms_raw.ptr))[0..nversyms];
-        for (versyms) |ver| {
-            const normalized_ver = if (ver & elf.VERSYM_VERSION >= self.verstrings.items.len - 1)
-                elf.VER_NDX_GLOBAL
-            else
-                ver;
-            self.versyms.appendAssumeCapacity(normalized_ver);
-        }
-    } else for (0..opts.symtab.len) |_| {
-        self.versyms.appendAssumeCapacity(elf.VER_NDX_GLOBAL);
+        const versyms = try gpa.alloc(elf.Versym, symtab.len);
+        errdefer gpa.free(versyms);
+        const buf = mem.sliceAsBytes(versyms);
+        const amt = try fs_file.preadAll(buf, shdr.sh_offset);
+        if (amt != buf.len) return error.UnexpectedEndOfFile;
+        break :vs versyms;
+    } else &.{};
+    defer gpa.free(versyms);
+
+    var nonlocal_esyms: std.ArrayListUnmanaged(elf.Elf64_Sym) = .empty;
+    defer nonlocal_esyms.deinit(gpa);
+
+    var nonlocal_versyms: std.ArrayListUnmanaged(elf.Versym) = .empty;
+    defer nonlocal_versyms.deinit(gpa);
+
+    var nonlocal_symbols: std.ArrayListUnmanaged(Parsed.Symbol) = .empty;
+    defer nonlocal_symbols.deinit(gpa);
+
+    var strtab = header.strtab;
+    header.strtab = .empty;
+    defer strtab.deinit(gpa);
+
+    for (symtab, 0..) |sym, i| {
+        const ver: elf.Versym = if (versyms.len == 0 or sym.st_shndx == elf.SHN_UNDEF)
+            .GLOBAL
+        else
+            .{ .VERSION = versyms[i].VERSION, .HIDDEN = false };
+
+        // https://github.com/ziglang/zig/issues/21678
+        //if (ver == .LOCAL) continue;
+        if (@as(u16, @bitCast(ver)) == 0) continue;
+
+        try nonlocal_esyms.ensureUnusedCapacity(gpa, 1);
+        try nonlocal_versyms.ensureUnusedCapacity(gpa, 1);
+        try nonlocal_symbols.ensureUnusedCapacity(gpa, 1);
+
+        const name = Elf.stringTableLookup(strtab.items, sym.st_name);
+        const is_default = versyms.len == 0 or !versyms[i].HIDDEN;
+        const mangled_name = if (is_default) sym.st_name else mn: {
+            const off: u32 = @intCast(strtab.items.len);
+            const version_string = versionStringLookup(strtab.items, verstrings.items, versyms[i]);
+            try strtab.ensureUnusedCapacity(gpa, name.len + version_string.len + 2);
+            // Reload since the string table might have been resized.
+            const name2 = Elf.stringTableLookup(strtab.items, sym.st_name);
+            const version_string2 = versionStringLookup(strtab.items, verstrings.items, versyms[i]);
+            strtab.appendSliceAssumeCapacity(name2);
+            strtab.appendAssumeCapacity('@');
+            strtab.appendSliceAssumeCapacity(version_string2);
+            strtab.appendAssumeCapacity(0);
+            break :mn off;
+        };
+
+        nonlocal_esyms.appendAssumeCapacity(sym);
+        nonlocal_versyms.appendAssumeCapacity(ver);
+        nonlocal_symbols.appendAssumeCapacity(.{
+            .mangled_name = mangled_name,
+        });
     }
-}
 
-fn initSymbols(self: *SharedObject, elf_file: *Elf, opts: struct {
-    symtab: []align(1) const elf.Elf64_Sym,
-    strtab: []const u8,
-}) !void {
-    const gpa = elf_file.base.comp.gpa;
-    const nsyms = opts.symtab.len;
+    const sections = header.sections;
+    header.sections = &.{};
+    errdefer gpa.free(sections);
 
-    try self.strtab.appendSlice(gpa, opts.strtab);
-    try self.symtab.ensureTotalCapacityPrecise(gpa, nsyms);
-    try self.symbols.ensureTotalCapacityPrecise(gpa, nsyms);
-    try self.symbols_extra.ensureTotalCapacityPrecise(gpa, nsyms * @sizeOf(Symbol.Extra));
-    try self.symbols_resolver.ensureTotalCapacityPrecise(gpa, nsyms);
-    self.symbols_resolver.resize(gpa, nsyms) catch unreachable;
-    @memset(self.symbols_resolver.items, 0);
-
-    for (opts.symtab, 0..) |sym, i| {
-        const hidden = self.versyms.items[i] & elf.VERSYM_HIDDEN != 0;
-        const name = self.getString(sym.st_name);
-        // We need to garble up the name so that we don't pick this symbol
-        // during symbol resolution. Thank you GNU!
-        const name_off = if (hidden) blk: {
-            const mangled = try std.fmt.allocPrint(gpa, "{s}@{s}", .{
-                name,
-                self.versionString(self.versyms.items[i]),
-            });
-            defer gpa.free(mangled);
-            break :blk try self.addString(gpa, mangled);
-        } else sym.st_name;
-        const out_esym_index: u32 = @intCast(self.symtab.items.len);
-        const out_esym = self.symtab.addOneAssumeCapacity();
-        out_esym.* = sym;
-        out_esym.st_name = name_off;
-        const out_sym_index = self.addSymbolAssumeCapacity();
-        const out_sym = &self.symbols.items[out_sym_index];
-        out_sym.value = @intCast(out_esym.st_value);
-        out_sym.name_offset = name_off;
-        out_sym.ref = .{ .index = 0, .file = 0 };
-        out_sym.esym_index = out_esym_index;
-        out_sym.version_index = self.versyms.items[out_esym_index];
-        out_sym.extra_index = self.addSymbolExtraAssumeCapacity(.{});
-    }
+    return .{
+        .sections = sections,
+        .stat = header.stat,
+        .soname_index = header.soname_index,
+        .strtab = try strtab.toOwnedSlice(gpa),
+        .symtab = try nonlocal_esyms.toOwnedSlice(gpa),
+        .versyms = try nonlocal_versyms.toOwnedSlice(gpa),
+        .symbols = try nonlocal_symbols.toOwnedSlice(gpa),
+        .verstrings = try verstrings.toOwnedSlice(gpa),
+    };
 }
 
 pub fn resolveSymbols(self: *SharedObject, elf_file: *Elf) !void {
     const gpa = elf_file.base.comp.gpa;
 
-    for (self.symtab.items, self.symbols_resolver.items, 0..) |esym, *resolv, i| {
+    for (self.parsed.symtab, self.symbols_resolver.items, 0..) |esym, *resolv, i| {
         const gop = try elf_file.resolver.getOrPut(gpa, .{
             .index = @intCast(i),
             .file = self.index,
@@ -253,7 +333,7 @@ pub fn resolveSymbols(self: *SharedObject, elf_file: *Elf) !void {
 }
 
 pub fn markLive(self: *SharedObject, elf_file: *Elf) void {
-    for (self.symtab.items, 0..) |esym, i| {
+    for (self.parsed.symtab, 0..) |esym, i| {
         if (esym.st_shndx != elf.SHN_UNDEF) continue;
 
         const ref = self.resolveSymbol(@intCast(i), elf_file);
@@ -308,29 +388,21 @@ pub fn writeSymtab(self: *SharedObject, elf_file: *Elf) void {
     }
 }
 
-pub fn versionString(self: SharedObject, index: elf.Elf64_Versym) [:0]const u8 {
-    const off = self.verstrings.items[index & elf.VERSYM_VERSION];
-    return self.getString(off);
+pub fn versionString(self: SharedObject, index: elf.Versym) [:0]const u8 {
+    return self.parsed.versionString(index);
+}
+
+fn versionStringLookup(strtab: []const u8, verstrings: []const u32, index: elf.Versym) [:0]const u8 {
+    const off = verstrings[index.VERSION];
+    return Elf.stringTableLookup(strtab, off);
 }
 
 pub fn asFile(self: *SharedObject) File {
     return .{ .shared_object = self };
 }
 
-fn verdefNum(self: *SharedObject) u32 {
-    for (self.dynamic_table.items) |entry| switch (entry.d_tag) {
-        elf.DT_VERDEFNUM => return @intCast(entry.d_val),
-        else => {},
-    };
-    return 0;
-}
-
 pub fn soname(self: *SharedObject) []const u8 {
-    for (self.dynamic_table.items) |entry| switch (entry.d_tag) {
-        elf.DT_SONAME => return self.getString(@intCast(entry.d_val)),
-        else => {},
-    };
-    return std.fs.path.basename(self.path.sub_path);
+    return self.parsed.soname() orelse self.path.basename();
 }
 
 pub fn initSymbolAliases(self: *SharedObject, elf_file: *Elf) !void {
@@ -360,7 +432,7 @@ pub fn initSymbolAliases(self: *SharedObject, elf_file: *Elf) !void {
         aliases.appendAssumeCapacity(@intCast(index));
     }
 
-    std.mem.sort(u32, aliases.items, SortAlias{ .so = self, .ef = elf_file }, SortAlias.lessThan);
+    mem.sort(u32, aliases.items, SortAlias{ .so = self, .ef = elf_file }, SortAlias.lessThan);
 
     self.aliases = aliases.moveToUnmanaged();
 }
@@ -384,17 +456,8 @@ pub fn symbolAliases(self: *SharedObject, index: u32, elf_file: *Elf) []const u3
     return aliases.items[start..end];
 }
 
-fn addString(self: *SharedObject, allocator: Allocator, str: []const u8) !u32 {
-    const off: u32 = @intCast(self.strtab.items.len);
-    try self.strtab.ensureUnusedCapacity(allocator, str.len + 1);
-    self.strtab.appendSliceAssumeCapacity(str);
-    self.strtab.appendAssumeCapacity(0);
-    return off;
-}
-
 pub fn getString(self: SharedObject, off: u32) [:0]const u8 {
-    assert(off < self.strtab.items.len);
-    return mem.sliceTo(@as([*:0]const u8, @ptrCast(self.strtab.items.ptr + off)), 0);
+    return Elf.stringTableLookup(self.parsed.strtab, off);
 }
 
 pub fn resolveSymbol(self: SharedObject, index: Symbol.Index, elf_file: *Elf) Elf.Ref {
@@ -402,25 +465,14 @@ pub fn resolveSymbol(self: SharedObject, index: Symbol.Index, elf_file: *Elf) El
     return elf_file.resolver.get(resolv).?;
 }
 
-fn addSymbol(self: *SharedObject, allocator: Allocator) !Symbol.Index {
-    try self.symbols.ensureUnusedCapacity(allocator, 1);
-    return self.addSymbolAssumeCapacity();
-}
-
-fn addSymbolAssumeCapacity(self: *SharedObject) Symbol.Index {
+pub fn addSymbolAssumeCapacity(self: *SharedObject) Symbol.Index {
     const index: Symbol.Index = @intCast(self.symbols.items.len);
     self.symbols.appendAssumeCapacity(.{ .file_index = self.index });
     return index;
 }
 
-pub fn addSymbolExtra(self: *SharedObject, allocator: Allocator, extra: Symbol.Extra) !u32 {
-    const fields = @typeInfo(Symbol.Extra).@"struct".fields;
-    try self.symbols_extra.ensureUnusedCapacity(allocator, fields.len);
-    return self.addSymbolExtraAssumeCapacity(extra);
-}
-
 pub fn addSymbolExtraAssumeCapacity(self: *SharedObject, extra: Symbol.Extra) u32 {
-    const index = @as(u32, @intCast(self.symbols_extra.items.len));
+    const index: u32 = @intCast(self.symbols_extra.items.len);
     const fields = @typeInfo(Symbol.Extra).@"struct".fields;
     inline for (fields) |field| {
         self.symbols_extra.appendAssumeCapacity(switch (field.type) {
@@ -465,7 +517,7 @@ pub fn format(
     _ = unused_fmt_string;
     _ = options;
     _ = writer;
-    @compileError("do not format shared objects directly");
+    @compileError("unreachable");
 }
 
 pub fn fmtSymtab(self: SharedObject, elf_file: *Elf) std.fmt.Formatter(formatSymtab) {
@@ -509,8 +561,10 @@ const elf = std.elf;
 const log = std.log.scoped(.elf);
 const mem = std.mem;
 const Path = std.Build.Cache.Path;
-
+const Stat = std.Build.Cache.File.Stat;
 const Allocator = mem.Allocator;
+
 const Elf = @import("../Elf.zig");
 const File = @import("file.zig").File;
 const Symbol = @import("Symbol.zig");
+const Diags = @import("../../link.zig").Diags;

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -29,10 +29,9 @@ pub fn unpack(self: *Archive, macho_file: *MachO, path: Path, handle_index: File
         pos += @sizeOf(ar_hdr);
 
         if (!mem.eql(u8, &hdr.ar_fmag, ARFMAG)) {
-            try diags.reportParseError(path, "invalid header delimiter: expected '{s}', found '{s}'", .{
+            return diags.failParse(path, "invalid header delimiter: expected '{s}', found '{s}'", .{
                 std.fmt.fmtSliceEscapeLower(ARFMAG), std.fmt.fmtSliceEscapeLower(&hdr.ar_fmag),
             });
-            return error.MalformedArchive;
         }
 
         var hdr_size = try hdr.size();

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -29,14 +29,8 @@ pub fn flushObject(macho_file: *MachO, comp: *Compilation, module_obj_path: ?Pat
     }
 
     for (positionals.items) |obj| {
-        macho_file.classifyInputFile(obj.path, .{ .path = obj.path }, obj.must_link) catch |err| switch (err) {
-            error.UnknownFileType => try diags.reportParseError(obj.path, "unknown file type for an input file", .{}),
-            else => |e| try diags.reportParseError(
-                obj.path,
-                "unexpected error: reading input file failed with error {s}",
-                .{@errorName(e)},
-            ),
-        };
+        macho_file.classifyInputFile(obj.path, .{ .path = obj.path }, obj.must_link) catch |err|
+            diags.addParseError(obj.path, "failed to read input file: {s}", .{@errorName(err)});
     }
 
     if (diags.hasErrors()) return error.FlushFailure;
@@ -95,14 +89,8 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
     }
 
     for (positionals.items) |obj| {
-        macho_file.classifyInputFile(obj.path, .{ .path = obj.path }, obj.must_link) catch |err| switch (err) {
-            error.UnknownFileType => try diags.reportParseError(obj.path, "unknown file type for an input file", .{}),
-            else => |e| try diags.reportParseError(
-                obj.path,
-                "unexpected error: reading input file failed with error {s}",
-                .{@errorName(e)},
-            ),
-        };
+        macho_file.classifyInputFile(obj.path, .{ .path = obj.path }, obj.must_link) catch |err|
+            diags.addParseError(obj.path, "failed to read input file: {s}", .{@errorName(err)});
     }
 
     if (diags.hasErrors()) return error.FlushFailure;


### PR DESCRIPTION
Make shared_objects a StringArrayHashMap so that deduping does not need to happen in flush. That deduping code also was using an O(N^2) algorithm, which is not allowed in this codebase. There is another violation of this rule in resolveSymbols but this commit does not address it.

This required reworking shared object parsing, breaking it into independent components so that we could access soname earlier.

Shared object parsing had a few problems that I noticed and fixed in this commit:
* Many instances of incorrect use of align(1).
* `shnum * @sizeOf(elf.Elf64_Shdr)` can overflow based on user data.
* `@divExact` can cause illegal behavior based on user data.
* Strange versyms logic that wasn't present in mold nor lld. The logic was not commented and there is no git blame information in ziglang/zig nor kubkon/zld. I changed it to match mold and lld instead.
* Use of ArrayList for slices of memory that are never resized.
* finding DT_VERDEFNUM in a different loop than finding DT_SONAME. Ultimately I think we should follow mold's lead and ignore this integer, relying on null termination instead.
* Doing logic based on VER_FLG_BASE rather than ignoring it like mold and LLD do. No comment explaining why the behavior is different.
* Mutating the original ELF symbols rather than only storing the mangled name on the new Symbol struct.

I noticed something that I didn't try to address in this commit: Symbol stores a lot of redundant information that is already present in the ELF symbols. I suspect that the codebase could benefit from reworking Symbol to not store redundant information.

Additionally:
* Add some type safety to std.elf.
* Eliminate 1-3 file system reads for determining the kind of input files, by taking advantage of file name extension and handling error codes properly.
* Move more error handling methods to link.Diags and make them infallible and thread-safe
* Make the data dependencies obvious in the parameters of parseSharedObject. It's now clear that the first two steps (Header and Parsed) can be done during the main Compilation pipeline, rather than waiting for flush().