### PR TITLE
std.http.Client.fetch() to also return the Response

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1706,6 +1706,7 @@ pub const FetchOptions = struct {
 
 pub const FetchResult = struct {
     status: http.Status,
+    response: Response,
 };
 
 /// Perform a one-shot HTTP request with the provided options.
@@ -1766,6 +1767,7 @@ pub fn fetch(client: *Client, options: FetchOptions) !FetchResult {
 
     return .{
         .status = req.response.status,
+        .response = req.response,
     };
 }
 


### PR DESCRIPTION
## Reasoning

the zig `std.http.Client.fetch()` function is a really nice wrapper built around making a HTTP request, however it's missing the ability to inspect other content from the response, such as it's headers.

Right now if you wanted to make a simple request and also return the headers, writing your own `fetch` that also sends a response is the best way imo, so why not just make it apart of the std api 😄 