### PR TITLE
`libunwind`: Fix compilation for the x32 ABI.

### DIFF
--- a/lib/libunwind/include/__libunwind_config.h
+++ b/lib/libunwind/include/__libunwind_config.h
@@ -53,6 +53,9 @@
 #    else
 #      define _LIBUNWIND_CURSOR_SIZE 66
 #    endif
+#  elif defined(__ILP32__)
+#    define _LIBUNWIND_CONTEXT_SIZE 21
+#    define _LIBUNWIND_CURSOR_SIZE 28
 #  else
 #    define _LIBUNWIND_CONTEXT_SIZE 21
 #    define _LIBUNWIND_CURSOR_SIZE 33


### PR DESCRIPTION
See: https://github.com/llvm/llvm-project/pull/116608

This addresses:

* https://github.com/ziglang/zig-bootstrap/issues/20#issuecomment-2480917999
* https://github.com/ziglang/zig-bootstrap/issues/199