### PR TITLE
Add OpenTelemetry tracing API to standard library

### DIFF
--- a/lib/std/otel.zig
+++ b/lib/std/otel.zig
@@ -63,7 +63,7 @@ else
 pub const Types = struct {
     Context: type = Context.NULL_CONTEXT_TYPE,
     ContextAttachToken: type = Context.NULL_ATTACH_TOKEN_TYPE,
-    trace: trace.Types = trace.NULL_TYPES,
+    Span: type = trace.NULL_SPAN_TYPE,
 };
 
 pub const Functions = struct {

--- a/lib/std/otel.zig
+++ b/lib/std/otel.zig
@@ -1,0 +1,78 @@
+//! A set of APIs for instrumenting code with various telemetry data. Currently only
+//! two APIs are provided: `otel.Context`, and `otel.trace`.
+//!
+//! - `otel.Context` provides a way to link telemetry data together, giving you a
+//!   fuller picture of what is going on.
+//! - `otel.trace` provides a way to trace the flow of execution.
+//!
+//! By default these APIs do nothing, to collect telemetry data the software
+//! developer will need to specify an implementation, like so:
+//!
+//! ```zig
+//! pub const otel_types: std.otel.Types = .{
+//!     .context = path.to.context.implementation.TYPES,
+//!     .trace = path.to.trace.implementation.TYPES,
+//! };
+//! pub const otel_functions: std.otel.Functions = .{
+//!     .context = path.to.context.implementation.FUNCTIONS,
+//!     .trace = path.to.trace.implementation.FUNCTIONS,
+//! };
+//! ```
+//!
+//! Implementations will likely require you to call a function at runtime to
+//! properly set up it. Something like this:
+//!
+//! ```zig
+//! pub fn main() !void {
+//!     try path.to.context.implementation.init(.{});
+//!     defer path.to.context.implementation.deinit();
+//!     try path.to.trace.implementation.init(.{});
+//!     defer path.to.trace.implementation.deinit();
+//!
+//!     // the application code
+//! }
+//! ```
+//!
+//! See <https://opentelemetry.io/> for more information.
+
+pub const Attribute = @import("otel/attribute.zig").Attribute;
+pub const Context = @import("otel/Context.zig");
+
+pub const trace = @import("otel/trace.zig");
+
+// application configured options
+const root = @import("root");
+
+/// The types used inside opentelemetry API types. For example, the default trace
+/// API implementation sets the `trace.Span` type to `void` to make the tracing code
+/// a no-op.
+pub const types: Types = if (@hasDecl(root, "otel_types"))
+    root.otel_types
+else
+    .{};
+
+/// The functions that actually implement OpenTelemetry APIs. By default these are
+/// set to functions that do nothing.
+pub const functions: Functions = if (@hasDecl(root, "otel_functions"))
+    root.otel_functions
+else
+    .{};
+
+pub const Types = struct {
+    context: Context.Types = Context.NULL_TYPES,
+    trace: trace.Types = trace.NULL_TYPES,
+};
+
+pub const Functions = struct {
+    context: Context.Functions = Context.NULL_FUNCTIONS,
+    trace: trace.Functions = trace.NULL_FUNCTIONS,
+};
+
+pub const InstrumentationScope = struct {
+    name: []const u8,
+    version: ?[]const u8 = null,
+    /// since OpenTelemetry API 1.4.0
+    schema_url: ?[]const u8 = null,
+    /// since OpenTelemetry API 1.13.0
+    attributes: ?[]const Attribute = null,
+};

--- a/lib/std/otel.zig
+++ b/lib/std/otel.zig
@@ -43,9 +43,11 @@ pub const trace = @import("otel/trace.zig");
 // application configured options
 const root = @import("root");
 
-/// The types used inside opentelemetry API types. For example, the default trace
-/// API implementation sets the `trace.Span` type to `void` to make the tracing code
-/// a no-op.
+/// The concrete types that implement the APIs defined here. By default all of the
+/// APIs come with a no-op implementation. Library developers can use these APIs to
+/// instrument their libraries, and software developers can then choose an
+/// implementation of the API that matches the software's telemetry needs, or leave
+/// out telemetry all together.
 pub const types: Types = if (@hasDecl(root, "otel_types"))
     root.otel_types
 else
@@ -59,7 +61,8 @@ else
     .{};
 
 pub const Types = struct {
-    context: Context.Types = Context.NULL_TYPES,
+    Context: type = Context.NULL_CONTEXT_TYPE,
+    ContextAttachToken: type = Context.NULL_ATTACH_TOKEN_TYPE,
     trace: trace.Types = trace.NULL_TYPES,
 };
 

--- a/lib/std/otel/Context.zig
+++ b/lib/std/otel/Context.zig
@@ -1,0 +1,125 @@
+//! A type designed to propagate OpenTelemetry between different APIs in a loosely
+//! coupled way.
+//!
+//! Immutable.
+const Context = @This();
+
+/// The value used by the implementation to implement `Context`. No peeking!
+impl: std.otel.types.context.Context,
+
+pub fn destroy(context: Context) void {
+    std.otel.functions.context.destroy(context.impl);
+}
+
+pub fn getValue(context: Context, T: type) ?T {
+    var return_value: T = undefined;
+    if (std.otel.functions.context.get_value(context.impl, T, std.mem.asBytes(&return_value))) {
+        return return_value;
+    } else {
+        return null;
+    }
+}
+
+/// Returns a new Context with the given type set to the given `value`.
+pub fn withValue(context: Context, T: type, value: T) Context {
+    return .{ .impl = std.otel.functions.context.with_value(context.impl, T, std.mem.asBytes(&value)) };
+}
+
+/// Get the current context for the current "execution unit".
+///
+/// "Execution unit" will depend on the implementation, but generally means "the
+/// current thread".
+pub fn current() Context {
+    return .{ .impl = std.otel.functions.context.current() };
+}
+
+/// Mark the given Context as the current context for the current "execution unit".
+/// Every call to `attach` should be matched with a corresponding call to
+/// `AttachToken.detach`
+///
+/// Returns an `AttachToken` that must be used to detach this context from the
+/// execution unit.
+///
+/// "Execution unit" will depend on the implementation, but generally means "the
+/// current thread".
+pub fn attach(context: Context) AttachToken {
+    return .{ .impl = std.otel.functions.context.attach(context.impl) };
+}
+
+/// A value received after attaching a context to the current "execution unit". Used
+/// to detach the context, and may be used by the implementation to check that
+/// detach order is correct.
+pub const AttachToken = struct {
+    impl: std.otel.types.context.AttachToken,
+
+    pub fn detach(attach_token: AttachToken) void {
+        return std.otel.functions.context.detach(attach_token.impl);
+    }
+};
+
+/// The list of types that MUST be provided to implement the `otel.Context` api.
+pub const Types = struct {
+    Context: type,
+    AttachToken: type,
+};
+
+/// The list of Functions that MUST be provided to implement the `otel.Context` api.
+pub const Functions = struct {
+    get_value: fn (impl_types.Context, T: type, return_value: []u8) bool,
+    with_value: fn (impl_types.Context, T: type, value_bytes: []const u8) impl_types.Context,
+    destroy: fn (impl_types.Context) void,
+    current: fn () impl_types.Context,
+    attach: fn (impl_types.Context) impl_types.AttachToken,
+    detach: fn (impl_types.AttachToken) void,
+
+    const impl_types = std.otel.types.context;
+};
+
+/// The default types used to implement `Context` that do nothing.
+pub const NULL_TYPES: Types = .{
+    .Context = struct {},
+    .AttachToken = struct {},
+};
+
+/// The default functions used to implement `Context` that do nothing.
+pub const NULL_FUNCTIONS: Functions = .{
+    .get_value = nullGetValue,
+    .with_value = nullWithValue,
+    .destroy = nullDestroy,
+    .current = nullCurrent,
+    .attach = nullAttach,
+    .detach = nullDetach,
+};
+
+fn nullGetValue(context: std.otel.types.context.Context, T: type, return_value: []u8) bool {
+    _ = context;
+    _ = T;
+    _ = return_value;
+    return false;
+}
+
+fn nullWithValue(context: std.otel.types.context.Context, T: type, value_bytes: []const u8) std.otel.types.context.Context {
+    _ = context;
+    _ = T;
+    _ = value_bytes;
+    return .{};
+}
+
+fn nullDestroy(context: std.otel.types.context.Context) void {
+    _ = context;
+}
+
+fn nullCurrent() std.otel.types.context.Context {
+    return .{};
+}
+
+fn nullAttach(context: std.otel.types.context.Context) std.otel.types.context.AttachToken {
+    _ = context;
+    return .{};
+}
+
+fn nullDetach(attach_token: std.otel.types.context.AttachToken) void {
+    _ = attach_token;
+}
+
+const std = @import("../std.zig");

--- a/lib/std/otel/attribute.zig
+++ b/lib/std/otel/attribute.zig
@@ -1,0 +1,342 @@
+const attribute = @This();
+
+pub const Attribute = union(enum) {
+    standard: attribute.Standard,
+    dynamic: attribute.Dynamic,
+
+    pub const Type = attribute.Type;
+    pub const Dynamic = attribute.Dynamic;
+    pub const Standard = attribute.Standard;
+
+    pub fn listFromStruct(attributes: anytype) [@typeInfo(@TypeOf(attributes)).@"struct".fields.len]Attribute {
+        const struct_info = @typeInfo(@TypeOf(attributes)).@"struct";
+        const num_attributes = struct_info.fields.len;
+
+        var attrs: [num_attributes]Attribute = undefined;
+        inline for (attrs[0..], struct_info.fields) |*attr, field| {
+            if (@hasField(attribute.Standard, field.name)) {
+                attr.* = .{ .standard = @unionInit(attribute.Standard, field.name, @field(attributes, field.name)) };
+            } else {
+                attr.* = .{ .dynamic = .{
+                    .key = field.name,
+                    .value = attribute.Dynamic.Value.fromType(field.type, @field(attributes, field.name)),
+                } };
+            }
+        }
+
+        return attrs;
+    }
+
+    pub fn listFromSourceLocation(src: std.builtin.SourceLocation) [4]Attribute {
+        return [4]Attribute{
+            .{ .standard = .{ .@"code.filepath" = src.file } },
+            .{ .standard = .{ .@"code.function" = src.fn_name } },
+            .{ .standard = .{ .@"code.lineno" = src.line } },
+            .{ .standard = .{ .@"code.column" = src.column } },
+        };
+    }
+
+    pub fn jsonStringify(this: @This(), jw: anytype) !void {
+        switch (this) {
+            .dynamic => |dyn| try jw.write(dyn),
+            .standard => |standard| try standard.jsonStringify(jw),
+        }
+    }
+};
+
+pub const Type = enum {
+    // ------ primitive types ------
+
+    string,
+    boolean,
+    double,
+    integer,
+
+    // --- primitive array types ---
+
+    string_array,
+    boolean_array,
+    double_array,
+    integer_array,
+};
+
+/// This type makes no claims about data ownership. See attribute.Set for a type that owns its data.
+pub const Dynamic = struct {
+    key: []const u8,
+    value: Value,
+
+    pub const Value = union(Type) {
+        // ------ primitive types ------
+
+        string: []const u8,
+        boolean: bool,
+        double: f64,
+        integer: i64,
+
+        // --- primitive array types ---
+
+        string_array: []const []const u8,
+        boolean_array: []const bool,
+        double_array: []const f64,
+        integer_array: []const i64,
+
+        pub fn fromType(T: type, val: T) @This() {
+            switch (T) {
+                []const u8 => return .{ .string = val },
+                bool => return .{ .boolean = val },
+                f16, f32, f64, comptime_float => return .{ .double = val },
+                i32, i64, comptime_int => return .{ .integer = val },
+
+                []const []const u8 => return .{ .string_array = val },
+                []const bool => return .{ .boolean_array = val },
+                []const f64 => return .{ .double_array = val },
+                []const i64, []const comptime_int => return .{ .integer_array = val },
+                else => switch (@typeInfo(T)) {
+                    // enums are string encoded
+                    .@"enum" => return .{ .string = @tagName(val) },
+                    .int => |int_info| if ((int_info.signedness == .signed and int_info.bits <= 64) or (int_info.signedness == .unsigned and int_info.bits <= 63)) {
+                        return .{ .integer = val };
+                    } else @compileError("unsupported integer " ++ @typeName(T) ++ ", must fit into an i64"),
+
+                    else => @compileError("unsupported type " ++ @typeName(T)),
+                },
+            }
+        }
+
+        pub fn format(value: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+            switch (value) {
+                .string => |s| try writer.print("{}", .{std.zig.fmtEscapes(s)}),
+                .boolean => |b| try writer.print("{}", .{b}),
+                .double => |d| try writer.print("{e}", .{d}),
+                .integer => |i| try writer.print("{}", .{i}),
+
+                .string_array => |array| {
+                    try writer.writeAll("{");
+                    for (array) |string| {
+                        try writer.print(" \"{}\"", .{std.zig.fmtEscapes(string)});
+                    }
+                    try writer.writeAll(" }");
+                },
+                .boolean_array => |array| {
+                    try writer.writeAll("{");
+                    for (array) |boolean| {
+                        try writer.print(" {}", .{boolean});
+                    }
+                    try writer.writeAll(" }");
+                },
+                .double_array => |array| {
+                    try writer.writeAll("{");
+                    for (array) |double| {
+                        try writer.print(" {e}", .{double});
+                    }
+                    try writer.writeAll(" }");
+                },
+                .integer_array => |array| {
+                    try writer.writeAll("{");
+                    for (array) |integer| {
+                        try writer.print(" {d}", .{integer});
+                    }
+                    try writer.writeAll(" }");
+                },
+            }
+        }
+
+        pub fn jsonStringify(this: @This(), jw: anytype) !void {
+            try jw.beginObject();
+            switch (this) {
+                .string => |s| {
+                    try jw.objectField("stringValue");
+                    try jw.write(s);
+                },
+                .boolean => |b| {
+                    try jw.objectField("boolValue");
+                    try jw.write(b);
+                },
+                .double => |d| {
+                    try jw.objectField("doubleValue");
+                    try jw.write(d);
+                },
+                .integer => |i| {
+                    try jw.objectField("intValue");
+                    try jw.write(i);
+                },
+                .string_array => |array| {
+                    try jw.objectField("arrayValue");
+                    try jw.beginObject();
+                    try jw.objectField("values");
+                    try jw.beginArray();
+                    for (array) |string| {
+                        try jw.write(Value{ .string = string });
+                    }
+                    try jw.endArray();
+                    try jw.endObject();
+                },
+                .boolean_array => |array| {
+                    try jw.objectField("arrayValue");
+                    try jw.beginObject();
+                    try jw.objectField("values");
+                    try jw.beginArray();
+                    for (array) |boolean| {
+                        try jw.write(Value{ .boolean = boolean });
+                    }
+                    try jw.endArray();
+                    try jw.endObject();
+                },
+                .double_array => |array| {
+                    try jw.objectField("arrayValue");
+                    try jw.beginObject();
+                    try jw.objectField("values");
+                    try jw.beginArray();
+                    for (array) |double| {
+                        try jw.write(Value{ .double = double });
+                    }
+                    try jw.endArray();
+                    try jw.endObject();
+                },
+                .integer_array => |array| {
+                    try jw.objectField("arrayValue");
+                    try jw.beginObject();
+                    try jw.objectField("values");
+                    try jw.beginArray();
+                    for (array) |integer| {
+                        try jw.write(Value{ .integer = integer });
+                    }
+                    try jw.endArray();
+                    try jw.endObject();
+                },
+            }
+            try jw.endObject();
+        }
+    };
+
+    pub fn format(attr: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        try writer.print("{s}={}", .{ attr.key, attr.value });
+    }
+};
+
+/// Standard Attribute names.
+///
+/// Is a 31-bit integer for `Attribute.Set`. This allows using one bit of a 32-bit integer to both
+/// reference standard attribute names and index into a string table for custom attribute names.
+pub const Standard = union(enum(u31)) {
+    pub const Name = std.meta.Tag(Standard);
+
+    // --- service group (stable) ---
+    @"service.name": []const u8,
+    @"service.version": []const u8,
+
+    // --- telemetry group (stable) ---
+
+    @"telemetry.sdk.language": []const u8,
+    @"telemetry.sdk.name": []const u8,
+    @"telemetry.sdk.version": []const u8,
+
+    // --- server group (stable) ---
+    @"server.address": []const u8,
+    @"server.port": i64,
+
+    // --- client group (stable) ---
+
+    @"client.address": []const u8,
+    @"client.port": i64,
+
+    // --- network group (stable) ---
+
+    @"network.local.address": []const u8,
+    @"network.local.port": i64,
+    @"network.peer.address": []const u8,
+    @"network.peer.port": i64,
+    @"network.protocol.name": []const u8,
+    @"network.protocol.version": []const u8,
+    /// Should be serialized as a string.
+    @"network.transport": enum {
+        pipe,
+        tcp,
+        udp,
+        unix,
+    },
+    @"network.type": enum {
+        ipv4,
+        ipv6,
+    },
+
+    // ---- code group (experimental) ----
+
+    /// (experimental) The source code file name that identifies the code unit as
+    /// uniquely as possible (preferably an absolute file path).
+    @"code.filepath": []const u8,
+    /// (experimental)
+    @"code.function": []const u8,
+    /// (experimental) The line number in code.filepath best representing the operation.
+    /// It SHOULD point within the code unit named in code.function.
+    @"code.lineno": i64,
+    /// (experimental) The column number in code.filepath best representing the
+    /// operation. It SHOULD point within the code unit named in code.function.
+    @"code.column": i64,
+    /// (experimental)
+    @"code.namespace": []const u8,
+    /// (experimental)
+    @"code.stacktrace": []const u8,
+
+    // ------ error group ------
+
+    @"error.type": []const u8,
+
+    // ------ exception group ------
+
+    /// The exception message.
+    @"exception.message": []const u8,
+    /// The exceptions type. We use the error for this in Zig.
+    @"exception.type": []const u8,
+    @"exception.escaped": bool,
+    /// SHOULD be set to true if the exception event is recorded at a point where it is
+    /// known that the exception is escaping the scope of the span.
+    ///
+    /// An exception is considered to have escaped (or left) the scope of a span, if that
+    /// span is ended while the exception is still logically “in flight”. This may be
+    /// actually “in flight” in some languages (e.g. if the exception is passed to a
+    /// Context manager’s __exit__ method in Python) but will usually be caught at the
+    /// point of recording the exception in most languages.
+    @"exception.stacktrace": []const u8,
+
+    // ------ http group ------
+
+    /// Should be serialized as a string. "_OTHER" is used for unknown http methods.
+    @"http.request.method": std.http.Method,
+    @"http.request.method_original": []const u8,
+    /// [HTTP response status code](https://datatracker.ietf.org/doc/html/rfc7231#section-6)
+    @"http.request.status_code": i64,
+    @"http.request.resend_count": i64,
+
+    // ------ url group ------
+
+    @"url.full": []const u8,
+    @"url.scheme": []const u8,
+    @"url.path": []const u8,
+    @"url.query": []const u8,
+    @"url.fragment": []const u8,
+
+    // ------ user_agent group ------
+
+    @"user_agent.original": []const u8,
+
+    pub fn asDynamicValue(this: @This()) Dynamic.Value {
+        switch (this) {
+            inline else => |val| return Dynamic.Value.fromType(@TypeOf(val), val),
+        }
+    }
+
+    pub fn jsonStringify(this: @This(), jw: anytype) !void {
+        try jw.beginObject();
+
+        try jw.objectField("key");
+        try jw.write(@tagName(this));
+
+        try jw.objectField("value");
+        try jw.write(this.asDynamicValue());
+
+        try jw.endObject();
+    }
+};
+
+const std = @import("../std.zig");

--- a/lib/std/otel/trace.zig
+++ b/lib/std/otel/trace.zig
@@ -1,0 +1,514 @@
+//! This file provides an API to trace the path a request took through your code.
+//! Start by using the `scoped` function to create a tracer:
+//!
+//! ```zig
+//! const tracer = std.otel.trace.scoped(.{ .name = "com.example.lib" });
+//! ```
+//!
+//! With `tracer`, you can create a `Span` to indicate how long a particular
+//! task/function took:
+//!
+//! ```zig
+//! pub fn doAThing() {
+//!     const span = tracer.beginSpan("doing a thing", @src(), .{});
+//!     defer span.end(null);
+//!
+//!     // ... code that does the thing
+//! }
+//! ```
+//!
+//! Tracing functions will be a no-op by default. The software developer will need
+//! to specify an implementation to actually collect the tracing data. See
+//! `std.otel` for more information on setting up an implementation.
+//!
+//! See the [OpenTelemetry tracing API specification](https://opentelemetry.io/docs/specs/otel/trace/api/)
+//! for more information.
+
+const trace = @This();
+
+/// Create a type that will pass the given `InstrumentationScope` to each `createSpan` call.
+///
+/// In OpenTelemetry, this is called a Tracer, and is used to differentiate between
+/// e.g. tracing done by the std library and tracing done by your application.
+pub fn scoped(comptime scope: std.otel.InstrumentationScope) type {
+    return struct {
+        const this_scope = scope;
+
+        pub fn createSpan(
+            /// Concisely identifies the work done by the Span.
+            ///
+            /// For example, here are potential span names for an endpoint that gets a
+            /// hypothetical account information:
+            ///
+            /// |        Span Name        | Guidance                                                 |
+            /// |-------------------------|----------------------------------------------------------|
+            /// | get                     | Too general                                              |
+            /// | get_account/42          | Too specific                                             |
+            /// | get_account             | Good, and account_id=42 would make a nice Span attribute |
+            /// | get_account/{accountId} | Also good (using the “HTTP route”)                       |
+            comptime name: [:0]const u8,
+            /// The source location, which you can get with `@src()`. It is up to the
+            /// implementation how this is used, though an implementation following the
+            /// OpenTelemetry specification will attach it to the Span as `code.*` attributes.
+            comptime source_location: ?std.builtin.SourceLocation,
+            options: CreateSpanOptions,
+        ) Span {
+            return .{ .impl = std.otel.functions.trace.tracer_create_span(this_scope, name, source_location, options) };
+        }
+
+        /// Create a span using only the instrumentation scope and the source location.
+        ///
+        /// Technically not allowed by the OpenTelemetry spec. But when the use case is
+        /// profiling code and not remote requests, the name is redundant information.
+        /// Implementations can construct a name from the source location if they need to;
+        /// the function name should be a good first approximation. If you think that will
+        /// not be the case, consider using `createSpan` instead.
+        pub fn createSpanSourceLocation(
+            comptime source_location: std.builtin.SourceLocation,
+            options: CreateSpanOptions,
+        ) Span {
+            return .{ .impl = std.otel.functions.trace.tracer_create_span_source_location(this_scope, source_location, options) };
+        }
+
+        pub fn enabled() bool {
+            return @call(.auto, std.otel.functions.trace.tracer_enabled, .{this_scope});
+        }
+
+        /// Helper function that creates a span, puts it into an otel.Context, and sets that
+        /// context as the current context. Designed to minimize friction when marking up
+        /// source code. More advanced use cases should use `createSpan` directly. It is
+        /// implemented in terms of the OpenTelemetry API primitives.
+        pub fn beginSpan(
+            comptime name: [:0]const u8,
+            comptime source_location: ?std.builtin.SourceLocation,
+            options: CreateSpanOptions,
+        ) BeginSpanResult {
+            const new_span = createSpan(name, source_location, options);
+            const new_context = contextWithSpan(std.otel.Context.current(), new_span);
+            const attach_token = new_context.attach();
+            return .{ .span = new_span, .context = new_context, .attach_token = attach_token };
+        }
+
+        /// Helper function that creates a span, puts it into an otel.Context, and sets that
+        /// context as the current context. Designed to minimize friction when marking up
+        /// source code. More advanced use cases should use `createSpanSourceLocation` directly. It is
+        /// implemented in terms of the OpenTelemetry API primitives.
+        pub fn beginSpanSrc(
+            comptime source_location: std.builtin.SourceLocation,
+            options: CreateSpanOptions,
+        ) BeginSpanResult {
+            const new_span = createSpanSourceLocation(source_location, options);
+            const new_context = contextWithSpan(std.otel.Context.current(), new_span);
+            const attach_token = new_context.attach();
+            return .{ .span = new_span, .context = new_context, .attach_token = attach_token };
+        }
+    };
+}
+
+/// Helper type designed to minimize friction when marking up source code. See `scoped().beginSpan()`.
+pub const BeginSpanResult = struct {
+    span: Span,
+    context: std.otel.Context,
+    attach_token: std.otel.Context.AttachToken,
+
+    /// Helper function that ends the span and detaches and destroys the context.
+    /// Designed to minimize friction when marking up source code. To specify an end
+    /// time, use `Span.end`, `Context.detach`, and `Context.destroy` directly.
+    pub fn end(this: *const @This()) void {
+        this.span.end(null);
+        this.attach_token.detach();
+        this.context.destroy();
+    }
+};
+
+/// A Span represents a single operation within a trace. Spans can be nested to form
+/// a trace tree. Each trace contains a root span, which typically describes the
+/// entire operation and, optionally, one or more sub-spans for its sub-operations.
+pub const Span = struct {
+    impl: std.otel.types.trace.Span,
+
+    /// Gets the `SpanContext` associated with this span.
+    pub fn getContext(this: @This()) SpanContext {
+        return std.otel.functions.trace.span_get_context(this.impl);
+    }
+
+    /// Gets the `SpanContext` associated with this span.
+    pub fn isRecording(this: @This()) bool {
+        return std.otel.functions.trace.span_is_recording(this.impl);
+    }
+
+    pub fn setAttribute(this: @This(), attribute: std.otel.Attribute) void {
+        std.otel.functions.trace.span_set_attribute(this.impl, attribute);
+    }
+
+    pub fn addEvent(this: @This(), options: AddEventOptions) void {
+        std.otel.functions.trace.trace.span_add_event(this.impl, options);
+    }
+
+    pub fn setStatus(this: @This(), status: Status) void {
+        std.otel.functions.trace.span_set_status(this.impl, status);
+    }
+
+    pub fn updateName(this: @This(), new_name: []const u8) void {
+        std.otel.functions.trace.span_update_name(this.impl, new_name);
+    }
+
+    pub fn end(this: @This(), end_timestamp: ?i128) void {
+        std.otel.functions.trace.span_end(this.impl, end_timestamp);
+    }
+
+    pub fn recordException(this: @This(), err: anyerror, stack_trace: ?std.builtin.StackTrace) void {
+        std.otel.functions.trace.span_record_exception(this.impl, err, stack_trace);
+    }
+};
+
+pub fn contextWithSpan(context: std.otel.Context, span: Span) std.otel.Context {
+    return std.otel.functions.trace.context_with_span(context, span.impl);
+}
+
+pub fn contextExtractSpan(context: std.otel.Context) Span {
+    return .{ .impl = std.otel.functions.trace.context_extract_span(context) };
+}
+
+pub const CreateSpanOptions = struct {
+    parent_context: ParentContextOption = .implicit,
+    kind: SpanKind = .internal,
+    /// A list of attributes to associate with the Span. May be used to sampling decision.
+    ///
+    /// Adding attributes at creation time is preferred, as attributes added later are
+    /// not used when making sampling decisions.
+    attributes: []const std.otel.Attribute = &.{},
+    /// Linked Spans can be from the same or a different trace. Links added at Span
+    /// creation may be considered by Samplers to make a sampling decision.
+    links: []const Link = &.{},
+    /// Time when the span started in nanoseconds. This argument SHOULD only be set when
+    /// span creation time has already passed. If API is called at a moment of a Span
+    /// logical start, API user MUST NOT explicitly set this argument.
+    start_timestamp: ?i128 = null,
+};
+
+pub const ParentContextOption = union(enum) {
+    /// The Span is a root span
+    none,
+    /// Look in `otel.Context.current` for a parent span.
+    implicit,
+    /// Use the given `otel.Context` as the parent span.
+    explicit: std.otel.Context,
+};
+
+pub const SpanKind = enum(u32) {
+    unspecified = 0,
+    /// Default value. Indicates that the Span represents an internal operation within
+    /// an application, as opposed to operations with remote parents or children.
+    internal = 1,
+    /// Indicates that the Span covers server side handling of a remote request while the
+    /// client awaits a response.
+    server = 2,
+    /// Indicates that the Span describes a request to a remote service.
+    client = 3,
+    /// Indicates that the Span describes the initiation or scheduling of a local or
+    /// remote operation. This initiating Span often ends before the correlated
+    /// `consumer` Span, possibly even before the `consumer` span begins.
+    producer = 4,
+    /// Indicates that the Span represents the processing of an operation initiated by a
+    /// `producer`, where the `producer` does not wait for the outcome.
+    consumer = 5,
+};
+
+pub const AddEventOptions = struct {
+    name: []const u8,
+    timestamp: ?u64 = null,
+    attrs: []const std.otel.Attribute = &.{},
+};
+
+pub const Status = union(Code) {
+    unset,
+    ok,
+    @"error": []const u8,
+
+    pub const Code = enum(u2) {
+        unset = 0,
+        ok = 1,
+        @"error" = 2,
+    };
+
+    pub fn jsonStringify(this: @This(), jw: anytype) !void {
+        switch (this) {
+            .unset,
+            .ok,
+            => {
+                try jw.beginObject();
+                try jw.objectField("code");
+                try jw.write(@intFromEnum(@as(Code, this)));
+                try jw.endObject();
+            },
+            .@"error" => |msg| {
+                try jw.beginObject();
+                try jw.objectField("message");
+                try jw.write(msg);
+                try jw.objectField("code");
+                try jw.write(@intFromEnum(@as(Code, this)));
+                try jw.endObject();
+            },
+        }
+    }
+
+    pub fn format(this: @This(), comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        try writer.writeAll(@tagName(this));
+        switch (this) {
+            .unset,
+            .ok,
+            => {},
+            .@"error" => |msg| try writer.print("\"{}\"", .{std.zig.fmtEscapes(msg)}),
+        }
+    }
+};
+
+/// Used to link traces that go from client to server and then from server to other
+/// servers.
+///
+/// See W3C's Trace Context: https://www.w3.org/TR/trace-context/
+pub const SpanContext = struct {
+    trace_id: TraceId,
+    span_id: SpanId,
+    flags: trace.Flags,
+    state: trace.State,
+    is_remote: bool,
+
+    pub const INVALID = SpanContext{
+        .trace_id = TraceId.INVALID,
+        .span_id = SpanId.INVALID,
+        .flags = Flags.NONE,
+        .state = .{ .values = &.{} },
+        .is_remote = false,
+    };
+
+    pub fn isValid(this: @This()) bool {
+        return this.trace_id.isValid() and this.span_id.isValid();
+    }
+};
+
+/// See W3C's Trace Context: https://www.w3.org/TR/trace-context/
+pub const TraceId = struct {
+    bytes: [16]u8,
+
+    pub const INVALID = @This(){ .bytes = [_]u8{0} ** 16 };
+
+    pub fn hex(hex_string: *const [32]u8) @This() {
+        var trace_id: @This() = undefined;
+        const decoded = std.fmt.hexToBytes(&trace_id.bytes, hex_string) catch @panic("we specified the size of the string, and it should match exactly");
+        std.debug.assert(decoded.len == trace_id.bytes.len);
+        return trace_id;
+    }
+
+    pub fn isValid(this: @This()) bool {
+        return !std.mem.allEqual(u8, &this.bytes, 0);
+    }
+
+    pub fn jsonStringify(this: *const @This(), jw: anytype) !void {
+        try jw.print("\"{}\"", .{std.fmt.fmtSliceHexLower(&this.bytes)});
+    }
+};
+
+/// A unique id for each span.
+///
+/// See W3C's Trace Context: https://www.w3.org/TR/trace-context/
+pub const SpanId = struct {
+    bytes: [8]u8,
+
+    pub const INVALID = SpanId{ .bytes = [_]u8{0} ** 8 };
+
+    pub fn hex(hex_string: *const [16]u8) SpanId {
+        var trace_id: SpanId = undefined;
+        const decoded = std.fmt.hexToBytes(&trace_id.bytes, hex_string) catch @panic("we specified the size of the string, and it should match exactly");
+        std.debug.assert(decoded.len == trace_id.bytes.len);
+        return trace_id;
+    }
+
+    pub fn isValid(this: @This()) bool {
+        return !std.mem.allEqual(u8, &this.bytes, 0);
+    }
+
+    pub fn jsonStringify(this: *const @This(), jw: anytype) !void {
+        try jw.print("\"{}\"", .{std.fmt.fmtSliceHexLower(&this.bytes)});
+    }
+};
+
+/// See W3C's Trace Context: https://www.w3.org/TR/trace-context/
+pub const Flags = packed struct(u8) {
+    sampled: bool,
+    _reserved: u7 = 0,
+
+    pub const NONE = .{ .sampled = false };
+    pub const SAMPLED = .{ .sampled = true };
+};
+
+pub const State = struct {
+    values: []const std.meta.Tuple(&.{ []const u8, []const u8 }),
+};
+
+pub const Link = struct {
+    span_context: SpanContext,
+    attrs: []const std.otel.Attribute,
+};
+
+pub const Types = struct {
+    Span: type,
+};
+
+pub const Functions = struct {
+    tracer_enabled: fn (comptime std.otel.InstrumentationScope) bool,
+
+    tracer_create_span: fn (
+        comptime std.otel.InstrumentationScope,
+        comptime name: [:0]const u8,
+        comptime ?std.builtin.SourceLocation,
+        options: CreateSpanOptions,
+    ) impl_types.Span,
+
+    /// Create a span using only the source location.
+    ///
+    /// Technically not allowed by the OpenTelemetry spec. But when the use case is
+    /// profiling code and not remote requests, the name is redundant information.
+    /// Implementations can construct a name from the source location if they need to;
+    /// the function name should be a good first approximation. If you think that will
+    /// not be the case, consider using `tracer_create_span` instead.
+    tracer_create_span_source_location: fn (
+        comptime std.otel.InstrumentationScope,
+        comptime std.builtin.SourceLocation,
+        options: CreateSpanOptions,
+    ) impl_types.Span,
+
+    context_extract_span: fn (std.otel.Context) impl_types.Span,
+    context_with_span: fn (std.otel.Context, impl_types.Span) std.otel.Context,
+
+    span_get_context: fn (impl_types.Span) SpanContext,
+    span_is_recording: fn (impl_types.Span) bool,
+    span_set_attribute: fn (impl_types.Span, std.otel.Attribute) void,
+    span_add_event: fn (impl_types.Span, AddEventOptions) void,
+    span_add_link: fn (impl_types.Span, Link) void,
+    span_set_status: fn (impl_types.Span, Status) void,
+    span_update_name: fn (impl_types.Span, [:0]const u8) void,
+    span_end: fn (impl_types.Span, end_timestamp: ?i128) void,
+    span_record_exception: fn (impl_types.Span, anyerror, ?std.builtin.StackTrace) void,
+
+    const impl_types = std.otel.types.trace;
+};
+
+/// Types used by the default implementation of the otel.trace API, which does nothing.
+pub const NULL_TYPES: Types = .{
+    .Span = struct {
+        pub const NULL = @This(){};
+    },
+};
+
+/// Functions used by the default implementation of the otel.trace API, which do nothing.
+pub const NULL_FUNCTIONS: Functions = .{
+    .tracer_enabled = nullTracerEnabled,
+    .tracer_create_span = nullTracerCreateSpan,
+    .tracer_create_span_source_location = nullTracerCreateSpanSourceLocation,
+
+    .context_extract_span = nullContextExtractSpan,
+    .context_with_span = nullContextWithSpan,
+
+    .span_get_context = nullSpanGetContext,
+    .span_is_recording = nullSpanIsRecording,
+    .span_set_attribute = nullSpanSetAttribute,
+    .span_add_event = nullSpanAddEvent,
+    .span_add_link = nullSpanAddLink,
+    .span_set_status = nullSpanSetStatus,
+    .span_update_name = nullSpanUpdateName,
+    .span_end = nullSpanEnd,
+    .span_record_exception = nullSpanRecordException,
+};
+
+fn nullTracerEnabled(comptime scope: std.otel.InstrumentationScope) bool {
+    _ = scope;
+    return false;
+}
+
+fn nullTracerCreateSpan(
+    comptime tracer_scope: std.otel.InstrumentationScope,
+    comptime name: []const u8,
+    comptime source_location: ?std.builtin.SourceLocation,
+    options: CreateSpanOptions,
+) std.otel.types.trace.Span {
+    _ = tracer_scope;
+    _ = name;
+    _ = source_location;
+    _ = options;
+    // TODO: "The API MUST return a non-recording Span with the SpanContext in the parent Context (whether explicitly given or implicit current)."
+    // Not sure if we will implement this part of the spec, as it would return at least a SpanContext, which would probably affect performance.
+    return std.otel.types.trace.Span.NULL;
+}
+
+fn nullTracerCreateSpanSourceLocation(
+    comptime tracer_scope: std.otel.InstrumentationScope,
+    comptime source_location: std.builtin.SourceLocation,
+    options: CreateSpanOptions,
+) std.otel.types.trace.Span {
+    _ = tracer_scope;
+    _ = source_location;
+    _ = options;
+    // TODO: "The API MUST return a non-recording Span with the SpanContext in the parent Context (whether explicitly given or implicit current)."
+    // Not sure if we will implement this part of the spec, as it would return at least a SpanContext, which would probably affect performance.
+    return std.otel.types.trace.Span.NULL;
+}
+
+fn nullContextExtractSpan(context: std.otel.Context) std.otel.types.trace.Span {
+    _ = context;
+    return .NULL;
+}
+
+fn nullContextWithSpan(context: std.otel.Context, span: std.otel.types.trace.Span) std.otel.Context {
+    _ = span;
+    return context;
+}
+
+fn nullSpanGetContext(span: std.otel.types.trace.Span) SpanContext {
+    _ = span;
+    return SpanContext.INVALID;
+}
+
+fn nullSpanIsRecording(span: std.otel.types.trace.Span) bool {
+    _ = span;
+    return false;
+}
+
+fn nullSpanSetAttribute(span: std.otel.types.trace.Span, attribute: std.otel.Attribute) void {
+    _ = span;
+    _ = attribute;
+}
+
+fn nullSpanAddEvent(span: std.otel.types.trace.Span, options: AddEventOptions) void {
+    _ = span;
+    _ = options;
+}
+
+fn nullSpanAddLink(span: std.otel.types.trace.Span, link: Link) void {
+    _ = span;
+    _ = link;
+}
+
+fn nullSpanSetStatus(span: std.otel.types.trace.Span, status: Status) void {
+    _ = span;
+    _ = status;
+}
+
+fn nullSpanUpdateName(span: std.otel.types.trace.Span, new_name: []const u8) void {
+    _ = span;
+    _ = new_name;
+}
+
+fn nullSpanEnd(span: std.otel.types.trace.Span, end_timestamp: ?i128) void {
+    _ = span;
+    _ = end_timestamp;
+}
+
+fn nullSpanRecordException(span: std.otel.types.trace.Span, err: anyerror, stack_trace: ?std.builtin.StackTrace) void {
+    _ = span;
+    err catch {};
+    _ = stack_trace;
+}
+
+const std = @import("../std.zig");

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -77,6 +77,7 @@ pub const mem = @import("mem.zig");
 pub const meta = @import("meta.zig");
 pub const net = @import("net.zig");
 pub const os = @import("os.zig");
+pub const otel = @import("otel.zig");
 pub const once = @import("once.zig").once;
 pub const pdb = @import("pdb.zig");
 pub const posix = @import("posix.zig");

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -17,7 +17,6 @@ const target_util = @import("target.zig");
 const Package = @import("Package.zig");
 const link = @import("link.zig");
 const tracy = @import("tracy.zig");
-const trace = tracy.trace;
 const build_options = @import("build_options");
 const LibCInstallation = std.zig.LibCInstallation;
 const glibc = @import("glibc.zig");
@@ -43,6 +42,8 @@ pub const Directory = Cache.Directory;
 const Path = Cache.Path;
 
 pub const Config = @import("Compilation/Config.zig");
+
+const tracer = std.otel.trace.scoped(.{ .name = "zig.Compilation" });
 
 /// General-purpose allocator. Used for both temporary and long-term storage.
 gpa: Allocator,
@@ -2039,8 +2040,8 @@ fn cleanupAfterUpdate(comp: *Compilation) void {
 
 /// Detect changes to source files, perform semantic analysis, and update the output files.
 pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) !void {
-    const tracy_trace = trace(@src());
-    defer tracy_trace.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     // This arena is scoped to this one update.
     const gpa = comp.gpa;
@@ -4405,8 +4406,8 @@ pub const CImportResult = struct {
 pub fn cImport(comp: *Compilation, c_src: []const u8, owner_mod: *Package.Module) !CImportResult {
     dev.check(.translate_c_command);
 
-    const tracy_trace = trace(@src());
-    defer tracy_trace.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const cimport_zig_basename = "cimport.zig";
 
@@ -4684,8 +4685,8 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
     const self_exe_path = comp.self_exe_path orelse
         return comp.failCObj(c_object, "clang compilation disabled", .{});
 
-    const tracy_trace = trace(@src());
-    defer tracy_trace.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     log.debug("updating C object: {s}", .{c_object.src.src_path});
 
@@ -4987,8 +4988,8 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
     const self_exe_path = comp.self_exe_path orelse
         return comp.failWin32Resource(win32_resource, "unable to find self exe path", .{});
 
-    const tracy_trace = trace(@src());
-    defer tracy_trace.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const src_path = switch (win32_resource.src) {
         .rc => |rc_src| rc_src.src_path,
@@ -6265,8 +6266,8 @@ fn buildOutputFromZig(
     misc_task_tag: MiscTask,
     prog_node: std.Progress.Node,
 ) !void {
-    const tracy_trace = trace(@src());
-    defer tracy_trace.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = comp.gpa;
     var arena_allocator = std.heap.ArenaAllocator.init(gpa);
@@ -6391,8 +6392,8 @@ pub fn build_crt_file(
     /// created within this function.
     c_source_files: []CSourceFile,
 ) !void {
-    const tracy_trace = trace(@src());
-    defer tracy_trace.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = comp.gpa;
     var arena_allocator = std.heap.ArenaAllocator.init(gpa);

--- a/src/Liveness.zig
+++ b/src/Liveness.zig
@@ -12,11 +12,12 @@ const Allocator = std.mem.Allocator;
 const Log2Int = std.math.Log2Int;
 
 const Liveness = @This();
-const trace = @import("tracy.zig").trace;
 const Air = @import("Air.zig");
 const InternPool = @import("InternPool.zig");
 
 pub const Verify = @import("Liveness/Verify.zig");
+
+const tracer = std.otel.trace.scoped(.{ .name = "zig.liveness" });
 
 /// This array is split into sets of 4 bits per AIR instruction.
 /// The MSB (0bX000) is whether the instruction is unreferenced.
@@ -137,8 +138,8 @@ fn LivenessPassData(comptime pass: LivenessPass) type {
 }
 
 pub fn analyze(gpa: Allocator, air: Air, intern_pool: *InternPool) Allocator.Error!Liveness {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var a: Analysis = .{
         .gpa = gpa,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -168,6 +168,7 @@ const mem = std.mem;
 const Allocator = mem.Allocator;
 const assert = std.debug.assert;
 const log = std.log.scoped(.sema);
+const tracer = std.otel.trace.scoped(.{ .name = "zig.sema" });
 
 const Sema = @This();
 const Value = @import("Value.zig");
@@ -176,7 +177,6 @@ const Type = @import("Type.zig");
 const Air = @import("Air.zig");
 const Zir = std.zig.Zir;
 const Zcu = @import("Zcu.zig");
-const trace = @import("tracy.zig").trace;
 const Namespace = Zcu.Namespace;
 const CompileError = Zcu.CompileError;
 const SemaError = Zcu.SemaError;
@@ -2986,8 +2986,8 @@ fn zirEnumDecl(
     extended: Zir.Inst.Extended.InstData,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -3142,8 +3142,8 @@ fn zirUnionDecl(
     extended: Zir.Inst.Extended.InstData,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -3267,8 +3267,8 @@ fn zirOpaqueDecl(
     extended: Zir.Inst.Extended.InstData,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -3349,8 +3349,8 @@ fn zirErrorSetDecl(
     sema: *Sema,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -3376,8 +3376,8 @@ fn zirErrorSetDecl(
 }
 
 fn zirRetPtr(sema: *Sema, block: *Block) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
 
@@ -3403,8 +3403,8 @@ fn zirRetPtr(sema: *Sema, block: *Block) CompileError!Air.Inst.Ref {
 }
 
 fn zirRef(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_tok;
     const operand = try sema.resolveInst(inst_data.operand);
@@ -3412,8 +3412,8 @@ fn zirRef(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
 }
 
 fn zirEnsureResultUsed(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const operand = try sema.resolveInst(inst_data.operand);
@@ -3456,8 +3456,8 @@ fn ensureResultUsed(
 }
 
 fn zirEnsureResultNonError(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -3481,8 +3481,8 @@ fn zirEnsureResultNonError(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
 }
 
 fn zirEnsureErrUnionPayloadVoid(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -3508,8 +3508,8 @@ fn zirEnsureErrUnionPayloadVoid(sema: *Sema, block: *Block, inst: Zir.Inst.Index
 }
 
 fn zirIndexablePtrLen(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -3633,8 +3633,8 @@ fn zirAllocExtended(
 }
 
 fn zirAllocComptime(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const ty_src = block.src(.{ .node_offset_var_decl_ty = inst_data.src_node });
@@ -4029,8 +4029,8 @@ fn zirAllocInferredComptime(
 }
 
 fn zirAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
 
@@ -4058,8 +4058,8 @@ fn zirAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.I
 }
 
 fn zirAllocMut(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
 
@@ -4087,8 +4087,8 @@ fn zirAllocInferred(
     block: *Block,
     is_const: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = sema.gpa;
 
@@ -4120,8 +4120,8 @@ fn zirAllocInferred(
 }
 
 fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -4681,8 +4681,8 @@ fn zirValidatePtrStructInit(
     block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -5541,8 +5541,8 @@ fn addDeclaredHereNote(sema: *Sema, parent: *Zcu.ErrorMsg, decl_ty: Type) !void 
 }
 
 fn zirStoreToInferredPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pl_node = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(pl_node.src_node);
@@ -5637,8 +5637,8 @@ fn zirSetEvalBranchQuota(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Compi
 }
 
 fn zirStoreNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -5708,8 +5708,8 @@ fn uavRef(sema: *Sema, val: InternPool.Index) CompileError!Air.Inst.Ref {
 
 fn zirInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     _ = block;
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const int = sema.code.instructions.items(.data)[@intFromEnum(inst)].int;
     return sema.pt.intRef(Type.comptime_int, int);
@@ -5717,8 +5717,8 @@ fn zirInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Ins
 
 fn zirIntBig(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     _ = block;
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const int = sema.code.instructions.items(.data)[@intFromEnum(inst)].str;
     const byte_count = int.len * @sizeOf(std.math.big.Limb);
@@ -5754,8 +5754,8 @@ fn zirFloat128(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 }
 
 fn zirCompileError(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -5836,8 +5836,8 @@ fn zirTrap(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
 }
 
 fn zirLoop(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -5921,8 +5921,8 @@ fn zirLoop(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError
 }
 
 fn zirCImport(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -6042,8 +6042,8 @@ fn zirSuspendBlock(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) Comp
 }
 
 fn zirBlock(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index, force_comptime: bool) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pl_node = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = parent_block.nodeOffset(pl_node.src_node);
@@ -6168,8 +6168,8 @@ fn resolveAnalyzedBlock(
     merges: *Block.Merges,
     need_debug_scope: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = sema.gpa;
     const pt = sema.pt;
@@ -6376,8 +6376,8 @@ fn resolveAnalyzedBlock(
 }
 
 fn zirExport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -6557,8 +6557,8 @@ fn zirSetRuntimeSafety(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Compile
 }
 
 fn zirBreak(sema: *Sema, start_block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].@"break";
     const extra = sema.code.extraData(Zir.Inst.Break, inst_data.payload_index).data;
@@ -6590,8 +6590,8 @@ fn zirBreak(sema: *Sema, start_block: *Block, inst: Zir.Inst.Index) CompileError
 }
 
 fn zirSwitchContinue(sema: *Sema, start_block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].@"break";
     const extra = sema.code.extraData(Zir.Inst.Break, inst_data.payload_index).data;
@@ -7047,8 +7047,8 @@ fn zirCall(
     inst: Zir.Inst.Index,
     comptime kind: enum { direct, field },
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8525,8 +8525,8 @@ fn zirIntType(sema: *Sema, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
 }
 
 fn zirOptionalType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8640,8 +8640,8 @@ fn zirVectorType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
 }
 
 fn zirArrayType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -8661,8 +8661,8 @@ fn zirArrayType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
 }
 
 fn zirArrayTypeSentinel(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const extra = sema.code.extraData(Zir.Inst.ArrayTypeSentinel, inst_data.payload_index).data;
@@ -8699,8 +8699,8 @@ fn validateArrayElemType(sema: *Sema, block: *Block, elem_type: Type, elem_src: 
 }
 
 fn zirAnyframeType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     if (true) {
@@ -8715,8 +8715,8 @@ fn zirAnyframeType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErro
 }
 
 fn zirErrorUnionType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8771,8 +8771,8 @@ fn zirErrorValue(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
 }
 
 fn zirIntFromError(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8813,8 +8813,8 @@ fn zirIntFromError(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstD
 }
 
 fn zirErrorFromInt(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstData) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8858,8 +8858,8 @@ fn zirErrorFromInt(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstD
 }
 
 fn zirMergeErrorSets(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8915,8 +8915,8 @@ fn zirMergeErrorSets(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileEr
 
 fn zirEnumLiteral(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     _ = block;
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -8928,8 +8928,8 @@ fn zirEnumLiteral(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
 }
 
 fn zirDeclLiteral(sema: *Sema, block: *Block, inst: Zir.Inst.Index, do_coerce: bool) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -9108,8 +9108,8 @@ fn zirOptionalPayloadPtr(
     inst: Zir.Inst.Index,
     safety_check: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const optional_ptr = try sema.resolveInst(inst_data.operand);
@@ -9193,8 +9193,8 @@ fn zirOptionalPayload(
     inst: Zir.Inst.Index,
     safety_check: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -9246,8 +9246,8 @@ fn zirErrUnionPayload(
     block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -9301,8 +9301,8 @@ fn zirErrUnionPayloadPtr(
     block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const operand = try sema.resolveInst(inst_data.operand);
@@ -9387,8 +9387,8 @@ fn analyzeErrUnionPayloadPtr(
 
 /// Value in, value out
 fn zirErrUnionCode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -9421,8 +9421,8 @@ fn analyzeErrUnionCode(sema: *Sema, block: *Block, src: LazySrcLoc, operand: Air
 
 /// Pointer in, value out
 fn zirErrUnionCodePtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10296,8 +10296,8 @@ fn zirParamAnytype(
 }
 
 fn zirAsNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10306,8 +10306,8 @@ fn zirAsNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
 }
 
 fn zirAsShiftOperand(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10357,8 +10357,8 @@ fn analyzeAs(
 }
 
 fn zirIntFromPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10431,8 +10431,8 @@ fn zirIntFromPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
 }
 
 fn zirFieldVal(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10451,8 +10451,8 @@ fn zirFieldVal(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 }
 
 fn zirFieldPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10471,8 +10471,8 @@ fn zirFieldPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 }
 
 fn zirStructInitFieldPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10499,8 +10499,8 @@ fn zirStructInitFieldPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Compi
 }
 
 fn zirFieldValNamed(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10514,8 +10514,8 @@ fn zirFieldValNamed(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErr
 }
 
 fn zirFieldPtrNamed(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10529,8 +10529,8 @@ fn zirFieldPtrNamed(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErr
 }
 
 fn zirIntCast(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10699,8 +10699,8 @@ fn intCast(
 }
 
 fn zirBitcast(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10843,8 +10843,8 @@ fn zirBitcast(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
 }
 
 fn zirFloatCast(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10924,8 +10924,8 @@ fn zirFloatCast(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
 }
 
 fn zirElemVal(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10936,8 +10936,8 @@ fn zirElemVal(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
 }
 
 fn zirElemValNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -10950,8 +10950,8 @@ fn zirElemValNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
 }
 
 fn zirElemValImm(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].elem_val_imm;
     const array = try sema.resolveInst(inst_data.operand);
@@ -10960,8 +10960,8 @@ fn zirElemValImm(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
 }
 
 fn zirElemPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -10989,8 +10989,8 @@ fn zirElemPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
 }
 
 fn zirElemPtrNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -11003,8 +11003,8 @@ fn zirElemPtrNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
 }
 
 fn zirArrayInitElemPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -11024,8 +11024,8 @@ fn zirArrayInitElemPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Compile
 }
 
 fn zirSliceStart(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -11040,8 +11040,8 @@ fn zirSliceStart(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!
 }
 
 fn zirSliceEnd(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -11057,8 +11057,8 @@ fn zirSliceEnd(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 }
 
 fn zirSliceSentinel(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -11076,8 +11076,8 @@ fn zirSliceSentinel(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileErr
 }
 
 fn zirSliceLength(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -11760,8 +11760,8 @@ fn switchCond(
 const SwitchErrorSet = std.AutoHashMap(InternPool.NullTerminatedString, LazySrcLoc);
 
 fn zirSwitchBlockErrUnion(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -12084,8 +12084,8 @@ fn zirSwitchBlockErrUnion(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Comp
 }
 
 fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_ref: bool) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -14324,8 +14324,8 @@ fn zirHasDecl(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
 }
 
 fn zirImport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -14359,8 +14359,8 @@ fn zirImport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
 }
 
 fn zirEmbedFile(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
@@ -14411,8 +14411,8 @@ fn zirShl(
     inst: Zir.Inst.Index,
     air_tag: Air.Inst.Tag,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -14582,8 +14582,8 @@ fn zirShr(
     inst: Zir.Inst.Index,
     air_tag: Air.Inst.Tag,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -14718,8 +14718,8 @@ fn zirBitwise(
     inst: Zir.Inst.Index,
     air_tag: Air.Inst.Tag,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -14773,8 +14773,8 @@ fn zirBitwise(
 }
 
 fn zirBitNot(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -14919,8 +14919,8 @@ fn analyzeTupleCat(
 }
 
 fn zirArrayCat(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -15275,8 +15275,8 @@ fn analyzeTupleMul(
 }
 
 fn zirArrayMul(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -15512,8 +15512,8 @@ fn zirArithmetic(
     zir_tag: Zir.Inst.Tag,
     safety: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const src = block.src(.{ .node_offset_bin_op = inst_data.src_node });
@@ -16597,8 +16597,8 @@ fn zirOverflowArithmetic(
     extended: Zir.Inst.Extended.InstData,
     zir_tag: Zir.Inst.Extended,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const extra = sema.code.extraData(Zir.Inst.BinNode, extended.operand).data;
     const src = block.nodeOffset(extra.node);
@@ -17478,8 +17478,8 @@ fn analyzePtrArithmetic(
 }
 
 fn zirLoad(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -17494,8 +17494,8 @@ fn zirAsm(
     extended: Zir.Inst.Extended.InstData,
     tmpl_is_expr: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -17663,8 +17663,8 @@ fn zirCmpEq(
     op: std.math.CompareOperator,
     air_tag: Air.Inst.Tag,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -17782,8 +17782,8 @@ fn zirCmp(
     inst: Zir.Inst.Index,
     op: std.math.CompareOperator,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].pl_node;
     const extra = sema.code.extraData(Zir.Inst.Bin, inst_data.payload_index).data;
@@ -18141,8 +18141,8 @@ fn zirBuiltinSrc(
     block: *Block,
     extended: Zir.Inst.Extended.InstData,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19284,8 +19284,8 @@ fn zirTypeofPeer(
     extended: Zir.Inst.Extended.InstData,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const extra = sema.code.extraData(Zir.Inst.TypeOfPeer, extended.operand);
     const src = block.nodeOffset(extra.data.src_node);
@@ -19323,8 +19323,8 @@ fn zirTypeofPeer(
 }
 
 fn zirBoolNot(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19349,8 +19349,8 @@ fn zirBoolBr(
     inst: Zir.Inst.Index,
     is_bool_or: bool,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19518,8 +19518,8 @@ fn zirIsNonNull(
     block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -19533,8 +19533,8 @@ fn zirIsNonNullPtr(
     block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19561,8 +19561,8 @@ fn checkErrorType(sema: *Sema, block: *Block, src: LazySrcLoc, ty: Type) !void {
 }
 
 fn zirIsNonErr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -19572,8 +19572,8 @@ fn zirIsNonErr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Ai
 }
 
 fn zirIsNonErrPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19586,8 +19586,8 @@ fn zirIsNonErrPtr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
 }
 
 fn zirRetIsNonErr(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -19600,8 +19600,8 @@ fn zirCondbr(
     parent_block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19933,8 +19933,8 @@ fn zirRetImplicit(
     block: *Block,
     inst: Zir.Inst.Index,
 ) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -19980,8 +19980,8 @@ fn zirRetImplicit(
 }
 
 fn zirRetNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const operand = try sema.resolveInst(inst_data.operand);
@@ -19991,8 +19991,8 @@ fn zirRetNode(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!voi
 }
 
 fn zirRetLoad(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -20111,8 +20111,8 @@ fn zirRestoreErrRetIndex(sema: *Sema, start_block: *Block, extended: Zir.Inst.Ex
 /// its state at the point `block` was reached (or, if `block` is `none`, the
 /// point this function began execution).
 fn restoreErrRetIndex(sema: *Sema, start_block: *Block, src: LazySrcLoc, target_block: Zir.Inst.Ref, operand_zir: Zir.Inst.Ref) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -20274,8 +20274,8 @@ fn floatOpAllowed(tag: Zir.Inst.Tag) bool {
 }
 
 fn zirPtrType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -20429,8 +20429,8 @@ fn zirPtrType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
 }
 
 fn zirStructInitEmpty(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
     const src = block.nodeOffset(inst_data.src_node);
@@ -20449,8 +20449,8 @@ fn zirStructInitEmpty(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileE
 }
 
 fn zirStructInitEmptyResult(sema: *Sema, block: *Block, inst: Zir.Inst.Index, is_byref: bool) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -21614,8 +21614,8 @@ fn zirUnaryMath(
     air_tag: Air.Inst.Tag,
     comptime eval: fn (Value, Type, Allocator, Zcu.PerThread) Allocator.Error!Value,
 ) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -25458,8 +25458,8 @@ fn zirMulAdd(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
 }
 
 fn zirBuiltinCall(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -26528,8 +26528,8 @@ fn zirVarExtended(
 }
 
 fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;
@@ -36802,8 +36802,8 @@ fn unionFields(
     union_ty: InternPool.Index,
     union_type: InternPool.LoadedUnionType,
 ) CompileError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = sema.pt;
     const zcu = pt.zcu;

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -21,7 +21,7 @@ const Module = @import("../Package.zig").Module;
 const Sema = @import("../Sema.zig");
 const std = @import("std");
 const target_util = @import("../target.zig");
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.zcu" });
 const Type = @import("../Type.zig");
 const Value = @import("../Value.zig");
 const Zcu = @import("../Zcu.zig");
@@ -72,8 +72,8 @@ pub fn astGenFile(
     dev.check(.ast_gen);
     assert(!file.mod.isBuiltin());
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const comp = zcu.comp;
@@ -524,8 +524,8 @@ pub fn ensureFileAnalyzed(pt: Zcu.PerThread, file_index: Zcu.File.Index) Zcu.Sem
 /// is fully up-to-date. Note that the type of the `Nav` may not be fully resolved.
 /// Returns `error.AnalysisFail` if the `Cau` has an error.
 pub fn ensureCauAnalyzed(pt: Zcu.PerThread, cau_index: InternPool.Cau.Index) Zcu.SemaError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -689,8 +689,8 @@ fn ensureCauAnalyzedInner(
 pub fn ensureFuncBodyAnalyzed(pt: Zcu.PerThread, maybe_coerced_func_index: InternPool.Index) Zcu.SemaError!void {
     dev.check(.sema);
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -1045,8 +1045,8 @@ fn updateFileNamespace(pt: Zcu.PerThread, file_index: Zcu.File.Index) Allocator.
 }
 
 fn semaFile(pt: Zcu.PerThread, file_index: Zcu.File.Index) Zcu.SemaError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -1727,8 +1727,8 @@ pub fn scanNamespace(
     namespace_index: Zcu.Namespace.Index,
     decls: []const Zir.Inst.Index,
 ) Allocator.Error!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
@@ -1830,8 +1830,8 @@ const ScanDeclIter = struct {
     }
 
     fn scanDecl(iter: *ScanDeclIter, decl_inst: Zir.Inst.Index) Allocator.Error!void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const pt = iter.pt;
         const zcu = pt.zcu;
@@ -2015,8 +2015,8 @@ const ScanDeclIter = struct {
 };
 
 fn analyzeFnBody(pt: Zcu.PerThread, func_index: InternPool.Index) Zcu.SemaError!Air {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -8,7 +8,7 @@ const log = std.log.scoped(.codegen);
 const mem = std.mem;
 const math = std.math;
 const target_util = @import("target.zig");
-const trace = @import("tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.codegen" });
 
 const Air = @import("Air.zig");
 const Allocator = mem.Allocator;
@@ -126,8 +126,8 @@ pub fn generateLazySymbol(
 ) CodeGenError!Result {
     _ = reloc_parent;
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = bin_file.comp;
     const ip = &pt.zcu.intern_pool;
@@ -188,8 +188,8 @@ pub fn generateSymbol(
     code: *std.ArrayList(u8),
     reloc_parent: link.File.RelocInfo.Parent,
 ) CodeGenError!Result {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -12,7 +12,7 @@ const Value = @import("../Value.zig");
 const Type = @import("../Type.zig");
 const C = link.File.C;
 const Decl = Zcu.Decl;
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.c" });
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
 const InternPool = @import("../InternPool.zig");
@@ -2794,8 +2794,8 @@ pub fn genLazyFn(o: *Object, lazy_ctype_pool: *const CType.Pool, lazy_fn: LazyFn
 }
 
 pub fn genFunc(f: *Function) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const o = &f.object;
     const zcu = o.dg.pt.zcu;
@@ -2888,8 +2888,8 @@ pub fn genFunc(f: *Function) !void {
 }
 
 pub fn genDecl(o: *Object) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const pt = o.dg.pt;
     const zcu = pt.zcu;

--- a/src/glibc.zig
+++ b/src/glibc.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const mem = std.mem;
-const log = std.log;
+const log = std.log.scoped(.glibc);
 const fs = std.fs;
 const path = fs.path;
 const assert = std.debug.assert;
@@ -9,7 +9,7 @@ const Version = std.SemanticVersion;
 
 const Compilation = @import("Compilation.zig");
 const build_options = @import("build_options");
-const trace = @import("tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.glibc" });
 const Cache = std.Build.Cache;
 const Module = @import("Package/Module.zig");
 
@@ -56,8 +56,8 @@ pub const abilists_max_size = 800 * 1024; // Bigger than this and something is d
 /// This function will emit a log error when there is a problem with the zig
 /// installation and then return `error.ZigInstallationCorrupt`.
 pub fn loadMetaData(gpa: Allocator, contents: []const u8) LoadMetaDataError!*ABI {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var arena_allocator = std.heap.ArenaAllocator.init(gpa);
     errdefer arena_allocator.deinit();
@@ -735,8 +735,8 @@ fn wordDirective(target: std.Target) []const u8 {
 }
 
 pub fn buildSharedObjects(comp: *Compilation, prog_node: std.Progress.Node) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (!build_options.have_llvm) {
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
@@ -1221,8 +1221,8 @@ fn buildSharedLib(
     lib: Lib,
     prog_node: std.Progress.Node,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const basename = try std.fmt.allocPrint(arena, "lib{s}.so.{d}", .{ lib.name, lib.sover });
     const emit_bin = Compilation.EmitLoc{

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -5,7 +5,7 @@ const assert = std.debug.assert;
 const target_util = @import("target.zig");
 const Compilation = @import("Compilation.zig");
 const build_options = @import("build_options");
-const trace = @import("tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.libcxx" });
 const Module = @import("Package/Module.zig");
 
 pub const AbiVersion = enum(u2) {
@@ -119,8 +119,8 @@ pub fn buildLibCXX(comp: *Compilation, prog_node: std.Progress.Node) BuildError!
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
     defer arena_allocator.deinit();
@@ -363,8 +363,8 @@ pub fn buildLibCXXABI(comp: *Compilation, prog_node: std.Progress.Node) BuildErr
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
     defer arena_allocator.deinit();

--- a/src/libtsan.zig
+++ b/src/libtsan.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 
 const Compilation = @import("Compilation.zig");
 const build_options = @import("build_options");
-const trace = @import("tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.libtsan" });
 const Module = @import("Package/Module.zig");
 
 pub const BuildError = error{
@@ -18,8 +18,8 @@ pub fn buildTsan(comp: *Compilation, prog_node: std.Progress.Node) BuildError!vo
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
     defer arena_allocator.deinit();

--- a/src/libunwind.zig
+++ b/src/libunwind.zig
@@ -6,7 +6,7 @@ const target_util = @import("target.zig");
 const Compilation = @import("Compilation.zig");
 const Module = @import("Package/Module.zig");
 const build_options = @import("build_options");
-const trace = @import("tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.libunwind" });
 
 pub const BuildError = error{
     OutOfMemory,
@@ -19,8 +19,8 @@ pub fn buildStaticLib(comp: *Compilation, prog_node: std.Progress.Node) BuildErr
         return error.ZigCompilerNotBuiltWithLLVMExtensions;
     }
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var arena_allocator = std.heap.ArenaAllocator.init(comp.gpa);
     defer arena_allocator.deinit();

--- a/src/link.zig
+++ b/src/link.zig
@@ -5,7 +5,7 @@ const assert = std.debug.assert;
 const fs = std.fs;
 const mem = std.mem;
 const log = std.log.scoped(.link);
-const trace = @import("tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const wasi_libc = @import("wasi_libc.zig");
 
 const Air = @import("Air.zig");
@@ -1006,8 +1006,8 @@ pub const File = struct {
     pub fn linkAsArchive(base: *File, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) FlushError!void {
         dev.check(.lld_linker);
 
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const comp = base.comp;
         const gpa = comp.gpa;

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -14,7 +14,7 @@ const Alignment = InternPool.Alignment;
 const Compilation = @import("../Compilation.zig");
 const codegen = @import("../codegen/c.zig");
 const link = @import("../link.zig");
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const Type = @import("../Type.zig");
 const Value = @import("../Value.zig");
 const Air = @import("../Air.zig");
@@ -312,8 +312,8 @@ fn updateUav(self: *C, pt: Zcu.PerThread, i: usize) !void {
 }
 
 pub fn updateNav(self: *C, pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const zcu = pt.zcu;
@@ -409,8 +409,8 @@ fn abiDefines(self: *C, target: std.Target) !std.ArrayList(u8) {
 pub fn flushModule(self: *C, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
     _ = arena; // Has the same lifetime as the call to Compilation.update.
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const sub_prog_node = prog_node.start("Flush Module", 0);
     defer sub_prog_node.end();
@@ -793,8 +793,8 @@ fn flushAvBlock(
 }
 
 pub fn flushEmitH(zcu: *Zcu) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (true) return; // emit-h is regressed
 

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -596,8 +596,8 @@ fn growSectionVirtualMemory(self: *Coff, sect_id: u32, needed_size: u32) !void {
 }
 
 fn allocateAtom(self: *Coff, atom_index: Atom.Index, new_atom_size: u32, alignment: u32) !u32 {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const atom = self.getAtom(atom_index);
     const sect_id = @intFromEnum(atom.getSymbol(self).section_number) - 1;
@@ -1102,8 +1102,8 @@ pub fn updateFunc(self: *Coff, pt: Zcu.PerThread, func_index: InternPool.Index, 
     if (self.llvm_object) |llvm_object| {
         return llvm_object.updateFunc(pt, func_index, air, liveness);
     }
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -1196,8 +1196,8 @@ pub fn updateNav(
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
     if (self.llvm_object) |llvm_object| return llvm_object.updateNav(pt, nav_index);
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -1674,8 +1674,8 @@ pub fn flush(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: st
 }
 
 pub fn flushModule(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) link.File.FlushError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
@@ -2726,7 +2726,7 @@ const codegen = @import("../codegen.zig");
 const link = @import("../link.zig");
 const lld = @import("Coff/lld.zig");
 const target_util = @import("../target.zig");
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 
 const Air = @import("../Air.zig");
 pub const Atom = @import("Coff/Atom.zig");

--- a/src/link/Coff/lld.zig
+++ b/src/link/Coff/lld.zig
@@ -11,7 +11,7 @@ const Path = std.Build.Cache.Path;
 
 const mingw = @import("../../mingw.zig");
 const link = @import("../../link.zig");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 
 const Allocator = mem.Allocator;
 
@@ -22,8 +22,8 @@ const Zcu = @import("../../Zcu.zig");
 pub fn linkWithLLD(self: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
     dev.check(.lld_linker);
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = self.base.comp;
     const gpa = comp.gpa;

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -761,8 +761,8 @@ pub fn flush(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std
 }
 
 pub fn flushModule(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) link.File.FlushError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
@@ -1387,8 +1387,8 @@ pub fn parseObjectReportingFailure(self: *Elf, path: Path) void {
 }
 
 fn parseObject(self: *Elf, path: Path) ParseError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const handle = try path.root_dir.handle.openFile(path.sub_path, .{});
@@ -1410,8 +1410,8 @@ fn parseObject(self: *Elf, path: Path) ParseError!void {
 }
 
 fn parseArchive(self: *Elf, path: Path, must_link: bool) ParseError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const handle = try path.root_dir.handle.openFile(path.sub_path, .{});
@@ -1443,8 +1443,8 @@ fn parseSharedObject(
     files: *std.MultiArrayList(File.Entry),
     target: std.Target,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const handle = try lib.path.root_dir.handle.openFile(lib.path.sub_path, .{});
     defer handle.close();
@@ -1512,8 +1512,8 @@ fn parseSharedObject(
 }
 
 fn parseLdScript(self: *Elf, lib: SystemLib) ParseError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
@@ -1884,8 +1884,8 @@ pub fn initOutputSection(self: *Elf, args: struct {
 fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
     dev.check(.lld_linker);
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
@@ -2832,8 +2832,8 @@ pub fn addCommentString(self: *Elf) !void {
 }
 
 pub fn resolveMergeSections(self: *Elf) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var has_errors = false;
     for (self.objects.items) |index| {
@@ -5610,7 +5610,7 @@ const musl = @import("../musl.zig");
 const relocatable = @import("Elf/relocatable.zig");
 const relocation = @import("Elf/relocation.zig");
 const target_util = @import("../target.zig");
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "link" });
 const synthetic_sections = @import("Elf/synthetic_sections.zig");
 
 const Merge = @import("Elf/Merge.zig");

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -1415,8 +1415,8 @@ pub fn updateFunc(
     air: Air,
     liveness: Liveness,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
@@ -1539,8 +1539,8 @@ pub fn updateNav(
     pt: Zcu.PerThread,
     nav_index: InternPool.Nav.Index,
 ) link.File.UpdateNavError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
@@ -1625,8 +1625,8 @@ pub fn updateContainerType(
     pt: Zcu.PerThread,
     ty: InternPool.Index,
 ) link.File.UpdateNavError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.dwarf) |*dwarf| try dwarf.updateContainerType(pt, ty);
 }
@@ -1782,8 +1782,8 @@ pub fn updateExports(
     exported: Zcu.Exported,
     export_indices: []const u32,
 ) link.File.UpdateExportsError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = elf_file.base.comp.gpa;
@@ -1875,8 +1875,8 @@ pub fn updateNavLineNumber(
     pt: Zcu.PerThread,
     nav_index: InternPool.Nav.Index,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const ip = &pt.zcu.intern_pool;
     const nav = ip.getNav(nav_index);
@@ -2383,7 +2383,7 @@ const log = std.log.scoped(.link);
 const mem = std.mem;
 const relocation = @import("relocation.zig");
 const target_util = @import("../../target.zig");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -341,8 +341,8 @@ pub fn flush(self: *MachO, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: s
 }
 
 pub fn flushModule(self: *MachO, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) link.File.FlushError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = self.base.comp;
     const gpa = comp.gpa;
@@ -790,8 +790,8 @@ pub fn resolveLibSystem(
 }
 
 pub fn classifyInputFile(self: *MachO, path: Path, lib: SystemLib, must_link: bool) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     log.debug("classifying input file {}", .{path});
 
@@ -847,8 +847,8 @@ pub fn readArMagic(file: std.fs.File, offset: usize, buffer: *[Archive.SARMAG]u8
 }
 
 fn addObject(self: *MachO, path: Path, handle: File.HandleIndex, offset: u64) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const mtime: u64 = mtime: {
@@ -871,8 +871,8 @@ fn addObject(self: *MachO, path: Path, handle: File.HandleIndex, offset: u64) !v
 }
 
 pub fn parseInputFiles(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
     const tp = self.base.comp.thread_pool;
@@ -909,8 +909,8 @@ fn parseInputFileWorker(self: *MachO, file: File) void {
 }
 
 fn addArchive(self: *MachO, lib: SystemLib, must_link: bool, handle: File.HandleIndex, fat_arch: ?fat.Arch) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
 
@@ -930,8 +930,8 @@ fn addArchive(self: *MachO, lib: SystemLib, must_link: bool, handle: File.Handle
 }
 
 fn addDylib(self: *MachO, lib: SystemLib, explicit: bool, handle: File.HandleIndex, offset: u64) !File.Index {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
 
@@ -957,8 +957,8 @@ fn addDylib(self: *MachO, lib: SystemLib, explicit: bool, handle: File.HandleInd
 }
 
 fn addTbd(self: *MachO, lib: SystemLib, explicit: bool, handle: File.HandleIndex) !File.Index {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const index: File.Index = @intCast(try self.files.addOne(gpa));
@@ -1050,8 +1050,8 @@ fn accessFrameworkPath(
 }
 
 fn parseDependentDylibs(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.dylibs.items.len == 0) return;
 
@@ -1218,8 +1218,8 @@ fn parseDependentDylibs(self: *MachO) !void {
 /// 5. Remove references to dead objects/shared objects
 /// 6. Re-run symbol resolution on pruned objects and shared objects sets.
 pub fn resolveSymbols(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     // Resolve symbols in the ZigObject. For now, we assume that it's always live.
     if (self.getZigObject()) |zo| try zo.asFile().resolveSymbols(self);
@@ -1257,8 +1257,8 @@ pub fn resolveSymbols(self: *MachO) !void {
 }
 
 fn markLive(self: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.getZigObject()) |zo| zo.markLive(self);
     for (self.objects.items) |index| {
@@ -1286,8 +1286,8 @@ fn convertTentativeDefsAndResolveSpecialSymbols(self: *MachO) !void {
 }
 
 fn convertTentativeDefinitionsWorker(self: *MachO, object: *Object) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     object.convertTentativeDefinitions(self) catch |err| {
         self.reportParseError2(
             object.index,
@@ -1298,8 +1298,8 @@ fn convertTentativeDefinitionsWorker(self: *MachO, object: *Object) void {
 }
 
 fn resolveSpecialSymbolsWorker(self: *MachO, obj: *InternalObject) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
 
@@ -1310,8 +1310,8 @@ fn resolveSpecialSymbolsWorker(self: *MachO, obj: *InternalObject) void {
 }
 
 pub fn dedupLiterals(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     var lp: LiteralPool = .{};
@@ -1354,8 +1354,8 @@ fn claimUnresolved(self: *MachO) void {
 }
 
 fn checkDuplicates(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const tp = self.base.comp.thread_pool;
     const diags = &self.base.comp.link_diags;
@@ -1381,8 +1381,8 @@ fn checkDuplicates(self: *MachO) !void {
 }
 
 fn checkDuplicatesWorker(self: *MachO, file: File) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     file.checkDuplicates(self) catch |err| {
         self.reportParseError2(file.getIndex(), "failed to check for duplicate definitions: {s}", .{
             @errorName(err),
@@ -1391,8 +1391,8 @@ fn checkDuplicatesWorker(self: *MachO, file: File) void {
 }
 
 fn markImportsAndExports(self: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.getZigObject()) |zo| {
         zo.asFile().markImportsExports(self);
@@ -1406,8 +1406,8 @@ fn markImportsAndExports(self: *MachO) void {
 }
 
 fn deadStripDylibs(self: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.dylibs.items) |index| {
         self.getFile(index).?.dylib.markReferenced(self);
@@ -1425,8 +1425,8 @@ fn deadStripDylibs(self: *MachO) void {
 }
 
 fn scanRelocs(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const tp = self.base.comp.thread_pool;
     const diags = &self.base.comp.link_diags;
@@ -1489,8 +1489,8 @@ fn sortGlobalSymbolsByName(self: *MachO, symbols: []SymbolResolver.Index) void {
 }
 
 fn reportUndefs(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.undefined_treatment == .suppress or
         self.undefined_treatment == .dynamic_lookup) return;
@@ -1557,8 +1557,8 @@ fn reportUndefs(self: *MachO) !void {
 }
 
 fn initOutputSections(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.objects.items) |index| {
         try self.getFile(index).?.initOutputSections(self);
@@ -1842,8 +1842,8 @@ pub fn sortSections(self: *MachO) !void {
 }
 
 pub fn addAtomsToSections(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
 
@@ -1876,8 +1876,8 @@ pub fn addAtomsToSections(self: *MachO) !void {
 }
 
 fn calcSectionSizes(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
     const cpu_arch = self.getTarget().cpu.arch;
@@ -1973,8 +1973,8 @@ fn calcSectionSizes(self: *MachO) !void {
 }
 
 fn calcSectionSizeWorker(self: *MachO, sect_id: u8) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
 
@@ -2002,8 +2002,8 @@ fn calcSectionSizeWorker(self: *MachO, sect_id: u8) void {
 }
 
 fn createThunksWorker(self: *MachO, sect_id: u8) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const diags = &self.base.comp.link_diags;
     self.createThunks(sect_id) catch |err| {
         const header = self.sections.items(.header)[sect_id];
@@ -2014,8 +2014,8 @@ fn createThunksWorker(self: *MachO, sect_id: u8) void {
 }
 
 fn generateUnwindInfo(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
 
@@ -2392,8 +2392,8 @@ fn resizeSections(self: *MachO) !void {
 }
 
 fn writeSectionsAndUpdateLinkeditSizes(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const diags = &self.base.comp.link_diags;
@@ -2469,8 +2469,8 @@ fn writeSectionsAndUpdateLinkeditSizes(self: *MachO) !void {
 }
 
 fn writeAtomsWorker(self: *MachO, file: File) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     file.writeAtoms(self) catch |err| {
         self.reportParseError2(file.getIndex(), "failed to resolve relocations and write atoms: {s}", .{
             @errorName(err),
@@ -2479,8 +2479,8 @@ fn writeAtomsWorker(self: *MachO, file: File) void {
 }
 
 fn writeThunkWorker(self: *MachO, thunk: Thunk) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
 
@@ -2499,8 +2499,8 @@ fn writeThunkWorker(self: *MachO, thunk: Thunk) void {
 }
 
 fn writeSyntheticSectionWorker(self: *MachO, sect_id: u8, out: []u8) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
 
@@ -2555,8 +2555,8 @@ fn writeSyntheticSectionWorker(self: *MachO, sect_id: u8, out: []u8) void {
 }
 
 fn updateLazyBindSizeWorker(self: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &self.base.comp.link_diags;
 
@@ -2593,8 +2593,8 @@ pub fn updateLinkeditSizeWorker(self: *MachO, tag: enum {
 }
 
 fn writeSectionsToFile(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = self.sections.slice();
     for (slice.items(.header), slice.items(.out)) |header, out| {
@@ -2603,8 +2603,8 @@ fn writeSectionsToFile(self: *MachO) !void {
 }
 
 fn writeLinkeditSectionsToFile(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     try self.writeDyldInfo();
     try self.writeDataInCode();
     try self.writeSymtabToFile();
@@ -2612,8 +2612,8 @@ fn writeLinkeditSectionsToFile(self: *MachO) !void {
 }
 
 fn writeDyldInfo(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
     const base_off = self.getLinkeditSegment().fileoff;
@@ -2645,8 +2645,8 @@ fn writeDyldInfo(self: *MachO) !void {
 }
 
 pub fn writeDataInCode(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const gpa = self.base.comp.gpa;
     const cmd = self.data_in_code_cmd;
     var buffer = try std.ArrayList(u8).initCapacity(gpa, self.data_in_code.size());
@@ -2656,8 +2656,8 @@ pub fn writeDataInCode(self: *MachO) !void {
 }
 
 fn writeIndsymtab(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const gpa = self.base.comp.gpa;
     const cmd = self.dysymtab_cmd;
     const needed_size = cmd.nindirectsyms * @sizeOf(u32);
@@ -2668,16 +2668,16 @@ fn writeIndsymtab(self: *MachO) !void {
 }
 
 pub fn writeSymtabToFile(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const cmd = self.symtab_cmd;
     try self.base.file.?.pwriteAll(mem.sliceAsBytes(self.symtab.items), cmd.symoff);
     try self.base.file.?.pwriteAll(self.strtab.items, cmd.stroff);
 }
 
 fn writeUnwindInfo(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
 
@@ -2701,8 +2701,8 @@ fn writeUnwindInfo(self: *MachO) !void {
 }
 
 fn calcSymtabSize(self: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = self.base.comp.gpa;
 
@@ -3508,8 +3508,8 @@ pub fn getTarget(self: MachO) std.Target {
 /// the original file. This is super messy, but there doesn't seem any other
 /// way to please the XNU.
 pub fn invalidateKernelCache(dir: fs.Dir, sub_path: []const u8) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     if (comptime builtin.target.isDarwin() and builtin.target.cpu.arch == .aarch64) {
         try dir.copyFile(sub_path, dir, sub_path, .{});
     }
@@ -3777,8 +3777,8 @@ fn reportDependencyError(
 }
 
 fn reportDuplicates(self: *MachO) error{ HasDuplicates, OutOfMemory }!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.dupes.keys().len == 0) return; // Nothing to do
 
@@ -5210,8 +5210,8 @@ pub const KernE = enum(u32) {
 };
 
 fn createThunks(macho_file: *MachO, sect_id: u8) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const slice = macho_file.sections.slice();
@@ -5263,8 +5263,8 @@ fn advanceSection(sect: *macho.section_64, adv_size: u64, alignment: Atom.Alignm
 }
 
 fn scanThunkRelocs(thunk_index: Thunk.Index, gpa: Allocator, atoms: []const MachO.Ref, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const thunk = macho_file.getThunk(thunk_index);
 
@@ -5309,6 +5309,7 @@ const build_options = @import("build_options");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const fs = std.fs;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const log = std.log.scoped(.link);
 const state_log = std.log.scoped(.link_state);
 const macho = std.macho;
@@ -5328,7 +5329,6 @@ const load_commands = @import("MachO/load_commands.zig");
 const relocatable = @import("MachO/relocatable.zig");
 const tapi = @import("tapi.zig");
 const target_util = @import("../target.zig");
-const trace = @import("../tracy.zig").trace;
 const synthetic = @import("MachO/synthetic.zig");
 
 const Air = @import("../Air.zig");

--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -453,8 +453,8 @@ pub fn freeRelocs(self: *Atom, macho_file: *MachO) void {
 }
 
 pub fn scanRelocs(self: Atom, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     assert(self.isAlive());
 
     const relocs = self.getRelocs(macho_file);
@@ -570,8 +570,8 @@ fn reportUndefSymbol(self: Atom, rel: Relocation, macho_file: *MachO) !bool {
 }
 
 pub fn resolveRelocs(self: Atom, macho_file: *MachO, buffer: []u8) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     assert(!self.getInputSection(macho_file).isZerofill());
     const file = self.getFile(macho_file);
@@ -972,8 +972,8 @@ pub fn calcNumRelocs(self: Atom, macho_file: *MachO) u32 {
 }
 
 pub fn writeRelocs(self: Atom, macho_file: *MachO, code: []u8, buffer: []macho.relocation_info) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     relocs_log.debug("{x}: {s}", .{ self.getAddress(macho_file), self.getName(macho_file) });
 
@@ -1211,7 +1211,7 @@ const mem = std.mem;
 const log = std.log.scoped(.link);
 const relocs_log = std.log.scoped(.link_relocs);
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 
 const Allocator = mem.Allocator;
 const Atom = @This();

--- a/src/link/MachO/CodeSignature.zig
+++ b/src/link/MachO/CodeSignature.zig
@@ -7,7 +7,7 @@ const log = std.log.scoped(.link);
 const macho = std.macho;
 const mem = std.mem;
 const testing = std.testing;
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.macho" });
 const Allocator = mem.Allocator;
 const Hasher = @import("hasher.zig").ParallelHasher;
 const MachO = @import("../MachO.zig");
@@ -265,8 +265,8 @@ pub fn writeAdhocSignature(
     opts: WriteOpts,
     writer: anytype,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const allocator = macho_file.base.comp.gpa;
 

--- a/src/link/MachO/DebugSymbols.zig
+++ b/src/link/MachO/DebugSymbols.zig
@@ -362,8 +362,8 @@ fn allocatedSize(self: *DebugSymbols, start: u64) u64 {
 }
 
 fn writeLinkeditSegmentData(self: *DebugSymbols, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const page_size = macho_file.getPageSize();
     const seg = &self.segments.items[self.linkedit_segment_cmd_index.?];
@@ -379,8 +379,8 @@ fn writeLinkeditSegmentData(self: *DebugSymbols, macho_file: *MachO) !void {
 }
 
 pub fn writeSymtab(self: *DebugSymbols, off: u32, macho_file: *MachO) !u32 {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const gpa = self.allocator;
     const cmd = &self.symtab_cmd;
     cmd.nsyms = macho_file.symtab_cmd.nsyms;
@@ -459,7 +459,7 @@ const makeStaticString = MachO.makeStaticString;
 const math = std.math;
 const mem = std.mem;
 const padToIdeal = MachO.padToIdeal;
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.dsym" });
 
 const Allocator = mem.Allocator;
 const MachO = @import("../MachO.zig");

--- a/src/link/MachO/Dylib.zig
+++ b/src/link/MachO/Dylib.zig
@@ -54,8 +54,8 @@ pub fn parse(self: *Dylib, macho_file: *MachO) !void {
 }
 
 fn parseBinary(self: *Dylib, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const file = macho_file.getFileHandle(self.file_handle);
@@ -212,8 +212,8 @@ fn parseTrieNode(
     arena: Allocator,
     prefix: []const u8,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const size = try it.readUleb128();
     if (size > 0) {
         const flags = try it.readUleb128();
@@ -251,8 +251,8 @@ fn parseTrieNode(
 }
 
 fn parseTrie(self: *Dylib, data: []const u8, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const gpa = macho_file.base.comp.gpa;
     var arena = std.heap.ArenaAllocator.init(gpa);
     defer arena.deinit();
@@ -262,8 +262,8 @@ fn parseTrie(self: *Dylib, data: []const u8, macho_file: *MachO) !void {
 }
 
 fn parseTbd(self: *Dylib, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -521,8 +521,8 @@ fn initSymbols(self: *Dylib, macho_file: *MachO) !void {
 }
 
 pub fn resolveSymbols(self: *Dylib, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (!self.explicit and !self.hoisted) return;
 
@@ -557,8 +557,8 @@ pub fn isAlive(self: Dylib, macho_file: *MachO) bool {
 }
 
 pub fn markReferenced(self: *Dylib, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (0..self.symbols.items.len) |i| {
         const ref = self.getSymbolRef(@intCast(i), macho_file);
@@ -572,8 +572,8 @@ pub fn markReferenced(self: *Dylib, macho_file: *MachO) void {
 }
 
 pub fn calcSymtabSize(self: *Dylib, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.symbols.items, 0..) |*sym, i| {
         const ref = self.getSymbolRef(@intCast(i), macho_file);
@@ -589,8 +589,8 @@ pub fn calcSymtabSize(self: *Dylib, macho_file: *MachO) void {
 }
 
 pub fn writeSymtab(self: Dylib, macho_file: *MachO, ctx: anytype) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var n_strx = self.output_symtab_ctx.stroff;
     for (self.symbols.items, 0..) |sym, i| {
@@ -957,7 +957,7 @@ const macho = std.macho;
 const math = std.math;
 const mem = std.mem;
 const tapi = @import("../tapi.zig");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "link" });
 const std = @import("std");
 const Allocator = mem.Allocator;
 const Path = std.Build.Cache.Path;

--- a/src/link/MachO/InternalObject.zig
+++ b/src/link/MachO/InternalObject.zig
@@ -128,8 +128,8 @@ pub fn initSymbols(self: *InternalObject, macho_file: *MachO) !void {
 }
 
 pub fn resolveSymbols(self: *InternalObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -160,8 +160,8 @@ pub fn resolveSymbols(self: *InternalObject, macho_file: *MachO) !void {
 }
 
 pub fn resolveBoundarySymbols(self: *InternalObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     var boundary_symbols = std.StringArrayHashMap(MachO.Ref).init(gpa);
@@ -221,8 +221,8 @@ pub fn resolveBoundarySymbols(self: *InternalObject, macho_file: *MachO) !void {
 }
 
 pub fn markLive(self: *InternalObject, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (0..self.symbols.items.len) |i| {
         const nlist = self.symtab.items[i];
@@ -339,8 +339,8 @@ fn addObjcSelrefsSection(self: *InternalObject, methname_sym_index: Symbol.Index
 }
 
 pub fn resolveObjcMsgSendSymbols(self: *InternalObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -397,8 +397,8 @@ pub fn resolveObjcMsgSendSymbols(self: *InternalObject, macho_file: *MachO) !voi
 }
 
 pub fn resolveLiterals(self: *InternalObject, lp: *MachO.LiteralPool, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -433,8 +433,8 @@ pub fn resolveLiterals(self: *InternalObject, lp: *MachO.LiteralPool, macho_file
 }
 
 pub fn dedupLiterals(self: *InternalObject, lp: MachO.LiteralPool, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.getAtoms()) |atom_index| {
         const atom = self.getAtom(atom_index) orelse continue;
@@ -483,8 +483,8 @@ pub fn dedupLiterals(self: *InternalObject, lp: MachO.LiteralPool, macho_file: *
 }
 
 pub fn scanRelocs(self: *InternalObject, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     if (self.getEntryRef(macho_file)) |ref| {
         if (ref.getFile(macho_file) != null) {
@@ -599,8 +599,8 @@ pub fn calcSymtabSize(self: *InternalObject, macho_file: *MachO) void {
 }
 
 pub fn writeAtoms(self: *InternalObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.getAtoms()) |atom_index| {
         const atom = self.getAtom(atom_index) orelse continue;
@@ -904,7 +904,7 @@ const assert = std.debug.assert;
 const macho = std.macho;
 const mem = std.mem;
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "link" });
 
 const Allocator = std.mem.Allocator;
 const Atom = @import("Atom.zig");

--- a/src/link/MachO/Object.zig
+++ b/src/link/MachO/Object.zig
@@ -69,8 +69,8 @@ pub fn deinit(self: *Object, allocator: Allocator) void {
 }
 
 pub fn parse(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     log.debug("parsing {}", .{self.fmtPath()});
 
@@ -292,8 +292,8 @@ pub fn isPtrLiteral(sect: macho.section_64) bool {
 }
 
 fn initSubsections(self: *Object, allocator: Allocator, nlists: anytype) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const slice = self.sections.slice();
     for (slice.items(.header), slice.items(.subsections), 0..) |sect, *subsections, n_sect| {
         if (isCstringLiteral(sect)) continue;
@@ -382,8 +382,8 @@ fn initSubsections(self: *Object, allocator: Allocator, nlists: anytype) !void {
 }
 
 fn initSections(self: *Object, allocator: Allocator, nlists: anytype) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const slice = self.sections.slice();
 
     try self.atoms.ensureUnusedCapacity(allocator, self.sections.items(.header).len);
@@ -435,8 +435,8 @@ fn initSections(self: *Object, allocator: Allocator, nlists: anytype) !void {
 }
 
 fn initCstringLiterals(self: *Object, allocator: Allocator, file: File.Handle, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = self.sections.slice();
 
@@ -503,8 +503,8 @@ fn initCstringLiterals(self: *Object, allocator: Allocator, file: File.Handle, m
 }
 
 fn initFixedSizeLiterals(self: *Object, allocator: Allocator, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = self.sections.slice();
 
@@ -568,8 +568,8 @@ fn initFixedSizeLiterals(self: *Object, allocator: Allocator, macho_file: *MachO
 }
 
 fn initPointerLiterals(self: *Object, allocator: Allocator, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = self.sections.slice();
 
@@ -626,8 +626,8 @@ fn initPointerLiterals(self: *Object, allocator: Allocator, macho_file: *MachO) 
 }
 
 pub fn resolveLiterals(self: *Object, lp: *MachO.LiteralPool, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const file = macho_file.getFileHandle(self.file_handle);
@@ -713,8 +713,8 @@ pub fn resolveLiterals(self: *Object, lp: *MachO.LiteralPool, macho_file: *MachO
 }
 
 pub fn dedupLiterals(self: *Object, lp: MachO.LiteralPool, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.getAtoms()) |atom_index| {
         const atom = self.getAtom(atom_index) orelse continue;
@@ -757,8 +757,8 @@ pub fn dedupLiterals(self: *Object, lp: MachO.LiteralPool, macho_file: *MachO) v
 }
 
 pub fn findAtom(self: Object, addr: u64) ?Atom.Index {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const slice = self.sections.slice();
     for (slice.items(.header), slice.items(.subsections), 0..) |sect, subs, n_sect| {
         if (subs.items.len == 0) continue;
@@ -771,8 +771,8 @@ pub fn findAtom(self: Object, addr: u64) ?Atom.Index {
 }
 
 fn findAtomInSection(self: Object, addr: u64, n_sect: u8) ?Atom.Index {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const slice = self.sections.slice();
     const sect = slice.items(.header)[n_sect];
     const subsections = slice.items(.subsections)[n_sect];
@@ -809,8 +809,8 @@ fn findAtomInSection(self: Object, addr: u64, n_sect: u8) ?Atom.Index {
 }
 
 fn linkNlistToAtom(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     for (self.symtab.items(.nlist), self.symtab.items(.atom)) |nlist, *atom| {
         if (!nlist.stab() and nlist.sect()) {
             const sect = self.sections.items(.header)[nlist.n_sect - 1];
@@ -838,8 +838,8 @@ fn linkNlistToAtom(self: *Object, macho_file: *MachO) !void {
 }
 
 fn initSymbols(self: *Object, allocator: Allocator, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = self.symtab.slice();
     const nsyms = slice.items(.nlist).len;
@@ -892,8 +892,8 @@ fn initSymbols(self: *Object, allocator: Allocator, macho_file: *MachO) !void {
 }
 
 fn initSymbolStabs(self: *Object, allocator: Allocator, nlists: anytype, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const SymbolLookup = struct {
         ctx: *const Object,
@@ -996,8 +996,8 @@ fn sortAtoms(self: *Object, macho_file: *MachO) !void {
 }
 
 fn initRelocs(self: *Object, file: File.Handle, cpu_arch: std.Target.Cpu.Arch, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const slice = self.sections.slice();
 
     for (slice.items(.header), slice.items(.relocs)) |sect, *out| {
@@ -1037,8 +1037,8 @@ fn initRelocs(self: *Object, file: File.Handle, cpu_arch: std.Target.Cpu.Arch, m
 }
 
 fn initEhFrameRecords(self: *Object, allocator: Allocator, sect_id: u8, file: File.Handle, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const nlists = self.symtab.items(.nlist);
     const slice = self.sections.slice();
     const sect = slice.items(.header)[sect_id];
@@ -1130,8 +1130,8 @@ fn initEhFrameRecords(self: *Object, allocator: Allocator, sect_id: u8, file: Fi
 }
 
 fn initUnwindRecords(self: *Object, allocator: Allocator, sect_id: u8, file: File.Handle, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const SymbolLookup = struct {
         ctx: *const Object,
@@ -1355,8 +1355,8 @@ fn parseUnwindRecords(self: *Object, allocator: Allocator, cpu_arch: std.Target.
 /// TODO in the future, we want parse debug info and debug line sections so that
 /// we can provide nice error locations to the user.
 fn parseDebugInfo(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -1507,8 +1507,8 @@ fn findCompileUnit(self: *Object, args: struct {
 }
 
 pub fn resolveSymbols(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -1545,8 +1545,8 @@ pub fn resolveSymbols(self: *Object, macho_file: *MachO) !void {
 }
 
 pub fn markLive(self: *Object, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (0..self.symbols.items.len) |i| {
         const nlist = self.symtab.items(.nlist)[i];
@@ -1564,8 +1564,8 @@ pub fn markLive(self: *Object, macho_file: *MachO) void {
 }
 
 pub fn mergeSymbolVisibility(self: *Object, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.symbols.items, 0..) |sym, i| {
         const ref = self.getSymbolRef(@intCast(i), macho_file);
@@ -1580,8 +1580,8 @@ pub fn mergeSymbolVisibility(self: *Object, macho_file: *MachO) void {
 }
 
 pub fn scanRelocs(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.getAtoms()) |atom_index| {
         const atom = self.getAtom(atom_index) orelse continue;
@@ -1605,8 +1605,8 @@ pub fn scanRelocs(self: *Object, macho_file: *MachO) !void {
 }
 
 pub fn convertTentativeDefinitions(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     const gpa = macho_file.base.comp.gpa;
 
     for (self.symbols.items, self.globals.items, 0..) |*sym, off, i| {
@@ -1663,8 +1663,8 @@ fn addSection(self: *Object, allocator: Allocator, segname: []const u8, sectname
 }
 
 pub fn parseAr(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const handle = macho_file.getFileHandle(self.file_handle);
@@ -1770,8 +1770,8 @@ pub fn writeAr(self: Object, ar_format: Archive.Format, macho_file: *MachO, writ
 }
 
 pub fn calcSymtabSize(self: *Object, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const is_obj = macho_file.base.isObject();
 
@@ -1868,8 +1868,8 @@ pub fn calcStabsSize(self: *Object, macho_file: *MachO) void {
 }
 
 pub fn writeAtoms(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const headers = self.sections.items(.header);
@@ -1907,8 +1907,8 @@ pub fn writeAtoms(self: *Object, macho_file: *MachO) !void {
 }
 
 pub fn writeAtomsRelocatable(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const headers = self.sections.items(.header);
@@ -1948,8 +1948,8 @@ pub fn writeAtomsRelocatable(self: *Object, macho_file: *MachO) !void {
 }
 
 pub fn calcCompactUnwindSizeRelocatable(self: *Object, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const ctx = &self.compact_unwind_ctx;
 
@@ -1969,8 +1969,8 @@ pub fn calcCompactUnwindSizeRelocatable(self: *Object, macho_file: *MachO) void 
 }
 
 pub fn writeCompactUnwindRelocatable(self: *Object, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const cpu_arch = macho_file.getTarget().cpu.arch;
 
@@ -2049,8 +2049,8 @@ pub fn writeCompactUnwindRelocatable(self: *Object, macho_file: *MachO) !void {
 }
 
 pub fn writeSymtab(self: Object, macho_file: *MachO, ctx: anytype) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var n_strx = self.output_symtab_ctx.stroff;
     for (self.symbols.items, 0..) |sym, i| {
@@ -3217,6 +3217,8 @@ const aarch64 = struct {
         }
     }
 };
+
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.MachO.Object" });
 
 const assert = std.debug.assert;
 const dwarf = @import("dwarf.zig");

--- a/src/link/MachO/UnwindInfo.zig
+++ b/src/link/MachO/UnwindInfo.zig
@@ -42,8 +42,8 @@ fn canFold(macho_file: *MachO, lhs_ref: Record.Ref, rhs_ref: Record.Ref) bool {
 }
 
 pub fn generate(info: *UnwindInfo, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -264,8 +264,8 @@ pub fn generate(info: *UnwindInfo, macho_file: *MachO) !void {
 }
 
 pub fn calcSize(info: UnwindInfo) usize {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var total_size: usize = 0;
     total_size += @sizeOf(macho.unwind_info_section_header);
@@ -708,7 +708,7 @@ const log = std.log.scoped(.link);
 const macho = std.macho;
 const math = std.math;
 const mem = std.mem;
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.macho" });
 
 const Allocator = mem.Allocator;
 const Atom = @import("Atom.zig");

--- a/src/link/MachO/ZigObject.zig
+++ b/src/link/MachO/ZigObject.zig
@@ -43,8 +43,8 @@ debug_info_header_dirty: bool = false,
 debug_line_header_dirty: bool = false,
 
 pub fn init(self: *ZigObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = macho_file.base.comp;
     const gpa = comp.gpa;
@@ -200,8 +200,8 @@ pub fn freeAtomRelocs(self: *ZigObject, atom: Atom, macho_file: *MachO) void {
 }
 
 pub fn resolveSymbols(self: *ZigObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -238,8 +238,8 @@ pub fn resolveSymbols(self: *ZigObject, macho_file: *MachO) !void {
 }
 
 pub fn markLive(self: *ZigObject, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (0..self.symbols.items.len) |i| {
         const nlist = self.symtab.items(.nlist)[i];
@@ -257,8 +257,8 @@ pub fn markLive(self: *ZigObject, macho_file: *MachO) void {
 }
 
 pub fn mergeSymbolVisibility(self: *ZigObject, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.symbols.items, 0..) |sym, i| {
         const ref = self.getSymbolRef(@intCast(i), macho_file);
@@ -323,8 +323,8 @@ pub fn writeAr(self: ZigObject, ar_format: Archive.Format, writer: anytype) !voi
 }
 
 pub fn claimUnresolved(self: *ZigObject, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.symbols.items, 0..) |*sym, i| {
         const nlist = self.symtab.items(.nlist)[i];
@@ -447,8 +447,8 @@ pub fn writeRelocs(self: *ZigObject, macho_file: *MachO) !void {
 // For example, TLS data gets written out via traditional route.
 // Is there any better way of handling this?
 pub fn writeAtomsRelocatable(self: *ZigObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.getAtoms()) |atom_index| {
         const atom = self.getAtom(atom_index) orelse continue;
@@ -471,8 +471,8 @@ pub fn writeAtomsRelocatable(self: *ZigObject, macho_file: *MachO) !void {
 // For example, TLS data gets written out via traditional route.
 // Is there any better way of handling this?
 pub fn writeAtoms(self: *ZigObject, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.getAtoms()) |atom_index| {
         const atom = self.getAtom(atom_index) orelse continue;
@@ -489,8 +489,8 @@ pub fn writeAtoms(self: *ZigObject, macho_file: *MachO) !void {
 }
 
 pub fn calcSymtabSize(self: *ZigObject, macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (self.symbols.items, 0..) |*sym, i| {
         const ref = self.getSymbolRef(@intCast(i), macho_file);
@@ -516,8 +516,8 @@ pub fn calcSymtabSize(self: *ZigObject, macho_file: *MachO) void {
 }
 
 pub fn writeSymtab(self: ZigObject, macho_file: *MachO, ctx: anytype) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var n_strx = self.output_symtab_ctx.stroff;
     for (self.symbols.items, 0..) |sym, i| {
@@ -768,8 +768,8 @@ pub fn updateFunc(
     air: Air,
     liveness: Liveness,
 ) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -873,8 +873,8 @@ pub fn updateNav(
     pt: Zcu.PerThread,
     nav_index: InternPool.Nav.Index,
 ) link.File.UpdateNavError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
@@ -1264,8 +1264,8 @@ pub fn updateExports(
     exported: Zcu.Exported,
     export_indices: []const u32,
 ) link.File.UpdateExportsError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const zcu = pt.zcu;
     const gpa = macho_file.base.comp.gpa;
@@ -1817,6 +1817,8 @@ const x86_64 = struct {
     }
 };
 
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.MachO.ZigObject" });
+
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 const codegen = @import("../../codegen.zig");
@@ -1825,7 +1827,6 @@ const log = std.log.scoped(.link);
 const macho = std.macho;
 const mem = std.mem;
 const target_util = @import("../../target.zig");
-const trace = @import("../../tracy.zig").trace;
 const std = @import("std");
 
 const Air = @import("../../Air.zig");

--- a/src/link/MachO/dyld_info/Rebase.zig
+++ b/src/link/MachO/dyld_info/Rebase.zig
@@ -20,8 +20,8 @@ pub fn deinit(rebase: *Rebase, gpa: Allocator) void {
 }
 
 pub fn updateSize(rebase: *Rebase, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -654,7 +654,7 @@ const log = std.log.scoped(.link_dyld_info);
 const macho = std.macho;
 const mem = std.mem;
 const testing = std.testing;
-const trace = @import("../../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.dyld_info" });
 
 const Allocator = mem.Allocator;
 const File = @import("../file.zig").File;

--- a/src/link/MachO/dyld_info/Trie.zig
+++ b/src/link/MachO/dyld_info/Trie.zig
@@ -39,8 +39,8 @@ edges: std.ArrayListUnmanaged(Edge) = .empty,
 /// This operation may change the layout of the trie by splicing edges in
 /// certain circumstances.
 fn put(self: *Trie, allocator: Allocator, symbol: ExportSymbol) !void {
-    // const tracy = trace(@src());
-    // defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const node_index = try self.putNode(self.root.?, allocator, symbol.name);
     const slice = self.nodes.slice();
@@ -88,8 +88,8 @@ fn putNode(self: *Trie, node_index: Node.Index, allocator: Allocator, label: []c
 }
 
 pub fn updateSize(self: *Trie, macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -131,8 +131,8 @@ pub fn updateSize(self: *Trie, macho_file: *MachO) !void {
 /// there are no gaps after every `Node` is ULEB128 encoded.
 /// Call this method before trying to `write` the trie to a byte stream.
 fn finalize(self: *Trie, allocator: Allocator) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var ordered_nodes = std.ArrayList(Node.Index).init(allocator);
     defer ordered_nodes.deinit();
@@ -414,7 +414,7 @@ const macho = std.macho;
 const mem = std.mem;
 const std = @import("std");
 const testing = std.testing;
-const trace = @import("../../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.macho" });
 
 const Allocator = mem.Allocator;
 const MachO = @import("../../MachO.zig");

--- a/src/link/MachO/dyld_info/bind.zig
+++ b/src/link/MachO/dyld_info/bind.zig
@@ -28,8 +28,8 @@ pub const Bind = struct {
     }
 
     pub fn updateSize(self: *Self, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const gpa = macho_file.base.comp.gpa;
         const cpu_arch = macho_file.getTarget().cpu.arch;
@@ -280,8 +280,8 @@ pub const WeakBind = struct {
     }
 
     pub fn updateSize(self: *Self, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const gpa = macho_file.base.comp.gpa;
         const cpu_arch = macho_file.getTarget().cpu.arch;
@@ -524,8 +524,8 @@ pub const LazyBind = struct {
     }
 
     pub fn updateSize(self: *Self, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const gpa = macho_file.base.comp.gpa;
 
@@ -689,7 +689,7 @@ const log = std.log.scoped(.link_dyld_info);
 const macho = std.macho;
 const mem = std.mem;
 const testing = std.testing;
-const trace = @import("../../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.dyld_info" });
 const std = @import("std");
 
 const Allocator = mem.Allocator;

--- a/src/link/MachO/eh_frame.zig
+++ b/src/link/MachO/eh_frame.zig
@@ -9,8 +9,8 @@ pub const Cie = struct {
     alive: bool = false,
 
     pub fn parse(cie: *Cie, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const data = cie.getData(macho_file);
         const aug = std.mem.sliceTo(@as([*:0]const u8, @ptrCast(data.ptr + 9)), 0);
@@ -145,8 +145,8 @@ pub const Fde = struct {
     alive: bool = true,
 
     pub fn parse(fde: *Fde, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const data = fde.getData(macho_file);
         const object = fde.getObject(macho_file);
@@ -310,8 +310,8 @@ pub const Iterator = struct {
 };
 
 pub fn calcSize(macho_file: *MachO) !u32 {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var offset: u32 = 0;
 
@@ -352,8 +352,8 @@ pub fn calcSize(macho_file: *MachO) !u32 {
 }
 
 pub fn calcNumRelocs(macho_file: *MachO) u32 {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var nreloc: u32 = 0;
 
@@ -371,8 +371,8 @@ pub fn calcNumRelocs(macho_file: *MachO) u32 {
 }
 
 pub fn write(macho_file: *MachO, buffer: []u8) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const sect = macho_file.sections.items(.header)[macho_file.eh_frame_sect_index.?];
     const addend: i64 = switch (macho_file.getTarget().cpu.arch) {
@@ -450,8 +450,8 @@ pub fn write(macho_file: *MachO, buffer: []u8) void {
 }
 
 pub fn writeRelocs(macho_file: *MachO, code: []u8, relocs: []macho.relocation_info) error{Overflow}!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const cpu_arch = macho_file.getTarget().cpu.arch;
     const sect = macho_file.sections.items(.header)[macho_file.eh_frame_sect_index.?];
@@ -544,7 +544,7 @@ const macho = std.macho;
 const math = std.math;
 const mem = std.mem;
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 
 const Allocator = std.mem.Allocator;
 const Atom = @import("Atom.zig");

--- a/src/link/MachO/file.zig
+++ b/src/link/MachO/file.zig
@@ -132,8 +132,8 @@ pub const File = union(enum) {
     }
 
     pub fn markImportsExports(file: File, macho_file: *MachO) void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const nsyms = switch (file) {
             .dylib => unreachable,
@@ -155,8 +155,8 @@ pub const File = union(enum) {
     }
 
     pub fn markExportsRelocatable(file: File, macho_file: *MachO) void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         assert(file == .object or file == .zig_object);
 
@@ -170,8 +170,8 @@ pub const File = union(enum) {
     }
 
     pub fn createSymbolIndirection(file: File, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const nsyms = switch (file) {
             inline else => |x| x.symbols.items.len,
@@ -201,8 +201,8 @@ pub const File = union(enum) {
     }
 
     pub fn claimUnresolved(file: File, macho_file: *MachO) void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         assert(file == .object or file == .zig_object);
 
@@ -232,8 +232,8 @@ pub const File = union(enum) {
     }
 
     pub fn claimUnresolvedRelocatable(file: File, macho_file: *MachO) void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         assert(file == .object or file == .zig_object);
 
@@ -254,8 +254,8 @@ pub const File = union(enum) {
     }
 
     pub fn checkDuplicates(file: File, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const gpa = macho_file.base.comp.gpa;
 
@@ -279,8 +279,8 @@ pub const File = union(enum) {
     }
 
     pub fn initOutputSections(file: File, macho_file: *MachO) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
         for (file.getAtoms()) |atom_index| {
             const atom = file.getAtom(atom_index) orelse continue;
             if (!atom.isAlive()) continue;
@@ -380,7 +380,7 @@ const macho = std.macho;
 const Allocator = std.mem.Allocator;
 const Path = std.Build.Cache.Path;
 
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const Archive = @import("Archive.zig");
 const Atom = @import("Atom.zig");
 const InternalObject = @import("InternalObject.zig");

--- a/src/link/MachO/hasher.zig
+++ b/src/link/MachO/hasher.zig
@@ -9,8 +9,8 @@ pub fn ParallelHasher(comptime Hasher: type) type {
             chunk_size: u64 = 0x4000,
             max_file_size: ?u64 = null,
         }) !void {
-            const tracy = trace(@src());
-            defer tracy.end();
+            const span = tracer.beginSpanSrc(@src(), .{});
+            defer span.end();
 
             var wg: WaitGroup = .{};
 
@@ -55,8 +55,8 @@ pub fn ParallelHasher(comptime Hasher: type) type {
             out: *[hash_size]u8,
             err: *fs.File.PReadError!usize,
         ) void {
-            const tracy = trace(@src());
-            defer tracy.end();
+            const span = tracer.beginSpanSrc(@src(), .{});
+            defer span.end();
             err.* = file.preadAll(buffer, fstart);
             Hasher.hash(buffer, out, .{});
         }
@@ -69,7 +69,7 @@ const assert = std.debug.assert;
 const fs = std.fs;
 const mem = std.mem;
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.macho" });
 
 const Allocator = mem.Allocator;
 const ThreadPool = std.Thread.Pool;

--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -222,8 +222,8 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
 }
 
 fn parseInputFilesAr(macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (macho_file.objects.items) |index| {
         macho_file.getFile(index).?.parseAr(macho_file) catch |err| switch (err) {
@@ -280,8 +280,8 @@ fn initOutputSections(macho_file: *MachO) !void {
 }
 
 fn calcSectionSizes(macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &macho_file.base.comp.link_diags;
 
@@ -333,8 +333,8 @@ fn calcSectionSizes(macho_file: *MachO) !void {
 }
 
 fn calcSectionSizeWorker(macho_file: *MachO, sect_id: u8) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = macho_file.sections.slice();
     const header = &slice.items(.header)[sect_id];
@@ -354,8 +354,8 @@ fn calcSectionSizeWorker(macho_file: *MachO, sect_id: u8) void {
 }
 
 fn calcEhFrameSizeWorker(macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &macho_file.base.comp.link_diags;
 
@@ -373,8 +373,8 @@ fn calcEhFrameSizeWorker(macho_file: *MachO) void {
 }
 
 fn calcCompactUnwindSize(macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     var nrec: u32 = 0;
     var nreloc: u32 = 0;
@@ -394,8 +394,8 @@ fn calcCompactUnwindSize(macho_file: *MachO) void {
 }
 
 fn calcSymtabSize(macho_file: *MachO) error{OutOfMemory}!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
 
@@ -569,8 +569,8 @@ fn sortReloc(ctx: void, lhs: macho.relocation_info, rhs: macho.relocation_info) 
 }
 
 fn sortRelocs(macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     for (macho_file.sections.items(.relocs)) |*relocs| {
         mem.sort(macho.relocation_info, relocs.items, {}, sortReloc);
@@ -578,8 +578,8 @@ fn sortRelocs(macho_file: *MachO) void {
 }
 
 fn writeSections(macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const gpa = macho_file.base.comp.gpa;
     const diags = &macho_file.base.comp.link_diags;
@@ -636,8 +636,8 @@ fn writeSections(macho_file: *MachO) !void {
 }
 
 fn writeAtomsWorker(macho_file: *MachO, file: File) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
     file.writeAtomsRelocatable(macho_file) catch |err| {
         macho_file.reportParseError2(file.getIndex(), "failed to write atoms: {s}", .{
             @errorName(err),
@@ -646,8 +646,8 @@ fn writeAtomsWorker(macho_file: *MachO, file: File) void {
 }
 
 fn writeEhFrameWorker(macho_file: *MachO) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &macho_file.base.comp.link_diags;
     const sect_index = macho_file.eh_frame_sect_index.?;
@@ -658,8 +658,8 @@ fn writeEhFrameWorker(macho_file: *MachO) void {
 }
 
 fn writeCompactUnwindWorker(macho_file: *MachO, object: *Object) void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const diags = &macho_file.base.comp.link_diags;
     object.writeCompactUnwindRelocatable(macho_file) catch |err|
@@ -667,8 +667,8 @@ fn writeCompactUnwindWorker(macho_file: *MachO, object: *Object) void {
 }
 
 fn writeSectionsToFile(macho_file: *MachO) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const slice = macho_file.sections.slice();
     for (slice.items(.header), slice.items(.out), slice.items(.relocs)) |header, out, relocs| {
@@ -767,7 +767,7 @@ const math = std.math;
 const mem = std.mem;
 const state_log = std.log.scoped(.link_state);
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "link" });
 const Path = std.Build.Cache.Path;
 
 const Archive = @import("Archive.zig");

--- a/src/link/MachO/synthetic.zig
+++ b/src/link/MachO/synthetic.zig
@@ -28,8 +28,8 @@ pub const GotSection = struct {
     }
 
     pub fn write(got: GotSection, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
         for (got.symbols.items) |ref| {
             const sym = ref.getSymbol(macho_file).?;
             const value = if (sym.flags.import) @as(u64, 0) else sym.getAddress(.{}, macho_file);
@@ -97,8 +97,8 @@ pub const StubsSection = struct {
     }
 
     pub fn write(stubs: StubsSection, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
         const cpu_arch = macho_file.getTarget().cpu.arch;
         const laptr_sect = macho_file.sections.items(.header)[macho_file.la_symbol_ptr_sect_index.?];
 
@@ -176,8 +176,8 @@ pub const StubsHelperSection = struct {
     }
 
     pub fn size(stubs_helper: StubsHelperSection, macho_file: *MachO) usize {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
         _ = stubs_helper;
         const cpu_arch = macho_file.getTarget().cpu.arch;
         var s: usize = preambleSize(cpu_arch);
@@ -190,8 +190,8 @@ pub const StubsHelperSection = struct {
     }
 
     pub fn write(stubs_helper: StubsHelperSection, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         try stubs_helper.writePreamble(macho_file, writer);
 
@@ -294,8 +294,8 @@ pub const LaSymbolPtrSection = struct {
     }
 
     pub fn write(laptr: LaSymbolPtrSection, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
         _ = laptr;
         const cpu_arch = macho_file.getTarget().cpu.arch;
         const sect = macho_file.sections.items(.header)[macho_file.stubs_helper_sect_index.?];
@@ -344,8 +344,8 @@ pub const TlvPtrSection = struct {
     }
 
     pub fn write(tlv: TlvPtrSection, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         for (tlv.symbols.items) |ref| {
             const sym = ref.getSymbol(macho_file).?;
@@ -422,8 +422,8 @@ pub const ObjcStubsSection = struct {
     }
 
     pub fn write(objc: ObjcStubsSection, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         const obj = macho_file.getInternalObject().?;
 
@@ -525,8 +525,8 @@ pub const Indsymtab = struct {
     }
 
     pub fn write(ind: Indsymtab, macho_file: *MachO, writer: anytype) !void {
-        const tracy = trace(@src());
-        defer tracy.end();
+        const span = tracer.beginSpanSrc(@src(), .{});
+        defer span.end();
 
         _ = ind;
 
@@ -624,7 +624,7 @@ const assert = std.debug.assert;
 const macho = std.macho;
 const math = std.math;
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "link" });
 
 const Allocator = std.mem.Allocator;
 const MachO = @import("../MachO.zig");

--- a/src/link/MachO/uuid.zig
+++ b/src/link/MachO/uuid.zig
@@ -5,8 +5,8 @@
 /// TODO LLD also hashes the output filename to disambiguate between same builds with different
 /// output files. Should we also do that?
 pub fn calcUuid(comp: *const Compilation, file: fs.File, file_size: u64, out: *[Md5.digest_length]u8) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const chunk_size: usize = 1024 * 1024;
     const num_chunks: usize = std.math.cast(usize, @divTrunc(file_size, chunk_size)) orelse return error.Overflow;
@@ -41,7 +41,7 @@ inline fn conform(out: *[Md5.digest_length]u8) void {
 const fs = std.fs;
 const mem = std.mem;
 const std = @import("std");
-const trace = @import("../../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link.macho" });
 
 const Compilation = @import("../../Compilation.zig");
 const Md5 = std.crypto.hash.Md5;

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -8,7 +8,7 @@ const InternPool = @import("../InternPool.zig");
 const Compilation = @import("../Compilation.zig");
 const aout = @import("Plan9/aout.zig");
 const codegen = @import("../codegen.zig");
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const File = link.File;
 const build_options = @import("build_options");
 const Air = @import("../Air.zig");
@@ -588,8 +588,8 @@ pub fn flushModule(self: *Plan9, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
         @panic("Attempted to compile for object format that was disabled by build configuration");
     }
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     _ = arena; // Has the same lifetime as the call to Compilation.update.
 

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -33,7 +33,7 @@ const InternPool = @import("../InternPool.zig");
 const Compilation = @import("../Compilation.zig");
 const link = @import("../link.zig");
 const codegen = @import("../codegen/spirv.zig");
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const build_options = @import("build_options");
 const Air = @import("../Air.zig");
 const Liveness = @import("../Liveness.zig");
@@ -204,8 +204,8 @@ pub fn flushModule(self: *SpirV, arena: Allocator, tid: Zcu.PerThread.Id, prog_n
         @panic("Attempted to compile for architecture that was disabled by build configuration");
     }
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const sub_prog_node = prog_node.start("Flush Module", 0);
     defer sub_prog_node.end();

--- a/src/link/Wasm.zig
+++ b/src/link/Wasm.zig
@@ -14,7 +14,7 @@ const lldMain = @import("../main.zig").lldMain;
 const log = std.log.scoped(.link);
 const gc_log = std.log.scoped(.gc);
 const mem = std.mem;
-const trace = @import("../tracy.zig").trace;
+const tracer = std.otel.trace.scoped(.{ .name = "zig.link" });
 const types = @import("Wasm/types.zig");
 const wasi_libc = @import("../wasi_libc.zig");
 
@@ -2495,8 +2495,8 @@ pub fn flush(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: st
 
 /// Uses the in-house linker to link one or multiple object -and archive files into a WebAssembly binary.
 pub fn flushModule(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) link.File.FlushError!void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = wasm.base.comp;
     const diags = &comp.link_diags;
@@ -3350,8 +3350,8 @@ fn emitImport(wasm: *Wasm, writer: anytype, import: types.Import) !void {
 fn linkWithLLD(wasm: *Wasm, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.Progress.Node) !void {
     dev.check(.lld_linker);
 
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const comp = wasm.base.comp;
     const shared_memory = comp.config.shared_memory;
@@ -4052,8 +4052,8 @@ pub fn getOrCreateAtomForNav(wasm_file: *Wasm, pt: Zcu.PerThread, nav: InternPoo
 /// Verifies all resolved symbols and checks whether itself needs to be marked alive,
 /// as well as any of its references.
 fn markReferences(wasm: *Wasm) !void {
-    const tracy = trace(@src());
-    defer tracy.end();
+    const span = tracer.beginSpanSrc(@src(), .{});
+    defer span.end();
 
     const do_garbage_collect = wasm.base.gc_sections;
     const comp = wasm.base.comp;

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,7 +46,7 @@ pub const std_options = .{
 };
 
 pub const otel_types: std.otel.Types = if (build_options.enable_tracy) .{
-    .trace = tracy.TRACE_TYPES,
+    .Span = tracy.SPAN_TYPE,
 } else .{};
 
 pub const otel_functions: std.otel.Functions = if (build_options.enable_tracy) .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,6 +45,16 @@ pub const std_options = .{
     },
 };
 
+pub const otel_types: std.otel.Types = if (build_options.enable_tracy) .{
+    .trace = tracy.TRACE_TYPES,
+} else .{};
+
+pub const otel_functions: std.otel.Functions = if (build_options.enable_tracy) .{
+    .trace = tracy.TRACE_FUNCTIONS,
+} else .{};
+
+const tracer = std.otel.trace.scoped(.{ .name = "zig" });
+
 pub const Panic = crash_report.Panic;
 
 var wasi_preopens: fs.wasi.Preopens = undefined;
@@ -211,7 +221,7 @@ fn verifyLibcxxCorrectlyLinked() void {
 }
 
 fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
-    const tr = tracy.trace(@src());
+    const tr = tracer.beginSpanSrc(@src(), .{});
     defer tr.end();
 
     if (args.len <= 1) {

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -10,9 +10,10 @@ pub const enable_callstack = enable and build_options.enable_tracy_callstack;
 // TODO: make this configurable
 const callstack_depth = 10;
 
-pub const TRACE_TYPES: otel.trace.Types = if (enable) .{
-    .Span = ___tracy_c_zone_context,
-} else otel.trace.NULL_TYPES;
+pub const SPAN_TYPE = if (enable)
+    ___tracy_c_zone_context
+else
+    otel.trace.NULL_SPAN_TYPE;
 
 pub const TRACE_FUNCTIONS: otel.trace.Functions = if (enable) .{
     .tracer_enabled = tracerEnabled,

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
+const otel = std.otel;
 
 pub const enable = build_options.enable_tracy;
 pub const enable_allocation = enable and build_options.enable_tracy_allocation;
@@ -9,11 +10,11 @@ pub const enable_callstack = enable and build_options.enable_tracy_callstack;
 // TODO: make this configurable
 const callstack_depth = 10;
 
-pub const TRACE_TYPES: std.otel.trace.Types = if (enable) .{
+pub const TRACE_TYPES: otel.trace.Types = if (enable) .{
     .Span = ___tracy_c_zone_context,
-} else std.otel.trace.NULL_TYPES;
+} else otel.trace.NULL_TYPES;
 
-pub const TRACE_FUNCTIONS: std.otel.trace.Functions = if (enable) .{
+pub const TRACE_FUNCTIONS: otel.trace.Functions = if (enable) .{
     .tracer_enabled = tracerEnabled,
     .tracer_create_span = tracerCreateSpan,
     .tracer_create_span_source_location = tracerCreateSpanSourceLocation,
@@ -30,18 +31,18 @@ pub const TRACE_FUNCTIONS: std.otel.trace.Functions = if (enable) .{
     .span_update_name = ___tracy_c_zone_context.updateName,
     .span_end = ___tracy_c_zone_context.end,
     .span_record_exception = ___tracy_c_zone_context.recordException,
-} else std.otel.trace.NULL_FUNCTIONS;
+} else otel.trace.NULL_FUNCTIONS;
 
-pub fn tracerEnabled(comptime scope: std.otel.InstrumentationScope) bool {
+pub fn tracerEnabled(comptime scope: otel.InstrumentationScope) bool {
     _ = scope;
     return build_options.enable;
 }
 
 pub fn tracerCreateSpan(
-    comptime scope: std.otel.InstrumentationScope,
+    comptime scope: otel.InstrumentationScope,
     comptime name: [:0]const u8,
     comptime src: ?std.builtin.SourceLocation,
-    options: std.otel.trace.CreateSpanOptions,
+    options: otel.trace.CreateSpanOptions,
 ) ___tracy_c_zone_context {
     _ = scope;
     _ = options;
@@ -67,9 +68,9 @@ pub fn tracerCreateSpan(
 }
 
 pub fn tracerCreateSpanSourceLocation(
-    comptime scope: std.otel.InstrumentationScope,
+    comptime scope: otel.InstrumentationScope,
     comptime src: std.builtin.SourceLocation,
-    options: std.otel.trace.CreateSpanOptions,
+    options: otel.trace.CreateSpanOptions,
 ) ___tracy_c_zone_context {
     _ = scope;
     _ = options;
@@ -92,13 +93,13 @@ pub fn tracerCreateSpanSourceLocation(
     }
 }
 
-pub fn contextExtractSpan(context: std.otel.Context) ___tracy_c_zone_context {
-    const ctx = std.otel.Context.getValue(context, ___tracy_c_zone_context) orelse return .NULL;
+pub fn contextExtractSpan(context: otel.Context) ___tracy_c_zone_context {
+    const ctx = otel.Context.getValue(context, ___tracy_c_zone_context) orelse return .NULL;
     return ctx;
 }
 
-pub fn contextWithSpan(context: std.otel.Context, zone_ctx: ___tracy_c_zone_context) std.otel.Context {
-    return std.otel.Context.withValue(context, ___tracy_c_zone_context, zone_ctx);
+pub fn contextWithSpan(context: otel.Context, zone_ctx: ___tracy_c_zone_context) otel.Context {
+    return otel.Context.withValue(context, ___tracy_c_zone_context, zone_ctx);
 }
 
 const ___tracy_c_zone_context = extern struct {
@@ -107,9 +108,9 @@ const ___tracy_c_zone_context = extern struct {
 
     pub const NULL = ___tracy_c_zone_context{ .id = 0, .active = 0 };
 
-    pub fn getContext(self: @This()) std.otel.trace.SpanContext {
+    pub fn getContext(self: @This()) otel.trace.SpanContext {
         _ = self;
-        return std.otel.trace.SpanContext.INVALID;
+        return otel.trace.SpanContext.INVALID;
     }
 
     pub fn isRecording(self: @This()) bool {
@@ -117,22 +118,22 @@ const ___tracy_c_zone_context = extern struct {
         return self.active != 0;
     }
 
-    pub fn setAttribute(self: @This(), attribute: std.otel.Attribute) void {
+    pub fn setAttribute(self: @This(), attribute: otel.Attribute) void {
         _ = self;
         _ = attribute;
     }
 
-    pub fn addEvent(self: @This(), options: std.otel.trace.AddEventOptions) void {
+    pub fn addEvent(self: @This(), options: otel.trace.AddEventOptions) void {
         _ = self;
         _ = options;
     }
 
-    pub fn addLink(self: @This(), link: std.otel.trace.Link) void {
+    pub fn addLink(self: @This(), link: otel.trace.Link) void {
         _ = self;
         _ = link;
     }
 
-    pub fn setStatus(self: @This(), status: std.otel.trace.Status) void {
+    pub fn setStatus(self: @This(), status: otel.trace.Status) void {
         _ = self;
         _ = status;
     }


### PR DESCRIPTION
- Use `std.otel.trace` API in compiler
- Change `src/tracy.zig` to implement tracy backend for `std.otel.trace` API.

Closes issue [#5987](https://github.com/ziglang/zig/issues/5987).

There are a few deviations from the OpenTelemetry tracing API specification:

- The null API is supposed to propagate the SpanContext. Since this would require _at least_ putting a `otel.trace.SpanContext` on the stack, I elected to ignore this part of the specification.
- `createSpanSourceLocation` is provided as asecond way of creating a span. The specification says that `createSpan` MUST be the only way to create a span. However, as far as I'm concerned, the "name" is redundant when you already have the source location, and the function name can be used as a first approximation to a user provided "name".