### PR TITLE
compiler: Disallow `align(0)` everywhere in the language.

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2584,18 +2584,7 @@ fn validateAlign(
     src: LazySrcLoc,
     alignment: u64,
 ) !Alignment {
-    const result = try validateAlignAllowZero(sema, block, src, alignment);
-    if (result == .none) return sema.fail(block, src, "alignment must be >= 1", .{});
-    return result;
-}
-
-fn validateAlignAllowZero(
-    sema: *Sema,
-    block: *Block,
-    src: LazySrcLoc,
-    alignment: u64,
-) !Alignment {
-    if (alignment == 0) return .none;
+    if (alignment == 0) return sema.fail(block, src, "alignment must be >= 1", .{});
     if (!std.math.isPowerOfTwo(alignment)) {
         return sema.fail(block, src, "alignment value '{d}' is not a power of two", .{
             alignment,
@@ -20477,7 +20466,7 @@ fn zirPtrType(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
             else => {},
         }
         const align_bytes = (try val.getUnsignedIntSema(pt)).?;
-        break :blk try sema.validateAlignAllowZero(block, align_src, align_bytes);
+        break :blk try sema.validateAlign(block, align_src, align_bytes);
     } else .none;
 
     const address_space: std.builtin.AddressSpace = if (inst_data.flags.has_addrspace) blk: {
@@ -26839,7 +26828,7 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
         if (val.isGenericPoison()) {
             break :blk null;
         }
-        break :blk try sema.validateAlignAllowZero(block, align_src, try val.toUnsignedIntSema(pt));
+        break :blk try sema.validateAlign(block, align_src, try val.toUnsignedIntSema(pt));
     } else if (extra.data.bits.has_align_ref) blk: {
         const align_ref: Zir.Inst.Ref = @enumFromInt(sema.code.extra[extra_index]);
         extra_index += 1;
@@ -26857,7 +26846,7 @@ fn zirFuncFancy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!A
             error.GenericPoison => break :blk null,
             else => |e| return e,
         };
-        break :blk try sema.validateAlignAllowZero(block, align_src, try align_val.toUnsignedIntSema(pt));
+        break :blk try sema.validateAlign(block, align_src, try align_val.toUnsignedIntSema(pt));
     } else .none;
 
     const @"addrspace": ?std.builtin.AddressSpace = if (extra.data.bits.has_addrspace_body) blk: {

--- a/test/cases/compile_errors/align_zero.zig
+++ b/test/cases/compile_errors/align_zero.zig
@@ -1,0 +1,52 @@
+pub var global_var: i32 align(0) = undefined;
+
+pub export fn a() void {
+    _ = &global_var;
+}
+
+pub extern var extern_var: i32 align(0);
+
+pub export fn b() void {
+    _ = &extern_var;
+}
+
+pub export fn c() align(0) void {}
+
+pub export fn d() void {
+    _ = *align(0) fn () i32;
+}
+
+pub export fn e() void {
+    var local_var: i32 align(0) = undefined;
+    _ = &local_var;
+}
+
+pub export fn f() void {
+    _ = *align(0) i32;
+}
+
+pub export fn g() void {
+    _ = []align(0) i32;
+}
+
+pub export fn h() void {
+    _ = struct { field: i32 align(0) };
+}
+
+pub export fn i() void {
+    _ = union { field: i32 align(0) };
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:31: error: alignment must be >= 1
+// :7:38: error: alignment must be >= 1
+// :13:25: error: alignment must be >= 1
+// :16:16: error: alignment must be >= 1
+// :20:30: error: alignment must be >= 1
+// :25:16: error: alignment must be >= 1
+// :29:17: error: alignment must be >= 1
+// :33:35: error: alignment must be >= 1
+// :37:34: error: alignment must be >= 1

--- a/test/cases/compile_errors/function_alignment_on_unsupported_target.zig
+++ b/test/cases/compile_errors/function_alignment_on_unsupported_target.zig
@@ -1,4 +1,4 @@
-export fn entry() align(0) void {}
+export fn entry() align(64) void {}
 
 // error
 // backend=stage2


### PR DESCRIPTION
### Release Notes

Zig previously accepted `align(0)` in certain positions while rejecting it in others. Where it was accepted, it was taken to mean the default ABI alignment; in other words, it was strictly redundant.

This release makes `align(0)` an error everywhere in the language, thus leaving the design space for this alignment value open. (One possibility being explored here is that `align(0)` could allow the compiler to do bit packing in auto-layout structs.)