### PR TITLE
fix std.zig.Ast.rootDecls on .zon mode Ast

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -205,9 +205,11 @@ pub fn extraData(tree: Ast, index: usize, comptime T: type) T {
 }
 
 pub fn rootDecls(tree: Ast) []const Node.Index {
-    // Root is always index 0.
     const nodes_data = tree.nodes.items(.data);
-    return tree.extra_data[nodes_data[0].lhs..nodes_data[0].rhs];
+    return switch (tree.mode) {
+        .zig => tree.extra_data[nodes_data[0].lhs..nodes_data[0].rhs],
+        .zon => (&nodes_data[0].lhs)[0..1],
+    };
 }
 
 pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {


### PR DESCRIPTION
The root node is encoded differently depending whether it is a .zig or .zon file.
```zig
//! Abstract Syntax Tree for Zig source code.
//! For Zig syntax, the root node is at nodes[0] and contains the list of
//! sub-nodes.
//! For Zon syntax, the root node is at nodes[0] and contains lhs as the node
//! index of the main expression.
```
The Zig compiler codebase never calls rootDecls on .zon files but I do :)