### PR TITLE
compiler: Only omit frame pointers by default for `ReleaseSmall`

### DIFF
--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -205,8 +205,8 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
     const omit_frame_pointer = b: {
         if (options.inherited.omit_frame_pointer) |x| break :b x;
         if (options.parent) |p| break :b p.omit_frame_pointer;
-        if (optimize_mode == .Debug) break :b false;
-        break :b true;
+        if (optimize_mode == .ReleaseSmall) break :b true;
+        break :b false;
     };
 
     const sanitize_thread = b: {


### PR DESCRIPTION
Frame pointers make both debugging and profiling work better, and [the overhead is reportedly 1% or less for typical programs](https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html). I think the pros outweigh the cons here. People who *really* care about that 1% can simply use the `-fomit-frame-pointer` option to reclaim it. For `ReleaseSmall`, though, it makes sense to omit frame pointers by default for the sake of code size, as we already strip the binary in this case anyway.

Closes #22161.