### PR TITLE
Sema: fix use of Zcu.LazySrcLoc in error message

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8999,7 +8999,7 @@ fn zirIntFromEnum(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
                     block,
                     operand_src,
                     "untagged union '{}' cannot be converted to integer",
-                    .{src},
+                    .{operand_ty.fmt(pt)},
                 );
             };
 

--- a/test/cases/compile_errors/untagged_union_integer_conversion.zig
+++ b/test/cases/compile_errors/untagged_union_integer_conversion.zig
@@ -1,0 +1,11 @@
+const UntaggedUnion = union {};
+comptime {
+    @intFromEnum(@as(UntaggedUnion, undefined));
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:18: error: untagged union 'tmp.UntaggedUnion' cannot be converted to integer
+// :1:23: note: union declared here


### PR DESCRIPTION
It currently prints as:

```
:3:18: error: untagged union 'Zcu.LazySrcLoc{ .base_node_inst = InternPool.TrackedInst.Index(104), .offset = Zcu.LazySrcLoc.Offset{ .node_offset = Zcu.LazySrcLoc.Offset.TracedOffset{ .x = -2, .trace = (value tracing disabled) } } }' cannot be converted to integer
````