### PR TITLE
fmt: add -fjit flag to zig fmt

### DIFF
--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -29,6 +29,17 @@ const Fmt = struct {
     const SeenMap = std.AutoHashMap(fs.File.INode, void);
 };
 
+pub fn main() !void {
+    var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_instance.deinit();
+    const arena = arena_instance.allocator();
+    const gpa = arena;
+
+    const args = try process.argsAlloc(arena);
+
+    return run(gpa, arena, args[1..]);
+}
+
 pub fn run(
     gpa: Allocator,
     arena: Allocator,
@@ -74,6 +85,10 @@ pub fn run(
                     i += 1;
                     const next_arg = args[i];
                     try excluded_files.append(next_arg);
+                } else if (mem.eql(u8, arg, "-fjit")) {
+                    if (i != 0) {
+                        fatal("-fjit must be the first argument when specified", .{});
+                    }
                 } else {
                     fatal("unrecognized parameter: '{s}'", .{arg});
                 }


### PR DESCRIPTION
There wasn't really a "good" way to do this. Realistically, I would want to move src/fmt.zig back to lib/compiler/fmt.zig, but one would not be able to `@import` it from there. Moving lib into src/ would be a bit extreme. One could also consider moving main.zig into the repository root. Another possible option I considered was for src/fmt.zig to be copied to the destination libdir by build.zig (but one has to consider what happens with `-Dno-lib` builds).

This implementation assumes that a `src` directory is available in a parent i.e. we are in a zig build tree. If this assumption fails, we fall back to looking in `lib/compiler` for fmt.zig.

Happy for this to be closed if unwanted.