### PR TITLE
std: add optional times pointer for futimes, futimens, utimes, utimensat

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -9387,11 +9387,11 @@ pub extern "c" fn malloc(usize) ?*anyopaque;
 pub extern "c" fn realloc(?*anyopaque, usize) ?*anyopaque;
 pub extern "c" fn free(?*anyopaque) void;
 
-pub extern "c" fn futimes(fd: fd_t, times: *[2]timeval) c_int;
-pub extern "c" fn utimes(path: [*:0]const u8, times: *[2]timeval) c_int;
+pub extern "c" fn futimes(fd: fd_t, times: ?*[2]timeval) c_int;
+pub extern "c" fn utimes(path: [*:0]const u8, times: ?*[2]timeval) c_int;
 
-pub extern "c" fn utimensat(dirfd: fd_t, pathname: [*:0]const u8, times: *[2]timespec, flags: u32) c_int;
-pub extern "c" fn futimens(fd: fd_t, times: *const [2]timespec) c_int;
+pub extern "c" fn utimensat(dirfd: fd_t, pathname: [*:0]const u8, times: ?*[2]timespec, flags: u32) c_int;
+pub extern "c" fn futimens(fd: fd_t, times: ?*const [2]timespec) c_int;
 
 pub extern "c" fn pthread_create(
     noalias newthread: *pthread_t,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -608,11 +608,11 @@ pub inline fn vfork() usize {
     return @call(.always_inline, syscall0, .{.vfork});
 }
 
-pub fn futimens(fd: i32, times: *const [2]timespec) usize {
+pub fn futimens(fd: i32, times: ?*const [2]timespec) usize {
     return utimensat(fd, null, times, 0);
 }
 
-pub fn utimensat(dirfd: i32, path: ?[*:0]const u8, times: *const [2]timespec, flags: u32) usize {
+pub fn utimensat(dirfd: i32, path: ?[*:0]const u8, times: ?*const [2]timespec, flags: u32) usize {
     return syscall4(.utimensat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), @intFromPtr(times), flags);
 }
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -5767,17 +5767,27 @@ pub const FutimensError = error{
     ReadOnlyFileSystem,
 } || UnexpectedError;
 
-pub fn futimens(fd: fd_t, times: *const [2]timespec) FutimensError!void {
+pub fn futimens(fd: fd_t, times: ?*const [2]timespec) FutimensError!void {
     if (native_os == .wasi and !builtin.link_libc) {
         // TODO WASI encodes `wasi.fstflags` to signify magic values
         // similar to UTIME_NOW and UTIME_OMIT. Currently, we ignore
         // this here, but we should really handle it somehow.
-        const atim = times[0].toTimestamp();
-        const mtim = times[1].toTimestamp();
-        switch (wasi.fd_filestat_set_times(fd, atim, mtim, .{
-            .ATIM = true,
-            .MTIM = true,
-        })) {
+        const error_code = blk: {
+            if (times) |times_arr| {
+                const atim = times_arr[0].toTimestamp();
+                const mtim = times_arr[1].toTimestamp();
+                break :blk wasi.fd_filestat_set_times(fd, atim, mtim, .{
+                    .ATIM = true,
+                    .MTIM = true,
+                });
+            }
+
+            break :blk wasi.fd_filestat_set_times(fd, 0, 0, .{
+                .ATIM_NOW = true,
+                .MTIM_NOW = true,
+            });
+        };
+        switch (error_code) {
             .SUCCESS => return,
             .ACCES => return error.AccessDenied,
             .PERM => return error.PermissionDenied,


### PR DESCRIPTION
Fixes #22194 

For optional pointer with WASI, passes 0 for atim and mtim and sets flags for ATIM_NOW and MTIM_NOW to true in futimens.