### PR TITLE
link/Elf: ensure we always sort all relocations by r_offset in -r mode

### DIFF
--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -398,6 +398,10 @@ fn parseEhFrame(
     defer gpa.free(relocs);
     const rel_start: u32 = @intCast(self.relocs.items.len);
     try self.relocs.appendUnalignedSlice(gpa, relocs);
+
+    // We expect relocations to be sorted by r_offset as per this comment in mold linker:
+    // https://github.com/rui314/mold/blob/8e4f7b53832d8af4f48a633a8385cbc932d1944e/src/input-files.cc#L653
+    // Except for RISCV and Loongarch which do not seem to be uphold this convention.
     if (target.cpu.arch == .riscv64) {
         sortRelocs(self.relocs.items[rel_start..][0..relocs.len]);
     }


### PR DESCRIPTION
According to a comment in mold, this is the expected (and desired) condition by the linkers, except for some architectures (RISCV and Loongarch) where this condition does not have to upheld.

If you follow the changes in this patch and in particular doc comments I have linked the comment/code in mold that explains and implements this.

I have also modified `testEhFrameRelocatable` test to now test both cases such that `zig ld -r a.o b.o -o c.o` and `zig ld -r b.o a.o -o d.o`. In both cases, `c.o` and `d.o` should produce valid object files which was not the case before this patch.