### PR TITLE
Sema: make source location in checkCallConvSupportsVarArgs more meaningful

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9659,7 +9659,13 @@ fn funcCommon(
         if (is_generic) {
             return sema.fail(block, func_src, "generic function cannot be variadic", .{});
         }
-        try sema.checkCallConvSupportsVarArgs(block, cc_src, cc);
+        const va_args_src = block.src(.{
+            .fn_proto_param = .{
+                .fn_proto_node_offset = src_node_offset,
+                .param_index = @intCast(block.params.len), // va_arg must be the last parameter
+            },
+        });
+        try sema.checkCallConvSupportsVarArgs(block, va_args_src, cc);
     }
 
     const ret_poison = bare_return_type.isGenericPoison();

--- a/test/cases/compile_errors/invalid_variadic_function.zig
+++ b/test/cases/compile_errors/invalid_variadic_function.zig
@@ -11,7 +11,7 @@ comptime {
 // error
 // target=x86_64-linux
 //
-// :1:1: error: variadic function does not support 'auto' calling convention
-// :1:1: note: supported calling conventions: 'x86_64_sysv', 'x86_64_win'
-// :1:1: error: variadic function does not support 'inline' calling convention
-// :1:1: note: supported calling conventions: 'x86_64_sysv', 'x86_64_win'
+// :1:8: error: variadic function does not support 'auto' calling convention
+// :1:8: note: supported calling conventions: 'x86_64_sysv', 'x86_64_win'
+// :2:16: error: variadic function does not support 'inline' calling convention
+// :2:16: note: supported calling conventions: 'x86_64_sysv', 'x86_64_win'


### PR DESCRIPTION
As calling convention may not be specified explicitly in the source, so use va_arg's location instead.