### PR TITLE
I/O peeking

### DIFF
--- a/lib/std/io/Reader.zig
+++ b/lib/std/io/Reader.zig
@@ -344,20 +344,8 @@ pub fn readStructEndian(self: Self, comptime T: type, endian: std.builtin.Endian
 /// an enum tag, casts the integer to the enum tag and returns it. Otherwise, returns an `error.InvalidValue`.
 /// TODO optimization taking advantage of most fields being in order
 pub fn readEnum(self: Self, comptime Enum: type, endian: std.builtin.Endian) anyerror!Enum {
-    const E = error{
-        /// An integer was read, but it did not match any of the tags in the supplied enum.
-        InvalidValue,
-    };
-    const type_info = @typeInfo(Enum).@"enum";
-    const tag = try self.readInt(type_info.tag_type, endian);
-
-    inline for (std.meta.fields(Enum)) |field| {
-        if (tag == field.value) {
-            return @field(Enum, field.name);
-        }
-    }
-
-    return E.InvalidValue;
+        const buf = try self.readBytesNoEof(@divExact(@typeInfo(@typeInfo(Enum).@"enum".tag_type).int.bits, 8));
+        return std.mem.readEnum(Enum, &buf, endian);
 }
 
 /// Reads the stream until the end, ignoring all the data.


### PR DESCRIPTION
Introduce:
- `std.io.GenericPeeker` and `std.io.AnyPeeker`, interfaces to a peekable stream.
- peeking support in `std.io.BufferedReader`
- peeking support in `std.io.FixedBufferStream`

This is intended to be a simple, well-tested, good-enough solution that still provides a rich API and fits well with the existing I/O APIs until they get the rewrite they deserve. It resolves the main issue of `PeekStream`: its redundancy with `BufferedReader`, as well as doing more than `PeekStream` used to provide by supporting similar operations to the `Reader`s and being more flexible by not requiring a buffer and forgoing the `ungetc`/`putBack`-style API.

https://github.com/ziglang/zig/blob/513b44e49a19e4947dbd45d32472fb75052b9412/lib/std/io.zig#L373-L389

resolve #4501 
previously: #19310 #16114 #4878 #4505
related: #19297