### PR TITLE
Add `armeb-linux-*`, `thumbeb-linux-*`, and `aarch64_be-linux-*` to CI

### DIFF
--- a/lib/compiler_rt/arm.zig
+++ b/lib/compiler_rt/arm.zig
@@ -233,6 +233,7 @@ test "__aeabi_frsub" {
 
 test "__aeabi_drsub" {
     if (!builtin.cpu.arch.isArm() or builtin.cpu.arch.isThumb()) return error.SkipZigTest;
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22061
     const inf64 = std.math.inf(f64);
     const maxf64 = std.math.floatMax(f64);
     const frsub_data = [_][3]f64{

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2596,6 +2596,7 @@ test "positional/alignment/width/precision" {
 }
 
 test "vector" {
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     if (builtin.target.cpu.arch == .riscv64) {
         // https://github.com/ziglang/zig/issues/4486
         return error.SkipZigTest;

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -462,6 +462,7 @@ pub fn prefixScan(comptime op: std.builtin.ReduceOp, comptime hop: isize, vec: a
 
 test "vector prefix scan" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     if (builtin.cpu.arch == .aarch64_be and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21893
 
     if (comptime builtin.cpu.arch.isMIPS()) {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -639,8 +639,9 @@ test "vector division operators" {
         }
     };
 
-    try S.doTheTest();
     try comptime S.doTheTest();
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
+    try S.doTheTest();
 }
 
 test "vector bitwise not operator" {
@@ -1098,8 +1099,9 @@ test "@addWithOverflow" {
             }
         }
     };
-    try S.doTheTest();
     try comptime S.doTheTest();
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
+    try S.doTheTest();
 }
 
 test "@subWithOverflow" {
@@ -1131,8 +1133,9 @@ test "@subWithOverflow" {
             }
         }
     };
-    try S.doTheTest();
     try comptime S.doTheTest();
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
+    try S.doTheTest();
 }
 
 test "@mulWithOverflow" {
@@ -1154,8 +1157,9 @@ test "@mulWithOverflow" {
             try expectEqual(expected, overflow);
         }
     };
-    try S.doTheTest();
     try comptime S.doTheTest();
+    if (builtin.cpu.arch == .armeb and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
+    try S.doTheTest();
 }
 
 test "@shlWithOverflow" {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -309,6 +309,30 @@ const test_targets = blk: {
 
         .{
             .target = .{
+                .cpu_arch = .aarch64_be,
+                .os_tag = .linux,
+                .abi = .none,
+            },
+        },
+        .{
+            .target = .{
+                .cpu_arch = .aarch64_be,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .aarch64_be,
+                .os_tag = .linux,
+                .abi = .gnu,
+            },
+            .link_libc = true,
+        },
+
+        .{
+            .target = .{
                 .cpu_arch = .arm,
                 .os_tag = .linux,
                 .abi = .eabi,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -356,6 +356,53 @@ const test_targets = blk: {
 
         .{
             .target = .{
+                .cpu_arch = .armeb,
+                .os_tag = .linux,
+                .abi = .eabi,
+            },
+        },
+        .{
+            .target = .{
+                .cpu_arch = .armeb,
+                .os_tag = .linux,
+                .abi = .eabihf,
+            },
+        },
+        .{
+            .target = .{
+                .cpu_arch = .armeb,
+                .os_tag = .linux,
+                .abi = .musleabi,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .armeb,
+                .os_tag = .linux,
+                .abi = .musleabihf,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .armeb,
+                .os_tag = .linux,
+                .abi = .gnueabi,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .armeb,
+                .os_tag = .linux,
+                .abi = .gnueabihf,
+            },
+            .link_libc = true,
+        },
+
+        .{
+            .target = .{
                 .cpu_arch = .thumb,
                 .os_tag = .linux,
                 .abi = .eabi,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -440,7 +440,7 @@ const test_targets = blk: {
             .target = std.Target.Query.parse(.{
                 .arch_os_abi = "thumb-linux-musleabi",
                 .cpu_features = "baseline+long_calls",
-            }) catch @panic("OOM"),
+            }) catch unreachable,
             .link_libc = true,
             .pic = false, // Long calls don't work with PIC.
             .skip_modules = &.{
@@ -454,7 +454,71 @@ const test_targets = blk: {
             .target = std.Target.Query.parse(.{
                 .arch_os_abi = "thumb-linux-musleabihf",
                 .cpu_features = "baseline+long_calls",
-            }) catch @panic("OOM"),
+            }) catch unreachable,
+            .link_libc = true,
+            .pic = false, // Long calls don't work with PIC.
+            .skip_modules = &.{
+                "behavior",
+                "c-import",
+                "compiler-rt",
+                "universal-libc",
+            },
+        },
+
+        .{
+            .target = .{
+                .cpu_arch = .thumbeb,
+                .os_tag = .linux,
+                .abi = .eabi,
+            },
+        },
+        .{
+            .target = .{
+                .cpu_arch = .thumbeb,
+                .os_tag = .linux,
+                .abi = .eabihf,
+            },
+        },
+        .{
+            .target = .{
+                .cpu_arch = .thumbeb,
+                .os_tag = .linux,
+                .abi = .musleabi,
+            },
+            .link_libc = true,
+            .skip_modules = &.{"std"},
+        },
+        .{
+            .target = .{
+                .cpu_arch = .thumbeb,
+                .os_tag = .linux,
+                .abi = .musleabihf,
+            },
+            .link_libc = true,
+            .skip_modules = &.{"std"},
+        },
+        // Calls are normally lowered to branch instructions that only support +/- 16 MB range when
+        // targeting Thumb. This is not sufficient for the std test binary linked statically with
+        // musl, so use long calls to avoid out-of-range relocations.
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "thumbeb-linux-musleabi",
+                .cpu_features = "baseline+long_calls",
+            }) catch unreachable,
+            .link_libc = true,
+            .pic = false, // Long calls don't work with PIC.
+            .skip_modules = &.{
+                "behavior",
+                "c-import",
+                "compiler-rt",
+                "universal-libc",
+            },
+        },
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "thumbeb-linux-musleabihf",
+                .cpu_features = "baseline+long_calls",
+            }) catch unreachable,
             .link_libc = true,
             .pic = false, // Long calls don't work with PIC.
             .skip_modules = &.{


### PR DESCRIPTION
With #22035 merged, we should hopefully no longer see the random unwind failures that occurred after #21894, so let's try this again.