### PR TITLE
fixes some compiler errors for darwin in #21094

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -928,7 +928,7 @@ pub const OS_SIGNPOST_ID_NULL: os_signpost_id_t = 0;
 pub const OS_SIGNPOST_ID_INVALID: os_signpost_id_t = !0;
 pub const OS_SIGNPOST_ID_EXCLUSIVE: os_signpost_id_t = 0xeeeeb0b5b2b2eeee;
 
-pub const os_log_t = opaque {};
+pub const os_log_t = *opaque {};
 pub const os_log_type_t = enum(u8) {
     /// default messages always captures
     OS_LOG_TYPE_DEFAULT = 0x00,
@@ -946,13 +946,13 @@ pub const OS_LOG_CATEGORY_POINTS_OF_INTEREST: *const u8 = "PointsOfInterest";
 pub const OS_LOG_CATEGORY_DYNAMIC_TRACING: *const u8 = "DynamicTracing";
 pub const OS_LOG_CATEGORY_DYNAMIC_STACK_TRACING: *const u8 = "DynamicStackTracing";
 
-pub extern "c" fn os_log_create(subsystem: [*]const u8, category: [*]const u8) *os_log_t;
-pub extern "c" fn os_log_type_enabled(log: *os_log_t, tpe: os_log_type_t) bool;
-pub extern "c" fn os_signpost_id_generate(log: *os_log_t) os_signpost_id_t;
-pub extern "c" fn os_signpost_interval_begin(log: *os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
-pub extern "c" fn os_signpost_interval_end(log: *os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
-pub extern "c" fn os_signpost_id_make_with_pointer(log: *os_log_t, ptr: ?*anyopaque) os_signpost_id_t;
-pub extern "c" fn os_signpost_enabled(log: *os_log_t) bool;
+pub extern "c" fn os_log_create(subsystem: [*]const u8, category: [*]const u8) os_log_t;
+pub extern "c" fn os_log_type_enabled(log: os_log_t, tpe: os_log_type_t) bool;
+pub extern "c" fn os_signpost_id_generate(log: os_log_t) os_signpost_id_t;
+pub extern "c" fn os_signpost_interval_begin(log: os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
+pub extern "c" fn os_signpost_interval_end(log: os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
+pub extern "c" fn os_signpost_id_make_with_pointer(log: os_log_t, ptr: ?*anyopaque) os_signpost_id_t;
+pub extern "c" fn os_signpost_enabled(log: os_log_t) bool;
 
 pub extern "c" fn pthread_setname_np(name: [*:0]const u8) c_int;
 pub extern "c" fn pthread_attr_set_qos_class_np(attr: *pthread_attr_t, qos_class: qos_class_t, relative_priority: c_int) c_int;

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -946,13 +946,13 @@ pub const OS_LOG_CATEGORY_POINTS_OF_INTEREST: *const u8 = "PointsOfInterest";
 pub const OS_LOG_CATEGORY_DYNAMIC_TRACING: *const u8 = "DynamicTracing";
 pub const OS_LOG_CATEGORY_DYNAMIC_STACK_TRACING: *const u8 = "DynamicStackTracing";
 
-pub extern "c" fn os_log_create(subsystem: [*]const u8, category: [*]const u8) os_log_t;
-pub extern "c" fn os_log_type_enabled(log: os_log_t, tpe: os_log_type_t) bool;
-pub extern "c" fn os_signpost_id_generate(log: os_log_t) os_signpost_id_t;
-pub extern "c" fn os_signpost_interval_begin(log: os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
-pub extern "c" fn os_signpost_interval_end(log: os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
-pub extern "c" fn os_signpost_id_make_with_pointer(log: os_log_t, ptr: ?*anyopaque) os_signpost_id_t;
-pub extern "c" fn os_signpost_enabled(log: os_log_t) bool;
+pub extern "c" fn os_log_create(subsystem: [*]const u8, category: [*]const u8) *os_log_t;
+pub extern "c" fn os_log_type_enabled(log: *os_log_t, tpe: os_log_type_t) bool;
+pub extern "c" fn os_signpost_id_generate(log: *os_log_t) os_signpost_id_t;
+pub extern "c" fn os_signpost_interval_begin(log: *os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
+pub extern "c" fn os_signpost_interval_end(log: *os_log_t, signpos: os_signpost_id_t, func: [*]const u8, ...) void;
+pub extern "c" fn os_signpost_id_make_with_pointer(log: *os_log_t, ptr: ?*anyopaque) os_signpost_id_t;
+pub extern "c" fn os_signpost_enabled(log: *os_log_t) bool;
 
 pub extern "c" fn pthread_setname_np(name: [*:0]const u8) c_int;
 pub extern "c" fn pthread_attr_set_qos_class_np(attr: *pthread_attr_t, qos_class: qos_class_t, relative_priority: c_int) c_int;


### PR DESCRIPTION
Fixes most of the compiler errors in #21094 regarding darwin. Changed the functions to return/take *os_log_t instead of os_log_t as it seems that os_log_t is an alias for a pointer in apples docs.