### PR TITLE
langref: fixes incorrect description of cmpxchg functions

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4559,7 +4559,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the current value is the given expected value. It's the equivalent of this code,
       except atomic:
       </p>
       {#code|not_atomic_cmpxchgStrong.zig#}
@@ -4581,7 +4581,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the current value is the given expected value. It's the equivalent of this code,
       except atomic:
       </p>
       {#syntax_block|zig|cmpxchgWeakButNotAtomic#}


### PR DESCRIPTION
for a few releases now the textual description of cmpxchg has been incorrect; the code example has been correct; null is returned if the exchange successfully happens, not if it failed due to mismatch.