### PR TITLE
Some portability improvements and cleanups in `zig.h`

### DIFF
--- a/lib/zig.h
+++ b/lib/zig.h
@@ -68,9 +68,16 @@
 #define zig_x86
 #endif
 
+#if defined(__has_include)
+#define zig_has_include(include) __has_include(include)
+#else
+#define zig_has_include(include) 0
+#endif
+
 #ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
 #define __STDC_WANT_IEC_60559_TYPES_EXT__
 #endif
+
 #include <float.h>
 #include <limits.h>
 #include <stdarg.h>
@@ -82,7 +89,7 @@
 
 #if __STDC_VERSION__ >= 202311L
 /* bool, true, and false are provided by the language. */
-#elif __STDC_VERSION__ >= 199901L
+#elif __STDC_VERSION__ >= 199901L || zig_has_include(<stdbool.h>)
 #include <stdbool.h>
 #else
 typedef char bool;
@@ -428,7 +435,7 @@ zig_extern void *memset (void *, int, size_t);
 
 /* ===================== 8/16/32/64-bit Integer Support ===================== */
 
-#if __STDC_VERSION__ >= 199901L || defined(zig_msvc)
+#if __STDC_VERSION__ >= 199901L || defined(zig_msvc) || zig_has_include(<stdint.h>)
 #include <stdint.h>
 #else
 
@@ -3655,7 +3662,7 @@ zig_float_builtins(64)
     res = zig_atomicrmw_expected; \
 } while (0)
 
-#if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+#if (__STDC_VERSION__ >= 201112L || (zig_has_include(<stdatomic.h>) && !defined(zig_msvc))) && !defined(__STDC_NO_ATOMICS__)
 #include <stdatomic.h>
 typedef enum memory_order zig_memory_order;
 #define zig_memory_order_relaxed memory_order_relaxed

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -10,6 +10,8 @@
 #define zig_gnuc
 #elif defined(__GNUC__)
 #define zig_gnuc
+#elif defined(__IBMC__)
+#define zig_xlc
 #elif defined(__TINYC__)
 #define zig_tinyc
 #elif defined(__slimcc__)
@@ -77,6 +79,18 @@
 #else
 #define zig_little_endian 0
 #define zig_big_endian 1
+#endif
+
+#if defined(_WIN32)
+#define zig_coff
+#elif defined(__ELF__)
+#define zig_elf
+#elif defined(__MVS__)
+#define zig_goff
+#elif defined(__MACH__)
+#define zig_macho
+#elif defined(_AIX)
+#define zig_xcoff
 #endif
 
 #define zig_concat(lhs, rhs) lhs##rhs
@@ -236,14 +250,14 @@
 #define zig_mangle_c(symbol) "_" symbol
 #endif /* zig_x86_64 */
 #else /* zig_msvc */
-#if __APPLE__
+#if defined(zig_macho)
 #define zig_mangle_c(symbol) "_" symbol
-#else /* __APPLE__ */
+#else /* zig_macho */
 #define zig_mangle_c(symbol) symbol
-#endif /* __APPLE__ */
+#endif /* zig_macho */
 #endif /* zig_msvc */
 
-#if (zig_has_attribute(alias) || defined(zig_tinyc)) && !__APPLE__
+#if (zig_has_attribute(alias) || defined(zig_tinyc)) && !defined(zig_macho)
 #define zig_export(symbol, name) __attribute__((alias(symbol)))
 #elif defined(zig_msvc)
 #define zig_export(symbol, name) ; \

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -13,6 +13,61 @@
 #define zig_slimcc
 #endif
 
+#if defined(__aarch64__) || (defined(zig_msvc) && defined(_M_ARM64))
+#define zig_aarch64
+#elif defined(__thumb__) || (defined(zig_msvc) && defined(_M_ARM))
+#define zig_thumb
+#define zig_arm
+#elif defined(__arm__)
+#define zig_arm
+#elif defined(__hexagon__)
+#define zig_hexagon
+#elif defined(__loongarch32)
+#define zig_loongarch32
+#define zig_loongarch
+#elif defined(__loongarch64)
+#define zig_loongarch64
+#define zig_loongarch
+#elif defined(__mips64)
+#define zig_mips64
+#define zig_mips
+#elif defined(__mips__)
+#define zig_mips32
+#define zig_mips
+#elif defined(__powerpc64__)
+#define zig_powerpc64
+#define zig_powerpc
+#elif defined(__powerpc__)
+#define zig_powerpc32
+#define zig_powerpc
+#elif defined(__riscv) && __riscv_xlen == 32
+#define zig_riscv32
+#define zig_riscv
+#elif defined(__riscv) && __riscv_xlen == 64
+#define zig_riscv64
+#define zig_riscv
+#elif defined(__s390x__)
+#define zig_s390x
+#elif defined(__sparc__) && defined(__arch64__)
+#define zig_sparc64
+#define zig_sparc
+#elif defined(__sparc__)
+#define zig_sparc32
+#define zig_sparc
+#elif defined(__wasm32__)
+#define zig_wasm32
+#define zig_wasm
+#elif defined(__wasm64__)
+#define zig_wasm64
+#define zig_wasm
+#elif defined(__i386__) || (defined(zig_msvc) && defined(_M_IX86))
+#define zig_x86_32
+#define zig_x86
+#elif defined (__x86_64__) || (defined(zig_msvc) && defined(_M_X64))
+#define zig_x86_64
+#define zig_x86
+#endif
+
 #ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
 #define __STDC_WANT_IEC_60559_TYPES_EXT__
 #endif
@@ -24,7 +79,7 @@
 
 #if defined(zig_msvc)
 #include <intrin.h>
-#elif defined(__i386__) || defined(__x86_64__)
+#elif defined(zig_x86)
 #include <cpuid.h>
 #endif
 
@@ -74,7 +129,7 @@ typedef char bool;
 #define zig_threadlocal zig_threadlocal_unavailable
 #endif
 
-#if !defined(zig_clang) && defined(zig_gnuc) && (defined(__i386__) || defined(__x86_64__))
+#if !defined(zig_clang) && defined(zig_gnuc) && defined(zig_x86)
 #define zig_f128_has_miscompilations 1
 #else
 #define zig_f128_has_miscompilations 0
@@ -195,11 +250,11 @@ typedef char bool;
 #endif
 
 #if defined(zig_msvc)
-#if _M_X64
+#if defined(zig_x86_64)
 #define zig_mangle_c(symbol) symbol
-#else /*_M_X64 */
+#else /* zig_x86_64 */
 #define zig_mangle_c(symbol) "_" symbol
-#endif /*_M_X64 */
+#endif /* zig_x86_64 */
 #else /* zig_msvc */
 #if __APPLE__
 #define zig_mangle_c(symbol) "_" symbol
@@ -259,27 +314,27 @@ typedef char bool;
 
 #if zig_has_builtin(trap)
 #define zig_trap() __builtin_trap()
-#elif defined(zig_msvc) && (defined(_M_IX86) || defined(_M_X64))
+#elif defined(zig_msvc) && defined(zig_x86)
 #define zig_trap() __ud2()
 #elif defined(zig_msvc)
 #define zig_trap() __fastfail(7)
-#elif defined(__thumb__)
+#elif defined(zig_thumb)
 #define zig_trap() __asm__ volatile("udf #0xfe")
-#elif defined(__arm__) || defined(__aarch64__)
+#elif defined(zig_arm) || defined(zig_aarch64)
 #define zig_trap() __asm__ volatile("udf #0xfdee")
-#elif defined(__hexagon__)
+#elif defined(zig_hexagon)
 #define zig_trap() __asm__ volatile("r27:26 = memd(#0xbadc0fee)")
-#elif defined(__loongarch__) || defined(__powerpc__)
+#elif defined(zig_loongarch) || defined(zig_powerpc)
 #define zig_trap() __asm__ volatile(".word 0x0")
-#elif defined(__mips__)
+#elif defined(zig_mips)
 #define zig_trap() __asm__ volatile(".word 0x3d")
-#elif defined(__riscv)
+#elif defined(zig_riscv)
 #define zig_trap() __asm__ volatile("unimp")
-#elif defined(__s390__)
+#elif defined(zig_s390x)
 #define zig_trap() __asm__ volatile("j 0x2")
-#elif defined(__sparc__)
+#elif defined(zig_sparc)
 #define zig_trap() __asm__ volatile("illtrap")
-#elif defined(__i386__) || defined(__x86_64__)
+#elif defined(zig_x86)
 #define zig_trap() __asm__ volatile("ud2")
 #else
 #define zig_trap() zig_trap_unavailable
@@ -289,25 +344,25 @@ typedef char bool;
 #define zig_breakpoint() __builtin_debugtrap()
 #elif defined(zig_msvc)
 #define zig_breakpoint() __debugbreak()
-#elif defined(__arm__)
+#elif defined(zig_arm)
 #define zig_breakpoint() __asm__ volatile("bkpt #0x0")
-#elif defined(__aarch64__)
+#elif defined(zig_aarch64)
 #define zig_breakpoint() __asm__ volatile("brk #0xf000")
-#elif defined(__hexagon__)
+#elif defined(zig_hexagon)
 #define zig_breakpoint() __asm__ volatile("brkpt")
-#elif defined(__loongarch__)
+#elif defined(zig_loongarch)
 #define zig_breakpoint() __asm__ volatile("break 0x0")
-#elif defined(__mips__)
+#elif defined(zig_mips)
 #define zig_breakpoint() __asm__ volatile("break")
-#elif defined(__powerpc__)
+#elif defined(zig_powerpc)
 #define zig_breakpoint() __asm__ volatile("trap")
-#elif defined(__riscv)
+#elif defined(zig_riscv)
 #define zig_breakpoint() __asm__ volatile("ebreak")
-#elif defined(__s390__)
+#elif defined(zig_s390x)
 #define zig_breakpoint() __asm__ volatile("j 0x6")
-#elif defined(__sparc__)
+#elif defined(zig_sparc)
 #define zig_breakpoint() __asm__ volatile("ta 0x1")
-#elif defined(__i386__) || defined(__x86_64__)
+#elif defined(zig_x86)
 #define zig_breakpoint() __asm__ volatile("int $0x3")
 #else
 #define zig_breakpoint() zig_breakpoint_unavailable
@@ -3095,7 +3150,7 @@ typedef uint16_t zig_f16;
 #undef zig_init_special_f16
 #define zig_init_special_f16(sign, name, arg, repr) repr
 #endif
-#if __APPLE__ && (defined(__i386__) || defined(__x86_64__))
+#if defined(__APPLE__) && defined(zig_x86)
 typedef uint16_t zig_compiler_rt_f16;
 #else
 typedef zig_f16 zig_compiler_rt_f16;
@@ -3228,7 +3283,7 @@ typedef __float128 zig_f128;
 #define zig_has_f128 0
 #undef zig_make_special_f128
 #undef zig_init_special_f128
-#if __APPLE__ || defined(__aarch64__)
+#if __APPLE__ || defined(zig_aarch64)
 typedef __attribute__((__vector_size__(2 * sizeof(uint64_t)))) uint64_t zig_v2u64;
 zig_basic_operator(zig_v2u64, xor_v2u64, ^)
 #define zig_repr_f128 v2u64
@@ -3650,7 +3705,7 @@ typedef int zig_memory_order;
 #define    zig_atomic_load(res, obj,      order, Type, ReprType)       __atomic_load      (obj, &(res), order)
 #undef  zig_atomicrmw_xchg_float
 #define zig_atomicrmw_xchg_float zig_atomicrmw_xchg
-#elif defined(zig_msvc) && (_M_IX86 || _M_X64)
+#elif defined(zig_msvc) && defined(zig_x86)
 #define zig_memory_order_relaxed 0
 #define zig_memory_order_acquire 2
 #define zig_memory_order_release 3
@@ -3670,7 +3725,7 @@ typedef int zig_memory_order;
 #define  zig_atomicrmw_max(res, obj, arg, order, Type, ReprType) res = zig_msvc_atomicrmw_max_ ##Type(obj, arg)
 #define   zig_atomic_store(     obj, arg, order, Type, ReprType)       zig_msvc_atomic_store_  ##Type(obj, arg)
 #define    zig_atomic_load(res, obj,      order, Type, ReprType) res = zig_msvc_atomic_load_   ##order##_##Type(obj)
-/* TODO: zig_msvc && (_M_ARM || _M_ARM64) */
+/* TODO: zig_msvc && (zig_thumb || zig_aarch64) */
 #else
 #define zig_memory_order_relaxed 0
 #define zig_memory_order_acquire 2
@@ -3693,7 +3748,7 @@ typedef int zig_memory_order;
 #define    zig_atomic_load(res, obj,      order, Type, ReprType) zig_atomics_unavailable
 #endif
 
-#if defined(zig_msvc) && (_M_IX86 || _M_X64)
+#if defined(zig_msvc) && defined(zig_x86)
 
 /* TODO: zig_msvc_atomic_load should load 32 bit without interlocked on x86, and load 64 bit without interlocked on x64 */
 
@@ -3790,7 +3845,7 @@ zig_msvc_atomics(i16,  int16_t,   short, 16, 16)
 zig_msvc_atomics(u32, uint32_t,    long,   , 32)
 zig_msvc_atomics(i32,  int32_t,    long,   , 32)
 
-#if _M_X64
+#if defined(zig_x86_64)
 zig_msvc_atomics(u64, uint64_t, __int64, 64, 64)
 zig_msvc_atomics(i64,  int64_t, __int64, 64, 64)
 #endif
@@ -3835,11 +3890,11 @@ zig_msvc_atomics(i64,  int64_t, __int64, 64, 64)
     }
 
 zig_msvc_flt_atomics(f32,    long,   , 32)
-#if _M_X64
+#if defined(zig_x86_64)
 zig_msvc_flt_atomics(f64, int64_t, 64, 64)
 #endif
 
-#if _M_IX86
+#if defined(zig_x86_32)
 static inline void zig_msvc_atomic_barrier() {
     int32_t barrier;
     __asm {
@@ -3876,7 +3931,7 @@ static inline bool zig_msvc_cmpxchg_p32(void volatile* obj, void* expected, void
     if (!success) *(void**)expected = initial;
     return success;
 }
-#else /* _M_IX86 */
+#else /* zig_x86_32 */
 static inline void* zig_msvc_atomicrmw_xchg_p64(void volatile* obj, void* arg) {
     return _InterlockedExchangePointer(obj, arg);
 }
@@ -3937,13 +3992,13 @@ static inline void zig_msvc_atomic_store_i128(zig_i128 volatile* obj, zig_i128 a
     while (!zig_cmpxchg_weak(obj, expected, arg, zig_memory_order_seq_cst, zig_memory_order_seq_cst, i128, zig_i128));
 }
 
-#endif /* _M_IX86 */
+#endif /* zig_x86_32 */
 
-#endif /* zig_msvc && (_M_IX86 || _M_X64) */
+#endif /* zig_msvc && zig_x86 */
 
 /* ======================== Special Case Intrinsics ========================= */
 
-#if defined(_M_ARM) || defined(__thumb__)
+#if defined(zig_thumb)
 
 static inline void* zig_thumb_windows_teb(void) {
     void* teb = 0;
@@ -3955,7 +4010,7 @@ static inline void* zig_thumb_windows_teb(void) {
     return teb;
 }
 
-#elif defined(_M_ARM64) || defined(__arch64__)
+#elif defined(zig_aarch64)
 
 static inline void* zig_aarch64_windows_teb(void) {
     void* teb = 0;
@@ -3967,7 +4022,7 @@ static inline void* zig_aarch64_windows_teb(void) {
     return teb;
 }
 
-#elif defined(_M_IX86) || defined(__i386__)
+#elif defined(zig_x86_32)
 
 static inline void* zig_x86_windows_teb(void) {
     void* teb = 0;
@@ -3979,7 +4034,7 @@ static inline void* zig_x86_windows_teb(void) {
     return teb;
 }
 
-#elif defined(_M_X64) || defined(__x86_64__)
+#elif defined(zig_x86_64)
 
 static inline void* zig_x86_64_windows_teb(void) {
     void* teb = 0;
@@ -3993,7 +4048,7 @@ static inline void* zig_x86_64_windows_teb(void) {
 
 #endif
 
-#if (defined(zig_msvc) && (_M_IX86 || _M_X64)) || defined(__i386__) || defined(__x86_64__)
+#if defined(zig_x86)
 
 static inline void zig_x86_cpuid(uint32_t leaf_id, uint32_t subid, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx) {
 #if defined(zig_msvc)

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -79,8 +79,6 @@
 
 #if defined(zig_msvc)
 #include <intrin.h>
-#elif defined(zig_x86)
-#include <cpuid.h>
 #endif
 
 #if __STDC_VERSION__ >= 202311L
@@ -4058,19 +4056,29 @@ static inline void zig_x86_cpuid(uint32_t leaf_id, uint32_t subid, uint32_t* eax
     *ebx = (uint32_t)cpu_info[1];
     *ecx = (uint32_t)cpu_info[2];
     *edx = (uint32_t)cpu_info[3];
+#elif defined(zig_gnuc) || defined(zig_tinyc) || defined(zig_slimcc)
+    __asm__("cpuid" : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx) : "a"(leaf_id), "c"(subid));
 #else
-    __cpuid_count(leaf_id, subid, *eax, *ebx, *ecx, *edx);
+    *eax = 0;
+    *ebx = 0;
+    *ecx = 0;
+    *edx = 0;
 #endif
 }
 
 static inline uint32_t zig_x86_get_xcr0(void) {
 #if defined(zig_msvc)
     return (uint32_t)_xgetbv(0);
-#else
+#elif defined(zig_gnuc) || defined(zig_tinyc) || defined(zig_slimcc)
     uint32_t eax;
     uint32_t edx;
     __asm__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(0));
     return eax;
+#else
+    *eax = 0;
+    *ebx = 0;
+    *ecx = 0;
+    *edx = 0;
 #endif
 }
 

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -31,6 +31,8 @@ typedef char bool;
 #define zig_gnuc
 #elif defined(__TINYC__)
 #define zig_tinyc
+#elif defined(__slimcc__)
+#define zig_slimcc
 #endif
 
 #define zig_concat(lhs, rhs) lhs##rhs
@@ -61,7 +63,7 @@ typedef char bool;
 #define zig_threadlocal thread_local
 #elif __STDC_VERSION__ >= 201112L
 #define zig_threadlocal _Thread_local
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(zig_slimcc)
 #define zig_threadlocal __thread
 #elif _MSC_VER
 #define zig_threadlocal __declspec(thread)

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -25,6 +25,14 @@ typedef char bool;
 #endif
 #endif
 
+#if defined(__clang__)
+#define zig_clang
+#elif defined(__GNUC__)
+#define zig_gnuc
+#elif defined(__TINYC__)
+#define zig_tinyc
+#endif
+
 #define zig_concat(lhs, rhs) lhs##rhs
 #define zig_expand_concat(lhs, rhs) zig_concat(lhs, rhs)
 
@@ -57,12 +65,6 @@ typedef char bool;
 #define zig_threadlocal __declspec(thread)
 #else
 #define zig_threadlocal zig_threadlocal_unavailable
-#endif
-
-#if defined(__clang__)
-#define zig_clang
-#elif defined(__GNUC__)
-#define zig_gnuc
 #endif
 
 #if defined(zig_gnuc) && (defined(__i386__) || defined(__x86_64__))
@@ -124,13 +126,13 @@ typedef char bool;
 
 #if __STDC_VERSION__ >= 199901L
 #define zig_restrict restrict
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(zig_tinyc)
 #define zig_restrict __restrict
 #else
 #define zig_restrict
 #endif
 
-#if zig_has_attribute(aligned)
+#if zig_has_attribute(aligned) || defined(zig_tinyc)
 #define zig_under_align(alignment) __attribute__((aligned(alignment)))
 #elif _MSC_VER
 #define zig_under_align(alignment) __declspec(align(alignment))
@@ -144,7 +146,7 @@ typedef char bool;
 #define zig_align(alignment) zig_under_align(alignment)
 #endif
 
-#if zig_has_attribute(aligned)
+#if zig_has_attribute(aligned) || defined(zig_tinyc)
 #define zig_align_fn(alignment) __attribute__((aligned(alignment)))
 #elif _MSC_VER
 #define zig_align_fn(alignment)
@@ -152,7 +154,7 @@ typedef char bool;
 #define zig_align_fn zig_align_fn_unavailable
 #endif
 
-#if zig_has_attribute(packed)
+#if zig_has_attribute(packed) || defined(zig_tinyc)
 #define zig_packed(definition) __attribute__((packed)) definition
 #elif _MSC_VER
 #define zig_packed(definition) __pragma(pack(1)) definition __pragma(pack())
@@ -160,7 +162,7 @@ typedef char bool;
 #define zig_packed(definition) zig_packed_unavailable
 #endif
 
-#if zig_has_attribute(section)
+#if zig_has_attribute(section) || defined(zig_tinyc)
 #define zig_linksection(name) __attribute__((section(name)))
 #define zig_linksection_fn zig_linksection
 #elif _MSC_VER
@@ -171,7 +173,7 @@ typedef char bool;
 #define zig_linksection_fn zig_linksection
 #endif
 
-#if zig_has_builtin(unreachable) || defined(zig_gnuc)
+#if zig_has_builtin(unreachable) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_unreachable() __builtin_unreachable()
 #else
 #define zig_unreachable()
@@ -197,7 +199,7 @@ typedef char bool;
 #endif /* __APPLE__ */
 #endif /* _MSC_VER */
 
-#if zig_has_attribute(alias) && !__APPLE__
+#if (zig_has_attribute(alias) || defined(zig_tinyc)) && !__APPLE__
 #define zig_export(symbol, name) __attribute__((alias(symbol)))
 #elif _MSC_VER
 #define zig_export(symbol, name) ; \
@@ -235,7 +237,7 @@ typedef char bool;
 #define zig_expand_import_0(Type, fn_name, libc_name, sig_args, call_args) zig_import(Type, fn_name, libc_name, sig_args, call_args)
 #define zig_expand_import_1(Type, fn_name, libc_name, sig_args, call_args) zig_import_builtin(Type, fn_name, libc_name, sig_args, call_args)
 
-#if zig_has_attribute(weak) || defined(zig_gnuc)
+#if zig_has_attribute(weak) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_weak_linkage __attribute__((weak))
 #define zig_weak_linkage_fn __attribute__((weak))
 #elif _MSC_VER
@@ -302,7 +304,7 @@ typedef char bool;
 #define zig_breakpoint() zig_breakpoint_unavailable
 #endif
 
-#if zig_has_builtin(return_address) || defined(zig_gnuc)
+#if zig_has_builtin(return_address) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_return_address() __builtin_extract_return_addr(__builtin_return_address(0))
 #elif defined(_MSC_VER)
 #define zig_return_address() _ReturnAddress()
@@ -310,7 +312,7 @@ typedef char bool;
 #define zig_return_address() 0
 #endif
 
-#if zig_has_builtin(frame_address) || defined(zig_gnuc)
+#if zig_has_builtin(frame_address) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_frame_address() __builtin_frame_address(0)
 #else
 #define zig_frame_address() 0
@@ -332,7 +334,7 @@ typedef char bool;
 
 #if __STDC_VERSION__ >= 201112L
 #define zig_noreturn _Noreturn
-#elif zig_has_attribute(noreturn) || defined(zig_gnuc)
+#elif zig_has_attribute(noreturn) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_noreturn __attribute__((noreturn))
 #elif _MSC_VER
 #define zig_noreturn __declspec(noreturn)
@@ -1136,7 +1138,7 @@ static inline int64_t zig_bit_reverse_i64(int64_t val, uint8_t bits) {
     static inline uint8_t zig_popcount_i##w(int##w##_t val, uint8_t bits) { \
         return zig_popcount_u##w((uint##w##_t)val, bits); \
     }
-#if zig_has_builtin(popcount) || defined(zig_gnuc)
+#if zig_has_builtin(popcount) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_builtin_popcount(w) \
     static inline uint8_t zig_popcount_u##w(uint##w##_t val, uint8_t bits) { \
         (void)bits; \
@@ -1165,7 +1167,7 @@ zig_builtin_popcount(64)
     static inline uint8_t zig_ctz_i##w(int##w##_t val, uint8_t bits) { \
         return zig_ctz_u##w((uint##w##_t)val, bits); \
     }
-#if zig_has_builtin(ctz) || defined(zig_gnuc)
+#if zig_has_builtin(ctz) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_builtin_ctz(w) \
     static inline uint8_t zig_ctz_u##w(uint##w##_t val, uint8_t bits) { \
         if (val == 0) return bits; \
@@ -1190,7 +1192,7 @@ zig_builtin_ctz(64)
     static inline uint8_t zig_clz_i##w(int##w##_t val, uint8_t bits) { \
         return zig_clz_u##w((uint##w##_t)val, bits); \
     }
-#if zig_has_builtin(clz) || defined(zig_gnuc)
+#if zig_has_builtin(clz) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_builtin_clz(w) \
     static inline uint8_t zig_clz_u##w(uint##w##_t val, uint8_t bits) { \
         if (val == 0) return bits; \

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -376,6 +376,8 @@ typedef char bool;
 
 #if zig_has_builtin(frame_address) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_frame_address() __builtin_frame_address(0)
+#elif defined(zig_msvc)
+#define zig_frame_address() _AddressOfReturnAddress()
 #else
 #define zig_frame_address() 0
 #endif

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -237,6 +237,8 @@ typedef char bool;
 
 #if zig_has_builtin(unreachable) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_unreachable() __builtin_unreachable()
+#elif defined(zig_msvc)
+#define zig_unreachable() __assume(0)
 #else
 #define zig_unreachable()
 #endif

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -15,14 +15,14 @@
 #include <cpuid.h>
 #endif
 
-#if !defined(__cplusplus) && __STDC_VERSION__ <= 201710L
-#if __STDC_VERSION__ >= 199901L
+#if __STDC_VERSION__ >= 202311L
+/* bool, true, and false are provided by the language. */
+#elif __STDC_VERSION__ >= 199901L
 #include <stdbool.h>
 #else
 typedef char bool;
 #define false 0
 #define true  1
-#endif
 #endif
 
 #if defined(__clang__)
@@ -57,7 +57,9 @@ typedef char bool;
 #define zig_big_endian 1
 #endif
 
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 202311L
+#define zig_threadlocal thread_local
+#elif __STDC_VERSION__ >= 201112L
 #define zig_threadlocal _Thread_local
 #elif defined(__GNUC__)
 #define zig_threadlocal __thread
@@ -140,7 +142,9 @@ typedef char bool;
 #define zig_under_align zig_align_unavailable
 #endif
 
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 202311L
+#define zig_align(alignment) alignas(alignment)
+#elif __STDC_VERSION__ >= 201112L
 #define zig_align(alignment) _Alignas(alignment)
 #else
 #define zig_align(alignment) zig_under_align(alignment)
@@ -332,7 +336,9 @@ typedef char bool;
 #define zig_wasm_memory_grow(index, delta) zig_unimplemented()
 #endif
 
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 202311L
+#define zig_noreturn [[noreturn]]
+#elif __STDC_VERSION__ >= 201112L
 #define zig_noreturn _Noreturn
 #elif zig_has_attribute(noreturn) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_noreturn __attribute__((noreturn))

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -1,5 +1,17 @@
 #undef linux
 
+#if defined(_MSC_VER)
+#define zig_msvc
+#elif defined(__clang__)
+#define zig_clang
+#elif defined(__GNUC__)
+#define zig_gnuc
+#elif defined(__TINYC__)
+#define zig_tinyc
+#elif defined(__slimcc__)
+#define zig_slimcc
+#endif
+
 #ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
 #define __STDC_WANT_IEC_60559_TYPES_EXT__
 #endif
@@ -9,7 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if _MSC_VER
+#if defined(zig_msvc)
 #include <intrin.h>
 #elif defined(__i386__) || defined(__x86_64__)
 #include <cpuid.h>
@@ -23,16 +35,6 @@
 typedef char bool;
 #define false 0
 #define true  1
-#endif
-
-#if defined(__clang__)
-#define zig_clang
-#elif defined(__GNUC__)
-#define zig_gnuc
-#elif defined(__TINYC__)
-#define zig_tinyc
-#elif defined(__slimcc__)
-#define zig_slimcc
 #endif
 
 #define zig_concat(lhs, rhs) lhs##rhs
@@ -51,7 +53,7 @@ typedef char bool;
 #define zig_has_attribute(attribute) 0
 #endif
 
-#if defined(_MSC_VER) || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#if defined(zig_msvc) || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define zig_little_endian 1
 #define zig_big_endian 0
 #else
@@ -65,7 +67,7 @@ typedef char bool;
 #define zig_threadlocal _Thread_local
 #elif defined(__GNUC__) || defined(zig_slimcc)
 #define zig_threadlocal __thread
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_threadlocal __declspec(thread)
 #else
 #define zig_threadlocal zig_threadlocal_unavailable
@@ -77,7 +79,7 @@ typedef char bool;
 #define zig_f128_has_miscompilations 0
 #endif
 
-#if _MSC_VER
+#if defined(zig_msvc)
 #define zig_const_arr
 #define zig_callconv(c) __##c
 #else
@@ -88,7 +90,7 @@ typedef char bool;
 #if zig_has_attribute(naked) || defined(zig_gnuc)
 #define zig_naked_decl __attribute__((naked))
 #define zig_naked __attribute__((naked))
-#elif defined(_MSC_VER)
+#elif defined(zig_msvc)
 #define zig_naked_decl
 #define zig_naked __declspec(naked)
 #else
@@ -110,7 +112,7 @@ typedef char bool;
 
 #if zig_has_attribute(noinline)
 #define zig_never_inline __attribute__((noinline)) zig_maybe_flatten
-#elif defined(_MSC_VER)
+#elif defined(zig_msvc)
 #define zig_never_inline __declspec(noinline) zig_maybe_flatten
 #else
 #define zig_never_inline zig_never_inline_unavailable
@@ -138,7 +140,7 @@ typedef char bool;
 
 #if zig_has_attribute(aligned) || defined(zig_tinyc)
 #define zig_under_align(alignment) __attribute__((aligned(alignment)))
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_under_align(alignment) __declspec(align(alignment))
 #else
 #define zig_under_align zig_align_unavailable
@@ -154,7 +156,7 @@ typedef char bool;
 
 #if zig_has_attribute(aligned) || defined(zig_tinyc)
 #define zig_align_fn(alignment) __attribute__((aligned(alignment)))
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_align_fn(alignment)
 #else
 #define zig_align_fn zig_align_fn_unavailable
@@ -162,7 +164,7 @@ typedef char bool;
 
 #if zig_has_attribute(packed) || defined(zig_tinyc)
 #define zig_packed(definition) __attribute__((packed)) definition
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_packed(definition) __pragma(pack(1)) definition __pragma(pack())
 #else
 #define zig_packed(definition) zig_packed_unavailable
@@ -171,7 +173,7 @@ typedef char bool;
 #if zig_has_attribute(section) || defined(zig_tinyc)
 #define zig_linksection(name) __attribute__((section(name)))
 #define zig_linksection_fn zig_linksection
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_linksection(name) __pragma(section(name, read, write)) __declspec(allocate(name))
 #define zig_linksection_fn(name) __pragma(section(name, read, execute)) __declspec(code_seg(name))
 #else
@@ -191,23 +193,23 @@ typedef char bool;
 #define zig_extern extern
 #endif
 
-#if _MSC_VER
+#if defined(zig_msvc)
 #if _M_X64
 #define zig_mangle_c(symbol) symbol
 #else /*_M_X64 */
 #define zig_mangle_c(symbol) "_" symbol
 #endif /*_M_X64 */
-#else /* _MSC_VER */
+#else /* zig_msvc */
 #if __APPLE__
 #define zig_mangle_c(symbol) "_" symbol
 #else /* __APPLE__ */
 #define zig_mangle_c(symbol) symbol
 #endif /* __APPLE__ */
-#endif /* _MSC_VER */
+#endif /* zig_msvc */
 
 #if (zig_has_attribute(alias) || defined(zig_tinyc)) && !__APPLE__
 #define zig_export(symbol, name) __attribute__((alias(symbol)))
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_export(symbol, name) ; \
     __pragma(comment(linker, "/alternatename:" zig_mangle_c(name) "=" zig_mangle_c(symbol)))
 #else
@@ -217,24 +219,24 @@ typedef char bool;
 
 #define zig_mangled_tentative zig_mangled
 #define zig_mangled_final zig_mangled
-#if _MSC_VER
+#if defined(zig_msvc)
 #define zig_mangled(mangled, unmangled) ; \
     zig_export(#mangled, unmangled)
 #define zig_mangled_export(mangled, unmangled, symbol) \
     zig_export(unmangled, #mangled) \
     zig_export(symbol, unmangled)
-#else /* _MSC_VER */
+#else /* zig_msvc */
 #define zig_mangled(mangled, unmangled) __asm(zig_mangle_c(unmangled))
 #define zig_mangled_export(mangled, unmangled, symbol) \
     zig_mangled_final(mangled, unmangled) \
     zig_export(symbol, unmangled)
-#endif /* _MSC_VER */
+#endif /* zig_msvc */
 
-#if _MSC_VER
+#if defined(zig_msvc)
 #define zig_import(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type fn_name sig_args;\
     __pragma(comment(linker, "/alternatename:" zig_mangle_c(#fn_name) "=" zig_mangle_c(#libc_name)));
 #define zig_import_builtin(Type, fn_name, libc_name, sig_args, call_args) zig_import(Type, fn_name, sig_args, call_args)
-#else /* _MSC_VER */
+#else /* zig_msvc */
 #define zig_import(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type fn_name sig_args __asm(zig_mangle_c(#libc_name));
 #define zig_import_builtin(Type, fn_name, libc_name, sig_args, call_args) zig_extern Type libc_name sig_args; \
     static inline Type fn_name sig_args { return libc_name call_args; }
@@ -246,7 +248,7 @@ typedef char bool;
 #if zig_has_attribute(weak) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_weak_linkage __attribute__((weak))
 #define zig_weak_linkage_fn __attribute__((weak))
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_weak_linkage __declspec(selectany)
 #define zig_weak_linkage_fn
 #else
@@ -256,9 +258,9 @@ typedef char bool;
 
 #if zig_has_builtin(trap)
 #define zig_trap() __builtin_trap()
-#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+#elif defined(zig_msvc) && (defined(_M_IX86) || defined(_M_X64))
 #define zig_trap() __ud2()
-#elif defined(_MSC_VER)
+#elif defined(zig_msvc)
 #define zig_trap() __fastfail(7)
 #elif defined(__thumb__)
 #define zig_trap() __asm__ volatile("udf #0xfe")
@@ -284,7 +286,7 @@ typedef char bool;
 
 #if zig_has_builtin(debugtrap)
 #define zig_breakpoint() __builtin_debugtrap()
-#elif defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+#elif defined(zig_msvc) || defined(__MINGW32__) || defined(__MINGW64__)
 #define zig_breakpoint() __debugbreak()
 #elif defined(__arm__)
 #define zig_breakpoint() __asm__ volatile("bkpt #0x0")
@@ -312,7 +314,7 @@ typedef char bool;
 
 #if zig_has_builtin(return_address) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_return_address() __builtin_extract_return_addr(__builtin_return_address(0))
-#elif defined(_MSC_VER)
+#elif defined(zig_msvc)
 #define zig_return_address() _ReturnAddress()
 #else
 #define zig_return_address() 0
@@ -344,7 +346,7 @@ typedef char bool;
 #define zig_noreturn _Noreturn
 #elif zig_has_attribute(noreturn) || defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_noreturn __attribute__((noreturn))
-#elif _MSC_VER
+#elif defined(zig_msvc)
 #define zig_noreturn __declspec(noreturn)
 #else
 #define zig_noreturn
@@ -369,7 +371,7 @@ zig_extern void *memset (void *, int, size_t);
 
 /* ===================== 8/16/32/64-bit Integer Support ===================== */
 
-#if __STDC_VERSION__ >= 199901L || _MSC_VER
+#if __STDC_VERSION__ >= 199901L || defined(zig_msvc)
 #include <stdint.h>
 #else
 
@@ -1268,7 +1270,7 @@ typedef struct { zig_align(16)  int64_t hi; uint64_t lo; } zig_i128;
 #define zig_make_u128(hi, lo) ((zig_u128){ .h##i = (hi), .l##o = (lo) })
 #define zig_make_i128(hi, lo) ((zig_i128){ .h##i = (hi), .l##o = (lo) })
 
-#if _MSC_VER /* MSVC doesn't allow struct literals in constant expressions */
+#if defined(zig_msvc) /* MSVC doesn't allow struct literals in constant expressions */
 #define zig_init_u128(hi, lo) { .h##i = (hi), .l##o = (lo) }
 #define zig_init_i128(hi, lo) { .h##i = (hi), .l##o = (lo) }
 #else /* But non-MSVC doesn't like the unprotected commas */
@@ -3030,7 +3032,7 @@ static inline uint16_t zig_popcount_big(const void *val, bool is_signed, uint16_
 
 /* ========================= Floating Point Support ========================= */
 
-#if _MSC_VER
+#if defined(zig_msvc)
 float __cdecl nanf(char const* input);
 double __cdecl nan(char const* input);
 long double __cdecl nanl(char const* input);
@@ -3100,7 +3102,7 @@ typedef zig_f16 zig_compiler_rt_f16;
 
 #define zig_has_f32 1
 #define zig_libc_name_f32(name) name##f
-#if _MSC_VER
+#if defined(zig_msvc)
 #define zig_init_special_f32(sign, name, arg, repr) sign zig_make_f32(zig_msvc_flt_##name, )
 #else
 #define zig_init_special_f32(sign, name, arg, repr) zig_make_special_f32(sign, name, arg, repr)
@@ -3132,7 +3134,7 @@ typedef uint32_t zig_f32;
 #define zig_has_f64 1
 #define zig_libc_name_f64(name) name
 
-#if _MSC_VER
+#if defined(zig_msvc)
 #define zig_init_special_f64(sign, name, arg, repr) sign zig_make_f64(zig_msvc_flt_##name, )
 #else
 #define zig_init_special_f64(sign, name, arg, repr) zig_make_special_f64(sign, name, arg, repr)
@@ -3244,10 +3246,10 @@ typedef zig_u128 zig_f128;
 #endif
 #endif
 
-#if !_MSC_VER && defined(ZIG_TARGET_ABI_MSVC)
+#if !defined(zig_msvc) && defined(ZIG_TARGET_ABI_MSVC)
 /* Emulate msvc abi on a gnu compiler */
 typedef zig_f64 zig_c_longdouble;
-#elif _MSC_VER && !defined(ZIG_TARGET_ABI_MSVC)
+#elif defined(zig_msvc) && !defined(ZIG_TARGET_ABI_MSVC)
 /* Emulate gnu abi on an msvc compiler */
 typedef zig_f128 zig_c_longdouble;
 #else
@@ -3647,7 +3649,7 @@ typedef int zig_memory_order;
 #define    zig_atomic_load(res, obj,      order, Type, ReprType)       __atomic_load      (obj, &(res), order)
 #undef  zig_atomicrmw_xchg_float
 #define zig_atomicrmw_xchg_float zig_atomicrmw_xchg
-#elif _MSC_VER && (_M_IX86 || _M_X64)
+#elif defined(zig_msvc) && (_M_IX86 || _M_X64)
 #define zig_memory_order_relaxed 0
 #define zig_memory_order_acquire 2
 #define zig_memory_order_release 3
@@ -3667,7 +3669,7 @@ typedef int zig_memory_order;
 #define  zig_atomicrmw_max(res, obj, arg, order, Type, ReprType) res = zig_msvc_atomicrmw_max_ ##Type(obj, arg)
 #define   zig_atomic_store(     obj, arg, order, Type, ReprType)       zig_msvc_atomic_store_  ##Type(obj, arg)
 #define    zig_atomic_load(res, obj,      order, Type, ReprType) res = zig_msvc_atomic_load_   ##order##_##Type(obj)
-/* TODO: _MSC_VER && (_M_ARM || _M_ARM64) */
+/* TODO: zig_msvc && (_M_ARM || _M_ARM64) */
 #else
 #define zig_memory_order_relaxed 0
 #define zig_memory_order_acquire 2
@@ -3690,7 +3692,7 @@ typedef int zig_memory_order;
 #define    zig_atomic_load(res, obj,      order, Type, ReprType) zig_atomics_unavailable
 #endif
 
-#if _MSC_VER && (_M_IX86 || _M_X64)
+#if defined(zig_msvc) && (_M_IX86 || _M_X64)
 
 /* TODO: zig_msvc_atomic_load should load 32 bit without interlocked on x86, and load 64 bit without interlocked on x64 */
 
@@ -3936,7 +3938,7 @@ static inline void zig_msvc_atomic_store_i128(zig_i128 volatile* obj, zig_i128 a
 
 #endif /* _M_IX86 */
 
-#endif /* _MSC_VER && (_M_IX86 || _M_X64) */
+#endif /* zig_msvc && (_M_IX86 || _M_X64) */
 
 /* ======================== Special Case Intrinsics ========================= */
 
@@ -3944,7 +3946,7 @@ static inline void zig_msvc_atomic_store_i128(zig_i128 volatile* obj, zig_i128 a
 
 static inline void* zig_thumb_windows_teb(void) {
     void* teb = 0;
-#if defined(_MSC_VER)
+#if defined(zig_msvc)
     teb = (void*)_MoveFromCoprocessor(15, 0, 13, 0, 2);
 #elif defined(__GNUC__)
     __asm__ ("mrc p15, 0, %[ptr], c13, c0, 2" : [ptr] "=r" (teb));
@@ -3956,7 +3958,7 @@ static inline void* zig_thumb_windows_teb(void) {
 
 static inline void* zig_aarch64_windows_teb(void) {
     void* teb = 0;
-#if defined(_MSC_VER)
+#if defined(zig_msvc)
     teb = (void*)__readx18qword(0x0);
 #elif defined(__GNUC__)
     __asm__ ("mov %[ptr], x18" : [ptr] "=r" (teb));
@@ -3968,7 +3970,7 @@ static inline void* zig_aarch64_windows_teb(void) {
 
 static inline void* zig_x86_windows_teb(void) {
     void* teb = 0;
-#if defined(_MSC_VER)
+#if defined(zig_msvc)
     teb = (void*)__readfsdword(0x18);
 #elif defined(__GNUC__)
     __asm__ ("movl %%fs:0x18, %[ptr]" : [ptr] "=r" (teb));
@@ -3980,7 +3982,7 @@ static inline void* zig_x86_windows_teb(void) {
 
 static inline void* zig_x86_64_windows_teb(void) {
     void* teb = 0;
-#if defined(_MSC_VER)
+#if defined(zig_msvc)
     teb = (void*)__readgsqword(0x30);
 #elif defined(__GNUC__)
     __asm__ ("movq %%gs:0x30, %[ptr]" : [ptr] "=r" (teb));
@@ -3990,10 +3992,10 @@ static inline void* zig_x86_64_windows_teb(void) {
 
 #endif
 
-#if (_MSC_VER && (_M_IX86 || _M_X64)) || defined(__i386__) || defined(__x86_64__)
+#if (defined(zig_msvc) && (_M_IX86 || _M_X64)) || defined(__i386__) || defined(__x86_64__)
 
 static inline void zig_x86_cpuid(uint32_t leaf_id, uint32_t subid, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx) {
-#if _MSC_VER
+#if defined(zig_msvc)
     int cpu_info[4];
     __cpuidex(cpu_info, leaf_id, subid);
     *eax = (uint32_t)cpu_info[0];
@@ -4006,7 +4008,7 @@ static inline void zig_x86_cpuid(uint32_t leaf_id, uint32_t subid, uint32_t* eax
 }
 
 static inline uint32_t zig_x86_get_xcr0(void) {
-#if _MSC_VER
+#if defined(zig_msvc)
     return (uint32_t)_xgetbv(0);
 #else
     uint32_t eax;

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -4,6 +4,7 @@
 #define zig_msvc
 #elif defined(__clang__)
 #define zig_clang
+#define zig_gnuc
 #elif defined(__GNUC__)
 #define zig_gnuc
 #elif defined(__TINYC__)
@@ -65,7 +66,7 @@ typedef char bool;
 #define zig_threadlocal thread_local
 #elif __STDC_VERSION__ >= 201112L
 #define zig_threadlocal _Thread_local
-#elif defined(__GNUC__) || defined(zig_slimcc)
+#elif defined(zig_gnuc) || defined(zig_slimcc)
 #define zig_threadlocal __thread
 #elif defined(zig_msvc)
 #define zig_threadlocal __declspec(thread)
@@ -73,7 +74,7 @@ typedef char bool;
 #define zig_threadlocal zig_threadlocal_unavailable
 #endif
 
-#if defined(zig_gnuc) && (defined(__i386__) || defined(__x86_64__))
+#if !defined(zig_clang) && defined(zig_gnuc) && (defined(__i386__) || defined(__x86_64__))
 #define zig_f128_has_miscompilations 1
 #else
 #define zig_f128_has_miscompilations 0
@@ -132,7 +133,7 @@ typedef char bool;
 
 #if __STDC_VERSION__ >= 199901L
 #define zig_restrict restrict
-#elif defined(__GNUC__) || defined(zig_tinyc)
+#elif defined(zig_gnuc) || defined(zig_tinyc)
 #define zig_restrict __restrict
 #else
 #define zig_restrict
@@ -3626,7 +3627,7 @@ typedef enum memory_order zig_memory_order;
 #define zig_atomicrmw_add_float zig_atomicrmw_add
 #undef  zig_atomicrmw_sub_float
 #define zig_atomicrmw_sub_float zig_atomicrmw_sub
-#elif defined(__GNUC__)
+#elif defined(zig_gnuc)
 typedef int zig_memory_order;
 #define zig_memory_order_relaxed __ATOMIC_RELAXED
 #define zig_memory_order_acquire __ATOMIC_ACQUIRE
@@ -3948,7 +3949,7 @@ static inline void* zig_thumb_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)_MoveFromCoprocessor(15, 0, 13, 0, 2);
-#elif defined(__GNUC__)
+#elif defined(zig_gnuc)
     __asm__ ("mrc p15, 0, %[ptr], c13, c0, 2" : [ptr] "=r" (teb));
 #endif
     return teb;
@@ -3960,7 +3961,7 @@ static inline void* zig_aarch64_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)__readx18qword(0x0);
-#elif defined(__GNUC__)
+#elif defined(zig_gnuc)
     __asm__ ("mov %[ptr], x18" : [ptr] "=r" (teb));
 #endif
     return teb;
@@ -3972,7 +3973,7 @@ static inline void* zig_x86_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)__readfsdword(0x18);
-#elif defined(__GNUC__)
+#elif defined(zig_gnuc)
     __asm__ ("movl %%fs:0x18, %[ptr]" : [ptr] "=r" (teb));
 #endif
     return teb;
@@ -3984,7 +3985,7 @@ static inline void* zig_x86_64_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)__readgsqword(0x30);
-#elif defined(__GNUC__)
+#elif defined(zig_gnuc)
     __asm__ ("movq %%gs:0x30, %[ptr]" : [ptr] "=r" (teb));
 #endif
     return teb;

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -4002,7 +4002,7 @@ static inline void* zig_thumb_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)_MoveFromCoprocessor(15, 0, 13, 0, 2);
-#elif defined(zig_gnuc)
+#elif defined(zig_gnuc) || defined(zig_tinyc) || defined(zig_slimcc)
     __asm__ ("mrc p15, 0, %[ptr], c13, c0, 2" : [ptr] "=r" (teb));
 #endif
     return teb;
@@ -4014,7 +4014,7 @@ static inline void* zig_aarch64_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)__readx18qword(0x0);
-#elif defined(zig_gnuc)
+#elif defined(zig_gnuc) || defined(zig_tinyc) || defined(zig_slimcc)
     __asm__ ("mov %[ptr], x18" : [ptr] "=r" (teb));
 #endif
     return teb;
@@ -4026,7 +4026,7 @@ static inline void* zig_x86_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)__readfsdword(0x18);
-#elif defined(zig_gnuc)
+#elif defined(zig_gnuc) || defined(zig_tinyc) || defined(zig_slimcc)
     __asm__ ("movl %%fs:0x18, %[ptr]" : [ptr] "=r" (teb));
 #endif
     return teb;
@@ -4038,7 +4038,7 @@ static inline void* zig_x86_64_windows_teb(void) {
     void* teb = 0;
 #if defined(zig_msvc)
     teb = (void*)__readgsqword(0x30);
-#elif defined(zig_gnuc)
+#elif defined(zig_gnuc) || defined(zig_tinyc) || defined(zig_slimcc)
     __asm__ ("movq %%gs:0x30, %[ptr]" : [ptr] "=r" (teb));
 #endif
     return teb;

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -75,7 +75,6 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdint.h>
 
 #if defined(zig_msvc)
 #include <intrin.h>

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -287,7 +287,7 @@ typedef char bool;
 
 #if zig_has_builtin(debugtrap)
 #define zig_breakpoint() __builtin_debugtrap()
-#elif defined(zig_msvc) || defined(__MINGW32__) || defined(__MINGW64__)
+#elif defined(zig_msvc)
 #define zig_breakpoint() __debugbreak()
 #elif defined(__arm__)
 #define zig_breakpoint() __asm__ volatile("bkpt #0x0")

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -41,7 +41,7 @@ typedef char bool;
 #define zig_has_attribute(attribute) 0
 #endif
 
-#if __LITTLE_ENDIAN__ || _MSC_VER
+#if defined(_MSC_VER) || __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define zig_little_endian 1
 #define zig_big_endian 0
 #else

--- a/lib/zig.h
+++ b/lib/zig.h
@@ -81,15 +81,51 @@
 #define zig_big_endian 1
 #endif
 
-#if defined(_WIN32)
+#if defined(_AIX)
+#define zig_aix
+#elif defined(__MACH__)
+#define zig_darwin
+#elif defined(__DragonFly__)
+#define zig_dragonfly
+#define zig_bsd
+#elif defined(__EMSCRIPTEN__)
+#define zig_emscripten
+#elif defined(__FreeBSD__)
+#define zig_freebsd
+#define zig_bsd
+#elif defined(__Fuchsia__)
+#define zig_fuchsia
+#elif defined(__HAIKU__)
+#define zig_haiku
+#elif defined(__gnu_hurd__)
+#define zig_hurd
+#elif defined(__linux__)
+#define zig_linux
+#elif defined(__NetBSD__)
+#define zig_netbsd
+#define zig_bsd
+#elif defined(__OpenBSD__)
+#define zig_openbsd
+#define zig_bsd
+#elif defined(__SVR4)
+#define zig_solaris
+#elif defined(__wasi__)
+#define zig_wasi
+#elif defined(_WIN32)
+#define zig_windows
+#elif defined(__MVS__)
+#define zig_zos
+#endif
+
+#if defined(zig_windows)
 #define zig_coff
 #elif defined(__ELF__)
 #define zig_elf
-#elif defined(__MVS__)
+#elif defined(zig_zos)
 #define zig_goff
-#elif defined(__MACH__)
+#elif defined(zig_darwin)
 #define zig_macho
-#elif defined(_AIX)
+#elif defined(zig_aix)
 #define zig_xcoff
 #endif
 
@@ -3163,7 +3199,7 @@ typedef uint16_t zig_f16;
 #undef zig_init_special_f16
 #define zig_init_special_f16(sign, name, arg, repr) repr
 #endif
-#if defined(__APPLE__) && defined(zig_x86)
+#if defined(zig_darwin) && defined(zig_x86)
 typedef uint16_t zig_compiler_rt_f16;
 #else
 typedef zig_f16 zig_compiler_rt_f16;
@@ -3302,7 +3338,7 @@ typedef __float128 zig_f128;
 #define zig_has_f128 0
 #undef zig_make_special_f128
 #undef zig_init_special_f128
-#if __APPLE__ || defined(zig_aarch64)
+#if defined(zig_darwin) || defined(zig_aarch64)
 typedef __attribute__((__vector_size__(2 * sizeof(uint64_t)))) uint64_t zig_v2u64;
 zig_basic_operator(zig_v2u64, xor_v2u64, ^)
 #define zig_repr_f128 v2u64


### PR DESCRIPTION
I recommend reviewing each commit individually.

Closes #22114. There's still more work to do in `bootstrap.c` for non-GCC/Clang compilers, but I'll do that in #22054.