### PR TITLE
Flags for SIOC{G,S}IFFLAGS

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -7121,6 +7121,19 @@ pub const SIOCPROTOPRIVATE = 0x89E0;
 
 pub const IFNAMESIZE = 16;
 
+pub const IFF = packed struct(u16) {
+    UP: bool = false,
+    BROADCAST: bool = false,
+    DEBUG: bool = false,
+    LOOPBACK: bool = false,
+    POINTOPOINT: bool = false,
+    NOTRAILERS: bool = false,
+    RUNNING: bool = false,
+    NOARP: bool = false,
+    PROMISC: bool = false,
+    _9: u7 = 0,
+};
+
 pub const ifmap = extern struct {
     mem_start: usize,
     mem_end: usize,
@@ -7140,7 +7153,7 @@ pub const ifreq = extern struct {
         broadaddr: sockaddr,
         netmask: sockaddr,
         hwaddr: sockaddr,
-        flags: i16,
+        flags: IFF,
         ivalue: i32,
         mtu: i32,
         map: ifmap,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -104,6 +104,7 @@ pub const SIOCGIFINDEX = system.SIOCGIFINDEX;
 pub const SO = system.SO;
 pub const SOCK = system.SOCK;
 pub const SOL = system.SOL;
+pub const IFF = system.IFF;
 pub const STDERR_FILENO = system.STDERR_FILENO;
 pub const STDIN_FILENO = system.STDIN_FILENO;
 pub const STDOUT_FILENO = system.STDOUT_FILENO;


### PR DESCRIPTION
Adds a packed struct for SIOCGIFFLAGS and SIOCSIFFLAGS

Addresses #21890
Quick checked this with the following code.

```
const std = @import("std");

pub fn main() !void {
    const sock = try std.posix.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, 0);
    const ifname = "wlp0s20f3";
    var ifr: std.posix.ifreq = std.mem.zeroInit(std.posix.ifreq, .{});
    @memcpy(ifr.ifrn.name[0..ifname.len], ifname);
    ifr.ifrn.name[ifname.len] = 0;
    try std.posix.ioctl_SIOCGIFINDEX(sock, &ifr);
    const rval = std.posix.errno(std.os.linux.ioctl(sock, std.os.linux.SIOCGIFFLAGS, @intFromPtr(&ifr)));
    if (rval != .SUCCESS) {
        return error.FlagsGetFailed;
    }

    std.debug.print("Flags set:\n", .{});

    if (ifr.ifru.flags.UP) {
        std.debug.print("UP\n", .{});
    }
    if (ifr.ifru.flags.BROADCAST) {
        std.debug.print("BROADCAST\n", .{});
    }
    if (ifr.ifru.flags.DEBUG) {
        std.debug.print("DEBUG\n", .{});
    }
    if (ifr.ifru.flags.LOOPBACK) {
        std.debug.print("LOOPBACK\n", .{});
    }
    if (ifr.ifru.flags.POINTOPOINT) {
        std.debug.print("POINTOPOINT\n", .{});
    }
    if (ifr.ifru.flags.NOTRAILERS) {
        std.debug.print("NOTRAILERS\n", .{});
    }
    if (ifr.ifru.flags.RUNNING) {
        std.debug.print("RUNNING\n", .{});
    }
    if (ifr.ifru.flags.NOARP) {
        std.debug.print("NOARP\n", .{});
    }
    if (ifr.ifru.flags.PROMISC) {
        std.debug.print("PROMISC\n", .{});
    }

    // requires elevated permissions to execute
    // ifr.ifru.flags.PROMISC = true;
    // ifr.ifru.flags.BROADCAST = true;

    // rval = std.posix.errno(std.os.linux.ioctl(sock, std.os.linux.SIOCSIFFLAGS, @intFromPtr(&ifr)));
    // switch (rval) {
    //     .SUCCESS => {},
    //     .PERM => return error.FailedPermissions,
    //     else => {},
    // }
}

```