### PR TITLE
change fatal on error.UnsupportedFlags to a std.log.err and return

### DIFF
--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -101,7 +101,10 @@ const Os = switch (builtin.os.tag) {
                 .REPORT_FID = true,
                 .REPORT_TARGET_FID = true,
             }, 0) catch |err| switch (err) {
-                error.UnsupportedFlags => fatal("fanotify_init failed due to old kernel; requires 5.17+", .{}),
+                error.UnsupportedFlags => |e| {
+                    std.log.err("fanotify_init failed due to old kernel; requires 5.17+", .{});
+                    return e;
+                },
                 else => |e| return e,
             };
             return .{


### PR DESCRIPTION
Fixes #21543.
Revival of https://github.com/ziglang/zig/pull/21545.

Changes a call to fatal() from Os.init(), called from Watch.init(), to a log message and returns the error. This will help clients like zls fail gracefully: https://github.com/zigtools/zls/pull/2041.
