### PR TITLE
docs: fibonacci text update

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -3993,7 +3993,7 @@ fn performFn(start_value: i32) i32 {
       </p>
       <p>
       What if we fix the base case, but put the wrong value in the
-      {#syntax#}expect{#endsyntax#} line?
+      {#syntax#}assert{#endsyntax#} line?
       </p>
       {#code|test_fibonacci_comptime_unreachable.zig#}
 


### PR DESCRIPTION
The code example uses `assert` instead of `expect`
https://github.com/ziglang/zig/blob/6188cb8e50882a55c90578114556c6d1b7073e9d/doc/langref/test_fibonacci_comptime_unreachable.zig#L9