### PR TITLE
remove unused `needs_mem_loc` field

### DIFF
--- a/lib/std/zig/BuiltinFn.zig
+++ b/lib/std/zig/BuiltinFn.zig
@@ -124,17 +124,6 @@ pub const Tag = enum {
     work_group_id,
 };
 
-pub const MemLocRequirement = enum {
-    /// The builtin never needs a memory location.
-    never,
-    /// The builtin always needs a memory location.
-    always,
-    /// The builtin forwards the question to argument at index 0.
-    forward0,
-    /// The builtin forwards the question to argument at index 1.
-    forward1,
-};
-
 pub const EvalToError = enum {
     /// The builtin cannot possibly evaluate to an error.
     never,
@@ -146,8 +135,6 @@ pub const EvalToError = enum {
 
 tag: Tag,
 
-/// Info about the builtin call's ability to take advantage of a result location pointer.
-needs_mem_loc: MemLocRequirement = .never,
 /// Info about the builtin call's possibility of returning an error.
 eval_to_error: EvalToError = .never,
 /// `true` if the builtin call can be the left-hand side of an expression (assigned to).
@@ -193,7 +180,6 @@ pub const list = list: {
             "@as",
             .{
                 .tag = .as,
-                .needs_mem_loc = .forward1,
                 .eval_to_error = .maybe,
                 .param_count = 2,
             },
@@ -230,7 +216,6 @@ pub const list = list: {
             "@bitCast",
             .{
                 .tag = .bit_cast,
-                .needs_mem_loc = .forward0,
                 .param_count = 1,
             },
         },
@@ -311,7 +296,6 @@ pub const list = list: {
             "@call",
             .{
                 .tag = .call,
-                .needs_mem_loc = .always,
                 .eval_to_error = .maybe,
                 .param_count = 3,
             },
@@ -503,7 +487,6 @@ pub const list = list: {
             "@field",
             .{
                 .tag = .field,
-                .needs_mem_loc = .always,
                 .eval_to_error = .maybe,
                 .param_count = 2,
                 .allows_lvalue = true,
@@ -817,7 +800,6 @@ pub const list = list: {
             "@src",
             .{
                 .tag = .src,
-                .needs_mem_loc = .always,
                 .param_count = 0,
                 .illegal_outside_function = true,
             },
@@ -987,7 +969,6 @@ pub const list = list: {
             "@unionInit",
             .{
                 .tag = .union_init,
-                .needs_mem_loc = .always,
                 .param_count = 3,
             },
         },


### PR DESCRIPTION
This field isn't used anymore and was related to old RLS.
cc @mlugg 