### PR TITLE
Dwarf: preserve deduped struct navs

### DIFF
--- a/lib/std/dwarf/AT.zig
+++ b/lib/std/dwarf/AT.zig
@@ -224,6 +224,8 @@ pub const ZIG_parent = 0x2ccd;
 pub const ZIG_padding = 0x2cce;
 pub const ZIG_relative_decl = 0x2cd0;
 pub const ZIG_decl_line_relative = 0x2cd1;
+pub const ZIG_comptime_value = 0x2cd2;
+pub const ZIG_comptime_default_value = 0x2cd3;
 pub const ZIG_sentinel = 0x2ce2;
 
 // UPC extension.

--- a/lib/std/dwarf/TAG.zig
+++ b/lib/std/dwarf/TAG.zig
@@ -119,3 +119,4 @@ pub const PGI_interface_block = 0xA020;
 
 // ZIG extensions.
 pub const ZIG_padding = 0xfdb1;
+pub const ZIG_comptime_value = 0xfdb2;

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -1163,7 +1163,7 @@ const Local = struct {
                 capacity: u32,
             };
             fn header(list: ListSelf) *Header {
-                return @ptrFromInt(@intFromPtr(list.bytes) - bytes_offset);
+                return @alignCast(@ptrCast(list.bytes - bytes_offset));
             }
             pub fn view(list: ListSelf) View {
                 const capacity = list.header().capacity;
@@ -1372,7 +1372,7 @@ const Shard = struct {
                 }
             };
             fn header(map: @This()) *Header {
-                return @ptrFromInt(@intFromPtr(map.entries) - entries_offset);
+                return @alignCast(@ptrCast(@as([*]u8, @ptrCast(map.entries)) - entries_offset));
             }
 
             const Entry = extern struct {

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -4126,6 +4126,7 @@ pub const @"anyframe": Type = .{ .ip_index = .anyframe_type };
 pub const @"null": Type = .{ .ip_index = .null_type };
 pub const @"undefined": Type = .{ .ip_index = .undefined_type };
 pub const @"noreturn": Type = .{ .ip_index = .noreturn_type };
+pub const enum_literal: Type = .{ .ip_index = .enum_literal_type };
 
 pub const @"c_char": Type = .{ .ip_index = .c_char_type };
 pub const @"c_short": Type = .{ .ip_index = .c_short_type };

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2632,7 +2632,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
 
             const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
             if (type_gop.found_existing) {
-                dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).clear();
+                if (dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).len > 0) break :tag .decl_alias;
                 nav_gop.value_ptr.* = type_gop.value_ptr.*;
             } else {
                 if (nav_gop.found_existing)
@@ -2733,7 +2733,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
 
             const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
             if (type_gop.found_existing) {
-                dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).clear();
+                if (dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).len > 0) break :tag .decl_alias;
                 nav_gop.value_ptr.* = type_gop.value_ptr.*;
             } else {
                 if (nav_gop.found_existing)
@@ -2788,7 +2788,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
 
             const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
             if (type_gop.found_existing) {
-                dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).clear();
+                if (dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).len > 0) break :tag .decl_alias;
                 nav_gop.value_ptr.* = type_gop.value_ptr.*;
             } else {
                 if (nav_gop.found_existing)
@@ -2879,7 +2879,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
 
             const type_gop = try dwarf.types.getOrPut(dwarf.gpa, nav_val.toIntern());
             if (type_gop.found_existing) {
-                dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).clear();
+                if (dwarf.debug_info.section.getUnit(wip_nav.unit).getEntry(type_gop.value_ptr.*).len > 0) break :tag .decl_alias;
                 nav_gop.value_ptr.* = type_gop.value_ptr.*;
             } else {
                 if (nav_gop.found_existing)


### PR DESCRIPTION
```zig
fn Foo(comptime T: type) type {
    return struct {
        x: T,
        const Bar = struct { x: u32 };
    };
}
pub fn main() void {
    var foo1: Foo(u32) = .{ .x = 1 };
    var foo2: Foo(bool) = .{ .x = false };
    _ = .{ &foo1, &foo2, @TypeOf(foo1).Bar, @TypeOf(foo2).Bar };
    @breakpoint();
}
```
```
(lldb) p @TypeOf(foo1)
(type) struct {}
(lldb) p @TypeOf(foo2)
(type) struct {
  Bar = struct {}
}
```
&downarrow;
```
(lldb) p @TypeOf(foo1)
(type) struct {
  Bar = struct {}
}
(lldb) p @TypeOf(foo2)
(type) struct {
  Bar = repro.repro.Foo(u32).Bar
}
```

Also, start porting stage2 pretty printers to self-hosted debug info and thread-safe internpool changes.