### PR TITLE
`Compilation`: Pass `-municode` on to Clang.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5625,6 +5625,10 @@ pub fn addCCArgs(
         },
     }
 
+    if (comp.mingw_unicode_entry_point) {
+        try argv.append("-municode");
+    }
+
     if (target.cpu.arch.isThumb()) {
         try argv.append("-mthumb");
     }


### PR DESCRIPTION
This is supposed to define the UNICODE macro; it's not just a linker option.

Closes #21978.