### PR TITLE
ensure `InstMap` capacity before remapping error code

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1813,6 +1813,7 @@ fn analyzeBodyInner(
                 const extra = sema.code.extraData(Zir.Inst.DeferErrCode, inst_data.payload_index).data;
                 const defer_body = sema.code.bodySlice(extra.index, extra.len);
                 const err_code = try sema.resolveInst(inst_data.err_code);
+                try map.ensureSpaceForInstructions(sema.gpa, defer_body);
                 map.putAssumeCapacity(extra.remapped_err_code, err_code);
                 if (sema.analyzeBodyInner(block, defer_body)) |_| {
                     // The defer terminated noreturn - no more analysis needed.

--- a/test/behavior/defer.zig
+++ b/test/behavior/defer.zig
@@ -234,3 +234,12 @@ test "errdefer capture" {
     s.bar2() catch {};
     if (s.fail) return error.TestExpectedError;
 }
+
+test "errdefer in test block" {
+    errdefer |err| {
+        _ = &err;
+    }
+    var x: bool = false;
+    _ = &x;
+    if (x) return error.Something;
+}


### PR DESCRIPTION
fixes #22174

there's another `ensureSpaceForInstructions` call inside of `analyzeBodyInner`, but it shouldn't incur any cost since it checks if the map already has room for the indices.