### PR TITLE
Sema: disallow unsafe in-memory coercions

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1364,20 +1364,20 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
     );
 }
 
-fn nextArg(args: [][:0]const u8, idx: *usize) ?[:0]const u8 {
+fn nextArg(args: []const [:0]const u8, idx: *usize) ?[:0]const u8 {
     if (idx.* >= args.len) return null;
     defer idx.* += 1;
     return args[idx.*];
 }
 
-fn nextArgOrFatal(args: [][:0]const u8, idx: *usize) [:0]const u8 {
+fn nextArgOrFatal(args: []const [:0]const u8, idx: *usize) [:0]const u8 {
     return nextArg(args, idx) orelse {
         std.debug.print("expected argument after '{s}'\n  access the help menu with 'zig build -h'\n", .{args[idx.* - 1]});
         process.exit(1);
     };
 }
 
-fn argsRest(args: [][:0]const u8, idx: usize) ?[][:0]const u8 {
+fn argsRest(args: []const [:0]const u8, idx: usize) ?[]const [:0]const u8 {
     if (idx >= args.len) return null;
     return args[idx..];
 }

--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -1232,16 +1232,16 @@ pub extern "c" fn posix_spawn(
     path: [*:0]const u8,
     actions: ?*const posix_spawn_file_actions_t,
     attr: ?*const posix_spawnattr_t,
-    argv: [*:null]?[*:0]const u8,
-    env: [*:null]?[*:0]const u8,
+    argv: [*:null]const ?[*:0]const u8,
+    env: [*:null]const ?[*:0]const u8,
 ) c_int;
 pub extern "c" fn posix_spawnp(
     pid: *pid_t,
     path: [*:0]const u8,
     actions: ?*const posix_spawn_file_actions_t,
     attr: ?*const posix_spawnattr_t,
-    argv: [*:null]?[*:0]const u8,
-    env: [*:null]?[*:0]const u8,
+    argv: [*:null]const ?[*:0]const u8,
+    env: [*:null]const ?[*:0]const u8,
 ) c_int;
 
 pub const E = enum(u16) {

--- a/src/DarwinPosixSpawn.zig
+++ b/src/DarwinPosixSpawn.zig
@@ -161,8 +161,8 @@ pub fn spawn(
     path: []const u8,
     actions: ?Actions,
     attr: ?Attr,
-    argv: [*:null]?[*:0]const u8,
-    envp: [*:null]?[*:0]const u8,
+    argv: [*:null]const ?[*:0]const u8,
+    envp: [*:null]const ?[*:0]const u8,
 ) Error!std.c.pid_t {
     const posix_path = try std.posix.toPosixPath(path);
     return spawnZ(&posix_path, actions, attr, argv, envp);
@@ -172,8 +172,8 @@ pub fn spawnZ(
     path: [*:0]const u8,
     actions: ?Actions,
     attr: ?Attr,
-    argv: [*:null]?[*:0]const u8,
-    envp: [*:null]?[*:0]const u8,
+    argv: [*:null]const ?[*:0]const u8,
+    envp: [*:null]const ?[*:0]const u8,
 ) Error!std.c.pid_t {
     var pid: std.c.pid_t = undefined;
     switch (errno(std.c.posix_spawn(

--- a/src/clang.zig
+++ b/src/clang.zig
@@ -2224,8 +2224,8 @@ pub const ErrorMsg = extern struct {
 
 pub const LoadFromCommandLine = ZigClangLoadFromCommandLine;
 extern fn ZigClangLoadFromCommandLine(
-    args_begin: [*]?[*]const u8,
-    args_end: [*]?[*]const u8,
+    args_begin: [*]?[*:0]const u8,
+    args_end: [*]?[*:0]const u8,
     errors_ptr: *[*]ErrorMsg,
     errors_len: *usize,
     resources_path: [*:0]const u8,

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -997,7 +997,7 @@ fn markRelocsDirtyByAddress(coff: *Coff, addr: u32) void {
     }
 }
 
-fn resolveRelocs(coff: *Coff, atom_index: Atom.Index, relocs: []*const Relocation, code: []u8, image_base: u64) void {
+fn resolveRelocs(coff: *Coff, atom_index: Atom.Index, relocs: []const *const Relocation, code: []u8, image_base: u64) void {
     log.debug("relocating '{s}'", .{coff.getAtom(atom_index).getName(coff)});
     for (relocs) |reloc| {
         reloc.resolve(atom_index, code, image_base, coff);

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -79,8 +79,8 @@ pub const Context = struct {
 
 pub fn translate(
     gpa: mem.Allocator,
-    args_begin: [*]?[*]const u8,
-    args_end: [*]?[*]const u8,
+    args_begin: [*]?[*:0]const u8,
+    args_end: [*]?[*:0]const u8,
     errors: *std.zig.ErrorBundle,
     resources_path: [*:0]const u8,
 ) !std.zig.Ast {

--- a/test/cases/compile_errors/implicit_cast_between_C_pointer_and_Zig_pointer-bad_const-align-child.zig
+++ b/test/cases/compile_errors/implicit_cast_between_C_pointer_and_Zig_pointer-bad_const-align-child.zig
@@ -38,7 +38,7 @@ export fn f() void {
 // :8:18: error: expected type '*u8', found '[*c]const u8'
 // :8:18: note: cast discards const qualifier
 // :13:19: error: expected type '*u32', found '[*c]u8'
-// :13:19: note: pointer type child 'u8' cannot cast into pointer type child 'u32'
+// :13:19: note: '[*c]u8' could have null values which are illegal in type '*u32'
 // :18:22: error: expected type '[*c]u32', found '*align(1) u32'
 // :18:22: note: pointer alignment '1' cannot cast into pointer alignment '4'
 // :23:21: error: expected type '[*c]u8', found '*const u8'

--- a/test/cases/compile_errors/implicit_casting_C_pointers_which_would_mess_up_null_semantics.zig
+++ b/test/cases/compile_errors/implicit_casting_C_pointers_which_would_mess_up_null_semantics.zig
@@ -13,7 +13,7 @@ export fn entry2() void {
     var slice: []u8 = &buf;
     var opt_many_ptr: [*]u8 = slice.ptr;
     var ptr_opt_many_ptr = &opt_many_ptr;
-    var c_ptr: [*c][*c]const u8 = ptr_opt_many_ptr;
+    var c_ptr: [*c][*c]u8 = ptr_opt_many_ptr;
     _ = &slice;
     _ = &ptr_opt_many_ptr;
     _ = &c_ptr;
@@ -24,8 +24,7 @@ export fn entry2() void {
 // target=native
 //
 // :6:24: error: expected type '*const [*]const u8', found '[*c]const [*c]const u8'
-// :6:24: note: pointer type child '[*c]const u8' cannot cast into pointer type child '[*]const u8'
-// :6:24: note: '[*c]const u8' could have null values which are illegal in type '[*]const u8'
-// :16:35: error: expected type '[*c][*c]const u8', found '*[*]u8'
-// :16:35: note: pointer type child '[*]u8' cannot cast into pointer type child '[*c]const u8'
-// :16:35: note: mutable '[*]u8' allows illegal null values stored to type '[*c]const u8'
+// :6:24: note: '[*c]const [*c]const u8' could have null values which are illegal in type '*const [*]const u8'
+// :16:29: error: expected type '[*c][*c]u8', found '*[*]u8'
+// :16:29: note: pointer type child '[*]u8' cannot cast into pointer type child '[*c]u8'
+// :16:29: note: mutable '[*c]u8' would allow illegal null values stored to type '[*]u8'

--- a/test/cases/compile_errors/invalid_pointer_coercions.zig
+++ b/test/cases/compile_errors/invalid_pointer_coercions.zig
@@ -1,0 +1,77 @@
+//! This file contains pointer coercions which are invalid because the element types are only
+//! in-memory coercible *in one direction*. When casting a mutable pointer, the element type
+//! must coerce in both directions for the pointer to coerce. Otherwise, you could do something
+//! like this, where `A` coerces to `B` but not vice-versa:
+//!
+//! ```
+//! var x: A = undefined;
+//! const p: *B = &x; // `*A` -> `*B`
+//! p.* = some_b;
+//! const some_b_as_a = x;
+//! ```
+
+export fn error_set_to_larger() void {
+    var x: error{Foo} = undefined;
+    _ = @as(*const error{ Foo, Bar }, &x); // this is ok
+    _ = @as(*error{ Foo, Bar }, &x); // compile error
+}
+
+export fn error_set_to_anyerror() void {
+    var x: error{Foo} = undefined;
+    _ = @as(*const anyerror, &x); // this is ok
+    _ = @as(*anyerror, &x); // compile error
+}
+
+export fn error_union_to_anyerror_union() void {
+    var x: error{Foo}!u32 = undefined;
+    _ = @as(*const anyerror!u32, &x); // this is ok
+    _ = @as(*anyerror!u32, &x); // compile error
+}
+
+export fn ptr_to_const_ptr() void {
+    var x: *u32 = undefined;
+    _ = @as(*const *const u32, &x); // this is ok
+    _ = @as(**const u32, &x); // compile error
+}
+
+export fn ptr_to_allowzero_ptr() void {
+    var x: *u32 = undefined;
+    _ = @as(*const *allowzero u32, &x); // this is ok
+    _ = @as(**allowzero u32, &x); // compile error
+}
+
+export fn ptr_to_volatile_ptr() void {
+    var x: *u32 = undefined;
+    _ = @as(*const *volatile u32, &x); // this is ok
+    _ = @as(**volatile u32, &x); // compile error
+}
+
+export fn ptr_to_underaligned_ptr() void {
+    var x: *u32 = undefined;
+    _ = @as(*const *align(1) u32, &x); // this is ok
+    _ = @as(**align(1) u32, &x); // compile error
+}
+
+// error
+//
+// :16:33: error: expected type '*error{Foo,Bar}', found '*error{Foo}'
+// :16:33: note: pointer type child 'error{Foo}' cannot cast into pointer type child 'error{Foo,Bar}'
+// :16:33: note: 'error.Bar' not a member of destination error set
+// :22:24: error: expected type '*anyerror', found '*error{Foo}'
+// :22:24: note: pointer type child 'error{Foo}' cannot cast into pointer type child 'anyerror'
+// :22:24: note: global error set cannot cast into a smaller set
+// :28:28: error: expected type '*anyerror!u32', found '*error{Foo}!u32'
+// :28:28: note: pointer type child 'error{Foo}!u32' cannot cast into pointer type child 'anyerror!u32'
+// :28:28: note: global error set cannot cast into a smaller set
+// :34:26: error: expected type '**const u32', found '**u32'
+// :34:26: note: pointer type child '*u32' cannot cast into pointer type child '*const u32'
+// :34:26: note: mutable '*const u32' would allow illegal const pointers stored to type '*u32'
+// :40:30: error: expected type '**allowzero u32', found '**u32'
+// :40:30: note: pointer type child '*u32' cannot cast into pointer type child '*allowzero u32'
+// :40:30: note: mutable '*allowzero u32' would allow illegal null values stored to type '*u32'
+// :46:29: error: expected type '**volatile u32', found '**u32'
+// :46:29: note: pointer type child '*u32' cannot cast into pointer type child '*volatile u32'
+// :46:29: note: mutable '*volatile u32' would allow illegal volatile pointers stored to type '*u32'
+// :52:29: error: expected type '**align(1) u32', found '**u32'
+// :52:29: note: pointer type child '*u32' cannot cast into pointer type child '*align(1) u32'
+// :52:29: note: pointer alignment '4' cannot cast into pointer alignment '1'

--- a/test/cases/compile_errors/use_implicit_casts_to_assign_null_to_non-nullable_pointer.zig
+++ b/test/cases/compile_errors/use_implicit_casts_to_assign_null_to_non-nullable_pointer.zig
@@ -12,4 +12,4 @@ export fn entry() void {
 //
 // :4:24: error: expected type '*?*i32', found '**i32'
 // :4:24: note: pointer type child '*i32' cannot cast into pointer type child '?*i32'
-// :4:24: note: mutable '*i32' allows illegal null values stored to type '?*i32'
+// :4:24: note: mutable '?*i32' would allow illegal null values stored to type '*i32'


### PR DESCRIPTION
The error messages here aren't amazing yet, but this is an improvement on status quo, because the current behavior allows false negative compile errors, so effectively miscompiles.

Resolves: #15874