### PR TITLE
Provide a detailed message for invalid arch in target triple

### DIFF
--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -193,6 +193,9 @@ pub const ParseOptions = struct {
 
         /// If error.UnknownCpuFeature is returned, this will be populated.
         unknown_feature_name: ?[]const u8 = null,
+
+        /// If error.UnknownArchitecture is returned, this will be populated.
+        unknown_architecture_name: ?[]const u8 = null,
     };
 };
 
@@ -208,8 +211,10 @@ pub fn parse(args: ParseOptions) !Query {
     const arch_name = it.first();
     const arch_is_native = mem.eql(u8, arch_name, "native");
     if (!arch_is_native) {
-        result.cpu_arch = std.meta.stringToEnum(Target.Cpu.Arch, arch_name) orelse
+        result.cpu_arch = std.meta.stringToEnum(Target.Cpu.Arch, arch_name) orelse {
+            diags.unknown_architecture_name = arch_name;
             return error.UnknownArchitecture;
+        };
     }
     const arch = result.cpu_arch orelse builtin.cpu.arch;
     diags.arch = arch;

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -660,6 +660,17 @@ pub fn parseTargetQueryOrReportFatalError(
             }
             fatal("unknown object format: '{s}'", .{opts.object_format.?});
         },
+        error.UnknownArchitecture => {
+            help: {
+                var help_text = std.ArrayList(u8).init(allocator);
+                defer help_text.deinit();
+                inline for (@typeInfo(std.Target.Cpu.Arch).@"enum".fields) |field| {
+                    help_text.writer().print(" {s}\n", .{field.name}) catch break :help;
+                }
+                std.log.info("available architectures:\n{s}\nnative", .{help_text.items});
+            }
+            fatal("unknown architecture: '{s}'", .{diags.unknown_architecture_name.?});
+        },
         else => |e| fatal("unable to parse target query '{s}': {s}", .{
             opts.arch_os_abi, @errorName(e),
         }),

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -667,7 +667,7 @@ pub fn parseTargetQueryOrReportFatalError(
                 inline for (@typeInfo(std.Target.Cpu.Arch).@"enum".fields) |field| {
                     help_text.writer().print(" {s}\n", .{field.name}) catch break :help;
                 }
-                std.log.info("available architectures:\n{s}\nnative", .{help_text.items});
+                std.log.info("available architectures:\n{s} native\n", .{help_text.items});
             }
             fatal("unknown architecture: '{s}'", .{diags.unknown_architecture_name.?});
         },


### PR DESCRIPTION
adds arch error message. Matches format of invalid cpu and object format messages.

example: 
```
$ zig build-exe -target baz-macos main.zig
info: available architectures:
 amdgcn
 arc
 arm
 armeb
 thumb
 thumbeb
 aarch64
 aarch64_be
 avr
 bpfel
 bpfeb
 csky
 hexagon
 kalimba
 lanai
 loongarch32
 loongarch64
 m68k
 mips
 mipsel
 mips64
 mips64el
 msp430
 nvptx
 nvptx64
 powerpc
 powerpcle
 powerpc64
 powerpc64le
 propeller1
 propeller2
 riscv32
 riscv64
 s390x
 sparc
 sparc64
 spirv
 spirv32
 spirv64
 spu_2
 ve
 wasm32
 wasm64
 x86
 x86_64
 xcore
 xtensa
 native

error: unknown architecture: 'baz'
```
