### PR TITLE
`std.Target`: Remove armv7k/armv7s

### DIFF
--- a/lib/std/Target/arm.zig
+++ b/lib/std/Target/arm.zig
@@ -158,10 +158,8 @@ pub const Feature = enum {
     v6t2,
     v7a,
     v7em,
-    v7k,
     v7m,
     v7r,
-    v7s,
     v7ve,
     v8_1a,
     v8_1m_main,
@@ -1177,13 +1175,6 @@ pub const all_features = blk: {
             .thumb_mode,
         }),
     };
-    result[@intFromEnum(Feature.v7k)] = .{
-        .llvm_name = "armv7k",
-        .description = "ARMv7a architecture",
-        .dependencies = featureSet(&[_]Feature{
-            .v7a,
-        }),
-    };
     result[@intFromEnum(Feature.v7m)] = .{
         .llvm_name = "armv7-m",
         .description = "ARMv7m architecture",
@@ -1206,13 +1197,6 @@ pub const all_features = blk: {
             .hwdiv,
             .perfmon,
             .rclass,
-        }),
-    };
-    result[@intFromEnum(Feature.v7s)] = .{
-        .llvm_name = "armv7s",
-        .description = "ARMv7a architecture",
-        .dependencies = featureSet(&[_]Feature{
-            .v7a,
         }),
     };
     result[@intFromEnum(Feature.v7ve)] = .{

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -118,9 +118,6 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
             .{ .v6kz, "v6kz" },
             .{ .v6m, "v6m" },
             .{ .v6t2, "v6t2" },
-            // v7k and v7s imply v7a so they have to be tested first.
-            .{ .v7k, "v7k" },
-            .{ .v7s, "v7s" },
             .{ .v7a, "v7a" },
             .{ .v7em, "v7em" },
             .{ .v7m, "v7m" },

--- a/tools/update_cpu_features.zig
+++ b/tools/update_cpu_features.zig
@@ -699,11 +699,11 @@ const llvm_targets = [_]LlvmTarget{
             },
             .{
                 .llvm_name = "armv7k",
-                .zig_name = "v7k",
+                .omit = true,
             },
             .{
                 .llvm_name = "armv7s",
-                .zig_name = "v7s",
+                .omit = true,
             },
             .{
                 .llvm_name = "armv7ve",


### PR DESCRIPTION
Like d1d95294fd657f771657ea671a6984b860347fb0, this is more Apple nonsense where they abused the arch component of the triple to encode what's really an ABI.

Handling this correctly in Zig's target triple model would take quite a bit of work. Fortunately, the last Armv7-based Apple Watch was released in 2017 and these targets are now considered legacy. By the time Zig hits 1.0, they will be a distant memory. So just remove them.