### PR TITLE
`std.math`: Disable `isSignalNan` test on mips32.

### DIFF
--- a/lib/std/math/isnan.zig
+++ b/lib/std/math/isnan.zig
@@ -34,6 +34,7 @@ test isSignalNan {
         //       See https://github.com/ziglang/zig/issues/14366
         if (!builtin.cpu.arch.isArm() and
             !builtin.cpu.arch.isAARCH64() and
+            !builtin.cpu.arch.isMIPS32() and
             !builtin.cpu.arch.isPowerPC() and
             builtin.zig_backend != .stage2_c)
         {


### PR DESCRIPTION
https://github.com/ziglang/zig/issues/14366