### PR TITLE
`wasm2c`: Add big endian support.

### DIFF
--- a/stage1/wasm2c.c
+++ b/stage1/wasm2c.c
@@ -73,6 +73,8 @@ static void renderExpr(FILE *out, struct InputStream *in) {
     }
 }
 
+static const uint32_t big_endian = 0xff000000;
+
 int main(int argc, char **argv) {
     if (argc != 3) {
         fprintf(stderr, "usage: %s in.wasm.zst out.c\n", argv[0]);
@@ -80,7 +82,7 @@ int main(int argc, char **argv) {
     }
 
     const char *mod = "wasm";
-    bool is_big_endian = false; // TODO
+    bool is_big_endian = *(uint8_t *)&big_endian;
 
     struct InputStream in;
     InputStream_open(&in, argv[1]);
@@ -111,55 +113,55 @@ int main(int argc, char **argv) {
           "           (uint64_t)i32_byteswap(src >> 32) <<  0;\n"
           "}\n"
           "\n", out);
-    fputs("static uint16_t load16_align0(const uint8_t *ptr) {\n"
+    fputs("uint16_t load16_align0(const uint8_t *ptr) {\n"
           "    uint16_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i16_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint16_t load16_align1(const uint16_t *ptr) {\n"
+          "uint16_t load16_align1(const uint16_t *ptr) {\n"
           "    uint16_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i16_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint32_t load32_align0(const uint8_t *ptr) {\n"
+          "uint32_t load32_align0(const uint8_t *ptr) {\n"
           "    uint32_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i32_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint32_t load32_align1(const uint16_t *ptr) {\n"
+          "uint32_t load32_align1(const uint16_t *ptr) {\n"
           "    uint32_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i32_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint32_t load32_align2(const uint32_t *ptr) {\n"
+          "uint32_t load32_align2(const uint32_t *ptr) {\n"
           "    uint32_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i32_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint64_t load64_align0(const uint8_t *ptr) {\n"
+          "uint64_t load64_align0(const uint8_t *ptr) {\n"
           "    uint64_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint64_t load64_align1(const uint16_t *ptr) {\n"
+          "uint64_t load64_align1(const uint16_t *ptr) {\n"
           "    uint64_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint64_t load64_align2(const uint32_t *ptr) {\n"
+          "uint64_t load64_align2(const uint32_t *ptr) {\n"
           "    uint64_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    return val;\n"
           "}\n"
-          "static uint64_t load64_align3(const uint64_t *ptr) {\n"
+          "uint64_t load64_align3(const uint64_t *ptr) {\n"
           "    uint64_t val;\n"
           "    memcpy(&val, ptr, sizeof(val));\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
@@ -199,39 +201,39 @@ int main(int argc, char **argv) {
           "    return i64_ctz(lhs);\n"
           "}\n"
           "\n"
-          "static void store16_align0(uint8_t *ptr, uint16_t val) {\n", out);
+          "void store16_align0(uint8_t *ptr, uint16_t val) {\n", out);
     if (is_big_endian) fputs("    val = i16_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store16_align1(uint16_t *ptr, uint16_t val) {\n", out);
+          "void store16_align1(uint16_t *ptr, uint16_t val) {\n", out);
     if (is_big_endian) fputs("    val = i16_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store32_align0(uint8_t *ptr, uint32_t val) {\n", out);
+          "void store32_align0(uint8_t *ptr, uint32_t val) {\n", out);
     if (is_big_endian) fputs("    val = i32_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store32_align1(uint16_t *ptr, uint32_t val) {\n", out);
+          "void store32_align1(uint16_t *ptr, uint32_t val) {\n", out);
     if (is_big_endian) fputs("    val = i32_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store32_align2(uint32_t *ptr, uint32_t val) {\n", out);
+          "void store32_align2(uint32_t *ptr, uint32_t val) {\n", out);
     if (is_big_endian) fputs("    val = i32_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store64_align0(uint8_t *ptr, uint64_t val) {\n", out);
+          "void store64_align0(uint8_t *ptr, uint64_t val) {\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store64_align1(uint16_t *ptr, uint64_t val) {\n", out);
+          "void store64_align1(uint16_t *ptr, uint64_t val) {\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store64_align2(uint32_t *ptr, uint64_t val) {\n", out);
+          "void store64_align2(uint32_t *ptr, uint64_t val) {\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"
-          "static void store64_align3(uint64_t *ptr, uint64_t val) {\n", out);
+          "void store64_align3(uint64_t *ptr, uint64_t val) {\n", out);
     if (is_big_endian) fputs("    val = i64_byteswap(val);", out);
     fputs("    memcpy(ptr, &val, sizeof(val));\n"
           "}\n"

--- a/stage1/wasm2c.c
+++ b/stage1/wasm2c.c
@@ -76,13 +76,27 @@ static void renderExpr(FILE *out, struct InputStream *in) {
 static const uint32_t big_endian = 0xff000000;
 
 int main(int argc, char **argv) {
-    if (argc != 3) {
-        fprintf(stderr, "usage: %s in.wasm.zst out.c\n", argv[0]);
+    if (argc != 3 && argc != 4) {
+        fprintf(stderr, "usage: %s <in.wasm.zst> <out.c> [endian]\n", argv[0]);
         return 1;
     }
 
+    bool is_big_endian;
+
+    if (argc >= 4) {
+        if (!strcmp(argv[3], "big")) {
+            is_big_endian = true;
+        } else if (!strcmp(argv[3], "little")) {
+            is_big_endian = false;
+        } else {
+            fprintf(stderr, "endianness must be 'big' or 'little'\n");
+            return 1;
+        }
+    } else {
+        is_big_endian = *(uint8_t *)&big_endian; // Infer from host endianness.
+    }
+
     const char *mod = "wasm";
-    bool is_big_endian = *(uint8_t *)&big_endian;
 
     struct InputStream in;
     InputStream_open(&in, argv[1]);


### PR DESCRIPTION
I took a slightly unconventional approach to detecting endianness here. We have no compiler/platform-specific preprocessor checks in the stage1 C code today, and I think that's a property worth maintaining.

With this patch, I'm able to successfully run `s390x-linux-gnu-gcc ../stage1/wasm2c.c -o zig-wasm2c && qemu-s390x ./zig-wasm2c ../stage1/zig1.wasm zig1.c && s390x-linux-gnu-gcc -std=c99 -Os zig1.c ../stage1/wasi.c -o zig1 && qemu-s390x ../lib zig1 build-exe -ofmt=c -lc -OReleaseSmall ... -femit-bin=zig2.c`.