### PR TITLE
Fix silent zig fmt errors

### DIFF
--- a/lib/compiler/fmt.zig
+++ b/lib/compiler/fmt.zig
@@ -213,7 +213,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool, dir: fs.Dir, sub_
     fmtPathFile(fmt, file_path, check_mode, dir, sub_path) catch |err| switch (err) {
         error.IsDir, error.AccessDenied => return fmtPathDir(fmt, file_path, check_mode, dir, sub_path),
         else => {
-            std.log.err("unable to format '{s}': {s}", .{file_path, @errorName(err)});
+            std.log.err("unable to format '{s}': {s}", .{ file_path, @errorName(err) });
             fmt.any_error = true;
             return;
         },
@@ -247,7 +247,7 @@ fn fmtPathDir(
                 try fmtPathDir(fmt, full_path, check_mode, dir, entry.name);
             } else {
                 fmtPathFile(fmt, full_path, check_mode, dir, entry.name) catch |err| {
-                    std.log.err("unable to format '{s}': {s}", .{full_path, @errorName(err)});
+                    std.log.err("unable to format '{s}': {s}", .{ full_path, @errorName(err) });
                     fmt.any_error = true;
                     return;
                 };

--- a/lib/compiler/fmt.zig
+++ b/lib/compiler/fmt.zig
@@ -3,7 +3,6 @@ const mem = std.mem;
 const fs = std.fs;
 const process = std.process;
 const Allocator = std.mem.Allocator;
-const warn = std.log.warn;
 const Color = std.zig.Color;
 
 const usage_fmt =
@@ -214,7 +213,7 @@ fn fmtPath(fmt: *Fmt, file_path: []const u8, check_mode: bool, dir: fs.Dir, sub_
     fmtPathFile(fmt, file_path, check_mode, dir, sub_path) catch |err| switch (err) {
         error.IsDir, error.AccessDenied => return fmtPathDir(fmt, file_path, check_mode, dir, sub_path),
         else => {
-            warn("unable to format '{s}': {s}", .{ file_path, @errorName(err) });
+            std.log.err("unable to format '{s}': {s}", .{file_path, @errorName(err)});
             fmt.any_error = true;
             return;
         },
@@ -248,7 +247,7 @@ fn fmtPathDir(
                 try fmtPathDir(fmt, full_path, check_mode, dir, entry.name);
             } else {
                 fmtPathFile(fmt, full_path, check_mode, dir, entry.name) catch |err| {
-                    warn("unable to format '{s}': {s}", .{ full_path, @errorName(err) });
+                    std.log.err("unable to format '{s}': {s}", .{full_path, @errorName(err)});
                     fmt.any_error = true;
                     return;
                 };


### PR DESCRIPTION
`zig fmt` would silently fail for paths that didn't exist. This caused me significant confusion when I was trying to format a file but I had a typo in the name - the command looked like it succeeded in the terminal, but the file wasn't changing.

The problem was due to using the warn log level for the error - in `.ReleaseSafe` and `.ReleaseFast` build modes `.warn` messages aren't printed. I think it's fair to use the error level since `FileNotFound` errors like this cause `zig fmt` to produce a nonzero exit code. 

