### PR TITLE
tests: re-enable tests that now pass on aarch64-windows

### DIFF
--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -281,11 +281,6 @@ test "page aligned array on stack" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
-    if (builtin.cpu.arch == .aarch64 and builtin.os.tag == .windows) {
-        // https://github.com/ziglang/zig/issues/13679
-        return error.SkipZigTest;
-    }
-
     // Large alignment value to make it hard to accidentally pass.
     var array align(0x1000) = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
     var number1: u8 align(16) = 42;

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -1174,10 +1174,6 @@ test "arrays and vectors with big integers" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    // TODO: only aarch64-windows didn't pass in the PR that added this code.
-    //       figure out why if you can run this target.
-    if (builtin.os.tag == .windows and builtin.cpu.arch == .aarch64) return error.SkipZigTest;
-
     inline for (.{ u65528, u65529, u65535 }) |Int| {
         var a: [1]Int = undefined;
         a[0] = std.math.maxInt(Int);

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -2504,13 +2504,6 @@ test "@intFromBool on vector" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.cpu.arch == .aarch64 and builtin.os.tag == .windows)
-    {
-        // https://github.com/ziglang/zig/issues/19825
-        return error.SkipZigTest;
-    }
-
     const S = struct {
         fn doTheTest() !void {
             var a: @Vector(3, bool) = .{ false, true, false };

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -532,8 +532,6 @@ test "call generic function with from function called by the generic function" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.cpu.arch == .aarch64 and builtin.os.tag == .windows) return error.SkipZigTest;
 
     const GET = struct {
         key: []const u8,

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -140,13 +140,6 @@ test "@shuffle bool 1" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.cpu.arch == .aarch64 and builtin.os.tag == .windows)
-    {
-        // https://github.com/ziglang/zig/issues/19824
-        return error.SkipZigTest;
-    }
-
     const S = struct {
         fn doTheTest() !void {
             var x: @Vector(4, bool) = [4]bool{ false, true, false, true };


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/13679
Closes https://github.com/ziglang/zig/issues/19825
Closes https://github.com/ziglang/zig/issues/19824

Since I was set up to test on aarch64-windows as part of https://github.com/ziglang/zig/pull/21767, I checked other tests  that were being skipped. I've re-enabled these now that they pass.