### PR TITLE
Add note suggesting dropping try on non error-unions

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1754,9 +1754,9 @@ fn analyzeBodyInner(
                 const err_union = try sema.resolveInst(extra.data.operand);
                 const err_union_ty = sema.typeOf(err_union);
                 if (err_union_ty.zigTypeTag(zcu) != .error_union) {
-                    return sema.fail(block, operand_src, "expected error union type, found '{}'", .{
-                        err_union_ty.fmt(pt),
-                    });
+                    const msg = try sema.errMsg(operand_src, "expected error union type, found '{}'", .{err_union_ty.fmt(pt)});
+                    try sema.errNote(operand_src, msg, "consider omitting 'try'", .{});
+                    return sema.failWithOwnedErrorMsg(block, msg);
                 }
                 const is_non_err = try sema.analyzeIsNonErrComptimeOnly(block, operand_src, err_union);
                 assert(is_non_err != .none);
@@ -19840,9 +19840,9 @@ fn zirTry(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileError!
     const pt = sema.pt;
     const zcu = pt.zcu;
     if (err_union_ty.zigTypeTag(zcu) != .error_union) {
-        return sema.fail(parent_block, operand_src, "expected error union type, found '{}'", .{
-            err_union_ty.fmt(pt),
-        });
+        const msg = try sema.errMsg(operand_src, "expected error union type, found '{}'", .{err_union_ty.fmt(pt)});
+        try sema.errNote(operand_src, msg, "consider omitting 'try'", .{});
+        return sema.failWithOwnedErrorMsg(parent_block, msg);
     }
     const is_non_err = try sema.analyzeIsNonErrComptimeOnly(parent_block, operand_src, err_union);
     if (is_non_err != .none) {
@@ -19900,9 +19900,9 @@ fn zirTryPtr(sema: *Sema, parent_block: *Block, inst: Zir.Inst.Index) CompileErr
     const pt = sema.pt;
     const zcu = pt.zcu;
     if (err_union_ty.zigTypeTag(zcu) != .error_union) {
-        return sema.fail(parent_block, operand_src, "expected error union type, found '{}'", .{
-            err_union_ty.fmt(pt),
-        });
+        const msg = try sema.errMsg(operand_src, "expected error union type, found '{}'", .{err_union_ty.fmt(pt)});
+        try sema.errNote(operand_src, msg, "consider omitting 'try'", .{});
+        return sema.failWithOwnedErrorMsg(parent_block, msg);
     }
     const is_non_err = try sema.analyzeIsNonErrComptimeOnly(parent_block, operand_src, err_union);
     if (is_non_err != .none) {

--- a/test/cases/compile_errors/comptime_try_non_error.zig
+++ b/test/cases/compile_errors/comptime_try_non_error.zig
@@ -15,4 +15,5 @@ pub fn bar() u8 {
 // target=native
 //
 // :6:12: error: expected error union type, found 'u8'
+// :6:12: note: consider omitting 'try'
 // :2:8: note: called from here


### PR DESCRIPTION
Resolves #21845 

Output on `test/cases/compile_errors/comptime_try_non_error.zig`:
```
test/cases/compile_errors/comptime_try_non_error.zig:6:12: error: expected error union type, found 'u8'
    try bar();
        ~~~^~
test/cases/compile_errors/comptime_try_non_error.zig:6:12: note: consider omitting 'try'
test/cases/compile_errors/comptime_try_non_error.zig:2:8: note: called from here
    foo();
    ~~~^~
```

Output on example from issue:
```
> stage4/bin/zig build-exe a.zig
a.zig:6:44: error: expected error union type, found 'array_list.ArrayListAligned(u8,null)'
    const list = try std.ArrayList(u8).init(std.heap.page_allocator);
                     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
a.zig:6:44: note: consider omitting 'try'
```