### PR TITLE
`Compilation`: Disable LTO for mips n32.

### DIFF
--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -294,6 +294,12 @@ pub fn resolve(options: Options) ResolveError!Config {
         if (options.lto) |x| break :b x;
         if (!options.any_c_source_files) break :b false;
 
+        // https://github.com/llvm/llvm-project/pull/116537
+        if (target.cpu.arch.isMIPS64()) switch (target.abi) {
+            .gnuabin32, .muslabin32 => break :b false,
+            else => {},
+        };
+
         if (target.cpu.arch.isRISCV()) {
             // Clang and LLVM currently don't support RISC-V target-abi for LTO.
             // Compiling with LTO may fail or produce undesired results.


### PR DESCRIPTION
See: https://github.com/llvm/llvm-project/pull/116537