### PR TITLE
Allocator.free: document zero-length behavior

### DIFF
--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -301,8 +301,9 @@ pub fn reallocAdvanced(
     return mem.bytesAsSlice(T, new_bytes);
 }
 
-/// Free an array allocated with `alloc`. To free a single item,
-/// see `destroy`.
+/// Free an array allocated with `alloc`.
+/// If memory has length 0, free is a no-op.
+/// To free a single item, see `destroy`.
 pub fn free(self: Allocator, memory: anytype) void {
     const Slice = @typeInfo(@TypeOf(memory)).pointer;
     const bytes = mem.sliceAsBytes(memory);


### PR DESCRIPTION
It wasn't immediately clear from the implementation whether passing zero-length memory to free() was undefined behavior or intentionally supported. Since ArrayList and other core data structures rely on this behavior working correctly, this should be explicitly documented as part of the public API contract.

https://github.com/ziglang/zig/blob/53d7a7b3c023f0c26ae7ecc070645096d9adb3dd/lib/std/array_list.zig#L52-L59

cc @squeek502 