### PR TITLE
Add missing `pthread_key_t` definition for Darwin

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -7028,6 +7028,7 @@ pub const pthread_attr_t = switch (native_os) {
 
 pub const pthread_key_t = switch (native_os) {
     .linux, .emscripten => c_uint,
+    .macos, .ios, .tvos, .watchos, .visionos => c_ulong,
     .openbsd, .solaris, .illumos => c_int,
     else => void,
 };


### PR DESCRIPTION
The `pthread_key_t` type is currently defined as `void` on Darwin, making the `pthread_key_*` functions fail to compile. This defines it as a `c_ulong`.