### PR TITLE
fetch: Fix various issues related to `zig fetch --save`

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -7041,23 +7041,22 @@ fn cmdFetch(
             }
         }
 
-        const location_replace = try std.fmt.allocPrint(
-            arena,
-            "\"{f}\"",
-            .{std.zig.fmtString(saved_url)},
-        );
-        const hash_replace = try std.fmt.allocPrint(
-            arena,
-            "\"{f}\"",
-            .{std.zig.fmtString(package_hash_slice)},
-        );
-
         warn("overwriting existing dependency named '{s}'", .{name});
-        try fixups.replace_nodes_with_string.put(gpa, dep.location_node, location_replace);
-        if (dep.hash_node.unwrap()) |hash_node| {
-            try fixups.replace_nodes_with_string.put(gpa, hash_node, hash_replace);
+        if (dep.location == .url) {
+            const location_replace = try std.fmt.allocPrint(
+                arena,
+                "\"{f}\"",
+                .{std.zig.fmtString(saved_url)},
+            );
+            const hash_replace = try std.fmt.allocPrint(
+                arena,
+                "\"{f}\"",
+                .{std.zig.fmtString(package_hash_slice)},
+            );
+            try fixups.replace_nodes_with_string.put(gpa, dep.location_node, location_replace);
+            try fixups.replace_nodes_with_string.put(gpa, dep.hash_node.unwrap().?, hash_replace);
         } else {
-            // https://github.com/ziglang/zig/issues/21690
+            try fixups.replace_nodes_with_string.put(gpa, dep.node, new_node_init);
         }
     } else if (manifest.dependencies.count() > 0) {
         // Add fixup for adding another dependency.

--- a/src/main.zig
+++ b/src/main.zig
@@ -6888,8 +6888,8 @@ fn cmdFetch(
     var fetch: Package.Fetch = .{
         .arena = std.heap.ArenaAllocator.init(gpa),
         .location = switch (parsed_path_or_url) {
-            .path => |path| .{ .cli_path = path },
-            .url => |url| .{ .cli_url = url },
+            .path => |path| .{ .path = path },
+            .url => |url| .{ .url = url },
         },
         .location_tok = 0,
         .hash_tok = .none,

--- a/src/main.zig
+++ b/src/main.zig
@@ -6779,10 +6779,8 @@ const usage_fetch =
     \\  -h, --help                    Print this help and exit
     \\  --global-cache-dir [path]     Override path to global Zig cache directory
     \\  --debug-hash                  Print verbose hash information to stdout
-    \\  --save                        Add the fetched package to build.zig.zon
-    \\  --save=[name]                 Add the fetched package to build.zig.zon as name
-    \\  --save-exact                  Add the fetched package to build.zig.zon, storing the URL verbatim
-    \\  --save-exact=[name]           Add the fetched package to build.zig.zon as name, storing the URL verbatim
+    \\  --save[=name]                 Add the fetched package to build.zig.zon
+    \\  --save-exact[=name]           Add the fetched package to build.zig.zon, storing the URL verbatim
     \\
 ;
 


### PR DESCRIPTION
Closes #18639
Closes #21690

- `zig fetch --save file/path` is now an error.
- `--save`ing over an existing `path` entry will now correctly replace it with an `url` entry.
- Fetching by file URL (as in `zig fetch file:///C:/foo/bar.zip`) did not previously work, but does now.

The purpose of `zig fetch` is to copy a package to the global cache to avoid needing to access the network. It is not to manage your `build.zig.zon`. `--save` is provided as a convenience since calculating the hash by hand would be unreasonable, but it does not make sense to `--save` a package fetched by a (CWD-relative) file path since `path` entries in a build.zig.zon are for relative paths inside a package. `path` entries can only be added by manually editing your `build.zig.zon`.

Both `zig fetch` and `build.zig.zon` support fetching by file URL scheme, for example if a package is on an intranet network drive, but this did not previously always work due to a field being uninitialized and due to file URL-encoded absolute paths on Windows containing drive letters requiring extra attention. This PR fixes those bugs and improves validation to ensure file URLs are spec-compliant (based on RFC 8089 and https://url.spec.whatwg.org/).

I've verified the correctness of these changes by running the following commands locally (on Windows):
- `zig fetch --save ..\..\foo\` -> error (can't save when fetching by file path)
- `zig fetch --save ..\..\foo.zip` -> error (can't save when fetching by file path)
- `zig fetch --save file:///foo.zip` -> ok
- `zig fetch --save file:/foo.zip` -> ok
- `zig fetch --save file:///C:/foo.zip` -> ok
- `zig fetch --save file:/C:/foo.zip` -> ok
- `zig fetch --save file://LOCALhost/C:/foo.zip` -> ok
- `zig fetch --save file:foo.zip` -> error (invalid file URL)

Additionally, it turns out that there were a lot of test declarations in `/src` that were unreferenced and untested, some of which were for the package manager internals. I de-bitrotted those tests and added them under a new `test-compiler-internals` test set, which tests everything referenced by `/src/main.zig`.