### PR TITLE
`compiler-rt`: Fix `R_ARM_ABS32` relocation error in `__clzsi2_thumb1()`.

### DIFF
--- a/lib/compiler_rt/count0bits.zig
+++ b/lib/compiler_rt/count0bits.zig
@@ -73,13 +73,13 @@ fn __clzsi2_thumb1() callconv(.Naked) void {
         \\ subs r1, #4
         \\ movs r0, r2
         \\ 1:
-        \\ ldr r3, =LUT
+        \\ ldr r3, .lut
         \\ ldrb r0, [r3, r0]
         \\ subs r0, r1, r0
         \\ bx lr
         \\ .p2align 2
         \\ // Number of bits set in the 0-15 range
-        \\ LUT:
+        \\ .lut:
         \\ .byte 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4
     );
 


### PR DESCRIPTION
Closes #22050.