### PR TITLE
std.fs.File: Fix metadata error check on Linux

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1072,7 +1072,7 @@ pub fn metadata(self: File) MetadataError!Metadata {
                     &stx,
                 );
 
-                switch (posix.errno(rc)) {
+                switch (linux.E.init(rc)) {
                     .SUCCESS => {},
                     .ACCES => unreachable,
                     .BADF => unreachable,


### PR DESCRIPTION
On Linux, File.metadata calls the statx syscall directly. As such, the return value is the error code. Previously, it handled the error with `posix.errno`, which when libc is linked, treats the return value as a value set to -1 if there is an error with the error code in errno. If libc wasn't linked, it would be handled correctly.

In the Linux with libc linked case, this would cause the error result to always be treated as success (err val != -1), even when an error occurred.

The other use of `linux.statx` in File zig checked with `linux.E.init` which doesn't have the errno path with libc, so updated this case to do the same.