### PR TITLE
std.ArrayHashMap fix `eql` documentation

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -80,8 +80,10 @@ pub fn ArrayHashMapWithAllocator(
     comptime V: type,
     /// A namespace that provides these two functions:
     /// * `pub fn hash(self, K) u32`
-    /// * `pub fn eql(self, K, K) bool`
+    /// * `pub fn eql(self, K, K, usize) bool`
     ///
+    /// The final `usize` in the `eql` function represents the index of the key
+    /// that's already inside the map.
     comptime Context: type,
     /// When `false`, this data structure is biased towards cheap `eql`
     /// functions and avoids storing each key's hash in the table. Setting
@@ -525,7 +527,10 @@ pub fn ArrayHashMapUnmanaged(
     comptime V: type,
     /// A namespace that provides these two functions:
     /// * `pub fn hash(self, K) u32`
-    /// * `pub fn eql(self, K, K) bool`
+    /// * `pub fn eql(self, K, K, usize) bool`
+    ///
+    /// The final `usize` in the `eql` function represents the index of the key
+    /// that's already inside the map.
     comptime Context: type,
     /// When `false`, this data structure is biased towards cheap `eql`
     /// functions and avoids storing each key's hash in the table. Setting


### PR DESCRIPTION
In cf88cf2657d721c68055a284e8c498a18639f74c the eql function provided in the context of `ArrayHashMap` was changed to also include the key index, but this wasn't properly updated in the documentation.

Since a flat `usize` is unintuitive, I've tried to explain the function of the parameter as best I can based on the original commit.

Finally, I didn't do an extensive search if this eql definition is incorrectly stated anywhere outside of these 2 spots. But I somewhat doubt an file outside of `array_hash_map` would

solves #19990