### PR TITLE
Fix std.c.EXC.MASK struct to match definition in mach/exception_types.h

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -59,7 +59,7 @@ pub const EXC = enum(exception_type_t) {
     pub const SOFT_SIGNAL = 0x10003;
 
     pub const MASK = packed struct(u32) {
-        _bit0_unused: bool = false,
+        _0: u1 = 0,
         BAD_ACCESS: bool = false,
         BAD_INSTRUCTION: bool = false,
         ARITHMETIC: bool = false,
@@ -73,7 +73,7 @@ pub const EXC = enum(exception_type_t) {
         RESOURCE: bool = false,
         GUARD: bool = false,
         CORPSE_NOTIFY: bool = false,
-        _pad: u18 = 0,
+        _14: u18 = 0,
 
         pub const MACHINE: MASK = @bitCast(@as(u32, 0));
 

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -59,6 +59,7 @@ pub const EXC = enum(exception_type_t) {
     pub const SOFT_SIGNAL = 0x10003;
 
     pub const MASK = packed struct(u32) {
+        _bit0_unused: bool = false,
         BAD_ACCESS: bool = false,
         BAD_INSTRUCTION: bool = false,
         ARITHMETIC: bool = false,
@@ -72,6 +73,7 @@ pub const EXC = enum(exception_type_t) {
         RESOURCE: bool = false,
         GUARD: bool = false,
         CORPSE_NOTIFY: bool = false,
+        _pad: u18 = 0,
 
         pub const MACHINE: MASK = @bitCast(@as(u32, 0));
 


### PR DESCRIPTION
This change fixes two issues:
1. The Zig definition of `std.c.EXC.MASK` had the mask flags starting at bit 0, but the header it's copying has this:

```c
#define EXC_BAD_ACCESS          1

...

/*
 * Masks for exception definitions, above
 * bit zero is unused, therefore 1 word = 31 exception types
 */

#define EXC_MASK_BAD_ACCESS             (1 << EXC_BAD_ACCESS)
```

2. the structure wasn't padded to 32 bits

Obviously the mask isn't used anywhere is zig, because it would've caused a packed structure padding compile error. On the chance that it is used in the future, either by the compiler, or as an api provided by std, I figured I'd save future poor souls from mysterious bugs caused by the mask flags bits being off by one bit.