### PR TITLE
std.Build: accept comptime string as option value

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -407,7 +407,30 @@ fn userInputOptionsFromArgs(allocator: Allocator, args: anytype) UserInputOption
     var user_input_options = UserInputOptionsMap.init(allocator);
     inline for (@typeInfo(@TypeOf(args)).@"struct".fields) |field| {
         const v = @field(args, field.name);
-        const T = @TypeOf(v);
+
+        const type_info = @typeInfo(@TypeOf(v));
+        const is_comptime_str = is_comptime_str: switch (type_info) {
+            .pointer => |pointer| {
+                if (pointer.size == .One and pointer.is_const) {
+                    const child_type_info = @typeInfo(pointer.child);
+                    switch (child_type_info) {
+                        .array => |array| {
+                            if (array.child == u8) {
+                                if (array.sentinel) |sentinel| {
+                                    break :is_comptime_str @as(*const u8, @ptrCast(sentinel)).* == 0;
+                                }
+                            }
+                        },
+                        else => break :is_comptime_str false,
+                    }
+                }
+                break :is_comptime_str false;
+            },
+            else => break :is_comptime_str false,
+        };
+
+        const T = if (is_comptime_str) []const u8 else @TypeOf(v);
+
         switch (T) {
             Target.Query => {
                 user_input_options.put(field.name, .{


### PR DESCRIPTION
Small quality of life improvement for `std.Build` interface: accept comptime string as option value without the need to cast it to `[]const u8`.


## Problem

On one project I have a build option declared as such:
```zig
const str_opt = b.option([]const u8, "str_opt", "my str opt");
```

Then on another project I want to set that option:
```zig
const dep = b.dependency("other-project", .{
    .str_opt = @as([]const u8, "the str value")
});
```

I'm forced to cast it to `[]const u8`.

If I try this:
```zig
const dep = b.dependency("other-project", .{
    .str_opt = "the str value"
});
```

I get the error:
```
Build.zig:503:25: error: option 'opt_str' has unsupported type: *const [13:0]u8
```

## Expectation

Zig compiler automatically casts comptime strings to `[]const u8` if they are, for example, declared as the type of a function argument. I'd expect the same here.

## Diagnosis

`std.Build.userInputOptionsFromArgs` is a comptime function that evaluates its args using `@TypeOf` information. So the compiler has no way to know whether that requires an auto-cast or not.


## Solution

This PR tries to address the issue by forcing the `[]const u8` type when it encounters a value that looks like a comptime string.  As the inner `UserValue.value` uses a `[]const u8`, I suppose the behavior does not change.

I'm not sure if that's the correct way to infer if a value can be considered a "comptime string". But it works for my use case.