### PR TITLE
json: allow stringifying `type` fields comptime

### DIFF
--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -670,6 +670,9 @@ pub fn WriteStream(
                     const array: [info.len]info.child = value;
                     return self.write(&array);
                 },
+                .type => {
+                    return self.stringValue(@typeName(value));
+                },
                 else => @compileError("Unable to stringify type '" ++ @typeName(T) ++ "'"),
             }
             unreachable;

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -415,6 +415,15 @@ test "comptime stringify" {
         MyStruct{ .foo = 100 },
         MyStruct{ .foo = 1000 },
     }, .{}, 8) catch unreachable;
+
+    const MyStruct2 = struct {
+        type: type,
+    };
+    comptime testStringifyMaxDepth("[{\"type\":\"u1\"},{\"type\":\"[]const u8\"},{\"type\":\"anyopaque\"}]", [_]MyStruct2{
+        MyStruct2{ .type = u1 },
+        MyStruct2{ .type = []const u8 },
+        MyStruct2{ .type = anyopaque },
+    }, .{}, null) catch unreachable;
 }
 
 test "print" {


### PR DESCRIPTION
This lets one serialize `@typeInfo` as well.

```zig
const std = @import("std");

const Packed = packed struct {
    foo: u1,
    bar: u3,
};

pub fn main() !void {
    @setEvalBranchQuota(100_000);
    comptime var buf: std.BoundedArray(u8, 1024) = .{};
    comptime try std.json.stringify(@typeInfo(Packed), .{.whitespace = .indent_2}, buf.writer());
    std.debug.print("{s}\n", .{comptime buf.constSlice()[0..].*});
}
```

```json
{
  "struct": {
    "layout": "packed",
    "backing_integer": "u4",
    "fields": [
      {
        "name": "foo",
        "type": "u1",
        "default_value": null,
        "is_comptime": false,
        "alignment": 0
      },
      {
        "name": "bar",
        "type": "u3",
        "default_value": null,
        "is_comptime": false,
        "alignment": 0
      }
    ],
    "decls": [],
    "is_tuple": false
  }
}
```