### PR TITLE
link: fix failing incremental test cases

### DIFF
--- a/src/dev.zig
+++ b/src/dev.zig
@@ -23,7 +23,7 @@ pub const Env = enum {
     sema,
 
     /// - sema
-    /// - `zig build-* -fno-llvm -fno-lld -target x86_64-linux`
+    /// - `zig build-* -fincremental -fno-llvm -fno-lld -target x86_64-linux --listen=-`
     @"x86_64-linux",
 
     /// - sema
@@ -130,6 +130,8 @@ pub const Env = enum {
                 else => Env.ast_gen.supports(feature),
             },
             .@"x86_64-linux" => switch (feature) {
+                .stdio_listen,
+                .incremental,
                 .x86_64_backend,
                 .elf_linker,
                 => true,

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -1496,7 +1496,7 @@ pub fn updateFunc(
             });
             defer gpa.free(name);
             const osec = if (self.text_index) |sect_sym_index|
-                self.atom(self.symbol(sect_sym_index).ref.index).?.output_section_index
+                self.symbol(sect_sym_index).output_section_index
             else osec: {
                 const osec = try elf_file.addSection(.{
                     .name = try elf_file.insertShString(".text"),
@@ -1896,12 +1896,13 @@ pub fn deleteExport(
     } orelse return;
     const zcu = elf_file.base.comp.zcu.?;
     const exp_name = name.toSlice(&zcu.intern_pool);
-    const esym_index = metadata.@"export"(self, exp_name) orelse return;
+    const sym_index = metadata.@"export"(self, exp_name) orelse return;
     log.debug("deleting export '{s}'", .{exp_name});
-    const esym = &self.symtab.items(.elf_sym)[esym_index.*];
+    const esym_index = self.symbol(sym_index.*).esym_index;
+    const esym = &self.symtab.items(.elf_sym)[esym_index];
     _ = self.globals_lookup.remove(esym.st_name);
     esym.* = Elf.null_sym;
-    self.symtab.items(.shndx)[esym_index.*] = elf.SHN_UNDEF;
+    self.symtab.items(.shndx)[esym_index] = elf.SHN_UNDEF;
 }
 
 pub fn getGlobalSymbol(self: *ZigObject, elf_file: *Elf, name: []const u8, lib_name: ?[]const u8) !u32 {

--- a/test/incremental/add_decl
+++ b/test/incremental/add_decl
@@ -1,5 +1,4 @@
-// Disabled on self-hosted due to linker crash
-// #target=x86_64-linux-selfhosted
+#target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
 #target=x86_64-windows-cbe
 #update=initial version

--- a/test/incremental/fix_astgen_failure
+++ b/test/incremental/fix_astgen_failure
@@ -1,5 +1,4 @@
-// Disabled on self-hosted due to linker crash
-// #target=x86_64-linux-selfhosted
+#target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
 #target=x86_64-windows-cbe
 #update=initial version with error

--- a/test/incremental/function_becomes_inline
+++ b/test/incremental/function_becomes_inline
@@ -1,4 +1,4 @@
-//#target=x86_64-linux-selfhosted
+#target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
 #target=x86_64-windows-cbe
 #update=non-inline version

--- a/test/incremental/recursive_function_becomes_non_recursive
+++ b/test/incremental/recursive_function_becomes_non_recursive
@@ -1,4 +1,4 @@
-//#target=x86_64-linux-selfhosted
+#target=x86_64-linux-selfhosted
 #target=x86_64-linux-cbe
 #target=x86_64-windows-cbe
 #update=initial version


### PR DESCRIPTION
`zig build test-incremental` now passes with an llvm backend compiled `zig`, but not a self-hosted backend compiled `zig`.

Followup #21961