### PR TITLE
`std.zig.target`: Teach `isLibCLibName()` about emulated wasi-libc libraries

### DIFF
--- a/lib/std/zig/target.zig
+++ b/lib/std/zig/target.zig
@@ -223,8 +223,6 @@ pub fn isLibCLibName(target: std.Target, name: []const u8) bool {
     if (target.os.tag.isDarwin()) {
         if (eqlIgnoreCase(ignore_case, name, "System"))
             return true;
-        if (eqlIgnoreCase(ignore_case, name, "c"))
-            return true;
         if (eqlIgnoreCase(ignore_case, name, "dbm"))
             return true;
         if (eqlIgnoreCase(ignore_case, name, "dl"))

--- a/lib/std/zig/target.zig
+++ b/lib/std/zig/target.zig
@@ -218,6 +218,17 @@ pub fn isLibCLibName(target: std.Target, name: []const u8) bool {
             return true;
         if (eqlIgnoreCase(ignore_case, name, "xnet"))
             return true;
+
+        if (target.os.tag == .wasi) {
+            if (eqlIgnoreCase(ignore_case, name, "wasi-emulated-getpid"))
+                return true;
+            if (eqlIgnoreCase(ignore_case, name, "wasi-emulated-mman"))
+                return true;
+            if (eqlIgnoreCase(ignore_case, name, "wasi-emulated-process-clocks"))
+                return true;
+            if (eqlIgnoreCase(ignore_case, name, "wasi-emulated-signal"))
+                return true;
+        }
     }
 
     if (target.os.tag.isDarwin()) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3828,6 +3828,7 @@ fn createModule(
                 if (target.os.tag == .wasi) {
                     if (wasi_libc.getEmulatedLibCrtFile(lib_name)) |crt_file| {
                         try create_module.wasi_emulated_libs.append(arena, crt_file);
+                        create_module.opts.link_libc = true;
                         continue;
                     }
                 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3824,6 +3824,14 @@ fn createModule(
         for (create_module.cli_link_inputs.items) |cli_link_input| switch (cli_link_input) {
             .name_query => |nq| {
                 const lib_name = nq.name;
+
+                if (target.os.tag == .wasi) {
+                    if (wasi_libc.getEmulatedLibCrtFile(lib_name)) |crt_file| {
+                        try create_module.wasi_emulated_libs.append(arena, crt_file);
+                        continue;
+                    }
+                }
+
                 if (std.zig.target.isLibCLibName(target, lib_name)) {
                     create_module.opts.link_libc = true;
                     continue;
@@ -3832,6 +3840,7 @@ fn createModule(
                     create_module.opts.link_libcpp = true;
                     continue;
                 }
+
                 switch (target_util.classifyCompilerRtLibName(lib_name)) {
                     .none => {},
                     .only_libunwind, .both => {
@@ -3857,12 +3866,6 @@ fn createModule(
                     fatal("cannot use absolute path as a system library: {s}", .{lib_name});
                 }
 
-                if (target.os.tag == .wasi) {
-                    if (wasi_libc.getEmulatedLibCrtFile(lib_name)) |crt_file| {
-                        try create_module.wasi_emulated_libs.append(arena, crt_file);
-                        continue;
-                    }
-                }
                 unresolved_link_inputs.appendAssumeCapacity(cli_link_input);
                 any_name_queries_remaining = true;
             },


### PR DESCRIPTION
Plus some assorted fixes.