### PR TITLE
`std.Target`: Make `Cpu.baseline()` take OS into consideration and pick a better CPU for Apple targets

### DIFF
--- a/lib/compiler/aro/aro/target.zig
+++ b/lib/compiler/aro/aro/target.zig
@@ -709,8 +709,8 @@ pub fn toLLVMTriple(target: std.Target, buf: []u8) []const u8 {
 test "alignment functions - smoke test" {
     var target: std.Target = undefined;
     const x86 = std.Target.Cpu.Arch.x86_64;
-    target.cpu = std.Target.Cpu.baseline(x86);
     target.os = std.Target.Os.Tag.defaultVersionRange(.linux, x86);
+    target.cpu = std.Target.Cpu.baseline(x86, target.os);
     target.abi = std.Target.Abi.default(x86, target.os);
 
     try std.testing.expect(isTlsSupported(target));
@@ -722,8 +722,8 @@ test "alignment functions - smoke test" {
     try std.testing.expect(systemCompiler(target) == .gcc);
 
     const arm = std.Target.Cpu.Arch.arm;
-    target.cpu = std.Target.Cpu.baseline(arm);
     target.os = std.Target.Os.Tag.defaultVersionRange(.ios, arm);
+    target.cpu = std.Target.Cpu.baseline(arm, target.os);
     target.abi = std.Target.Abi.default(arm, target.os);
 
     try std.testing.expect(!isTlsSupported(target));

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1669,7 +1669,8 @@ pub const Cpu = struct {
             };
         }
 
-        pub fn baseline(arch: Arch) *const Model {
+        pub fn baseline(arch: Arch, os: Os) *const Model {
+            _ = os;
             return switch (arch) {
                 .arm, .armeb, .thumb, .thumbeb => &arm.cpu.baseline,
                 .hexagon => &hexagon.cpu.hexagonv60, // gcc/clang do not have a generic hexagon model.
@@ -1688,8 +1689,8 @@ pub const Cpu = struct {
 
     /// The "default" set of CPU features for cross-compiling. A conservative set
     /// of features that is expected to be supported on most available hardware.
-    pub fn baseline(arch: Arch) Cpu {
-        return Model.baseline(arch).toCpu(arch);
+    pub fn baseline(arch: Arch, os: Os) Cpu {
+        return Model.baseline(arch, os).toCpu(arch);
     }
 };
 

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1670,9 +1670,15 @@ pub const Cpu = struct {
         }
 
         pub fn baseline(arch: Arch, os: Os) *const Model {
-            _ = os;
             return switch (arch) {
                 .arm, .armeb, .thumb, .thumbeb => &arm.cpu.baseline,
+                .aarch64 => switch (os.tag) {
+                    .bridgeos, .driverkit, .macos => &aarch64.cpu.apple_m1,
+                    .ios, .tvos => &aarch64.cpu.apple_a7,
+                    .visionos => &aarch64.cpu.apple_m2,
+                    .watchos => &aarch64.cpu.apple_s4,
+                    else => generic(arch),
+                },
                 .hexagon => &hexagon.cpu.hexagonv60, // gcc/clang do not have a generic hexagon model.
                 .riscv32 => &riscv.cpu.baseline_rv32,
                 .riscv64 => &riscv.cpu.baseline_rv64,

--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -6,7 +6,7 @@
 /// `null` means native.
 cpu_arch: ?Target.Cpu.Arch = null,
 
-cpu_model: CpuModel = CpuModel.determined_by_cpu_arch,
+cpu_model: CpuModel = CpuModel.determined_by_arch_os,
 
 /// Sparse set of CPU features to add to the set from `cpu_model`.
 cpu_features_add: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,
@@ -48,7 +48,7 @@ pub const CpuModel = union(enum) {
 
     /// If CPU Architecture is native, then the CPU model will be native. Otherwise,
     /// it will be baseline.
-    determined_by_cpu_arch,
+    determined_by_arch_os,
 
     explicit: *const Target.Cpu.Model,
 
@@ -58,7 +58,7 @@ pub const CpuModel = union(enum) {
         const b_tag: Tag = b;
         if (a_tag != b_tag) return false;
         return switch (a) {
-            .native, .baseline, .determined_by_cpu_arch => true,
+            .native, .baseline, .determined_by_arch_os => true,
             .explicit => |a_model| a_model == b.explicit,
         };
     }
@@ -349,7 +349,7 @@ test parseVersion {
 
 pub fn isNativeCpu(self: Query) bool {
     return self.cpu_arch == null and
-        (self.cpu_model == .native or self.cpu_model == .determined_by_cpu_arch) and
+        (self.cpu_model == .native or self.cpu_model == .determined_by_arch_os) and
         self.cpu_features_sub.isEmpty() and self.cpu_features_add.isEmpty();
 }
 
@@ -461,7 +461,7 @@ pub fn serializeCpu(q: Query, buffer: *std.ArrayList(u8)) Allocator.Error!void {
         .baseline => {
             buffer.appendSliceAssumeCapacity("baseline");
         },
-        .determined_by_cpu_arch => {
+        .determined_by_arch_os => {
             if (q.cpu_arch == null) {
                 buffer.appendSliceAssumeCapacity("native");
             } else {

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -90,7 +90,7 @@ pub fn suggestVectorLength(comptime T: type) ?comptime_int {
 }
 
 test "suggestVectorLengthForCpu works with signed and unsigned values" {
-    comptime var cpu = std.Target.Cpu.baseline(std.Target.Cpu.Arch.x86_64);
+    comptime var cpu = std.Target.Cpu.baseline(std.Target.Cpu.Arch.x86_64, builtin.os);
     comptime cpu.features.addFeature(@intFromEnum(std.Target.x86.Feature.avx512f));
     comptime cpu.features.populateDependencies(&std.Target.x86.all_features);
     const expected_len: usize = switch (builtin.zig_backend) {

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -337,14 +337,14 @@ pub fn resolveTargetQuery(query: Target.Query) DetectError!Target {
 
     const cpu = switch (query.cpu_model) {
         .native => detectNativeCpuAndFeatures(cpu_arch, os, query),
-        .baseline => Target.Cpu.baseline(cpu_arch),
-        .determined_by_cpu_arch => if (query.cpu_arch == null)
+        .baseline => Target.Cpu.baseline(cpu_arch, os),
+        .determined_by_arch_os => if (query.cpu_arch == null)
             detectNativeCpuAndFeatures(cpu_arch, os, query)
         else
-            Target.Cpu.baseline(cpu_arch),
+            Target.Cpu.baseline(cpu_arch, os),
         .explicit => |model| model.toCpu(cpu_arch),
     } orelse backup_cpu_detection: {
-        break :backup_cpu_detection Target.Cpu.baseline(cpu_arch);
+        break :backup_cpu_detection Target.Cpu.baseline(cpu_arch, os);
     };
     var result = try detectAbiAndDynamicLinker(cpu, os, query);
     // For x86, we need to populate some CPU feature flags depending on architecture

--- a/src/main.zig
+++ b/src/main.zig
@@ -6299,7 +6299,7 @@ fn detectNativeCpuWithLLVM(
     llvm_cpu_name_z: ?[*:0]const u8,
     llvm_cpu_features_opt: ?[*:0]const u8,
 ) !std.Target.Cpu {
-    var result = std.Target.Cpu.baseline(arch);
+    var result = std.Target.Cpu.baseline(arch, builtin.os);
 
     if (llvm_cpu_name_z) |cpu_name_z| {
         const llvm_cpu_name = mem.span(cpu_name_z);


### PR DESCRIPTION
See: https://github.com/ziglang/zig-bootstrap/issues/194