### PR TITLE
Updated ascii.zig's isWhitespace function to use switch instead of for loop.

### DIFF
--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -136,7 +136,7 @@ pub fn isPrint(c: u8) bool {
 /// Returns whether this character is included in `whitespace`.
 pub fn isWhitespace(c: u8) bool {
     return switch (c) {
-        '\t'...'\r', ' ' => true,
+        ' ', '\t'...'\r' => true,
         else => false,
     };
 }

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -135,10 +135,10 @@ pub fn isPrint(c: u8) bool {
 
 /// Returns whether this character is included in `whitespace`.
 pub fn isWhitespace(c: u8) bool {
-    return for (whitespace) |other| {
-        if (c == other)
-            break true;
-    } else false;
+    return switch (c) {
+        ' ', '\t', '\n', '\r', control_code.vt, control_code.ff => true,
+        else => false,
+    };
 }
 
 /// Whitespace for general use.

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -136,7 +136,7 @@ pub fn isPrint(c: u8) bool {
 /// Returns whether this character is included in `whitespace`.
 pub fn isWhitespace(c: u8) bool {
     return switch (c) {
-        ' ', '\t', '\n', '\r', control_code.vt, control_code.ff => true,
+        '\t'...'\r', ' ' => true,
         else => false,
     };
 }


### PR DESCRIPTION
Instead of using a loop, using a switch statement might be better in the following scenario:

Before:

```zig
pub fn isWhitespace(c: u8) bool {
    return for (whitespace) |other| {
        if (c == other)
            break true;
    } else false;
}
```
After:
```zig
pub fn isWhitespace(c: u8) bool {
    return switch (c) {
        ' ', '\t'...'\r' => true,
        else => false,
    };
}
```

https://godbolt.org/z/TWfnvdnbf