### PR TITLE
Revert "test: Add aarch64_be-linux-(none,gnu,musl) to module tests."

### DIFF
--- a/test/tests.zig
+++ b/test/tests.zig
@@ -293,30 +293,6 @@ const test_targets = blk: {
 
         .{
             .target = .{
-                .cpu_arch = .aarch64_be,
-                .os_tag = .linux,
-                .abi = .none,
-            },
-        },
-        .{
-            .target = .{
-                .cpu_arch = .aarch64_be,
-                .os_tag = .linux,
-                .abi = .musl,
-            },
-            .link_libc = true,
-        },
-        .{
-            .target = .{
-                .cpu_arch = .aarch64_be,
-                .os_tag = .linux,
-                .abi = .gnu,
-            },
-            .link_libc = true,
-        },
-
-        .{
-            .target = .{
                 .cpu_arch = .arm,
                 .os_tag = .linux,
                 .abi = .eabi,


### PR DESCRIPTION
This reverts commit 4049be90de6a557c1ab522363fddbb71d3ccdb18.

See: https://github.com/ziglang/zig/issues/21911

I'll experiment some more with #21910 and try to reland this commit later.