### PR TITLE
Reduce our exposure to LLVM API breakage

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1363,7 +1363,10 @@ pub const Object = struct {
             .large => .Large,
         };
 
-        const float_abi: llvm.ABIType = if (comp.root_mod.resolved_target.result.floatAbi() == .hard) .Hard else .Soft;
+        const float_abi: llvm.TargetMachine.FloatABI = if (comp.root_mod.resolved_target.result.floatAbi() == .hard)
+            .Hard
+        else
+            .Soft;
 
         var target_machine = llvm.TargetMachine.create(
             target,

--- a/src/codegen/llvm/bindings.zig
+++ b/src/codegen/llvm/bindings.zig
@@ -57,6 +57,15 @@ pub const disposeMessage = LLVMDisposeMessage;
 extern fn LLVMDisposeMessage(Message: [*:0]const u8) void;
 
 pub const TargetMachine = opaque {
+    pub const FloatABI = enum(c_int) {
+        /// Target-specific (either soft or hard depending on triple, etc).
+        Default,
+        /// Soft float.
+        Soft,
+        // Hard float.
+        Hard,
+    };
+
     pub const create = ZigLLVMCreateTargetMachine;
     extern fn ZigLLVMCreateTargetMachine(
         T: *Target,
@@ -68,7 +77,7 @@ pub const TargetMachine = opaque {
         CodeModel: CodeModel,
         function_sections: bool,
         data_sections: bool,
-        float_abi: ABIType,
+        float_abi: FloatABI,
         abi_name: ?[*:0]const u8,
     ) *TargetMachine;
 
@@ -108,7 +117,7 @@ pub const TargetMachine = opaque {
             TraceStores: bool,
             CollectControlFlow: bool,
 
-            pub const Type = enum(c_uint) {
+            pub const Type = enum(c_int) {
                 None = 0,
                 Function,
                 BB,
@@ -164,15 +173,6 @@ pub const RelocMode = enum(c_int) {
     ROPI,
     RWPI,
     ROPI_RWPI,
-};
-
-pub const ABIType = enum(c_int) {
-    /// Target-specific (either soft or hard depending on triple, etc).
-    Default,
-    /// Soft float.
-    Soft,
-    // Hard float.
-    Hard,
 };
 
 pub const Target = opaque {
@@ -303,16 +303,14 @@ pub const LinkCOFF = ZigLLDLinkCOFF;
 pub const LinkELF = ZigLLDLinkELF;
 pub const LinkWasm = ZigLLDLinkWasm;
 
-pub const ObjectFormatType = enum(c_int) {
-    Unknown,
+pub const ArchiveKind = enum(c_int) {
+    GNU,
+    GNU64,
+    BSD,
+    DARWIN,
+    DARWIN64,
     COFF,
-    DXContainer,
-    ELF,
-    GOFF,
-    MachO,
-    SPIRV,
-    Wasm,
-    XCOFF,
+    AIXBIG,
 };
 
 pub const WriteArchive = ZigLLVMWriteArchive;
@@ -320,117 +318,8 @@ extern fn ZigLLVMWriteArchive(
     archive_name: [*:0]const u8,
     file_names_ptr: [*]const [*:0]const u8,
     file_names_len: usize,
-    os_type: OSType,
+    archive_kind: ArchiveKind,
 ) bool;
-
-pub const OSType = enum(c_int) {
-    UnknownOS,
-    Darwin,
-    DragonFly,
-    FreeBSD,
-    Fuchsia,
-    IOS,
-    KFreeBSD,
-    Linux,
-    Lv2,
-    MacOSX,
-    NetBSD,
-    OpenBSD,
-    Solaris,
-    UEFI,
-    Win32,
-    ZOS,
-    Haiku,
-    RTEMS,
-    NaCl,
-    AIX,
-    CUDA,
-    NVCL,
-    AMDHSA,
-    PS4,
-    PS5,
-    ELFIAMCU,
-    TvOS,
-    WatchOS,
-    BridgeOS,
-    DriverKit,
-    XROS,
-    Mesa3D,
-    AMDPAL,
-    HermitCore,
-    Hurd,
-    WASI,
-    Emscripten,
-    ShaderModel,
-    LiteOS,
-    Serenity,
-    Vulkan,
-};
-
-pub const ArchType = enum(c_int) {
-    UnknownArch,
-    arm,
-    armeb,
-    aarch64,
-    aarch64_be,
-    aarch64_32,
-    arc,
-    avr,
-    bpfel,
-    bpfeb,
-    csky,
-    dxil,
-    hexagon,
-    loongarch32,
-    loongarch64,
-    m68k,
-    mips,
-    mipsel,
-    mips64,
-    mips64el,
-    msp430,
-    ppc,
-    ppcle,
-    ppc64,
-    ppc64le,
-    r600,
-    amdgcn,
-    riscv32,
-    riscv64,
-    sparc,
-    sparcv9,
-    sparcel,
-    systemz,
-    tce,
-    tcele,
-    thumb,
-    thumbeb,
-    x86,
-    x86_64,
-    xcore,
-    xtensa,
-    nvptx,
-    nvptx64,
-    le32,
-    le64,
-    amdil,
-    amdil64,
-    hsail,
-    hsail64,
-    spir,
-    spir64,
-    spirv,
-    spirv32,
-    spirv64,
-    kalimba,
-    shave,
-    lanai,
-    wasm32,
-    wasm64,
-    renderscript32,
-    renderscript64,
-    ve,
-};
 
 pub const ParseCommandLineOptions = ZigLLVMParseCommandLineOptions;
 extern fn ZigLLVMParseCommandLineOptions(argc: usize, argv: [*]const [*:0]const u8) void;
@@ -438,7 +327,7 @@ extern fn ZigLLVMParseCommandLineOptions(argc: usize, argv: [*]const [*:0]const 
 pub const WriteImportLibrary = ZigLLVMWriteImportLibrary;
 extern fn ZigLLVMWriteImportLibrary(
     def_path: [*:0]const u8,
-    arch: ArchType,
+    coff_machine: c_uint,
     output_lib_path: [*:0]const u8,
     kill_at: bool,
 ) bool;

--- a/src/link.zig
+++ b/src/link.zig
@@ -1214,11 +1214,9 @@ pub const File = struct {
             object_files.items.ptr,
             object_files.items.len,
             switch (target.os.tag) {
-                .linux => .GNU,
-                .freebsd, .openbsd => .BSD,
-                .macos, .ios => .DARWIN,
-                .windows => .GNU,
-                else => .GNU,
+                .aix => .AIXBIG,
+                .windows => .COFF,
+                else => if (target.os.tag.isDarwin()) .DARWIN else .GNU,
             },
         );
         if (bad) return error.UnableToWriteArchive;

--- a/src/link.zig
+++ b/src/link.zig
@@ -1209,8 +1209,18 @@ pub const File = struct {
         const llvm = @import("codegen/llvm.zig");
         const target = comp.root_mod.resolved_target.result;
         llvm.initializeLLVMTarget(target.cpu.arch);
-        const os_tag = llvm.targetOs(target.os.tag);
-        const bad = llvm_bindings.WriteArchive(full_out_path_z, object_files.items.ptr, object_files.items.len, os_tag);
+        const bad = llvm_bindings.WriteArchive(
+            full_out_path_z,
+            object_files.items.ptr,
+            object_files.items.len,
+            switch (target.os.tag) {
+                .linux => .GNU,
+                .freebsd, .openbsd => .BSD,
+                .macos, .ios => .DARWIN,
+                .windows => .GNU,
+                else => .GNU,
+            },
+        );
         if (bad) return error.UnableToWriteArchive;
 
         if (!base.disable_lld_caching) {

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -283,13 +283,7 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
     const lib_final_path_z = try comp.global_cache_directory.joinZ(arena, &.{lib_final_path});
     if (llvm_bindings.WriteImportLibrary(
         def_final_path_z.ptr,
-        @intFromEnum(@as(std.coff.MachineType, switch (target.cpu.arch) {
-            .arm, .armeb, .thumb, .thumbeb => .ARMNT,
-            .aarch64, .aarch64_be => .ARM64,
-            .x86 => .I386,
-            .x86_64 => .X64,
-            else => unreachable,
-        })),
+        @intFromEnum(target.toCoffMachine()),
         lib_final_path_z.ptr,
         true,
     )) {

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -279,11 +279,20 @@ pub fn buildImportLib(comp: *Compilation, lib_name: []const u8) !void {
 
     if (!build_options.have_llvm) return error.ZigCompilerNotBuiltWithLLVMExtensions;
     const llvm_bindings = @import("codegen/llvm/bindings.zig");
-    const llvm = @import("codegen/llvm.zig");
-    const arch_tag = llvm.targetArch(target.cpu.arch);
     const def_final_path_z = try arena.dupeZ(u8, def_final_path);
     const lib_final_path_z = try comp.global_cache_directory.joinZ(arena, &.{lib_final_path});
-    if (llvm_bindings.WriteImportLibrary(def_final_path_z.ptr, arch_tag, lib_final_path_z.ptr, true)) {
+    if (llvm_bindings.WriteImportLibrary(
+        def_final_path_z.ptr,
+        @intFromEnum(@as(std.coff.MachineType, switch (target.cpu.arch) {
+            .arm, .armeb, .thumb, .thumbeb => .ARMNT,
+            .aarch64, .aarch64_be => .ARM64,
+            .x86 => .I386,
+            .x86_64 => .X64,
+            else => unreachable,
+        })),
+        lib_final_path_z.ptr,
+        true,
+    )) {
         // TODO surface a proper error here
         log.err("unable to turn {s}.def into {s}.lib", .{ lib_name, lib_name });
         return error.WritingImportLibFailed;

--- a/src/zig_llvm.cpp
+++ b/src/zig_llvm.cpp
@@ -50,6 +50,7 @@
 #include <llvm/Support/Timer.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
 #include <llvm/Target/CodeGenCWrappers.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
@@ -81,7 +82,7 @@ static const bool assertions_on = false;
 
 LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Triple,
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
-    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, ZigLLVMABIType float_abi,
+    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, ZigLLVMFloatABI float_abi,
     const char *abi_name)
 {
     std::optional<Reloc::Model> RM;
@@ -133,13 +134,13 @@ LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Tri
     opt.FunctionSections = function_sections;
     opt.DataSections = data_sections;
     switch (float_abi) {
-        case ZigLLVMABITypeDefault:
+        case ZigLLVMFloatABI_Default:
             opt.FloatABIType = FloatABI::Default;
             break;
-        case ZigLLVMABITypeSoft:
+        case ZigLLVMFloatABI_Soft:
             opt.FloatABIType = FloatABI::Soft;
             break;
-        case ZigLLVMABITypeHard:
+        case ZigLLVMFloatABI_Hard:
             opt.FloatABIType = FloatABI::Hard;
             break;
     }
@@ -213,7 +214,7 @@ static SanitizerCoverageOptions getSanCovOptions(ZigLLVMCoverageOptions z) {
 }
 
 ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
-        char **error_message, const struct ZigLLVMEmitOptions *options)
+    char **error_message, const ZigLLVMEmitOptions *options)
 {
     TimePassesIsEnabled = options->time_report;
 
@@ -419,7 +420,7 @@ struct ZigDiagnosticHandler : public DiagnosticHandler {
             BrokenDebugInfo = true;
         }
         return false;
-      }
+    }
 };
 
 void ZigLLVMEnableBrokenDebugInfoCheck(LLVMContextRef context_ref) {
@@ -435,35 +436,10 @@ void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv) {
     cl::ParseCommandLineOptions(argc, argv);
 }
 
-bool ZigLLVMWriteImportLibrary(const char *def_path, const ZigLLVM_ArchType arch,
-                               const char *output_lib_path, bool kill_at)
+bool ZigLLVMWriteImportLibrary(const char *def_path, unsigned int coff_machine,
+    const char *output_lib_path, bool kill_at)
 {
-    COFF::MachineTypes machine = COFF::IMAGE_FILE_MACHINE_UNKNOWN;
-
-    switch (arch) {
-        case ZigLLVM_x86:
-            machine = COFF::IMAGE_FILE_MACHINE_I386;
-            break;
-        case ZigLLVM_x86_64:
-            machine = COFF::IMAGE_FILE_MACHINE_AMD64;
-            break;
-        case ZigLLVM_arm:
-        case ZigLLVM_armeb:
-        case ZigLLVM_thumb:
-        case ZigLLVM_thumbeb:
-            machine = COFF::IMAGE_FILE_MACHINE_ARMNT;
-            break;
-        case ZigLLVM_aarch64:
-        case ZigLLVM_aarch64_be:
-            machine = COFF::IMAGE_FILE_MACHINE_ARM64;
-            break;
-        default:
-            break;
-    }
-
-    if (machine == COFF::IMAGE_FILE_MACHINE_UNKNOWN) {
-        return true;
-    }
+    COFF::MachineTypes machine = static_cast<COFF::MachineTypes>(coff_machine);
 
     auto bufOrErr = MemoryBuffer::getFile(def_path);
     if (!bufOrErr) {
@@ -515,30 +491,8 @@ bool ZigLLVMWriteImportLibrary(const char *def_path, const ZigLLVM_ArchType arch
 }
 
 bool ZigLLVMWriteArchive(const char *archive_name, const char **file_names, size_t file_name_count,
-        ZigLLVM_OSType os_type)
+    ZigLLVMArchiveKind archive_kind)
 {
-    object::Archive::Kind kind;
-    switch (os_type) {
-        case ZigLLVM_Win32:
-            // For some reason llvm-lib passes K_GNU on windows.
-            // See lib/ToolDrivers/llvm-lib/LibDriver.cpp:168 in libDriverMain
-            kind = object::Archive::K_GNU;
-            break;
-        case ZigLLVM_Linux:
-            kind = object::Archive::K_GNU;
-            break;
-        case ZigLLVM_MacOSX:
-        case ZigLLVM_Darwin:
-        case ZigLLVM_IOS:
-            kind = object::Archive::K_DARWIN;
-            break;
-        case ZigLLVM_OpenBSD:
-        case ZigLLVM_FreeBSD:
-            kind = object::Archive::K_BSD;
-            break;
-        default:
-            kind = object::Archive::K_GNU;
-    }
     SmallVector<NewArchiveMember, 4> new_members;
     for (size_t i = 0; i < file_name_count; i += 1) {
         Expected<NewArchiveMember> new_member = NewArchiveMember::getFile(file_names[i], true);
@@ -547,7 +501,7 @@ bool ZigLLVMWriteArchive(const char *archive_name, const char **file_names, size
         new_members.push_back(std::move(*new_member));
     }
     Error err = writeArchive(archive_name, new_members,
-        SymtabWritingMode::NormalSymtab, kind, true, false, nullptr);
+        SymtabWritingMode::NormalSymtab, static_cast<object::Archive::Kind>(archive_kind), true, false, nullptr);
 
     if (err) return true;
     return false;
@@ -586,236 +540,14 @@ bool ZigLLDLinkWasm(int argc, const char **argv, bool can_exit_early, bool disab
     return lld::wasm::link(args, llvm::outs(), llvm::errs(), can_exit_early, disable_output);
 }
 
-static_assert((Triple::ArchType)ZigLLVM_UnknownArch == Triple::UnknownArch, "");
-static_assert((Triple::ArchType)ZigLLVM_arm == Triple::arm, "");
-static_assert((Triple::ArchType)ZigLLVM_armeb == Triple::armeb, "");
-static_assert((Triple::ArchType)ZigLLVM_aarch64 == Triple::aarch64, "");
-static_assert((Triple::ArchType)ZigLLVM_aarch64_be == Triple::aarch64_be, "");
-static_assert((Triple::ArchType)ZigLLVM_aarch64_32 == Triple::aarch64_32, "");
-static_assert((Triple::ArchType)ZigLLVM_arc == Triple::arc, "");
-static_assert((Triple::ArchType)ZigLLVM_avr == Triple::avr, "");
-static_assert((Triple::ArchType)ZigLLVM_bpfel == Triple::bpfel, "");
-static_assert((Triple::ArchType)ZigLLVM_bpfeb == Triple::bpfeb, "");
-static_assert((Triple::ArchType)ZigLLVM_csky == Triple::csky, "");
-static_assert((Triple::ArchType)ZigLLVM_hexagon == Triple::hexagon, "");
-static_assert((Triple::ArchType)ZigLLVM_m68k == Triple::m68k, "");
-static_assert((Triple::ArchType)ZigLLVM_mips == Triple::mips, "");
-static_assert((Triple::ArchType)ZigLLVM_mipsel == Triple::mipsel, "");
-static_assert((Triple::ArchType)ZigLLVM_mips64 == Triple::mips64, "");
-static_assert((Triple::ArchType)ZigLLVM_mips64el == Triple::mips64el, "");
-static_assert((Triple::ArchType)ZigLLVM_msp430 == Triple::msp430, "");
-static_assert((Triple::ArchType)ZigLLVM_ppc == Triple::ppc, "");
-static_assert((Triple::ArchType)ZigLLVM_ppcle == Triple::ppcle, "");
-static_assert((Triple::ArchType)ZigLLVM_ppc64 == Triple::ppc64, "");
-static_assert((Triple::ArchType)ZigLLVM_ppc64le == Triple::ppc64le, "");
-static_assert((Triple::ArchType)ZigLLVM_r600 == Triple::r600, "");
-static_assert((Triple::ArchType)ZigLLVM_amdgcn == Triple::amdgcn, "");
-static_assert((Triple::ArchType)ZigLLVM_riscv32 == Triple::riscv32, "");
-static_assert((Triple::ArchType)ZigLLVM_riscv64 == Triple::riscv64, "");
-static_assert((Triple::ArchType)ZigLLVM_sparc == Triple::sparc, "");
-static_assert((Triple::ArchType)ZigLLVM_sparcv9 == Triple::sparcv9, "");
-static_assert((Triple::ArchType)ZigLLVM_sparcel == Triple::sparcel, "");
-static_assert((Triple::ArchType)ZigLLVM_systemz == Triple::systemz, "");
-static_assert((Triple::ArchType)ZigLLVM_tce == Triple::tce, "");
-static_assert((Triple::ArchType)ZigLLVM_tcele == Triple::tcele, "");
-static_assert((Triple::ArchType)ZigLLVM_thumb == Triple::thumb, "");
-static_assert((Triple::ArchType)ZigLLVM_thumbeb == Triple::thumbeb, "");
-static_assert((Triple::ArchType)ZigLLVM_x86 == Triple::x86, "");
-static_assert((Triple::ArchType)ZigLLVM_x86_64 == Triple::x86_64, "");
-static_assert((Triple::ArchType)ZigLLVM_xcore == Triple::xcore, "");
-static_assert((Triple::ArchType)ZigLLVM_xtensa == Triple::xtensa, "");
-static_assert((Triple::ArchType)ZigLLVM_nvptx == Triple::nvptx, "");
-static_assert((Triple::ArchType)ZigLLVM_nvptx64 == Triple::nvptx64, "");
-static_assert((Triple::ArchType)ZigLLVM_le32 == Triple::le32, "");
-static_assert((Triple::ArchType)ZigLLVM_le64 == Triple::le64, "");
-static_assert((Triple::ArchType)ZigLLVM_amdil == Triple::amdil, "");
-static_assert((Triple::ArchType)ZigLLVM_amdil64 == Triple::amdil64, "");
-static_assert((Triple::ArchType)ZigLLVM_hsail == Triple::hsail, "");
-static_assert((Triple::ArchType)ZigLLVM_hsail64 == Triple::hsail64, "");
-static_assert((Triple::ArchType)ZigLLVM_spir == Triple::spir, "");
-static_assert((Triple::ArchType)ZigLLVM_spir64 == Triple::spir64, "");
-static_assert((Triple::ArchType)ZigLLVM_spirv == Triple::spirv, "");
-static_assert((Triple::ArchType)ZigLLVM_spirv32 == Triple::spirv32, "");
-static_assert((Triple::ArchType)ZigLLVM_spirv64 == Triple::spirv64, "");
-static_assert((Triple::ArchType)ZigLLVM_kalimba == Triple::kalimba, "");
-static_assert((Triple::ArchType)ZigLLVM_shave == Triple::shave, "");
-static_assert((Triple::ArchType)ZigLLVM_lanai == Triple::lanai, "");
-static_assert((Triple::ArchType)ZigLLVM_wasm32 == Triple::wasm32, "");
-static_assert((Triple::ArchType)ZigLLVM_wasm64 == Triple::wasm64, "");
-static_assert((Triple::ArchType)ZigLLVM_renderscript32 == Triple::renderscript32, "");
-static_assert((Triple::ArchType)ZigLLVM_renderscript64 == Triple::renderscript64, "");
-static_assert((Triple::ArchType)ZigLLVM_ve == Triple::ve, "");
-static_assert((Triple::ArchType)ZigLLVM_LastArchType == Triple::LastArchType, "");
+static_assert((FloatABI::ABIType)ZigLLVMFloatABI_Default == FloatABI::ABIType::Default, "");
+static_assert((FloatABI::ABIType)ZigLLVMFloatABI_Soft == FloatABI::ABIType::Soft, "");
+static_assert((FloatABI::ABIType)ZigLLVMFloatABI_Hard == FloatABI::ABIType::Hard, "");
 
-static_assert((Triple::VendorType)ZigLLVM_UnknownVendor == Triple::UnknownVendor, "");
-static_assert((Triple::VendorType)ZigLLVM_Apple == Triple::Apple, "");
-static_assert((Triple::VendorType)ZigLLVM_PC == Triple::PC, "");
-static_assert((Triple::VendorType)ZigLLVM_SCEI == Triple::SCEI, "");
-static_assert((Triple::VendorType)ZigLLVM_Freescale == Triple::Freescale, "");
-static_assert((Triple::VendorType)ZigLLVM_IBM == Triple::IBM, "");
-static_assert((Triple::VendorType)ZigLLVM_ImaginationTechnologies == Triple::ImaginationTechnologies, "");
-static_assert((Triple::VendorType)ZigLLVM_MipsTechnologies == Triple::MipsTechnologies, "");
-static_assert((Triple::VendorType)ZigLLVM_NVIDIA == Triple::NVIDIA, "");
-static_assert((Triple::VendorType)ZigLLVM_CSR == Triple::CSR, "");
-static_assert((Triple::VendorType)ZigLLVM_AMD == Triple::AMD, "");
-static_assert((Triple::VendorType)ZigLLVM_Mesa == Triple::Mesa, "");
-static_assert((Triple::VendorType)ZigLLVM_SUSE == Triple::SUSE, "");
-static_assert((Triple::VendorType)ZigLLVM_OpenEmbedded == Triple::OpenEmbedded, "");
-static_assert((Triple::VendorType)ZigLLVM_LastVendorType == Triple::LastVendorType, "");
-
-static_assert((Triple::OSType)ZigLLVM_UnknownOS == Triple::UnknownOS, "");
-static_assert((Triple::OSType)ZigLLVM_Darwin == Triple::Darwin, "");
-static_assert((Triple::OSType)ZigLLVM_DragonFly == Triple::DragonFly, "");
-static_assert((Triple::OSType)ZigLLVM_FreeBSD == Triple::FreeBSD, "");
-static_assert((Triple::OSType)ZigLLVM_Fuchsia == Triple::Fuchsia, "");
-static_assert((Triple::OSType)ZigLLVM_IOS == Triple::IOS, "");
-// Commented out to work around a Debian/Ubuntu bug.
-// See https://github.com/ziglang/zig/issues/2076
-//static_assert((Triple::OSType)ZigLLVM_KFreeBSD == Triple::KFreeBSD, "");
-static_assert((Triple::OSType)ZigLLVM_Linux == Triple::Linux, "");
-static_assert((Triple::OSType)ZigLLVM_Lv2 == Triple::Lv2, "");
-static_assert((Triple::OSType)ZigLLVM_MacOSX == Triple::MacOSX, "");
-static_assert((Triple::OSType)ZigLLVM_NetBSD == Triple::NetBSD, "");
-static_assert((Triple::OSType)ZigLLVM_OpenBSD == Triple::OpenBSD, "");
-static_assert((Triple::OSType)ZigLLVM_Solaris == Triple::Solaris, "");
-static_assert((Triple::OSType)ZigLLVM_UEFI == Triple::UEFI, "");
-static_assert((Triple::OSType)ZigLLVM_Win32 == Triple::Win32, "");
-static_assert((Triple::OSType)ZigLLVM_ZOS == Triple::ZOS, "");
-static_assert((Triple::OSType)ZigLLVM_Haiku == Triple::Haiku, "");
-static_assert((Triple::OSType)ZigLLVM_RTEMS == Triple::RTEMS, "");
-static_assert((Triple::OSType)ZigLLVM_NaCl == Triple::NaCl, "");
-static_assert((Triple::OSType)ZigLLVM_AIX == Triple::AIX, "");
-static_assert((Triple::OSType)ZigLLVM_CUDA == Triple::CUDA, "");
-static_assert((Triple::OSType)ZigLLVM_NVCL == Triple::NVCL, "");
-static_assert((Triple::OSType)ZigLLVM_AMDHSA == Triple::AMDHSA, "");
-static_assert((Triple::OSType)ZigLLVM_PS4 == Triple::PS4, "");
-static_assert((Triple::OSType)ZigLLVM_ELFIAMCU == Triple::ELFIAMCU, "");
-static_assert((Triple::OSType)ZigLLVM_TvOS == Triple::TvOS, "");
-static_assert((Triple::OSType)ZigLLVM_WatchOS == Triple::WatchOS, "");
-static_assert((Triple::OSType)ZigLLVM_BridgeOS == Triple::BridgeOS, "");
-static_assert((Triple::OSType)ZigLLVM_DriverKit == Triple::DriverKit, "");
-static_assert((Triple::OSType)ZigLLVM_XROS == Triple::XROS, "");
-static_assert((Triple::OSType)ZigLLVM_Mesa3D == Triple::Mesa3D, "");
-static_assert((Triple::OSType)ZigLLVM_AMDPAL == Triple::AMDPAL, "");
-static_assert((Triple::OSType)ZigLLVM_HermitCore == Triple::HermitCore, "");
-static_assert((Triple::OSType)ZigLLVM_Hurd == Triple::Hurd, "");
-static_assert((Triple::OSType)ZigLLVM_WASI == Triple::WASI, "");
-static_assert((Triple::OSType)ZigLLVM_Emscripten == Triple::Emscripten, "");
-static_assert((Triple::OSType)ZigLLVM_ShaderModel == Triple::ShaderModel, "");
-static_assert((Triple::OSType)ZigLLVM_LiteOS == Triple::LiteOS, "");
-static_assert((Triple::OSType)ZigLLVM_Serenity == Triple::Serenity, "");
-static_assert((Triple::OSType)ZigLLVM_Vulkan == Triple::Vulkan, "");
-static_assert((Triple::OSType)ZigLLVM_LastOSType == Triple::LastOSType, "");
-
-static_assert((Triple::EnvironmentType)ZigLLVM_UnknownEnvironment == Triple::UnknownEnvironment, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNU == Triple::GNU, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUABIN32 == Triple::GNUABIN32, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUABI64 == Triple::GNUABI64, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUEABI == Triple::GNUEABI, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUEABIHF == Triple::GNUEABIHF, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUF32 == Triple::GNUF32, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUF64 == Triple::GNUF64, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUSF == Triple::GNUSF, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUX32 == Triple::GNUX32, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_GNUILP32 == Triple::GNUILP32, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_CODE16 == Triple::CODE16, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_EABI == Triple::EABI, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_EABIHF == Triple::EABIHF, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Android == Triple::Android, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Musl == Triple::Musl, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_MuslEABI == Triple::MuslEABI, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_MuslEABIHF == Triple::MuslEABIHF, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_MuslX32 == Triple::MuslX32, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_MSVC == Triple::MSVC, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Itanium == Triple::Itanium, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Cygnus == Triple::Cygnus, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_CoreCLR == Triple::CoreCLR, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Simulator == Triple::Simulator, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_MacABI == Triple::MacABI, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Pixel == Triple::Pixel, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Vertex == Triple::Vertex, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Geometry == Triple::Geometry, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Hull == Triple::Hull, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Domain == Triple::Domain, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Compute == Triple::Compute, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Library == Triple::Library, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_RayGeneration == Triple::RayGeneration, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Intersection == Triple::Intersection, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_AnyHit == Triple::AnyHit, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_ClosestHit == Triple::ClosestHit, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Miss == Triple::Miss, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Callable == Triple::Callable, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Mesh == Triple::Mesh, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_Amplification == Triple::Amplification, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_OpenCL == Triple::OpenCL, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_OpenHOS == Triple::OpenHOS, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_PAuthTest == Triple::PAuthTest, "");
-static_assert((Triple::EnvironmentType)ZigLLVM_LastEnvironmentType == Triple::LastEnvironmentType, "");
-
-static_assert((Triple::ObjectFormatType)ZigLLVM_UnknownObjectFormat == Triple::UnknownObjectFormat, "");
-static_assert((Triple::ObjectFormatType)ZigLLVM_COFF == Triple::COFF, "");
-static_assert((Triple::ObjectFormatType)ZigLLVM_ELF == Triple::ELF, "");
-static_assert((Triple::ObjectFormatType)ZigLLVM_GOFF == Triple::GOFF, "");
-static_assert((Triple::ObjectFormatType)ZigLLVM_MachO == Triple::MachO, "");
-static_assert((Triple::ObjectFormatType)ZigLLVM_Wasm == Triple::Wasm, "");
-static_assert((Triple::ObjectFormatType)ZigLLVM_XCOFF == Triple::XCOFF, "");
-
-static_assert((CallingConv::ID)ZigLLVM_C == llvm::CallingConv::C, "");
-static_assert((CallingConv::ID)ZigLLVM_Fast == llvm::CallingConv::Fast, "");
-static_assert((CallingConv::ID)ZigLLVM_Cold == llvm::CallingConv::Cold, "");
-static_assert((CallingConv::ID)ZigLLVM_GHC == llvm::CallingConv::GHC, "");
-static_assert((CallingConv::ID)ZigLLVM_HiPE == llvm::CallingConv::HiPE, "");
-static_assert((CallingConv::ID)ZigLLVM_AnyReg == llvm::CallingConv::AnyReg, "");
-static_assert((CallingConv::ID)ZigLLVM_PreserveMost == llvm::CallingConv::PreserveMost, "");
-static_assert((CallingConv::ID)ZigLLVM_PreserveAll == llvm::CallingConv::PreserveAll, "");
-static_assert((CallingConv::ID)ZigLLVM_Swift == llvm::CallingConv::Swift, "");
-static_assert((CallingConv::ID)ZigLLVM_CXX_FAST_TLS == llvm::CallingConv::CXX_FAST_TLS, "");
-static_assert((CallingConv::ID)ZigLLVM_Tail == llvm::CallingConv::Tail, "");
-static_assert((CallingConv::ID)ZigLLVM_CFGuard_Check == llvm::CallingConv::CFGuard_Check, "");
-static_assert((CallingConv::ID)ZigLLVM_SwiftTail == llvm::CallingConv::SwiftTail, "");
-static_assert((CallingConv::ID)ZigLLVM_FirstTargetCC == llvm::CallingConv::FirstTargetCC, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_StdCall == llvm::CallingConv::X86_StdCall, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_FastCall == llvm::CallingConv::X86_FastCall, "");
-static_assert((CallingConv::ID)ZigLLVM_ARM_APCS == llvm::CallingConv::ARM_APCS, "");
-static_assert((CallingConv::ID)ZigLLVM_ARM_AAPCS == llvm::CallingConv::ARM_AAPCS, "");
-static_assert((CallingConv::ID)ZigLLVM_ARM_AAPCS_VFP == llvm::CallingConv::ARM_AAPCS_VFP, "");
-static_assert((CallingConv::ID)ZigLLVM_MSP430_INTR == llvm::CallingConv::MSP430_INTR, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_ThisCall == llvm::CallingConv::X86_ThisCall, "");
-static_assert((CallingConv::ID)ZigLLVM_PTX_Kernel == llvm::CallingConv::PTX_Kernel, "");
-static_assert((CallingConv::ID)ZigLLVM_PTX_Device == llvm::CallingConv::PTX_Device, "");
-static_assert((CallingConv::ID)ZigLLVM_SPIR_FUNC == llvm::CallingConv::SPIR_FUNC, "");
-static_assert((CallingConv::ID)ZigLLVM_SPIR_KERNEL == llvm::CallingConv::SPIR_KERNEL, "");
-static_assert((CallingConv::ID)ZigLLVM_Intel_OCL_BI == llvm::CallingConv::Intel_OCL_BI, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_64_SysV == llvm::CallingConv::X86_64_SysV, "");
-static_assert((CallingConv::ID)ZigLLVM_Win64 == llvm::CallingConv::Win64, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_VectorCall == llvm::CallingConv::X86_VectorCall, "");
-static_assert((CallingConv::ID)ZigLLVM_DUMMY_HHVM == llvm::CallingConv::DUMMY_HHVM, "");
-static_assert((CallingConv::ID)ZigLLVM_DUMMY_HHVM_C == llvm::CallingConv::DUMMY_HHVM_C, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_INTR == llvm::CallingConv::X86_INTR, "");
-static_assert((CallingConv::ID)ZigLLVM_AVR_INTR == llvm::CallingConv::AVR_INTR, "");
-static_assert((CallingConv::ID)ZigLLVM_AVR_SIGNAL == llvm::CallingConv::AVR_SIGNAL, "");
-static_assert((CallingConv::ID)ZigLLVM_AVR_BUILTIN == llvm::CallingConv::AVR_BUILTIN, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_VS == llvm::CallingConv::AMDGPU_VS, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_GS == llvm::CallingConv::AMDGPU_GS, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_PS == llvm::CallingConv::AMDGPU_PS, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_CS == llvm::CallingConv::AMDGPU_CS, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_KERNEL == llvm::CallingConv::AMDGPU_KERNEL, "");
-static_assert((CallingConv::ID)ZigLLVM_X86_RegCall == llvm::CallingConv::X86_RegCall, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_HS == llvm::CallingConv::AMDGPU_HS, "");
-static_assert((CallingConv::ID)ZigLLVM_MSP430_BUILTIN == llvm::CallingConv::MSP430_BUILTIN, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_LS == llvm::CallingConv::AMDGPU_LS, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_ES == llvm::CallingConv::AMDGPU_ES, "");
-static_assert((CallingConv::ID)ZigLLVM_AArch64_VectorCall == llvm::CallingConv::AArch64_VectorCall, "");
-static_assert((CallingConv::ID)ZigLLVM_AArch64_SVE_VectorCall == llvm::CallingConv::AArch64_SVE_VectorCall, "");
-static_assert((CallingConv::ID)ZigLLVM_WASM_EmscriptenInvoke == llvm::CallingConv::WASM_EmscriptenInvoke, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_Gfx == llvm::CallingConv::AMDGPU_Gfx, "");
-static_assert((CallingConv::ID)ZigLLVM_M68k_INTR == llvm::CallingConv::M68k_INTR, "");
-static_assert((CallingConv::ID)ZigLLVM_AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0 == llvm::CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0, "");
-static_assert((CallingConv::ID)ZigLLVM_AArch64_SME_ABI_Support_Routines_PreserveMost_From_X2 == llvm::CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X2, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_CS_Chain == llvm::CallingConv::AMDGPU_CS_Chain, "");
-static_assert((CallingConv::ID)ZigLLVM_AMDGPU_CS_ChainPreserve == llvm::CallingConv::AMDGPU_CS_ChainPreserve, "");
-static_assert((CallingConv::ID)ZigLLVM_M68k_RTD == llvm::CallingConv::M68k_RTD, "");
-static_assert((CallingConv::ID)ZigLLVM_GRAAL == llvm::CallingConv::GRAAL, "");
-static_assert((CallingConv::ID)ZigLLVM_ARM64EC_Thunk_X64 == llvm::CallingConv::ARM64EC_Thunk_X64, "");
-static_assert((CallingConv::ID)ZigLLVM_ARM64EC_Thunk_Native == llvm::CallingConv::ARM64EC_Thunk_Native, "");
-static_assert((CallingConv::ID)ZigLLVM_MaxID == llvm::CallingConv::MaxID, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_GNU == object::Archive::Kind::K_GNU, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_GNU64 == object::Archive::Kind::K_GNU64, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_BSD == object::Archive::Kind::K_BSD, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_DARWIN == object::Archive::Kind::K_DARWIN, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_DARWIN64 == object::Archive::Kind::K_DARWIN64, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_COFF == object::Archive::Kind::K_COFF, "");
+static_assert((object::Archive::Kind)ZigLLVMArchiveKind_AIXBIG == object::Archive::Kind::K_AIXBIG, "");

--- a/src/zig_llvm.h
+++ b/src/zig_llvm.h
@@ -24,7 +24,8 @@
 // ATTENTION: If you modify this file, be sure to update the corresponding
 // extern function declarations in the self-hosted compiler.
 
-
+// synchronize with llvm/include/Transforms/Instrumentation.h::SanitizerCoverageOptions::Type
+// synchronize with codegen/llvm/bindings.zig::TargetMachine::EmitOptions::Coverage::Type
 enum ZigLLVMCoverageType {
     ZigLLVMCoverageType_None = 0,
     ZigLLVMCoverageType_Function,
@@ -67,18 +68,32 @@ struct ZigLLVMEmitOptions {
     ZigLLVMCoverageOptions coverage;
 };
 
-ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
-        char **error_message, const struct ZigLLVMEmitOptions *options);
-
-enum ZigLLVMABIType {
-    ZigLLVMABITypeDefault, // Target-specific (either soft or hard depending on triple, etc).
-    ZigLLVMABITypeSoft,    // Soft float.
-    ZigLLVMABITypeHard     // Hard float.
+// synchronize with llvm/include/Object/Archive.h::Object::Archive::Kind
+// synchronize with codegen/llvm/bindings.zig::ArchiveKind
+enum ZigLLVMArchiveKind {
+    ZigLLVMArchiveKind_GNU,
+    ZigLLVMArchiveKind_GNU64,
+    ZigLLVMArchiveKind_BSD,
+    ZigLLVMArchiveKind_DARWIN,
+    ZigLLVMArchiveKind_DARWIN64,
+    ZigLLVMArchiveKind_COFF,
+    ZigLLVMArchiveKind_AIXBIG,
 };
+
+// synchronize with llvm/include/Target/TargetOptions.h::FloatABI::ABIType
+// synchronize with codegen/llvm/bindings.zig::TargetMachine::FloatABI
+enum ZigLLVMFloatABI {
+    ZigLLVMFloatABI_Default, // Target-specific (either soft or hard depending on triple, etc).
+    ZigLLVMFloatABI_Soft,    // Soft float.
+    ZigLLVMFloatABI_Hard     // Hard float.
+};
+
+ZIG_EXTERN_C bool ZigLLVMTargetMachineEmitToFile(LLVMTargetMachineRef targ_machine_ref, LLVMModuleRef module_ref,
+    char **error_message, const ZigLLVMEmitOptions *options);
 
 ZIG_EXTERN_C LLVMTargetMachineRef ZigLLVMCreateTargetMachine(LLVMTargetRef T, const char *Triple,
     const char *CPU, const char *Features, LLVMCodeGenOptLevel Level, LLVMRelocMode Reloc,
-    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, enum ZigLLVMABIType float_abi,
+    LLVMCodeModel CodeModel, bool function_sections, bool data_sections, ZigLLVMFloatABI float_abi,
     const char *abi_name);
 
 ZIG_EXTERN_C void ZigLLVMSetOptBisectLimit(LLVMContextRef context_ref, int limit);
@@ -86,323 +101,16 @@ ZIG_EXTERN_C void ZigLLVMSetOptBisectLimit(LLVMContextRef context_ref, int limit
 ZIG_EXTERN_C void ZigLLVMEnableBrokenDebugInfoCheck(LLVMContextRef context_ref);
 ZIG_EXTERN_C bool ZigLLVMGetBrokenDebugInfo(LLVMContextRef context_ref);
 
-enum ZigLLVMTailCallKind {
-    ZigLLVMTailCallKindNone,
-    ZigLLVMTailCallKindTail,
-    ZigLLVMTailCallKindMustTail,
-    ZigLLVMTailCallKindNoTail,
-};
-
-enum ZigLLVM_CallingConv {
-    ZigLLVM_C = 0,
-    ZigLLVM_Fast = 8,
-    ZigLLVM_Cold = 9,
-    ZigLLVM_GHC = 10,
-    ZigLLVM_HiPE = 11,
-    ZigLLVM_AnyReg = 13,
-    ZigLLVM_PreserveMost = 14,
-    ZigLLVM_PreserveAll = 15,
-    ZigLLVM_Swift = 16,
-    ZigLLVM_CXX_FAST_TLS = 17,
-    ZigLLVM_Tail = 18,
-    ZigLLVM_CFGuard_Check = 19,
-    ZigLLVM_SwiftTail = 20,
-    ZigLLVM_FirstTargetCC = 64,
-    ZigLLVM_X86_StdCall = 64,
-    ZigLLVM_X86_FastCall = 65,
-    ZigLLVM_ARM_APCS = 66,
-    ZigLLVM_ARM_AAPCS = 67,
-    ZigLLVM_ARM_AAPCS_VFP = 68,
-    ZigLLVM_MSP430_INTR = 69,
-    ZigLLVM_X86_ThisCall = 70,
-    ZigLLVM_PTX_Kernel = 71,
-    ZigLLVM_PTX_Device = 72,
-    ZigLLVM_SPIR_FUNC = 75,
-    ZigLLVM_SPIR_KERNEL = 76,
-    ZigLLVM_Intel_OCL_BI = 77,
-    ZigLLVM_X86_64_SysV = 78,
-    ZigLLVM_Win64 = 79,
-    ZigLLVM_X86_VectorCall = 80,
-    ZigLLVM_DUMMY_HHVM = 81,
-    ZigLLVM_DUMMY_HHVM_C = 82,
-    ZigLLVM_X86_INTR = 83,
-    ZigLLVM_AVR_INTR = 84,
-    ZigLLVM_AVR_SIGNAL = 85,
-    ZigLLVM_AVR_BUILTIN = 86,
-    ZigLLVM_AMDGPU_VS = 87,
-    ZigLLVM_AMDGPU_GS = 88,
-    ZigLLVM_AMDGPU_PS = 89,
-    ZigLLVM_AMDGPU_CS = 90,
-    ZigLLVM_AMDGPU_KERNEL = 91,
-    ZigLLVM_X86_RegCall = 92,
-    ZigLLVM_AMDGPU_HS = 93,
-    ZigLLVM_MSP430_BUILTIN = 94,
-    ZigLLVM_AMDGPU_LS = 95,
-    ZigLLVM_AMDGPU_ES = 96,
-    ZigLLVM_AArch64_VectorCall = 97,
-    ZigLLVM_AArch64_SVE_VectorCall = 98,
-    ZigLLVM_WASM_EmscriptenInvoke = 99,
-    ZigLLVM_AMDGPU_Gfx = 100,
-    ZigLLVM_M68k_INTR = 101,
-    ZigLLVM_AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0 = 102,
-    ZigLLVM_AArch64_SME_ABI_Support_Routines_PreserveMost_From_X2 = 103,
-    ZigLLVM_AMDGPU_CS_Chain = 104,
-    ZigLLVM_AMDGPU_CS_ChainPreserve = 105,
-    ZigLLVM_M68k_RTD = 106,
-    ZigLLVM_GRAAL = 107,
-    ZigLLVM_ARM64EC_Thunk_X64 = 108,
-    ZigLLVM_ARM64EC_Thunk_Native = 109,
-    ZigLLVM_MaxID = 1023,
-};
-
 ZIG_EXTERN_C void ZigLLVMParseCommandLineOptions(size_t argc, const char *const *argv);
-
-// synchronize with llvm/include/ADT/Triple.h::ArchType
-// synchronize with std.Target.Cpu.Arch
-// synchronize with codegen/llvm/bindings.zig::ArchType
-enum ZigLLVM_ArchType {
-    ZigLLVM_UnknownArch,
-
-    ZigLLVM_arm,            // ARM (little endian): arm, armv.*, xscale
-    ZigLLVM_armeb,          // ARM (big endian): armeb
-    ZigLLVM_aarch64,        // AArch64 (little endian): aarch64
-    ZigLLVM_aarch64_be,     // AArch64 (big endian): aarch64_be
-    ZigLLVM_aarch64_32,     // AArch64 (little endian) ILP32: aarch64_32
-    ZigLLVM_arc,            // ARC: Synopsys ARC
-    ZigLLVM_avr,            // AVR: Atmel AVR microcontroller
-    ZigLLVM_bpfel,          // eBPF or extended BPF or 64-bit BPF (little endian)
-    ZigLLVM_bpfeb,          // eBPF or extended BPF or 64-bit BPF (big endian)
-    ZigLLVM_csky,           // CSKY: csky
-    ZigLLVM_dxil,           // DXIL 32-bit DirectX bytecode
-    ZigLLVM_hexagon,        // Hexagon: hexagon
-    ZigLLVM_loongarch32,    // LoongArch (32-bit): loongarch32
-    ZigLLVM_loongarch64,    // LoongArch (64-bit): loongarch64
-    ZigLLVM_m68k,           // M68k: Motorola 680x0 family
-    ZigLLVM_mips,           // MIPS: mips, mipsallegrex, mipsr6
-    ZigLLVM_mipsel,         // MIPSEL: mipsel, mipsallegrexe, mipsr6el
-    ZigLLVM_mips64,         // MIPS64: mips64, mips64r6, mipsn32, mipsn32r6
-    ZigLLVM_mips64el,       // MIPS64EL: mips64el, mips64r6el, mipsn32el, mipsn32r6el
-    ZigLLVM_msp430,         // MSP430: msp430
-    ZigLLVM_ppc,            // PPC: powerpc
-    ZigLLVM_ppcle,          // PPCLE: powerpc (little endian)
-    ZigLLVM_ppc64,          // PPC64: powerpc64, ppu
-    ZigLLVM_ppc64le,        // PPC64LE: powerpc64le
-    ZigLLVM_r600,           // R600: AMD GPUs HD2XXX - HD6XXX
-    ZigLLVM_amdgcn,         // AMDGCN: AMD GCN GPUs
-    ZigLLVM_riscv32,        // RISC-V (32-bit): riscv32
-    ZigLLVM_riscv64,        // RISC-V (64-bit): riscv64
-    ZigLLVM_sparc,          // Sparc: sparc
-    ZigLLVM_sparcv9,        // Sparcv9: Sparcv9
-    ZigLLVM_sparcel,        // Sparc: (endianness = little). NB: 'Sparcle' is a CPU variant
-    ZigLLVM_systemz,        // SystemZ: s390x
-    ZigLLVM_tce,            // TCE (http://tce.cs.tut.fi/): tce
-    ZigLLVM_tcele,          // TCE little endian (http://tce.cs.tut.fi/): tcele
-    ZigLLVM_thumb,          // Thumb (little endian): thumb, thumbv.*
-    ZigLLVM_thumbeb,        // Thumb (big endian): thumbeb
-    ZigLLVM_x86,            // X86: i[3-9]86
-    ZigLLVM_x86_64,         // X86-64: amd64, x86_64
-    ZigLLVM_xcore,          // XCore: xcore
-    ZigLLVM_xtensa,         // Tensilica: Xtensa
-    ZigLLVM_nvptx,          // NVPTX: 32-bit
-    ZigLLVM_nvptx64,        // NVPTX: 64-bit
-    ZigLLVM_le32,           // le32: generic little-endian 32-bit CPU (PNaCl)
-    ZigLLVM_le64,           // le64: generic little-endian 64-bit CPU (PNaCl)
-    ZigLLVM_amdil,          // AMDIL
-    ZigLLVM_amdil64,        // AMDIL with 64-bit pointers
-    ZigLLVM_hsail,          // AMD HSAIL
-    ZigLLVM_hsail64,        // AMD HSAIL with 64-bit pointers
-    ZigLLVM_spir,           // SPIR: standard portable IR for OpenCL 32-bit version
-    ZigLLVM_spir64,         // SPIR: standard portable IR for OpenCL 64-bit version
-    ZigLLVM_spirv,          // SPIR-V with logical memory layout.
-    ZigLLVM_spirv32,        // SPIR-V with 32-bit pointers
-    ZigLLVM_spirv64,        // SPIR-V with 64-bit pointers
-    ZigLLVM_kalimba,        // Kalimba: generic kalimba
-    ZigLLVM_shave,          // SHAVE: Movidius vector VLIW processors
-    ZigLLVM_lanai,          // Lanai: Lanai 32-bit
-    ZigLLVM_wasm32,         // WebAssembly with 32-bit pointers
-    ZigLLVM_wasm64,         // WebAssembly with 64-bit pointers
-    ZigLLVM_renderscript32, // 32-bit RenderScript
-    ZigLLVM_renderscript64, // 64-bit RenderScript
-    ZigLLVM_ve,             // NEC SX-Aurora Vector Engine
-    ZigLLVM_LastArchType = ZigLLVM_ve
-};
-
-enum ZigLLVM_VendorType {
-    ZigLLVM_UnknownVendor,
-
-    ZigLLVM_Apple,
-    ZigLLVM_PC,
-    ZigLLVM_SCEI,
-    ZigLLVM_Freescale,
-    ZigLLVM_IBM,
-    ZigLLVM_ImaginationTechnologies,
-    ZigLLVM_MipsTechnologies,
-    ZigLLVM_NVIDIA,
-    ZigLLVM_CSR,
-    ZigLLVM_AMD,
-    ZigLLVM_Mesa,
-    ZigLLVM_SUSE,
-    ZigLLVM_OpenEmbedded,
-
-    ZigLLVM_LastVendorType = ZigLLVM_OpenEmbedded
-};
-
-// synchronize with llvm/include/ADT/Triple.h::OsType
-// synchronize with std.Target.Os.Tag
-// synchronize with codegen/llvm/bindings.zig::OsType
-enum ZigLLVM_OSType {
-    ZigLLVM_UnknownOS,
-
-    ZigLLVM_Darwin,
-    ZigLLVM_DragonFly,
-    ZigLLVM_FreeBSD,
-    ZigLLVM_Fuchsia,
-    ZigLLVM_IOS,
-    ZigLLVM_KFreeBSD,
-    ZigLLVM_Linux,
-    ZigLLVM_Lv2,        // PS3
-    ZigLLVM_MacOSX,
-    ZigLLVM_NetBSD,
-    ZigLLVM_OpenBSD,
-    ZigLLVM_Solaris,
-    ZigLLVM_UEFI,
-    ZigLLVM_Win32,
-    ZigLLVM_ZOS,
-    ZigLLVM_Haiku,
-    ZigLLVM_RTEMS,
-    ZigLLVM_NaCl,       // Native Client
-    ZigLLVM_AIX,
-    ZigLLVM_CUDA,       // NVIDIA CUDA
-    ZigLLVM_NVCL,       // NVIDIA OpenCL
-    ZigLLVM_AMDHSA,     // AMD HSA Runtime
-    ZigLLVM_PS4,
-    ZigLLVM_PS5,
-    ZigLLVM_ELFIAMCU,
-    ZigLLVM_TvOS,       // Apple tvOS
-    ZigLLVM_WatchOS,    // Apple watchOS
-    ZigLLVM_BridgeOS,   // Apple bridgeOS
-    ZigLLVM_DriverKit,  // Apple DriverKit
-    ZigLLVM_XROS,       // Apple XROS
-    ZigLLVM_Mesa3D,
-    ZigLLVM_AMDPAL,     // AMD PAL Runtime
-    ZigLLVM_HermitCore, // HermitCore Unikernel/Multikernel
-    ZigLLVM_Hurd,       // GNU/Hurd
-    ZigLLVM_WASI,       // Experimental WebAssembly OS
-    ZigLLVM_Emscripten,
-    ZigLLVM_ShaderModel, // DirectX ShaderModel
-    ZigLLVM_LiteOS,
-    ZigLLVM_Serenity,
-    ZigLLVM_Vulkan,      // Vulkan SPIR-V
-    ZigLLVM_LastOSType = ZigLLVM_Vulkan
-};
-
-// Synchronize with target.cpp::abi_list
-enum ZigLLVM_EnvironmentType {
-    ZigLLVM_UnknownEnvironment,
-
-    ZigLLVM_GNU,
-    ZigLLVM_GNUABIN32,
-    ZigLLVM_GNUABI64,
-    ZigLLVM_GNUEABI,
-    ZigLLVM_GNUEABIHF,
-    ZigLLVM_GNUF32,
-    ZigLLVM_GNUF64,
-    ZigLLVM_GNUSF,
-    ZigLLVM_GNUX32,
-    ZigLLVM_GNUILP32,
-    ZigLLVM_CODE16,
-    ZigLLVM_EABI,
-    ZigLLVM_EABIHF,
-    ZigLLVM_Android,
-    ZigLLVM_Musl,
-    ZigLLVM_MuslEABI,
-    ZigLLVM_MuslEABIHF,
-    ZigLLVM_MuslX32,
-
-    ZigLLVM_MSVC,
-    ZigLLVM_Itanium,
-    ZigLLVM_Cygnus,
-    ZigLLVM_CoreCLR,
-    ZigLLVM_Simulator, // Simulator variants of other systems, e.g., Apple's iOS
-    ZigLLVM_MacABI, // Mac Catalyst variant of Apple's iOS deployment target.
-
-    ZigLLVM_Pixel,
-    ZigLLVM_Vertex,
-    ZigLLVM_Geometry,
-    ZigLLVM_Hull,
-    ZigLLVM_Domain,
-    ZigLLVM_Compute,
-    ZigLLVM_Library,
-    ZigLLVM_RayGeneration,
-    ZigLLVM_Intersection,
-    ZigLLVM_AnyHit,
-    ZigLLVM_ClosestHit,
-    ZigLLVM_Miss,
-    ZigLLVM_Callable,
-    ZigLLVM_Mesh,
-    ZigLLVM_Amplification,
-    ZigLLVM_OpenCL,
-    ZigLLVM_OpenHOS,
-
-    ZigLLVM_PAuthTest,
-
-    ZigLLVM_LastEnvironmentType = ZigLLVM_PAuthTest
-};
-
-enum ZigLLVM_ObjectFormatType {
-    ZigLLVM_UnknownObjectFormat,
-
-    ZigLLVM_COFF,
-    ZigLLVM_DXContainer,
-    ZigLLVM_ELF,
-    ZigLLVM_GOFF,
-    ZigLLVM_MachO,
-    ZigLLVM_SPIRV,
-    ZigLLVM_Wasm,
-    ZigLLVM_XCOFF,
-};
-
-#define ZigLLVM_DIFlags_Zero 0U
-#define ZigLLVM_DIFlags_Private 1U
-#define ZigLLVM_DIFlags_Protected 2U
-#define ZigLLVM_DIFlags_Public 3U
-#define ZigLLVM_DIFlags_FwdDecl (1U << 2)
-#define ZigLLVM_DIFlags_AppleBlock (1U << 3)
-#define ZigLLVM_DIFlags_BlockByrefStruct (1U << 4)
-#define ZigLLVM_DIFlags_Virtual (1U << 5)
-#define ZigLLVM_DIFlags_Artificial (1U << 6)
-#define ZigLLVM_DIFlags_Explicit (1U << 7)
-#define ZigLLVM_DIFlags_Prototyped (1U << 8)
-#define ZigLLVM_DIFlags_ObjcClassComplete (1U << 9)
-#define ZigLLVM_DIFlags_ObjectPointer (1U << 10)
-#define ZigLLVM_DIFlags_Vector (1U << 11)
-#define ZigLLVM_DIFlags_StaticMember (1U << 12)
-#define ZigLLVM_DIFlags_LValueReference (1U << 13)
-#define ZigLLVM_DIFlags_RValueReference (1U << 14)
-#define ZigLLVM_DIFlags_Reserved (1U << 15)
-#define ZigLLVM_DIFlags_SingleInheritance (1U << 16)
-#define ZigLLVM_DIFlags_MultipleInheritance (2 << 16)
-#define ZigLLVM_DIFlags_VirtualInheritance (3 << 16)
-#define ZigLLVM_DIFlags_IntroducedVirtual (1U << 18)
-#define ZigLLVM_DIFlags_BitField (1U << 19)
-#define ZigLLVM_DIFlags_NoReturn (1U << 20)
-#define ZigLLVM_DIFlags_TypePassByValue (1U << 22)
-#define ZigLLVM_DIFlags_TypePassByReference (1U << 23)
-#define ZigLLVM_DIFlags_EnumClass (1U << 24)
-#define ZigLLVM_DIFlags_Thunk (1U << 25)
-#define ZigLLVM_DIFlags_NonTrivial (1U << 26)
-#define ZigLLVM_DIFlags_BigEndian (1U << 27)
-#define ZigLLVM_DIFlags_LittleEndian (1U << 28)
-#define ZigLLVM_DIFlags_AllCallsDescribed (1U << 29)
 
 ZIG_EXTERN_C bool ZigLLDLinkCOFF(int argc, const char **argv, bool can_exit_early, bool disable_output);
 ZIG_EXTERN_C bool ZigLLDLinkELF(int argc, const char **argv, bool can_exit_early, bool disable_output);
 ZIG_EXTERN_C bool ZigLLDLinkWasm(int argc, const char **argv, bool can_exit_early, bool disable_output);
 
 ZIG_EXTERN_C bool ZigLLVMWriteArchive(const char *archive_name, const char **file_names, size_t file_name_count,
-        enum ZigLLVM_OSType os_type);
+    ZigLLVMArchiveKind archive_kind);
 
-ZIG_EXTERN_C bool ZigLLVMWriteImportLibrary(const char *def_path, const enum ZigLLVM_ArchType arch,
-                               const char *output_lib_path, bool kill_at);
+ZIG_EXTERN_C bool ZigLLVMWriteImportLibrary(const char *def_path, unsigned int coff_machine,
+    const char *output_lib_path, bool kill_at);
 
 #endif


### PR DESCRIPTION
LLVM recently introduced new `Triple::ArchType` members in 19.1.3 which broke our static assertions in `zig_llvm.cpp`. When implementing a fix for that, I realized that we don't even need a lot of the stuff we have in `zig_llvm.(cpp,h)` anymore. This PR trims the interface down considerably, and also fixes a few issues I noticed in the affected code.