### PR TITLE
build: increase max_rss to 7.8G

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -644,7 +644,7 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         .root_source_file = b.path("src/main.zig"),
         .target = options.target,
         .optimize = options.optimize,
-        .max_rss = 7_500_000_000,
+        .max_rss = 7_800_000_000,
         .strip = options.strip,
         .sanitize_thread = options.sanitize_thread,
         .single_threaded = options.single_threaded,


### PR DESCRIPTION
I've been consistently observing numbers in the 7659786240 ballpark when building with these settings:

```
e:\dev\zig-windows-x86_64-0.14.0-dev.2034+56996a280\zig.exe build %* ^
  -p build-stage4-release ^
  --search-prefix e:\dev\zig-bootstrap\out-win\x86_64-windows-gnu-native ^
  --zig-lib-dir c:\cygwin64\home\kcbanner\kit\zig\lib ^
  -Dstatic-llvm ^
  -Doptimize=ReleaseSafe ^
  -Dlog=true ^
  -Dstrip=false ^
  -Duse-zig-libcxx ^
  -Dno-langref ^
  -Dtarget=x86_64-windows-gnu
```