### PR TITLE
 Sema: fix wording in error message 

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -5511,7 +5511,7 @@ fn failWithBadMemberAccess(
         else => unreachable,
     };
     if (agg_ty.typeDeclInst(zcu)) |inst| if ((inst.resolve(ip) orelse return error.AnalysisFail) == .main_struct_inst) {
-        return sema.fail(block, field_src, "root struct of file '{}' has no member named '{}'", .{
+        return sema.fail(block, field_src, "root source file struct '{}' has no member named '{}'", .{
             agg_ty.fmt(pt), field_name.fmt(ip),
         });
     };

--- a/test/cases/compile_errors/bogus_compile_var.zig
+++ b/test/cases/compile_errors/bogus_compile_var.zig
@@ -7,5 +7,5 @@ export fn entry() usize {
 // backend=stage2
 // target=native
 //
-// :1:29: error: root struct of file 'builtin' has no member named 'bogus'
+// :1:29: error: root source file struct 'builtin' has no member named 'bogus'
 // note: struct declared here

--- a/test/cases/compile_errors/missing_main_fn_in_executable.zig
+++ b/test/cases/compile_errors/missing_main_fn_in_executable.zig
@@ -3,7 +3,7 @@
 // target=x86_64-linux
 // output_mode=Exe
 //
-// : error: root struct of file 'tmp' has no member named 'main'
+// : error: root source file struct 'tmp' has no member named 'main'
 // : note: struct declared here
 // : note: called from here
 // : note: called from here

--- a/test/cases/hello_world_with_updates.0.zig
+++ b/test/cases/hello_world_with_updates.0.zig
@@ -3,4 +3,4 @@
 // target=x86_64-linux,x86_64-macos
 // link_libc=true
 //
-// :?:?: error: root struct of file 'tmp' has no member named 'main'
+// :?:?: error: root source file struct 'tmp' has no member named 'main'


### PR DESCRIPTION
~~I think omitting the .zig file extension here is bad for several reasons,
but one is that if you have a directory with two empty files called "x.zig" and
"x.zig.zig" and then compile x.zig.zig, it says this:~~
```
~/lib/std/start.zig:604:46: error: root struct of file 'x.zig' has no member named 'main'
    const ReturnType = @typeinfo(@typeof(root.main)).@"fn".return_type.?;
                                         ~~~~^~~~~
x.zig.zig:1:1: note: struct declared here

^
```
~~It talks about x.zig in the message, but then x.zig.zig in the note below.
That, even though it never talks about the actual x.zig which is in the same
directory. This is confusing.~~

~~This is just the file name and I considered making this the full path to the file
but I think for this the testing infrastructure for compile errors has to be
improved because if it's the full path it might contain random temporary files in the
error message which is untestable. Might not be a problem though.
The other reason is that the full path would already be shown in the "struct declared here"
note which should follow below.~~