### PR TITLE
Fix compile error in `std.Random.enumValueWithIndex`

### DIFF
--- a/lib/std/Random.zig
+++ b/lib/std/Random.zig
@@ -86,7 +86,7 @@ pub fn enumValueWithIndex(r: Random, comptime EnumType: type, comptime Index: ty
     const values = comptime std.enums.values(EnumType);
     comptime assert(values.len > 0); // can't return anything
     comptime assert(maxInt(Index) >= values.len - 1); // can't access all values
-    comptime if (values.len == 1) return values[0];
+    if (values.len == 1) return values[0];
 
     const index = if (comptime values.len - 1 == maxInt(Index))
         r.int(Index)


### PR DESCRIPTION
Fixing a compile error in `std.Random.enumValueWithIndex` when handling enums with a single value, reproducible with the following code snippet:

```zig
const std = @import("std");

const SingleValueEnum = enum {
    one,
};

pub fn main() void
{
    var prng = std.Random.DefaultPrng.init(0);
    const random = prng.random().enumValue(SingleValueEnum);
    _ = random;
}
```

Error message:
```
/opt/compiler-explorer/zig-0.13.0/lib/std/Random.zig:89:35: error: function called at runtime cannot return value at comptime
```

Obviously randomizing a value for a single-value enum is a silly use case, but the compile error is unexpected regardless. I think the `comptime` keyword here was trying to express that the `if` should be evaluated at `comptime`, but I think
1. The correct way to write this is `if (comptime values.len == 1) return values[0];`
2. The `comptime` is redundant anyway, based on `values` being a comptime variable.