### PR TITLE
`Compilation`: Consider `*.rlib` files to be static libraries.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5890,7 +5890,9 @@ pub fn hasObjectExt(filename: []const u8) bool {
 }
 
 pub fn hasStaticLibraryExt(filename: []const u8) bool {
-    return mem.endsWith(u8, filename, ".a") or mem.endsWith(u8, filename, ".lib");
+    return mem.endsWith(u8, filename, ".a") or
+        mem.endsWith(u8, filename, ".lib") or
+        mem.endsWith(u8, filename, ".rlib");
 }
 
 pub fn hasCExt(filename: []const u8) bool {


### PR DESCRIPTION
These are produced by `rustc`: https://rustc-dev-guide.rust-lang.org/backend/libs-and-metadata.html#rlib

Closes #21819.