### PR TITLE
treat errno(6) (NXIO) as expected error in openatZ

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1817,6 +1817,7 @@ pub fn openatZ(dir_fd: fd_t, file_path: [*:0]const u8, flags: O, mode: mode_t) O
             .OPNOTSUPP => return error.FileLocksNotSupported,
             .AGAIN => return error.WouldBlock,
             .TXTBSY => return error.FileBusy,
+            .NXIO => return error.NoDevice,
             .ILSEQ => |err| if (native_os == .wasi)
                 return error.InvalidUtf8
             else


### PR DESCRIPTION
This PR adds explicitly handling of NXIO (errono(6)) to `std.posix.openatZ` to avoid verbose output when this error occurs.

related to: #18240 
