### PR TITLE
Fix std.fmt.Parser.peek compiler error from #20505

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -386,7 +386,7 @@ pub const Parser = struct {
         const original_i = self.iter.i;
         defer self.iter.i = original_i;
 
-        var i = 0;
+        var i: usize = 0;
         var code_point: ?u21 = null;
         while (i <= n) : (i += 1) {
             code_point = self.iter.nextCodepoint();


### PR DESCRIPTION
Simple fix to the compiler error in std.fmt.Parser.peek:
```
error: variable of type 'comptime_int' must be const or comptime
        var i = 0;
            ^
note: to modify this variable at runtime, it must be given an explicit fixed-size number type
```