### PR TITLE
Some miscellaneous LoongArch port work

### DIFF
--- a/lib/compiler_rt/clear_cache.zig
+++ b/lib/compiler_rt/clear_cache.zig
@@ -28,8 +28,10 @@ fn clear_cache(start: usize, end: usize) callconv(.C) void {
         .aarch64, .aarch64_be => true,
         else => false,
     };
-    const loongarch64 = switch (arch) {
-        .loongarch64 => true,
+    const loongarch = switch (arch) {
+        .loongarch32,
+        .loongarch64,
+        => true,
         else => false,
     };
     const mips = switch (arch) {
@@ -163,7 +165,7 @@ fn clear_cache(start: usize, end: usize) callconv(.C) void {
         // On Darwin, sys_icache_invalidate() provides this functionality
         sys_icache_invalidate(start, end - start);
         exportIt();
-    } else if (os == .linux and loongarch64) {
+    } else if (os == .linux and loongarch) {
         // See: https://github.com/llvm/llvm-project/blob/cf54cae26b65fc3201eff7200ffb9b0c9e8f9a13/compiler-rt/lib/builtins/clear_cache.c#L94-L95
         asm volatile (
             \\ ibar 0

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -2704,7 +2704,6 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
             .csky,
             .x86,
             .xcore,
-            .loongarch32,
             .kalimba,
             .spu_2,
             .xtensa,
@@ -2728,6 +2727,7 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
 
             .aarch64,
             .aarch64_be,
+            .loongarch32,
             .loongarch64,
             .mips64,
             .mips64el,
@@ -2808,7 +2808,6 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
 
             .csky,
             .xcore,
-            .loongarch32,
             .kalimba,
             .spu_2,
             .xtensa,
@@ -2838,6 +2837,7 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
 
             .aarch64,
             .aarch64_be,
+            .loongarch32,
             .loongarch64,
             .mips64,
             .mips64el,

--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -1338,7 +1338,7 @@ const LinuxThreadImpl = struct {
                       [len] "r" (self.mapped.len),
                     : "memory"
                 ),
-                .loongarch64 => asm volatile (
+                .loongarch32, .loongarch64 => asm volatile (
                     \\ or      $a0, $zero, %[ptr]
                     \\ or      $a1, $zero, %[len]
                     \\ ori     $a7, $zero, 215     # SYS_munmap

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -12453,6 +12453,9 @@ fn backendSupportsF80(target: std.Target) bool {
 /// if it produces miscompilations.
 fn backendSupportsF16(target: std.Target) bool {
     return switch (target.cpu.arch) {
+        // LoongArch can be removed from this list with LLVM 20.
+        .loongarch32,
+        .loongarch64,
         .hexagon,
         .powerpc,
         .powerpcle,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -520,6 +520,7 @@ const DataLayoutBuilder = struct {
             .arm,
             .armeb,
             .csky,
+            .loongarch32,
             .mips,
             .mipsel,
             .powerpc,
@@ -535,6 +536,7 @@ const DataLayoutBuilder = struct {
             .amdgcn,
             .bpfeb,
             .bpfel,
+            .loongarch64,
             .mips64,
             .mips64el,
             .powerpc64,
@@ -554,7 +556,6 @@ const DataLayoutBuilder = struct {
             .nvptx64,
             => &.{ 16, 32, 64 },
             .x86_64 => &.{ 8, 16, 32, 64 },
-            .loongarch64 => &.{64},
             else => &.{},
         }), 0..) |natural, index| switch (index) {
             0 => try writer.print("-n{d}", .{natural}),

--- a/test/llvm_targets.zig
+++ b/test/llvm_targets.zig
@@ -108,10 +108,6 @@ const targets = [_]std.Target.Query{
     .{ .cpu_arch = .lanai, .os_tag = .freestanding, .abi = .none },
 
     .{ .cpu_arch = .loongarch32, .os_tag = .freestanding, .abi = .none },
-    .{ .cpu_arch = .loongarch32, .os_tag = .linux, .abi = .gnu },
-    .{ .cpu_arch = .loongarch32, .os_tag = .linux, .abi = .gnuf32 },
-    .{ .cpu_arch = .loongarch32, .os_tag = .linux, .abi = .gnusf },
-    .{ .cpu_arch = .loongarch32, .os_tag = .linux, .abi = .musl },
     .{ .cpu_arch = .loongarch32, .os_tag = .linux, .abi = .none },
     .{ .cpu_arch = .loongarch32, .os_tag = .uefi, .abi = .none },
 


### PR DESCRIPTION
* Adds loongarch32 handling where sensible.
* Fixes the LLVM data layout string to include `-n32:64` for loongarch64 and `-n32` for loongarch32.
* I also went ahead and extended the `f16` workaround in the LLVM backend to LoongArch. I resisted doing this previously since the `f16` issues were supposed to be fixed with LLVM 19. But since [that turned out not to be the case](https://github.com/ziglang/zig-bootstrap/commit/37b6c3d88ce12335d508975f02c364eb98842a9d), let's just work around it until LLVM 20 so porting effort can move along in other areas.