### PR TITLE
compiler: Switch to DWARF 5 by default for `zig cc` and the LLVM backend.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5561,7 +5561,7 @@ pub fn addCCArgs(
             argv.appendSliceAssumeCapacity(&.{ "-g", "-gcodeview" });
         },
         .dwarf => |f| {
-            argv.appendAssumeCapacity("-gdwarf-4");
+            argv.appendAssumeCapacity("-gdwarf-5");
             switch (f) {
                 .@"32" => argv.appendAssumeCapacity("-gdwarf32"),
                 .@"64" => argv.appendAssumeCapacity("-gdwarf64"),

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1162,7 +1162,7 @@ pub const Object = struct {
                         module_flags.appendAssumeCapacity(try o.builder.metadataModuleFlag(
                             behavior_max,
                             try o.builder.metadataString("Dwarf Version"),
-                            try o.builder.metadataConstant(try o.builder.intConst(.i32, 4)),
+                            try o.builder.metadataConstant(try o.builder.intConst(.i32, 5)),
                         ));
 
                         if (f == .@"64") {

--- a/src/link/Elf/Atom.zig
+++ b/src/link/Elf/Atom.zig
@@ -1882,6 +1882,9 @@ const riscv = struct {
             .LO12_S,
             .ADD32,
             .SUB32,
+
+            .SUB_ULEB128,
+            .SET_ULEB128,
             => {},
 
             else => try atom.reportUnhandledRelocError(rel, elf_file),
@@ -2070,6 +2073,9 @@ const riscv = struct {
 
             .SET6 => riscv_util.writeSetSub6(.set, code[r_offset..][0..1], S + A),
             .SUB6 => riscv_util.writeSetSub6(.sub, code[r_offset..][0..1], S + A),
+
+            .SET_ULEB128 => try riscv_util.writeSetSubUleb(.set, stream, S + A),
+            .SUB_ULEB128 => try riscv_util.writeSetSubUleb(.sub, stream, S - A),
 
             else => try atom.reportUnhandledRelocError(rel, elf_file),
         }


### PR DESCRIPTION
This is the same version we're targeting for the self-hosted backends.