### PR TITLE
windows add .NO_DATA (232) 'The pipe is being closed' error support

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -644,6 +644,8 @@ pub const WriteFileError = error{
     SystemResources,
     OperationAborted,
     BrokenPipe,
+    // The pipe is being closed
+    NoData,
     NotOpenForWriting,
     /// The process cannot access the file because another process has locked
     /// a portion of the file.
@@ -683,6 +685,7 @@ pub fn WriteFile(
             .NOT_ENOUGH_QUOTA => return error.SystemResources,
             .IO_PENDING => unreachable,
             .BROKEN_PIPE => return error.BrokenPipe,
+            .NO_DATA => return error.NoData,
             .INVALID_HANDLE => return error.NotOpenForWriting,
             .LOCK_VIOLATION => return error.LockViolation,
             .NETNAME_DELETED => return error.ConnectionResetByPeer,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1181,6 +1181,10 @@ pub const WriteError = error{
     /// a portion of the file. Windows-only.
     LockViolation,
 
+    /// 'The pipe is being closed' may occur when piping to a process that doesn't consume all data e.g head.
+    /// Windows-only.
+    NoData,
+
     /// This error occurs when no global event loop is configured,
     /// and reading from the file descriptor would block.
     WouldBlock,


### PR DESCRIPTION
For issue: https://github.com/ziglang/zig/issues/21791

This handles the .NO_DATA = 232 Win32 Error ('The pipe is being closed') 
WriteError and WriteFileError member was named .NoData to maintain the connection to the underlying .NO_DATA win32 error despite that name not being particularly descriptive/intuitive. Perhaps consider another name if this seems to generic/misleading.

This is my first attempt at a github pull request on any project - so although it's a trivial change - please review for rookie mistakes.

Tested using:
zig test lib/std/std.zig --zig-lib-dir lib
No errors seen.

Tested with nightly 0.14.0-dev.2050+4adf63aef (just by replacing entire lib folder)
(was unable to build zig with zig-bootstrap due to OutOfMemory - and also tried msys but ran into llvm18 vs llvm19 issue) 
