### PR TITLE
`glibc`: Emit some fill data for stub symbols, thus giving each a unique address.

### DIFF
--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -938,7 +938,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                     // .globl _Exit_2_2_5
                     // .type _Exit_2_2_5, %function;
                     // .symver _Exit_2_2_5, _Exit@@GLIBC_2.2.5
-                    // _Exit_2_2_5:
+                    // _Exit_2_2_5: .long 0
                     const ver_index = versions_buffer[ver_buf_i];
                     const ver = metadata.all_versions[ver_index];
 
@@ -960,7 +960,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             \\.globl {s}
                             \\.type {s}, %function;
                             \\.symver {s}, {s}{s}GLIBC_{d}.{d}
-                            \\{s}:
+                            \\{s}: {s} 0
                             \\
                         , .{
                             sym_plus_ver,
@@ -971,6 +971,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             ver.major,
                             ver.minor,
                             sym_plus_ver,
+                            wordDirective(target),
                         });
                     } else {
                         const sym_plus_ver = if (want_default)
@@ -985,7 +986,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             \\.globl {s}
                             \\.type {s}, %function;
                             \\.symver {s}, {s}{s}GLIBC_{d}.{d}.{d}
-                            \\{s}:
+                            \\{s}: {s} 0
                             \\
                         , .{
                             sym_plus_ver,
@@ -997,6 +998,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             ver.minor,
                             ver.patch,
                             sym_plus_ver,
+                            wordDirective(target),
                         });
                     }
                 }
@@ -1103,7 +1105,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                     // .type environ_2_2_5, %object;
                     // .size environ_2_2_5, 4;
                     // .symver environ_2_2_5, environ@@GLIBC_2.2.5
-                    // environ_2_2_5:
+                    // environ_2_2_5: .fill 4, 1, 0
                     const ver_index = versions_buffer[ver_buf_i];
                     const ver = metadata.all_versions[ver_index];
 
@@ -1126,7 +1128,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             \\.type {s}, %object;
                             \\.size {s}, {d};
                             \\.symver {s}, {s}{s}GLIBC_{d}.{d}
-                            \\{s}:
+                            \\{s}: .fill {d}, 1, 0
                             \\
                         , .{
                             sym_plus_ver,
@@ -1139,6 +1141,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             ver.major,
                             ver.minor,
                             sym_plus_ver,
+                            size,
                         });
                     } else {
                         const sym_plus_ver = if (want_default)
@@ -1154,7 +1157,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             \\.type {s}, %object;
                             \\.size {s}, {d};
                             \\.symver {s}, {s}{s}GLIBC_{d}.{d}.{d}
-                            \\{s}:
+                            \\{s}: .fill {d}, 1, 0
                             \\
                         , .{
                             sym_plus_ver,
@@ -1168,6 +1171,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             ver.minor,
                             ver.patch,
                             sym_plus_ver,
+                            size,
                         });
                     }
                 }

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -935,6 +935,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                 var ver_buf_i: u8 = 0;
                 while (ver_buf_i < versions_len) : (ver_buf_i += 1) {
                     // Example:
+                    // .balign 4
                     // .globl _Exit_2_2_5
                     // .type _Exit_2_2_5, %function;
                     // .symver _Exit_2_2_5, _Exit@@GLIBC_2.2.5
@@ -957,12 +958,14 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                                 .{ sym_name, ver.major, ver.minor },
                             );
                         try stubs_asm.writer().print(
+                            \\.balign {d}
                             \\.globl {s}
                             \\.type {s}, %function;
                             \\.symver {s}, {s}{s}GLIBC_{d}.{d}
                             \\{s}: {s} 0
                             \\
                         , .{
+                            target.ptrBitWidth() / 8,
                             sym_plus_ver,
                             sym_plus_ver,
                             sym_plus_ver,
@@ -983,12 +986,14 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                                 .{ sym_name, ver.major, ver.minor, ver.patch },
                             );
                         try stubs_asm.writer().print(
+                            \\.balign {d}
                             \\.globl {s}
                             \\.type {s}, %function;
                             \\.symver {s}, {s}{s}GLIBC_{d}.{d}.{d}
                             \\{s}: {s} 0
                             \\
                         , .{
+                            target.ptrBitWidth() / 8,
                             sym_plus_ver,
                             sym_plus_ver,
                             sym_plus_ver,
@@ -1026,10 +1031,14 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
         // a strong reference.
         if (std.mem.eql(u8, lib.name, "c")) {
             try stubs_asm.writer().print(
+                \\.balign {d}
                 \\.globl _IO_stdin_used
                 \\{s} _IO_stdin_used
                 \\
-            , .{wordDirective(target)});
+            , .{
+                target.ptrBitWidth() / 8,
+                wordDirective(target),
+            });
         }
 
         const obj_inclusions_len = try inc_reader.readInt(u16, .little);
@@ -1101,6 +1110,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                 var ver_buf_i: u8 = 0;
                 while (ver_buf_i < versions_len) : (ver_buf_i += 1) {
                     // Example:
+                    // .balign 4
                     // .globl environ_2_2_5
                     // .type environ_2_2_5, %object;
                     // .size environ_2_2_5, 4;
@@ -1124,6 +1134,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                                 .{ sym_name, ver.major, ver.minor },
                             );
                         try stubs_asm.writer().print(
+                            \\.balign {d}
                             \\.globl {s}
                             \\.type {s}, %object;
                             \\.size {s}, {d};
@@ -1131,6 +1142,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             \\{s}: .fill {d}, 1, 0
                             \\
                         , .{
+                            target.ptrBitWidth() / 8,
                             sym_plus_ver,
                             sym_plus_ver,
                             sym_plus_ver,
@@ -1153,6 +1165,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                                 .{ sym_name, ver.major, ver.minor, ver.patch },
                             );
                         try stubs_asm.writer().print(
+                            \\.balign {d}
                             \\.globl {s}
                             \\.type {s}, %object;
                             \\.size {s}, {d};
@@ -1160,6 +1173,7 @@ pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !voi
                             \\{s}: .fill {d}, 1, 0
                             \\
                         , .{
+                            target.ptrBitWidth() / 8,
                             sym_plus_ver,
                             sym_plus_ver,
                             sym_plus_ver,


### PR DESCRIPTION
This prevents LLVM from...cleverly...merging all of the global variable stub symbols that we emit under certain circumstances. This was observed in practice when using zig-bootstrap for `arm(eb)-linux-gnueabi(hf)`. zig-bootstrap'd compilers for those targets will now run.

Additionally, align stub symbols to the target word size. Ideally we'd like to use whatever alignment glibc actually ends up using in the real `libc.so.6`. But we don't really have a way of getting at that information at the moment, and it's not present in the abilist files. I haven't yet seen a symbol that wasn't word-aligned, though, so I think this should be good enough for 99% of symbols, if not actually 100%.