### PR TITLE
`wasm2c`: Implement `PT_GNU_STACK`-based stack size expansion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,19 +805,24 @@ if(MSVC)
   set(ZIG_WASM2C_COMPILE_FLAGS "")
   set(ZIG1_COMPILE_FLAGS "/Os")
   set(ZIG2_COMPILE_FLAGS "/Od")
+  set(ZIG1_LINK_FLAGS "/STACK:16777216")
   set(ZIG2_LINK_FLAGS "/STACK:16777216 /FORCE:MULTIPLE")
 else()
   set(ZIG_WASM2C_COMPILE_FLAGS "-std=c99 -O2")
   set(ZIG1_COMPILE_FLAGS "-std=c99 -Os")
   set(ZIG2_COMPILE_FLAGS "-std=c99 -O0 -fno-stack-protector")
   if(APPLE)
+    set(ZIG1_LINK_FLAGS "-Wl,-stack_size,0x1000000")
     set(ZIG2_LINK_FLAGS "-Wl,-stack_size,0x10000000")
   elseif(MINGW)
+    set(ZIG1_LINK_FLAGS "-Wl,--stack,0x1000000")
     set(ZIG2_LINK_FLAGS "-Wl,--stack,0x10000000")
   # Solaris/illumos ld(1) does not provide a --stack-size option.
   elseif(CMAKE_HOST_SOLARIS)
+    unset(ZIG1_LINK_FLAGS)
     unset(ZIG2_LINK_FLAGS)
   else()
+    set(ZIG1_LINK_FLAGS "-Wl,-z,stack-size=0x1000000")
     set(ZIG2_LINK_FLAGS "-Wl,-z,stack-size=0x10000000")
   endif()
 endif()
@@ -839,7 +844,10 @@ add_custom_command(
 )
 
 add_executable(zig1 ${ZIG1_C_SOURCE} stage1/wasi.c)
-set_target_properties(zig1 PROPERTIES COMPILE_FLAGS ${ZIG1_COMPILE_FLAGS})
+set_target_properties(zig1 PROPERTIES
+  COMPILE_FLAGS ${ZIG1_COMPILE_FLAGS}
+  LINK_FLAGS "${ZIG1_LINK_FLAGS}"
+)
 
 if(MSVC)
   target_link_options(zig1 PRIVATE /STACK:0x10000000)

--- a/bootstrap.c
+++ b/bootstrap.c
@@ -114,7 +114,14 @@ int main(int argc, char **argv) {
     }
     {
         const char *child_argv[] = {
-            cc, "-o", "zig1", "zig1.c", "stage1/wasi.c", "-std=c99", "-Os", "-lm", NULL,
+            cc, "-o", "zig1", "zig1.c", "stage1/wasi.c",
+            "-std=c99", "-Os", "-lm",
+#if defined(__APPLE__)
+            "-Wl,-stack_size,0x1000000",
+#else
+            "-Wl,-z,stack-size=0x1000000",
+#endif
+            NULL,
         };
         print_and_run(child_argv);
     }

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -571,6 +571,7 @@ fn posixCallMainAndExit(argc_argv_ptr: [*]usize) callconv(.c) noreturn {
     std.posix.exit(callMainWithArgs(argc, argv, envp));
 }
 
+// This code should be kept in sync with stage1/wasi.c.
 fn expandStackSize(phdrs: []elf.Phdr) void {
     for (phdrs) |*phdr| {
         switch (phdr.p_type) {


### PR DESCRIPTION
This is currently limited to Linux like the code in `lib/std/start.zig` due to the use of `getauxval()`. There should be equivalent functions for other OSs (e.g. `elf_aux_info()` for FreeBSD), but support for those can be done as future work.

Closes #22111.