### PR TITLE
Revert "cmake: Add a `ZIG2_NO_RTLIB` option for building zig2 without compiler-rt."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,11 +830,6 @@ else()
   endif()
 endif()
 
-option(ZIG2_NO_RTLIB "Build zig2 without linking to a compiler runtime library (for `zig cc` only)" OFF)
-if(ZIG2_NO_RTLIB)
-  set(ZIG2_LINK_FLAGS "${ZIG2_LINK_FLAGS} -rtlib=none")
-endif()
-
 set(ZIG1_WASM_MODULE "${PROJECT_SOURCE_DIR}/stage1/zig1.wasm")
 set(ZIG1_C_SOURCE "${PROJECT_BINARY_DIR}/zig1.c")
 set(ZIG2_C_SOURCE "${PROJECT_BINARY_DIR}/zig2.c")


### PR DESCRIPTION
This reverts commit 3dd6456c0f8d50801d366062bcf5894bb5d9e7ac.

We didn't end up using this after all.