### PR TITLE
coff: fix incorrect default `image_base` values and re-enable shared library tests on Windows

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -274,11 +274,15 @@ pub fn createEmpty(
 
         .image_base = options.image_base orelse switch (output_mode) {
             .Exe => switch (target.cpu.arch) {
-                .aarch64 => 0x140000000,
-                .thumb, .x86_64, .x86 => 0x400000,
+                .aarch64, .x86_64 => 0x140000000,
+                .thumb, .x86 => 0x400000,
                 else => unreachable,
             },
-            .Lib => 0x10000000,
+            .Lib => switch (target.cpu.arch) {
+                .aarch64, .x86_64 => 0x180000000,
+                .thumb, .x86 => 0x10000000,
+                else => unreachable,
+            },
             .Obj => 0,
         },
 

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -5,11 +5,6 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Test it");
     b.default_step = test_step;
 
-    if (builtin.os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/16965
-        return;
-    }
-
     add(b, test_step, "test_c_Debug", "test_cpp_Debug", .Debug);
     add(b, test_step, "test_c_ReleaseFast", "test_cpp_ReleaseFast", .ReleaseFast);
     add(b, test_step, "test_c_ReleaseSmall", "test_cpp_ReleaseSmall", .ReleaseSmall);

--- a/test/standalone/coff_dwarf/build.zig
+++ b/test/standalone/coff_dwarf/build.zig
@@ -12,11 +12,6 @@ pub fn build(b: *std.Build) void {
     else
         b.resolveTargetQuery(.{ .os_tag = .windows });
 
-    if (builtin.cpu.arch == .aarch64) {
-        // https://github.com/ziglang/zig/issues/18427
-        return;
-    }
-
     const exe = b.addExecutable(.{
         .name = "main",
         .root_source_file = b.path("main.zig"),

--- a/test/standalone/load_dynamic_library/build.zig
+++ b/test/standalone/load_dynamic_library/build.zig
@@ -10,11 +10,6 @@ pub fn build(b: *std.Build) void {
 
     if (builtin.os.tag == .wasi) return;
 
-    if (builtin.os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/16960
-        return;
-    }
-
     const lib = b.addSharedLibrary(.{
         .name = "add",
         .root_source_file = b.path("add.zig"),

--- a/test/standalone/shared_library/build.zig
+++ b/test/standalone/shared_library/build.zig
@@ -4,11 +4,6 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Test it");
     b.default_step = test_step;
 
-    if (@import("builtin").os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/16959
-        return;
-    }
-
     const optimize: std.builtin.OptimizeMode = .Debug;
     const target = b.graph.host;
     const lib = b.addSharedLibrary(.{


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/16965
Closes https://github.com/ziglang/zig/issues/16959
Closes https://github.com/ziglang/zig/issues/16960
Closes https://github.com/ziglang/zig/issues/18427

As part of investigating a CI failure on aarch64-windows for https://github.com/ziglang/zig/pull/21758, I noticed that all the shared library tests were being skipped on either windows or aarch64-windows. I did some testing in an aarch64-windows VM, and noticed that the error happening here was a "Bad Image" error coming from the dll.

The way I figured this out was by removing each of the optional arguments from the linker line to see if I could get a different result. As it turned out, removing the -BASE:268435456 argument for the shared library caused the bug to go away. It turns out this value is incorrect for 64-bit targets, see: https://learn.microsoft.com/en-us/cpp/build/reference/base-base-address?view=msvc-170

Passing the correct value of 0x180000000 resolved the issue, which led me to the diff in this PR.

The regression that introduced this bug (as https://github.com/ziglang/zig/issues/18427 hints at) was this change in https://github.com/ziglang/zig/pull/18160:

```diff
-        if (self.base.options.image_base_override) |image_base| {
-            try argv.append(try std.fmt.allocPrint(arena, "-BASE:{d}", .{image_base}));
+        try argv.append(try std.fmt.allocPrint(arena, "-BASE:{d}", .{self.image_base}));
```

Instead of sending the optional override, `self.image_base` (which then contained the incorrect value for a 64-bit images) was now always being set on the linker line.

This didn't seem to cause an issue on x86_64, but it seems aarch64 Windows is more strict about this, and an image created with the wrong BASE would result in this "Bad Image" error there.

This PR fixes the `image_base` value as well as re-enables the disabled tests.
