### PR TITLE
Remove unused `buf` field from `std.fmt.Parser`

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -310,6 +310,8 @@ pub const Specifier = union(enum) {
     named: []const u8,
 };
 
+/// Intended for parsing std.fmt format strings without having to replicate the
+/// standard library behavior.
 pub const Parser = struct {
     pos: usize = 0,
     iter: std.unicode.Utf8Iterator,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -224,7 +224,6 @@ pub const Placeholder = struct {
     pub fn parse(comptime str: anytype) Placeholder {
         const view = std.unicode.Utf8View.initComptime(&str);
         comptime var parser = Parser{
-            .buf = &str,
             .iter = view.iterator(),
         };
 
@@ -312,9 +311,8 @@ pub const Specifier = union(enum) {
 };
 
 pub const Parser = struct {
-    buf: []const u8,
     pos: usize = 0,
-    iter: std.unicode.Utf8Iterator = undefined,
+    iter: std.unicode.Utf8Iterator,
 
     // Returns a decimal number or null if the current character is not a
     // digit

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -310,8 +310,10 @@ pub const Specifier = union(enum) {
     named: []const u8,
 };
 
-/// Intended for parsing std.fmt format strings without having to replicate the
-/// standard library behavior.
+/// A stream based parser for format strings.
+///
+/// Allows to implement formatters compatible with std.fmt without replicating
+/// the standard library behavior.
 pub const Parser = struct {
     pos: usize = 0,
     iter: std.unicode.Utf8Iterator,


### PR DESCRIPTION
And make the initialization less error prone by removing a default for `iter`, which is required for a functional parser.