### PR TITLE
Fix float vector comparisons with signed zero and NaN, add test coverage

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -38137,6 +38137,11 @@ fn compareScalar(
     const pt = sema.pt;
     const coerced_lhs = try pt.getCoerced(lhs, ty);
     const coerced_rhs = try pt.getCoerced(rhs, ty);
+
+    // Equality comparisons of signed zero and NaN need to use floating point semantics
+    if (coerced_lhs.isFloat(pt.zcu) or coerced_rhs.isFloat(pt.zcu))
+        return Value.compareHeteroSema(coerced_lhs, op, coerced_rhs, pt);
+
     switch (op) {
         .eq => return sema.valuesEqual(coerced_lhs, coerced_rhs, ty),
         .neq => return !(try sema.valuesEqual(coerced_lhs, coerced_rhs, ty)),

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -1132,6 +1132,8 @@ pub fn compareHeteroAdvanced(
             else => {},
         }
     }
+
+    if (lhs.isNan(zcu) or rhs.isNan(zcu)) return op == .neq;
     return (try orderAdvanced(lhs, rhs, strat, zcu, tid)).compare(op);
 }
 

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -194,7 +194,7 @@ fn testCmp(comptime T: type) !void {
         try expect(x <= 2.0);
     }
 
-    @setEvalBranchQuota(2_000);
+    @setEvalBranchQuota(4_000);
     var edges = [_]T{
         -math.inf(T),
         -math.floatMax(T),
@@ -210,6 +210,7 @@ fn testCmp(comptime T: type) !void {
     };
     _ = &edges;
     for (edges, 0..) |rhs, rhs_i| {
+        const rhs_v: @Vector(4, T) = @splat(rhs);
         for (edges, 0..) |lhs, lhs_i| {
             const no_nan = lhs_i != 5 and rhs_i != 5;
             const lhs_order = if (lhs_i < 5) lhs_i else lhs_i - 2;
@@ -220,6 +221,14 @@ fn testCmp(comptime T: type) !void {
             try expect((lhs > rhs) == (no_nan and lhs_order > rhs_order));
             try expect((lhs <= rhs) == (no_nan and lhs_order <= rhs_order));
             try expect((lhs >= rhs) == (no_nan and lhs_order >= rhs_order));
+
+            const lhs_v: @Vector(4, T) = @splat(lhs);
+            try expect(@reduce(.And, (lhs_v == rhs_v)) == (no_nan and lhs_order == rhs_order));
+            try expect(@reduce(.And, (lhs_v != rhs_v)) == !(no_nan and lhs_order == rhs_order));
+            try expect(@reduce(.And, (lhs_v < rhs_v)) == (no_nan and lhs_order < rhs_order));
+            try expect(@reduce(.And, (lhs_v > rhs_v)) == (no_nan and lhs_order > rhs_order));
+            try expect(@reduce(.And, (lhs_v <= rhs_v)) == (no_nan and lhs_order <= rhs_order));
+            try expect(@reduce(.And, (lhs_v >= rhs_v)) == (no_nan and lhs_order >= rhs_order));
         }
     }
 }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -135,6 +135,7 @@ test "cmp f16" {
 test "cmp f32" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.cpu.arch.isArm() and builtin.target.abi.float() == .soft) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21234
+    if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
 
     try testCmp(f32);
     try comptime testCmp(f32);
@@ -143,7 +144,7 @@ test "cmp f32" {
 test "cmp f64" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
-    if (builtin.cpu.arch.isArm() and builtin.target.floatAbi() == .soft) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21234
+    if (builtin.cpu.arch.isArm() and builtin.target.abi.float() == .soft) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21234
 
     try testCmp(f64);
     try comptime testCmp(f64);
@@ -236,7 +237,8 @@ test "vector cmp f16" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.cpu.arch.isArm() and builtin.target.floatAbi() == .soft) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21234
+    if (builtin.cpu.arch.isArm()) return error.SkipZigTest;
+    if (builtin.cpu.arch.isPowerPC64()) return error.SkipZigTest;
 
     try testCmpVector(f16);
     try comptime testCmpVector(f16);
@@ -247,7 +249,8 @@ test "vector cmp f32" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.cpu.arch.isArm() and builtin.target.floatAbi() == .soft) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21234
+    if (builtin.cpu.arch.isArm()) return error.SkipZigTest;
+    if (builtin.cpu.arch.isPowerPC64()) return error.SkipZigTest;
 
     try testCmpVector(f32);
     try comptime testCmpVector(f32);
@@ -258,7 +261,8 @@ test "vector cmp f64" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
-    if (builtin.cpu.arch.isArm() and builtin.target.floatAbi() == .soft) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21234
+    if (builtin.cpu.arch.isArm()) return error.SkipZigTest;
+    if (builtin.cpu.arch.isPowerPC64()) return error.SkipZigTest;
 
     try testCmpVector(f64);
     try comptime testCmpVector(f64);
@@ -272,6 +276,8 @@ test "vector cmp f128" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+    if (builtin.cpu.arch.isArm()) return error.SkipZigTest;
+    if (builtin.cpu.arch.isPowerPC64()) return error.SkipZigTest;
 
     try testCmpVector(f128);
     try comptime testCmpVector(f128);
@@ -286,7 +292,6 @@ test "vector cmp f80/c_longdouble" {
     try comptime testCmpVector(c_longdouble);
 }
 fn testCmpVector(comptime T: type) !void {
-    @setEvalBranchQuota(4_000);
     var edges = [_]T{
         -math.inf(T),
         -math.floatMax(T),


### PR DESCRIPTION
Closes https://github.com/ziglang/zig/issues/21932

- Value: fix comparison of NaN in compareHeteroAdvanaced
- Sema: fix equality comparison of signed zeroes and NaN in compareScalar
- tests: add test coverage for vector float comparisons