### PR TITLE
zig fmt: Fix formatting of if expressions

### DIFF
--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -454,8 +454,9 @@ fn renderExpression(r: *Render, node: Ast.Node.Index, space: Space) Error!void {
                 try renderToken(r, main_token, after_op_space); // catch keyword
             }
 
-            ais.pushIndentOneShot();
+            ais.pushIndent();
             try renderExpression(r, datas[node].rhs, space); // fallback
+            ais.popIndent();
         },
 
         .field_access => {
@@ -564,8 +565,9 @@ fn renderExpression(r: *Render, node: Ast.Node.Index, space: Space) Error!void {
                 try renderToken(r, op_token, .newline);
                 ais.popIndent();
             }
-            ais.pushIndentOneShot();
-            return renderExpression(r, infix.rhs, space);
+            ais.pushIndent();
+            try renderExpression(r, infix.rhs, space);
+            ais.popIndent();
         },
 
         .assign_destructure => {
@@ -594,8 +596,9 @@ fn renderExpression(r: *Render, node: Ast.Node.Index, space: Space) Error!void {
                 try renderToken(r, full.ast.equal_token, .newline);
                 ais.popIndent();
             }
-            ais.pushIndentOneShot();
-            return renderExpression(r, full.ast.value_expr, space);
+            ais.pushIndent();
+            try renderExpression(r, full.ast.value_expr, space);
+            ais.popIndent();
         },
 
         .bit_not,
@@ -725,8 +728,9 @@ fn renderExpression(r: *Render, node: Ast.Node.Index, space: Space) Error!void {
 
         .grouped_expression => {
             try renderToken(r, main_tokens[node], .none); // lparen
-            ais.pushIndentOneShot();
+            ais.pushIndent();
             try renderExpression(r, datas[node].lhs, .none);
+            ais.popIndent();
             return renderToken(r, datas[node].rhs, space); // rparen
         },
 
@@ -1243,8 +1247,9 @@ fn renderVarDeclWithoutFixups(
         try renderToken(r, eq_token, eq_space); // =
         ais.popIndent();
     }
-    ais.pushIndentOneShot();
-    return renderExpression(r, var_decl.ast.init_node, space); // ;
+    ais.pushIndent();
+    try renderExpression(r, var_decl.ast.init_node, space); // ;
+    ais.popIndent();
 }
 
 fn renderIf(r: *Render, if_node: Ast.full.If, space: Space) Error!void {


### PR DESCRIPTION
This fixes some issues with `zig fmt` and `if` expressions.

Sometimes when formatting an if expression, the renderer does not carry on with the correct indentation until the end of the if expression. See examples below.

## Before PR

```zig
test {
    const foo =
        if (1 == 2)
        1
    else if (3 > 4)
        2
    else
        0;

    const foo, const bar =
        if (1 == 2)
        .{ 0, 0 }
    else if (3 > 4)
        .{ 1, 1 }
    else
        .{ 2, 2 };

    const foo = 1 +
        if (1 == 2)
        2
    else
        0;

    errval catch |e|
        if (e == error.Meow)
        return 69
    else
        unreachable;

    return if (1 == 2)
        1
    else if (3 > 4)
        2
    else
        0;
}
```

## After PR

```zig
test {
    const foo =
        if (1 == 2)
            1
        else if (3 > 4)
            2
        else
            0;

    const foo, const bar =
        if (1 == 2)
            .{ 0, 0 }
        else if (3 > 4)
            .{ 1, 1 }
        else
            .{ 2, 2 };

    const foo = 1 +
            if (1 == 2)
                2
            else
                0;

    errval catch |e|
        if (e == error.Meow)
            return 69
        else
            unreachable;

    return if (1 == 2)
        1
    else if (3 > 4)
        2
    else
        0;
}
```