### PR TITLE
Do not use `undefined` for the ptr field of `Allocator`/`Random` instances

### DIFF
--- a/lib/std/Random.zig
+++ b/lib/std/Random.zig
@@ -29,8 +29,10 @@ pub const RomuTrio = @import("Random/RomuTrio.zig");
 pub const SplitMix64 = @import("Random/SplitMix64.zig");
 pub const ziggurat = @import("Random/ziggurat.zig");
 
-ptr: *anyopaque,
-fillFn: *const fn (ptr: *anyopaque, buf: []u8) void,
+/// The type erased pointer to the random implementation.
+/// If null, the random implementation has no associated state.
+ptr: ?*anyopaque,
+fillFn: *const fn (ptr: ?*anyopaque, buf: []u8) void,
 
 pub fn init(pointer: anytype, comptime fillFn: fn (ptr: @TypeOf(pointer), buf: []u8) void) Random {
     const Ptr = @TypeOf(pointer);
@@ -38,8 +40,8 @@ pub fn init(pointer: anytype, comptime fillFn: fn (ptr: @TypeOf(pointer), buf: [
     assert(@typeInfo(Ptr).pointer.size == .one); // Must be a single-item pointer
     assert(@typeInfo(@typeInfo(Ptr).pointer.child) == .@"struct"); // Must point to a struct
     const gen = struct {
-        fn fill(ptr: *anyopaque, buf: []u8) void {
-            const self: Ptr = @ptrCast(@alignCast(ptr));
+        fn fill(ptr: ?*anyopaque, buf: []u8) void {
+            const self: Ptr = @ptrCast(@alignCast(ptr.?));
             fillFn(self, buf);
         }
     };

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -44,7 +44,7 @@ var install_atfork_handler = std.once(struct {
 
 threadlocal var wipe_mem: []align(mem.page_size) u8 = &[_]u8{};
 
-fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
+fn tlsCsprngFill(_: ?*anyopaque, buffer: []u8) void {
     if (os_has_arc4random) {
         // arc4random is already a thread-local CSPRNG.
         return std.c.arc4random_buf(buffer.ptr, buffer.len);

--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -12,7 +12,7 @@ const posix = std.posix;
 /// We use this as a layer of indirection because global const pointers cannot
 /// point to thread-local variables.
 pub const interface: std.Random = .{
-    .ptr = undefined,
+    .ptr = null,
     .fillFn = tlsCsprngFill,
 };
 

--- a/lib/std/heap/PageAllocator.zig
+++ b/lib/std/heap/PageAllocator.zig
@@ -14,7 +14,7 @@ pub const vtable = Allocator.VTable{
     .free = free,
 };
 
-fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
+fn alloc(_: ?*anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
     _ = ra;
     _ = log2_align;
     assert(n > 0);
@@ -51,7 +51,7 @@ fn alloc(_: *anyopaque, n: usize, log2_align: u8, ra: usize) ?[*]u8 {
 }
 
 fn resize(
-    _: *anyopaque,
+    _: ?*anyopaque,
     buf_unaligned: []u8,
     log2_buf_align: u8,
     new_size: usize,
@@ -100,7 +100,7 @@ fn resize(
     return false;
 }
 
-fn free(_: *anyopaque, slice: []u8, log2_buf_align: u8, return_address: usize) void {
+fn free(_: ?*anyopaque, slice: []u8, log2_buf_align: u8, return_address: usize) void {
     _ = log2_buf_align;
     _ = return_address;
 

--- a/lib/std/heap/ThreadSafeAllocator.zig
+++ b/lib/std/heap/ThreadSafeAllocator.zig
@@ -14,16 +14,16 @@ pub fn allocator(self: *ThreadSafeAllocator) Allocator {
     };
 }
 
-fn alloc(ctx: *anyopaque, n: usize, log2_ptr_align: u8, ra: usize) ?[*]u8 {
-    const self: *ThreadSafeAllocator = @ptrCast(@alignCast(ctx));
+fn alloc(ctx: ?*anyopaque, n: usize, log2_ptr_align: u8, ra: usize) ?[*]u8 {
+    const self: *ThreadSafeAllocator = @ptrCast(@alignCast(ctx.?));
     self.mutex.lock();
     defer self.mutex.unlock();
 
     return self.child_allocator.rawAlloc(n, log2_ptr_align, ra);
 }
 
-fn resize(ctx: *anyopaque, buf: []u8, log2_buf_align: u8, new_len: usize, ret_addr: usize) bool {
-    const self: *ThreadSafeAllocator = @ptrCast(@alignCast(ctx));
+fn resize(ctx: ?*anyopaque, buf: []u8, log2_buf_align: u8, new_len: usize, ret_addr: usize) bool {
+    const self: *ThreadSafeAllocator = @ptrCast(@alignCast(ctx.?));
 
     self.mutex.lock();
     defer self.mutex.unlock();
@@ -31,8 +31,8 @@ fn resize(ctx: *anyopaque, buf: []u8, log2_buf_align: u8, new_len: usize, ret_ad
     return self.child_allocator.rawResize(buf, log2_buf_align, new_len, ret_addr);
 }
 
-fn free(ctx: *anyopaque, buf: []u8, log2_buf_align: u8, ret_addr: usize) void {
-    const self: *ThreadSafeAllocator = @ptrCast(@alignCast(ctx));
+fn free(ctx: ?*anyopaque, buf: []u8, log2_buf_align: u8, ret_addr: usize) void {
+    const self: *ThreadSafeAllocator = @ptrCast(@alignCast(ctx.?));
 
     self.mutex.lock();
     defer self.mutex.unlock();

--- a/lib/std/heap/WasmAllocator.zig
+++ b/lib/std/heap/WasmAllocator.zig
@@ -46,7 +46,7 @@ var frees = [1]usize{0} ** size_class_count;
 /// For each big size class, points to the freed pointer.
 var big_frees = [1]usize{0} ** big_size_class_count;
 
-fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, return_address: usize) ?[*]u8 {
+fn alloc(ctx: ?*anyopaque, len: usize, log2_align: u8, return_address: usize) ?[*]u8 {
     _ = ctx;
     _ = return_address;
     // Make room for the freelist next pointer.
@@ -84,7 +84,7 @@ fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, return_address: usize) ?[*
 }
 
 fn resize(
-    ctx: *anyopaque,
+    ctx: ?*anyopaque,
     buf: []u8,
     log2_buf_align: u8,
     new_len: usize,
@@ -112,7 +112,7 @@ fn resize(
 }
 
 fn free(
-    ctx: *anyopaque,
+    ctx: ?*anyopaque,
     buf: []u8,
     log2_buf_align: u8,
     return_address: usize,
@@ -161,7 +161,7 @@ fn allocBigPages(n: usize) usize {
 }
 
 const test_ally = Allocator{
-    .ptr = undefined,
+    .ptr = null,
     .vtable = &vtable,
 };
 

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -173,8 +173,8 @@ pub const ArenaAllocator = struct {
         return buf_node;
     }
 
-    fn alloc(ctx: *anyopaque, n: usize, log2_ptr_align: u8, ra: usize) ?[*]u8 {
-        const self: *ArenaAllocator = @ptrCast(@alignCast(ctx));
+    fn alloc(ctx: ?*anyopaque, n: usize, log2_ptr_align: u8, ra: usize) ?[*]u8 {
+        const self: *ArenaAllocator = @ptrCast(@alignCast(ctx.?));
         _ = ra;
 
         const ptr_align = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_ptr_align));
@@ -207,8 +207,8 @@ pub const ArenaAllocator = struct {
         }
     }
 
-    fn resize(ctx: *anyopaque, buf: []u8, log2_buf_align: u8, new_len: usize, ret_addr: usize) bool {
-        const self: *ArenaAllocator = @ptrCast(@alignCast(ctx));
+    fn resize(ctx: ?*anyopaque, buf: []u8, log2_buf_align: u8, new_len: usize, ret_addr: usize) bool {
+        const self: *ArenaAllocator = @ptrCast(@alignCast(ctx.?));
         _ = log2_buf_align;
         _ = ret_addr;
 
@@ -231,11 +231,11 @@ pub const ArenaAllocator = struct {
         }
     }
 
-    fn free(ctx: *anyopaque, buf: []u8, log2_buf_align: u8, ret_addr: usize) void {
+    fn free(ctx: ?*anyopaque, buf: []u8, log2_buf_align: u8, ret_addr: usize) void {
         _ = log2_buf_align;
         _ = ret_addr;
 
-        const self: *ArenaAllocator = @ptrCast(@alignCast(ctx));
+        const self: *ArenaAllocator = @ptrCast(@alignCast(ctx.?));
 
         const cur_node = self.state.buffer_list.first orelse return;
         const cur_buf = @as([*]u8, @ptrCast(cur_node))[@sizeOf(BufNode)..cur_node.data];

--- a/lib/std/heap/general_purpose_allocator.zig
+++ b/lib/std/heap/general_purpose_allocator.zig
@@ -715,13 +715,13 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
         }
 
         fn resize(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             old_mem: []u8,
             log2_old_align_u8: u8,
             new_size: usize,
             ret_addr: usize,
         ) bool {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             const log2_old_align = @as(Allocator.Log2Align, @intCast(log2_old_align_u8));
             self.mutex.lock();
             defer self.mutex.unlock();
@@ -834,12 +834,12 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
         }
 
         fn free(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             old_mem: []u8,
             log2_old_align_u8: u8,
             ret_addr: usize,
         ) void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             const log2_old_align = @as(Allocator.Log2Align, @intCast(log2_old_align_u8));
             self.mutex.lock();
             defer self.mutex.unlock();
@@ -977,8 +977,8 @@ pub fn GeneralPurposeAllocator(comptime config: Config) type {
             return true;
         }
 
-        fn alloc(ctx: *anyopaque, len: usize, log2_ptr_align: u8, ret_addr: usize) ?[*]u8 {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+        fn alloc(ctx: ?*anyopaque, len: usize, log2_ptr_align: u8, ret_addr: usize) ?[*]u8 {
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             self.mutex.lock();
             defer self.mutex.unlock();
             if (!self.isAllocationAllowed(len)) return null;

--- a/lib/std/heap/log_to_writer_allocator.zig
+++ b/lib/std/heap/log_to_writer_allocator.zig
@@ -29,12 +29,12 @@ pub fn LogToWriterAllocator(comptime Writer: type) type {
         }
 
         fn alloc(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             len: usize,
             log2_ptr_align: u8,
             ra: usize,
         ) ?[*]u8 {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             self.writer.print("alloc : {}", .{len}) catch {};
             const result = self.parent_allocator.rawAlloc(len, log2_ptr_align, ra);
             if (result != null) {
@@ -46,13 +46,13 @@ pub fn LogToWriterAllocator(comptime Writer: type) type {
         }
 
         fn resize(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             new_len: usize,
             ra: usize,
         ) bool {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             if (new_len <= buf.len) {
                 self.writer.print("shrink: {} to {}\n", .{ buf.len, new_len }) catch {};
             } else {
@@ -72,12 +72,12 @@ pub fn LogToWriterAllocator(comptime Writer: type) type {
         }
 
         fn free(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             ra: usize,
         ) void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             self.writer.print("free  : {}\n", .{buf.len}) catch {};
             self.parent_allocator.rawFree(buf, log2_buf_align, ra);
         }

--- a/lib/std/heap/logging_allocator.zig
+++ b/lib/std/heap/logging_allocator.zig
@@ -54,12 +54,12 @@ pub fn ScopedLoggingAllocator(
         }
 
         fn alloc(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             len: usize,
             log2_ptr_align: u8,
             ra: usize,
         ) ?[*]u8 {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             const result = self.parent_allocator.rawAlloc(len, log2_ptr_align, ra);
             if (result != null) {
                 logHelper(
@@ -78,13 +78,13 @@ pub fn ScopedLoggingAllocator(
         }
 
         fn resize(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             new_len: usize,
             ra: usize,
         ) bool {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             if (self.parent_allocator.rawResize(buf, log2_buf_align, new_len, ra)) {
                 if (new_len <= buf.len) {
                     logHelper(
@@ -113,12 +113,12 @@ pub fn ScopedLoggingAllocator(
         }
 
         fn free(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             ra: usize,
         ) void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             self.parent_allocator.rawFree(buf, log2_buf_align, ra);
             logHelper(success_log_level, "free - len: {}", .{buf.len});
         }

--- a/lib/std/heap/sbrk_allocator.zig
+++ b/lib/std/heap/sbrk_allocator.zig
@@ -38,7 +38,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
 
         // TODO don't do the naive locking strategy
         var lock: std.Thread.Mutex = .{};
-        fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, return_address: usize) ?[*]u8 {
+        fn alloc(ctx: ?*anyopaque, len: usize, log2_align: u8, return_address: usize) ?[*]u8 {
             _ = ctx;
             _ = return_address;
             lock.lock();
@@ -79,7 +79,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
         }
 
         fn resize(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             new_len: usize,
@@ -109,7 +109,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
         }
 
         fn free(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             return_address: usize,

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -69,13 +69,13 @@ pub fn ValidationAllocator(comptime T: type) type {
         }
 
         pub fn alloc(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             n: usize,
             log2_ptr_align: u8,
             ret_addr: usize,
         ) ?[*]u8 {
             assert(n > 0);
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             const underlying = self.getUnderlyingAllocatorPtr();
             const result = underlying.rawAlloc(n, log2_ptr_align, ret_addr) orelse
                 return null;
@@ -84,25 +84,25 @@ pub fn ValidationAllocator(comptime T: type) type {
         }
 
         pub fn resize(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             new_len: usize,
             ret_addr: usize,
         ) bool {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             assert(buf.len > 0);
             const underlying = self.getUnderlyingAllocatorPtr();
             return underlying.rawResize(buf, log2_buf_align, new_len, ret_addr);
         }
 
         pub fn free(
-            ctx: *anyopaque,
+            ctx: ?*anyopaque,
             buf: []u8,
             log2_buf_align: u8,
             ret_addr: usize,
         ) void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+            const self: *Self = @ptrCast(@alignCast(ctx.?));
             assert(buf.len > 0);
             const underlying = self.getUnderlyingAllocatorPtr();
             underlying.rawFree(buf, log2_buf_align, ret_addr);
@@ -134,7 +134,7 @@ pub fn alignAllocLen(full_len: usize, alloc_len: usize, len_align: u29) usize {
 }
 
 const fail_allocator = Allocator{
-    .ptr = undefined,
+    .ptr = null,
     .vtable = &failAllocator_vtable,
 };
 
@@ -144,7 +144,7 @@ const failAllocator_vtable = Allocator.VTable{
     .free = Allocator.noFree,
 };
 
-fn failAllocatorAlloc(_: *anyopaque, n: usize, log2_alignment: u8, ra: usize) ?[*]u8 {
+fn failAllocatorAlloc(_: ?*anyopaque, n: usize, log2_alignment: u8, ra: usize) ?[*]u8 {
     _ = n;
     _ = log2_alignment;
     _ = ra;

--- a/lib/std/os/uefi/pool_allocator.zig
+++ b/lib/std/os/uefi/pool_allocator.zig
@@ -13,7 +13,7 @@ const UefiPoolAllocator = struct {
     }
 
     fn alloc(
-        _: *anyopaque,
+        _: ?*anyopaque,
         len: usize,
         log2_ptr_align: u8,
         ret_addr: usize,
@@ -41,7 +41,7 @@ const UefiPoolAllocator = struct {
     }
 
     fn resize(
-        _: *anyopaque,
+        _: ?*anyopaque,
         buf: []u8,
         log2_old_ptr_align: u8,
         new_len: usize,
@@ -55,7 +55,7 @@ const UefiPoolAllocator = struct {
     }
 
     fn free(
-        _: *anyopaque,
+        _: ?*anyopaque,
         buf: []u8,
         log2_old_ptr_align: u8,
         ret_addr: usize,
@@ -69,7 +69,7 @@ const UefiPoolAllocator = struct {
 /// Supports the full Allocator interface, including alignment.
 /// For a direct call of `allocatePool`, see `raw_pool_allocator`.
 pub const pool_allocator = Allocator{
-    .ptr = undefined,
+    .ptr = null,
     .vtable = &pool_allocator_vtable,
 };
 
@@ -81,7 +81,7 @@ const pool_allocator_vtable = Allocator.VTable{
 
 /// Asserts allocations are 8 byte aligned and calls `boot_services.allocatePool`.
 pub const raw_pool_allocator = Allocator{
-    .ptr = undefined,
+    .ptr = null,
     .vtable = &raw_pool_allocator_table,
 };
 
@@ -92,7 +92,7 @@ const raw_pool_allocator_table = Allocator.VTable{
 };
 
 fn uefi_alloc(
-    _: *anyopaque,
+    _: ?*anyopaque,
     len: usize,
     log2_ptr_align: u8,
     ret_addr: usize,
@@ -108,7 +108,7 @@ fn uefi_alloc(
 }
 
 fn uefi_resize(
-    _: *anyopaque,
+    _: ?*anyopaque,
     buf: []u8,
     log2_old_ptr_align: u8,
     new_len: usize,
@@ -123,7 +123,7 @@ fn uefi_resize(
 }
 
 fn uefi_free(
-    _: *anyopaque,
+    _: ?*anyopaque,
     buf: []u8,
     log2_old_ptr_align: u8,
     ret_addr: usize,

--- a/lib/std/testing/failing_allocator.zig
+++ b/lib/std/testing/failing_allocator.zig
@@ -68,12 +68,12 @@ pub const FailingAllocator = struct {
     }
 
     fn alloc(
-        ctx: *anyopaque,
+        ctx: ?*anyopaque,
         len: usize,
         log2_ptr_align: u8,
         return_address: usize,
     ) ?[*]u8 {
-        const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
+        const self: *FailingAllocator = @ptrCast(@alignCast(ctx.?));
         if (self.alloc_index == self.fail_index) {
             if (!self.has_induced_failure) {
                 @memset(&self.stack_addresses, 0);
@@ -95,13 +95,13 @@ pub const FailingAllocator = struct {
     }
 
     fn resize(
-        ctx: *anyopaque,
+        ctx: ?*anyopaque,
         old_mem: []u8,
         log2_old_align: u8,
         new_len: usize,
         ra: usize,
     ) bool {
-        const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
+        const self: *FailingAllocator = @ptrCast(@alignCast(ctx.?));
         if (self.resize_index == self.resize_fail_index)
             return false;
         if (!self.internal_allocator.rawResize(old_mem, log2_old_align, new_len, ra))
@@ -116,12 +116,12 @@ pub const FailingAllocator = struct {
     }
 
     fn free(
-        ctx: *anyopaque,
+        ctx: ?*anyopaque,
         old_mem: []u8,
         log2_old_align: u8,
         ra: usize,
     ) void {
-        const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
+        const self: *FailingAllocator = @ptrCast(@alignCast(ctx.?));
         self.internal_allocator.rawFree(old_mem, log2_old_align, ra);
         self.deallocations += 1;
         self.freed_bytes += old_mem.len;


### PR DESCRIPTION
Previously, Allocator/Random implementations that did not store any state would set `ptr` to `undefined`. However, the use of undefined meant that it was always unsafe/illegal to compare the ptr fields of Allocator/Random. This restriction was not mentioned anywhere, though, and the ptr field *was* being compared in real code, e.g. `std.process.Child.collectOutput`, which can lead to undefined behavior in release modes (see #21756).

There are a few ways to address this:
1. Codify that comparing `ptr` is always illegal/unsafe, and remove all existing comparisons.
2. Set `ptr` to a legal dummy value, similar to the value returned by Allocator.alloc when a zero-length slice is requested.
3. Make `ptr` optional and set it to `null` for implementations that don't store any state

The first option seems like footgun central (at least until usage of `undefined` is fully safety-checked in safe modes), and the second option has its own issues since the dummy value could inadvertently be equal to a real mapped pointer, so the 3rd option was chosen.

Closes #21756
Closes #17704