### PR TITLE
Use options debug format if it is provided

### DIFF
--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -433,9 +433,7 @@ pub fn resolve(options: Options) ResolveError!Config {
 
     const debug_format: DebugFormat = b: {
         if (root_strip and !options.any_non_stripped) break :b .strip;
-        if (options.debug_format) |options_format| {
-            break :b options_format;
-        }
+        if (options.debug_format) |x| break :b x;
         break :b switch (target.ofmt) {
             .elf, .goff, .macho, .wasm, .xcoff => .{ .dwarf = .@"32" },
             .coff => .code_view,

--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -433,6 +433,9 @@ pub fn resolve(options: Options) ResolveError!Config {
 
     const debug_format: DebugFormat = b: {
         if (root_strip and !options.any_non_stripped) break :b .strip;
+        if (options.debug_format) |options_format| {
+            break :b options_format;
+        }
         break :b switch (target.ofmt) {
             .elf, .goff, .macho, .wasm, .xcoff => .{ .dwarf = .@"32" },
             .coff => .code_view,


### PR DESCRIPTION
Closes #19478 

As in the linked issue:

hello.zig
```
const std = @import("std");
pub fn main() void {
     std.debug.print("Hello, ziguana\n", .{});
}
```

Compilation and debug info
```
/home/bhetz -> zig build-obj -gdwarf64 -ODebug -target x86_64-linux hello.zig 
/home/bhetz -> objdump --dwarf=info hello.o | head -n 10

hello.o:     file format elf64-x86-64

Contents of the .debug_info section:

  Compilation Unit @ offset 0:
   Length:        0x3c779 (64-bit)
   Version:       4
   Abbrev Offset: 0
   Pointer Size:  8
/home/bhetz -> zig build-obj -gdwarf32 -ODebug -target x86-linux hello.zig 
/home/bhetz -> objdump --dwarf=info hello.o | head -n 10

hello.o:     file format elf32-i386

Contents of the .debug_info section:

  Compilation Unit @ offset 0:
   Length:        0x2c404 (32-bit)
   Version:       4
   Abbrev Offset: 0
   Pointer Size:  4
``` 