### PR TITLE
spirv: miscellaneous vulkan + zig stuff

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1573,7 +1573,7 @@ pub const Cpu = struct {
                 .fs, .gs, .ss => arch == .x86_64 or arch == .x86,
                 .global, .constant, .local, .shared => is_gpu,
                 .param => is_nvptx,
-                .input, .output, .uniform, .push_constant => is_spirv,
+                .input, .output, .uniform, .push_constant, .storage_buffer => is_spirv,
                 // TODO this should also check how many flash banks the cpu has
                 .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => arch == .avr,
 

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -515,6 +515,7 @@ pub const AddressSpace = enum(u5) {
     output,
     uniform,
     push_constant,
+    storage_buffer,
 
     // AVR address spaces.
     flash,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -37852,7 +37852,7 @@ pub fn analyzeAsAddressSpace(
         .gs, .fs, .ss => (arch == .x86 or arch == .x86_64) and ctx == .pointer,
         // TODO: check that .shared and .local are left uninitialized
         .param => is_nv,
-        .input, .output, .uniform, .push_constant => is_spirv,
+        .input, .output, .uniform, .push_constant, .storage_buffer => is_spirv,
         .global, .shared, .local => is_gpu,
         .constant => is_gpu and (ctx == .constant),
         // TODO this should also check how many flash banks the cpu has

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -17605,6 +17605,8 @@ fn analyzePtrArithmetic(
         } else break :rs ptr_src;
     };
 
+    try sema.requireRuntimeBlock(block, op_src, runtime_src);
+
     const target = zcu.getTarget();
     if (target_util.arePointersLogical(target, ptr_info.flags.address_space)) {
         return sema.failWithOwnedErrorMsg(block, msg: {
@@ -17623,7 +17625,6 @@ fn analyzePtrArithmetic(
         });
     }
 
-    try sema.requireRuntimeBlock(block, op_src, runtime_src);
     return block.addInst(.{
         .tag = air_tag,
         .data = .{ .ty_pl = .{

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -4370,13 +4370,24 @@ const NavGen = struct {
         defer self.gpa.free(ids);
 
         const result_id = self.spv.allocId();
-        try self.func.body.emit(self.spv.gpa, .OpInBoundsPtrAccessChain, .{
-            .id_result_type = result_ty_id,
-            .id_result = result_id,
-            .base = base,
-            .element = element,
-            .indexes = ids,
-        });
+        const target = self.getTarget();
+        switch (target.os.tag) {
+            .opencl => try self.func.body.emit(self.spv.gpa, .OpInBoundsPtrAccessChain, .{
+                .id_result_type = result_ty_id,
+                .id_result = result_id,
+                .base = base,
+                .element = element,
+                .indexes = ids,
+            }),
+            .vulkan => try self.func.body.emit(self.spv.gpa, .OpPtrAccessChain, .{
+                .id_result_type = result_ty_id,
+                .id_result = result_id,
+                .base = base,
+                .element = element,
+                .indexes = ids,
+            }),
+            else => unreachable,
+        }
         return result_id;
     }
 

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1882,7 +1882,7 @@ const NavGen = struct {
                 else => unreachable,
             },
             .shared => .Workgroup,
-            .local => .Private,
+            .local => .Function,
             .global => switch (target.os.tag) {
                 .opencl => .CrossWorkgroup,
                 .vulkan => .PhysicalStorageBuffer,

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1396,10 +1396,6 @@ const NavGen = struct {
 
         const child_ty_id = try self.resolveType(child_ty, child_repr);
 
-        if (storage_class == .Uniform or storage_class == .PushConstant) {
-            try self.spv.decorate(child_ty_id, .Block);
-        }
-
         try self.spv.sections.types_globals_constants.emit(self.spv.gpa, .OpTypePointer, .{
             .id_result = result_id,
             .storage_class = storage_class,
@@ -1746,6 +1742,10 @@ const NavGen = struct {
                         defer self.gpa.free(type_name);
                         try self.spv.debugName(result_id, type_name);
 
+                        if (target.os.tag == .vulkan) {
+                            try self.spv.decorate(result_id, .Block); // Decorate all structs as block for now...
+                        }
+
                         return result_id;
                     },
                     .struct_type => ip.loadStructType(ty.toIntern()),
@@ -1790,6 +1790,10 @@ const NavGen = struct {
                 const type_name = try self.resolveTypeName(ty);
                 defer self.gpa.free(type_name);
                 try self.spv.debugName(result_id, type_name);
+
+                if (target.os.tag == .vulkan) {
+                    try self.spv.decorate(result_id, .Block); // Decorate all structs as block for now...
+                }
 
                 return result_id;
             },

--- a/src/codegen/spirv.zig
+++ b/src/codegen/spirv.zig
@@ -1893,6 +1893,7 @@ const NavGen = struct {
             .input => .Input,
             .output => .Output,
             .uniform => .Uniform,
+            .storage_buffer => .StorageBuffer,
             .gs,
             .fs,
             .ss,

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -296,7 +296,7 @@ fn writeCapabilities(spv: *SpvModule, target: std.Target) !void {
     // TODO: Integrate with a hypothetical feature system
     const caps: []const spec.Capability = switch (target.os.tag) {
         .opencl => &.{ .Kernel, .Addresses, .Int8, .Int16, .Int64, .Float64, .Float16, .Vector16, .GenericPointer },
-        .vulkan => &.{ .Shader, .PhysicalStorageBufferAddresses, .Int8, .Int16, .Int64, .Float64, .Float16 },
+        .vulkan => &.{ .Shader, .PhysicalStorageBufferAddresses, .Int8, .Int16, .Int64, .Float64, .Float16, .VariablePointers, .VariablePointersStorageBuffer },
         else => unreachable,
     };
 

--- a/src/link/SpirV/deduplicate.zig
+++ b/src/link/SpirV/deduplicate.zig
@@ -511,6 +511,14 @@ pub fn run(parser: *BinaryModule.Parser, binary: *BinaryModule, progress: std.Pr
             }
 
             if (maybe_result_id_offset == null or maybe_result_id_offset.? != i) {
+                // Only emit forward pointers before type, constant, and global instructions.
+                // Debug and Annotation instructions don't need the forward pointer, and it
+                // messes up the logical layout of the module.
+                switch (inst.opcode.class()) {
+                    .TypeDeclaration, .ConstantCreation, .Memory => {},
+                    else => continue,
+                }
+
                 const id: ResultId = @enumFromInt(operand.*);
                 const index = info.entities.getIndex(id) orelse continue;
                 const entity = info.entities.values()[index];

--- a/src/target.zig
+++ b/src/target.zig
@@ -458,7 +458,7 @@ pub fn arePointersLogical(target: std.Target, as: AddressSpace) bool {
         .global => false,
         // TODO: Allowed with VK_KHR_variable_pointers.
         .shared => true,
-        .constant, .local, .input, .output, .uniform, .push_constant => true,
+        .constant, .local, .input, .output, .uniform, .push_constant, .storage_buffer => true,
         else => unreachable,
     };
 }


### PR DESCRIPTION
This branch contains some fixes and improvements to help compile Andrew's DAW shaders converted to Zig (see https://codeberg.org/Snektron/daw/src/branch/main/shaders/ui.zig).

- Forbid more pointer arithmetic.
- Properly resolve type inputs in assembly. The frontend doesn't reject it yet so we might as well.
- Properly handle globals declared from inline assembly
- Make the default 'generic' address space for Vulkan be Function. We still need to change this properly, but at least things work now.
- Add the storabe_buffer address space
- Emit ArrayStride for many-item pointers
- Don't emit OpTypeForwardPointer for debug annotations
- Require variable pointers for now. Its important to note that these are not physical pointers, and we cannot do many things with them. We need variable pointers for now to enable ptr_elem_ptr, which is apparently not allowed without them if the base index is a pointer (and not a pointer to an array). Specifically, this is required for accessing elements in storage buffers: in Zig these are currently declared as a regular pointer, and so we need to be able to perform arithmetic on it. In GLSL these are usually OpTypeRuntimeArray, but there isn't really a satisfactory way to represent these in Zig currently.