### PR TITLE
`Compilation`: Disable LTO for all ILP32-on-LP64 ABIs.

### DIFF
--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -295,10 +295,16 @@ pub fn resolve(options: Options) ResolveError!Config {
         if (!options.any_c_source_files) break :b false;
 
         // https://github.com/llvm/llvm-project/pull/116537
-        if (target.cpu.arch.isMIPS64()) switch (target.abi) {
-            .gnuabin32, .muslabin32 => break :b false,
+        switch (target.abi) {
+            .gnuabin32,
+            .gnuilp32,
+            .gnux32,
+            .ilp32,
+            .muslabin32,
+            .muslx32,
+            => break :b false,
             else => {},
-        };
+        }
 
         if (target.cpu.arch.isRISCV()) {
             // Clang and LLVM currently don't support RISC-V target-abi for LTO.


### PR DESCRIPTION
Extension of 3a6a8b8aa540413d099a6f41a0d8f882f22acb45 (#22006) to all similar ABIs. The LLD issue affects them all.