### PR TITLE
Fix unknown file extension with .rmeta

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5886,7 +5886,8 @@ pub const FileExt = enum {
 pub fn hasObjectExt(filename: []const u8) bool {
     return mem.endsWith(u8, filename, ".o") or
         mem.endsWith(u8, filename, ".lo") or
-        mem.endsWith(u8, filename, ".obj");
+        mem.endsWith(u8, filename, ".obj") or
+        mem.endsWith(u8, filename, ".rmeta");
 }
 
 pub fn hasStaticLibraryExt(filename: []const u8) bool {


### PR DESCRIPTION
The rust compile emits ``.rmeta`` files that are required in order to compile Rust programs.  More information can be found here: https://rustc-dev-guide.rust-lang.org/backend/libs-and-metadata.html#rmeta

Zig currently rejects these files as an "unknown file extension."  This fix allows for ``.rmeta`` files.

Fixes https://github.com/ziglang/zig/issues/22168.