### PR TITLE
`Compilation`: Enable LTO for libraries by default

### DIFF
--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -308,8 +308,8 @@ pub fn resolve(options: Options) ResolveError!Config {
         }
 
         break :b switch (options.output_mode) {
-            .Lib, .Obj => false,
-            .Exe => switch (root_optimize_mode) {
+            .Obj => false,
+            .Lib, .Exe => switch (root_optimize_mode) {
                 .Debug => false,
                 .ReleaseSafe, .ReleaseFast, .ReleaseSmall => true,
             },


### PR DESCRIPTION
Just curious to see if this'll work in CI. If it does, we can merge after #22171 to avoid conflicts in that.