### PR TITLE
disallow stores to element types with no comptime size

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -31958,6 +31958,14 @@ fn storePtr2(
         });
     }
 
+    // Don't allow stores to element types that have no comptime size.
+    switch (elem_ty.zigTypeTag(zcu)) {
+        .@"fn",
+        .@"opaque",
+        => return sema.fail(block, ptr_src, "pointer element type must have a comptime-known size", .{}),
+        else => {},
+    }
+
     const store_inst = if (is_ret)
         try block.addBinOp(.store, ptr, operand)
     else

--- a/test/cases/compile_errors/store_no_comptime_size.zig
+++ b/test/cases/compile_errors/store_no_comptime_size.zig
@@ -1,0 +1,15 @@
+export fn a() void {
+    const x: *fn () void = @ptrFromInt(4);
+    x.* = undefined;
+}
+
+export fn b(x: *anyopaque) void {
+    x.* = undefined;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :3:6: error: pointer element type must have a comptime-known size
+// :7:6: error: pointer element type must have a comptime-known size


### PR DESCRIPTION
other types such as `@TypeOf(undefined)` and `@TypeOf(null)` also don't have a comptime known size, however, they're OPV types so we currently allow it. 

resolves #22175