### PR TITLE
`std.Target`: Fix `charSignedness()` for hexagon.

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -2746,6 +2746,7 @@ pub fn charSignedness(target: Target) std.builtin.Signedness {
         .aarch64_be,
         .arc,
         .csky,
+        .hexagon,
         .msp430,
         .powerpc,
         .powerpcle,


### PR DESCRIPTION
Hexagon uses unsigned `char`.