### PR TITLE
implement new interrupt calling conventions in the llvm backend

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -470,7 +470,7 @@ pub const CallingConvention = union(enum(u8)) {
         /// `null` means the default for this calling convention.
         incoming_stack_alignment: ?u64 = null,
         /// The privilege mode.
-        mode: PrivilegeMode = .machine,
+        mode: PrivilegeMode,
 
         pub const PrivilegeMode = enum(u2) {
             supervisor,


### PR DESCRIPTION
closes #20671
closes #21805 

anyone know of other issues this closes?

adds support for:
- `riscv64_interrupt`
- `riscv32_interrupt`
- `mips_interrupt`
- `mips64_interrupt`
- `arm_interrupt`
- `csky_interrupt`