### PR TITLE
`link.Coff`: Pass `-lldmingw` to LLD earlier and regardless of `-lc`.

### DIFF
--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1832,6 +1832,10 @@ fn linkWithLLD(coff: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: 
         const linker_command = "lld-link";
         try argv.appendSlice(&[_][]const u8{ comp.self_exe_path.?, linker_command });
 
+        if (target.isMinGW()) {
+            try argv.append("-lldmingw");
+        }
+
         try argv.append("-ERRORLIMIT:0");
         try argv.append("-NOLOGO");
         if (comp.config.debug_format != .strip) {
@@ -2053,8 +2057,6 @@ fn linkWithLLD(coff: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: 
             .win32 => {
                 if (link_in_crt) {
                     if (target.abi.isGnu()) {
-                        try argv.append("-lldmingw");
-
                         if (target.cpu.arch == .x86) {
                             try argv.append("-ALTERNATENAME:__image_base__=___ImageBase");
                         } else {


### PR DESCRIPTION
The `-lldmingw` option affects a lot of logic throughout LLD. We need to pass it for `*-windows-gnu` even when we're not actually linking MinGW since we're still using the MinGW ABI with all that that entails. (One particular problem we would run into is missing handling of `stdcall`-decorated symbols for 32-bit x86.) Also, various other LLD options are sensitive to this option, so it's best to pass it as early as possible.

Closes #11817.