### PR TITLE
`watchos`: add os to `aarch64` architecture

### DIFF
--- a/lib/std/debug/Dwarf/abi.zig
+++ b/lib/std/debug/Dwarf/abi.zig
@@ -293,7 +293,7 @@ pub fn regBytes(
             else => error.UnimplementedOs,
         },
         .aarch64 => switch (builtin.os.tag) {
-            .macos, .ios => switch (reg_number) {
+            .macos, .ios, .watchos => switch (reg_number) {
                 0...28 => mem.asBytes(&ucontext_ptr.mcontext.ss.regs[reg_number]),
                 29 => mem.asBytes(&ucontext_ptr.mcontext.ss.fp),
                 30 => mem.asBytes(&ucontext_ptr.mcontext.ss.lr),


### PR DESCRIPTION
Needed for creating libraries that run both on physical Apple Watches and the watchOS simulator.

---

[Example Makefile](https://github.com/marionauta/zig-watchos-makefile/blob/main/Makefile)

While trying to build Zig code to run on the Apple Watch, Xcode requires the libraries to be in the following formats:

1. amd64 (aarch64) & x86_64 for the watchOS simulator.
2. amd64 (aarch64) & amd64_32 (aarch64_32) for a physical watchOS device.

This PR adds the `.watchos` os tag to the `.aarch64` architecture, mirroring both iOS and macOS. Runs with no problems.

Notes:

1. There we no changes needed for `x86_64`.
2. The `aarch64_32` architecture is exclusive to the Apple Watch and not supported by Zig, so I didn't add it. You can see in the linked `Makefile` that I first compiled Zig to LLVM bytecode (`.bc`) and then the bytecode to an object file with Apple's clang, which does know about `aarch64_32`.