### PR TITLE
std.os.uefi: Fix calling convention build error

### DIFF
--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -26,9 +26,9 @@ pub var system_table: *tables.SystemTable = undefined;
 pub const Event = *opaque {};
 
 /// The calling convention used for all external functions part of the UEFI API.
-pub const cc = switch (@import("builtin").target.cpu.arch) {
-    .x86_64 => .Win64,
-    else => .C,
+pub const cc: std.builtin.CallingConvention = switch (@import("builtin").target.cpu.arch) {
+    .x86_64 => .{ .x86_64_win = .{} },
+    else => .c,
 };
 
 pub const MacAddress = extern struct {


### PR DESCRIPTION
Much like in #21615 there seems to be nothing in CI that covers substantial parts of `std.os.uefi` and it will keep regressing unless that's addressed.