### PR TITLE
Add `is_dll_import` to @extern, to support `__declspec(dllimport)` with the MSVC ABI

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -70,6 +70,14 @@ pub const GlobalLinkage = enum {
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
+pub const DllStorageClass = enum {
+    default,
+    import,
+    @"export",
+};
+
+/// This data structure is used by the Zig language code generation and
+/// therefore must be kept in sync with the compiler implementation.
 pub const SymbolVisibility = enum {
     default,
     hidden,
@@ -683,6 +691,7 @@ pub const ExternOptions = struct {
     library_name: ?[]const u8 = null,
     linkage: GlobalLinkage = .strong,
     is_thread_local: bool = false,
+    dll_storage_class: DllStorageClass = .default,
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -70,14 +70,6 @@ pub const GlobalLinkage = enum {
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
-pub const DllStorageClass = enum {
-    default,
-    import,
-    @"export",
-};
-
-/// This data structure is used by the Zig language code generation and
-/// therefore must be kept in sync with the compiler implementation.
 pub const SymbolVisibility = enum {
     default,
     hidden,
@@ -691,7 +683,7 @@ pub const ExternOptions = struct {
     library_name: ?[]const u8 = null,
     linkage: GlobalLinkage = .strong,
     is_thread_local: bool = false,
-    dll_storage_class: DllStorageClass = .default,
+    is_dll_import: bool = false,
 };
 
 /// This data structure is used by the Zig language code generation and

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2054,6 +2054,7 @@ pub const Key = union(enum) {
         is_const: bool,
         is_threadlocal: bool,
         is_weak_linkage: bool,
+        is_dll_import: bool,
         alignment: Alignment,
         @"addrspace": std.builtin.AddressSpace,
         /// The ZIR instruction which created this extern; used only for source locations.
@@ -2675,6 +2676,7 @@ pub const Key = union(enum) {
                 asBytes(&e.ty) ++ asBytes(&e.lib_name) ++
                 asBytes(&e.is_const) ++ asBytes(&e.is_threadlocal) ++
                 asBytes(&e.is_weak_linkage) ++ asBytes(&e.alignment) ++
+                asBytes(&e.is_dll_import) ++ asBytes(&e.alignment) ++
                 asBytes(&e.@"addrspace") ++ asBytes(&e.zir_index)),
         };
     }
@@ -2771,6 +2773,7 @@ pub const Key = union(enum) {
                     a_info.is_const == b_info.is_const and
                     a_info.is_threadlocal == b_info.is_threadlocal and
                     a_info.is_weak_linkage == b_info.is_weak_linkage and
+                    a_info.is_dll_import == b_info.is_dll_import and
                     a_info.alignment == b_info.alignment and
                     a_info.@"addrspace" == b_info.@"addrspace" and
                     a_info.zir_index == b_info.zir_index;
@@ -5370,7 +5373,8 @@ pub const Tag = enum(u8) {
             is_const: bool,
             is_threadlocal: bool,
             is_weak_linkage: bool,
-            _: u29 = 0,
+            is_dll_import: bool,
+            _: u28 = 0,
         };
     };
 
@@ -6715,6 +6719,7 @@ pub fn indexToKey(ip: *const InternPool, index: Index) Key {
                 .is_const = extra.flags.is_const,
                 .is_threadlocal = extra.flags.is_threadlocal,
                 .is_weak_linkage = extra.flags.is_weak_linkage,
+                .is_dll_import = extra.flags.is_dll_import,
                 .alignment = nav.status.resolved.alignment,
                 .@"addrspace" = nav.status.resolved.@"addrspace",
                 .zir_index = extra.zir_index,
@@ -7381,6 +7386,7 @@ pub fn get(ip: *InternPool, gpa: Allocator, tid: Zcu.PerThread.Id, key: Key) All
                         .is_const = false,
                         .is_threadlocal = variable.is_threadlocal,
                         .is_weak_linkage = variable.is_weak_linkage,
+                        .is_dll_import = false,
                     },
                 }),
             });
@@ -8644,6 +8650,7 @@ pub fn getExtern(
             .is_const = key.is_const,
             .is_threadlocal = key.is_threadlocal,
             .is_weak_linkage = key.is_weak_linkage,
+            .is_dll_import = key.is_dll_import,
         },
         .zir_index = key.zir_index,
         .owner_nav = owner_nav,

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2676,8 +2676,8 @@ pub const Key = union(enum) {
                 asBytes(&e.ty) ++ asBytes(&e.lib_name) ++
                 asBytes(&e.is_const) ++ asBytes(&e.is_threadlocal) ++
                 asBytes(&e.is_weak_linkage) ++ asBytes(&e.alignment) ++
-                asBytes(&e.is_dll_import) ++ asBytes(&e.alignment) ++
-                asBytes(&e.@"addrspace") ++ asBytes(&e.zir_index)),
+                asBytes(&e.is_dll_import) ++ asBytes(&e.@"addrspace") ++
+                asBytes(&e.zir_index)),
         };
     }
 

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -1340,11 +1340,11 @@ pub fn isLazySize(val: Value, zcu: *Zcu) bool {
     };
 }
 
-pub fn isPtrToThreadLocal(val: Value, zcu: *Zcu) bool {
+pub fn isPtrRuntimeValue(val: Value, zcu: *Zcu) bool {
     const ip = &zcu.intern_pool;
     const nav = ip.getBackingNav(val.toIntern()).unwrap() orelse return false;
     return switch (ip.indexToKey(ip.getNav(nav).status.resolved.val)) {
-        .@"extern" => |e| e.is_threadlocal,
+        .@"extern" => |e| e.is_threadlocal or e.is_dll_import,
         .variable => |v| v.is_threadlocal,
         else => false,
     };

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1522,6 +1522,7 @@ pub const SrcLoc = struct {
             .init_field_cache,
             .init_field_library,
             .init_field_thread_local,
+            .init_field_dll_storage_class,
             => |builtin_call_node| {
                 const wanted = switch (src_loc.lazy) {
                     .init_field_name => "name",
@@ -1533,6 +1534,7 @@ pub const SrcLoc = struct {
                     .init_field_cache => "cache",
                     .init_field_library => "library",
                     .init_field_thread_local => "thread_local",
+                    .init_field_dll_storage_class => "dll_storage_class",
                     else => unreachable,
                 };
                 const tree = try src_loc.file_scope.getTree(gpa);
@@ -1959,6 +1961,7 @@ pub const LazySrcLoc = struct {
         init_field_cache: i32,
         init_field_library: i32,
         init_field_thread_local: i32,
+        init_field_dll_storage_class: i32,
         /// The source location points to the value of an item in a specific
         /// case of a `switch`.
         switch_case_item: SwitchItem,

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1522,7 +1522,7 @@ pub const SrcLoc = struct {
             .init_field_cache,
             .init_field_library,
             .init_field_thread_local,
-            .init_field_dll_storage_class,
+            .init_field_dll_import,
             => |builtin_call_node| {
                 const wanted = switch (src_loc.lazy) {
                     .init_field_name => "name",
@@ -1534,7 +1534,7 @@ pub const SrcLoc = struct {
                     .init_field_cache => "cache",
                     .init_field_library => "library",
                     .init_field_thread_local => "thread_local",
-                    .init_field_dll_storage_class => "dll_storage_class",
+                    .init_field_dll_import => "dll_import",
                     else => unreachable,
                 };
                 const tree = try src_loc.file_scope.getTree(gpa);
@@ -1961,7 +1961,7 @@ pub const LazySrcLoc = struct {
         init_field_cache: i32,
         init_field_library: i32,
         init_field_thread_local: i32,
-        init_field_dll_storage_class: i32,
+        init_field_dll_import: i32,
         /// The source location points to the value of an item in a specific
         /// case of a `switch`.
         switch_case_item: SwitchItem,

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2763,6 +2763,7 @@ pub fn getCoerced(pt: Zcu.PerThread, val: Value, new_ty: Type) Allocator.Error!V
                 .is_const = e.is_const,
                 .is_threadlocal = e.is_threadlocal,
                 .is_weak_linkage = e.is_weak_linkage,
+                .is_dll_import = e.is_dll_import,
                 .alignment = e.alignment,
                 .@"addrspace" = e.@"addrspace",
                 .zir_index = e.zir_index,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -3237,10 +3237,10 @@ pub const Object = struct {
         const ip = &zcu.intern_pool;
         const nav = ip.getNav(nav_index);
         const resolved = nav.status.resolved;
-        const is_extern, const is_threadlocal, const is_weak_linkage = switch (ip.indexToKey(resolved.val)) {
-            .variable => |variable| .{ false, variable.is_threadlocal, variable.is_weak_linkage },
-            .@"extern" => |@"extern"| .{ true, @"extern".is_threadlocal, @"extern".is_weak_linkage },
-            else => .{ false, false, false },
+        const is_extern, const is_threadlocal, const is_weak_linkage, const is_dll_import = switch (ip.indexToKey(resolved.val)) {
+            .variable => |variable| .{ false, variable.is_threadlocal, variable.is_weak_linkage, false },
+            .@"extern" => |@"extern"| .{ true, @"extern".is_threadlocal, @"extern".is_weak_linkage, @"extern".is_dll_import },
+            else => .{ false, false, false, false },
         };
 
         const variable_index = try o.builder.addVariable(
@@ -3257,6 +3257,7 @@ pub const Object = struct {
             if (is_threadlocal and !zcu.navFileScope(nav_index).mod.single_threaded)
                 variable_index.setThreadLocal(.generaldynamic, &o.builder);
             if (is_weak_linkage) variable_index.setLinkage(.extern_weak, &o.builder);
+            if (is_dll_import) variable_index.setDllStorageClass(.dllimport, &o.builder);
         } else {
             variable_index.setLinkage(.internal, &o.builder);
             variable_index.setUnnamedAddr(.unnamed_addr, &o.builder);

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -2528,6 +2528,10 @@ pub const Variable = struct {
             return self.ptrConst(builder).global.setLinkage(linkage, builder);
         }
 
+        pub fn setDllStorageClass(self: Index, class: DllStorageClass, builder: *Builder) void {
+            return self.ptrConst(builder).global.setDllStorageClass(class, builder);
+        }
+
         pub fn setUnnamedAddr(self: Index, unnamed_addr: UnnamedAddr, builder: *Builder) void {
             return self.ptrConst(builder).global.setUnnamedAddr(unnamed_addr, builder);
         }

--- a/test/cases/compile_errors/builtin_extern_in_comptime_scope.zig
+++ b/test/cases/compile_errors/builtin_extern_in_comptime_scope.zig
@@ -1,0 +1,18 @@
+const foo_tl = @extern(*i32, .{ .name = "foo", .is_thread_local = true });
+const foo_dll = @extern(*i32, .{ .name = "foo", .is_dll_import = true });
+pub export fn entry() void {
+    _ = foo_tl;
+}
+pub export fn entry2() void {
+    _ = foo_dll;
+}
+// error
+// backend=stage2
+// target=native
+//
+// :1:16: error: unable to resolve comptime value
+// :1:16: note: global variable initializer must be comptime-known
+// :1:16: note: thread local and dll imported variables have runtime-known addresses
+// :2:17: error: unable to resolve comptime value
+// :2:17: note: global variable initializer must be comptime-known
+// :2:17: note: thread local and dll imported variables have runtime-known addresses

--- a/test/standalone/extern/build.zig
+++ b/test/standalone/extern/build.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
     const optimize: std.builtin.OptimizeMode = .Debug;
 
     const obj = b.addObject(.{
@@ -9,12 +12,20 @@ pub fn build(b: *std.Build) void {
         .target = b.graph.host,
         .optimize = optimize,
     });
-    const main = b.addTest(.{
+    const shared = b.addSharedLibrary(.{
+        .name = "shared",
+        .target = b.graph.host,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    if (b.graph.host.result.abi == .msvc) shared.defineCMacro("API", "__declspec(dllexport)");
+    shared.addCSourceFile(.{ .file = b.path("shared.c"), .flags = &.{} });
+    const test_exe = b.addTest(.{
         .root_source_file = b.path("main.zig"),
         .optimize = optimize,
     });
-    main.addObject(obj);
+    test_exe.addObject(obj);
+    test_exe.linkLibrary(shared);
 
-    const test_step = b.step("test", "Test it");
-    test_step.dependOn(&main.step);
+    test_step.dependOn(&b.addRunArtifact(test_exe).step);
 }

--- a/test/standalone/extern/main.zig
+++ b/test/standalone/extern/main.zig
@@ -1,4 +1,5 @@
 const assert = @import("std").debug.assert;
+const testing = @import("std").testing;
 
 const updateHidden = @extern(*const fn (u32) callconv(.C) void, .{ .name = "updateHidden" });
 const getHidden = @extern(*const fn () callconv(.C) u32, .{ .name = "getHidden" });
@@ -8,14 +9,18 @@ const T = extern struct { x: u32 };
 test {
     const mut_val_ptr = @extern(*f64, .{ .name = "mut_val" });
     const const_val_ptr = @extern(*const T, .{ .name = "const_val" });
+    const shared_val_ptr = @extern(*c_int, .{ .name = "shared_val", .is_dll_import = true });
 
     assert(getHidden() == 0);
     updateHidden(123);
     assert(getHidden() == 123);
-
     assert(mut_val_ptr.* == 1.23);
     mut_val_ptr.* = 10.0;
     assert(mut_val_ptr.* == 10.0);
 
     assert(const_val_ptr.x == 42);
+
+    assert(shared_val_ptr.* == 1234);
+    shared_val_ptr.* = 1235;
+    assert(shared_val_ptr.* == 1235);
 }

--- a/test/standalone/extern/shared.c
+++ b/test/standalone/extern/shared.c
@@ -1,0 +1,5 @@
+#ifndef API
+#define API
+#endif
+
+API int shared_val = 1234;


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/15903
Closes https://github.com/ziglang/zig/issues/21749

This change adds `is_dll_import: bool` to the options to `@extern`. This has the effect of setting the LLVM DLL Storage Class of the global to `dllimport`, which then generates the correct code to load from such a symbol at runtime - by prepending `__imp_` to the symbol name and loading from that symbol instead. 

This is necessary for the `msvc` ABI, as the "auto imports" features that make this work on `-gnu` are MinGW specific and don't exist there (see https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fauto-import).

As part of this change I also added an error note that explains why you can't place an `@extern` that uses either `is_thread_local` or `is_dll_import` in a comptime scope (because the address is runtime-known). To do this I added a new optional field to `NeededComptimeReason` which does seem a bit heavy-handed since it's only used in this one place - I can easily change this to build one single, longer `needed_comptime_reason` if that is preferred.

Other changes:
- `tests/standalone/extern` wasn't actually running the test step, that is fixed now

A question for reviewers about existing behaviour:

No compile errors are currently emitted when using optional pointers in `@extern` in comptime scopes - as an example:

```
const foo_opt_data = @extern(?*u32, .{
    .name = "foo_opt_data",
    .linkage = .strong,
    .is_dll_import = true,
});
```
This doesn't result in a compile error, but a linker error instead, because a `@main.foo_opt_data` global is generated that is initialized from a non-existent symbol `@foo_opt_data`, this can't be available at comptime because the value is only known at runtime.

```
@main.foo_opt_data = internal unnamed_addr constant ptr @foo_opt_data, align 8, !dbg !3934
```

I tried to determine the cause for this, and I thought it was `isPtrRuntimeValue` not unwrapping the optional properly when getting the backing nav, but it seems to handle that in `ip.getBackinNav`. I'm happy to fix this as part of this pr and add a compile error test case for this to `builtin_extern_in_comptime_scope`, if someone can point me in the right direction.