### PR TITLE
`std.meta.eql`: use `==` directly when comparing `packed struct`s

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -738,7 +738,7 @@ test TagPayload {
 }
 
 /// Compares two of any type for equality. Containers that do not support comparison
-/// are compared field-wise.Pointers are not followed.
+/// are compared on a field-by-field basis. Pointers are not followed.
 pub fn eql(a: anytype, b: @TypeOf(a)) bool {
     const T = @TypeOf(a);
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -738,7 +738,7 @@ test TagPayload {
 }
 
 /// Compares two of any type for equality. Containers that do not support comparison
-/// are compared on a field-by-field basis. Pointers are not followed.
+/// on their own are compared on a field-by-field basis. Pointers are not followed.
 pub fn eql(a: anytype, b: @TypeOf(a)) bool {
     const T = @TypeOf(a);
 

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -737,13 +737,15 @@ test TagPayload {
     try testing.expect(MovedEvent == @TypeOf(e.Moved));
 }
 
-/// Compares two of any type for equality. Containers are compared on a field-by-field basis,
-/// where possible. Pointers are not followed.
+/// Compares two of any type for equality. Containers that do not support comparison
+/// are compared field-wise.Pointers are not followed.
 pub fn eql(a: anytype, b: @TypeOf(a)) bool {
     const T = @TypeOf(a);
 
     switch (@typeInfo(T)) {
         .@"struct" => |info| {
+            if (info.layout == .@"packed") return a == b;
+
             inline for (info.fields) |field_info| {
                 if (!eql(@field(a, field_info.name), @field(b, field_info.name))) return false;
             }


### PR DESCRIPTION
Implementation of `std.meta.eql` updated to reflect the changes made by #21678. This is a breaking change as floats contained within `packed struct`s are now compared bitwise (this might be a reason to reject this pull request).