### PR TITLE
std: Add branchHint to `std.math.pow`

### DIFF
--- a/lib/std/math/pow.zig
+++ b/lib/std/math/pow.zig
@@ -48,6 +48,7 @@ pub fn pow(comptime T: type, x: T, y: T) T {
     // pow(nan, y) = nan    for all y
     // pow(x, nan) = nan    for all x
     if (math.isNan(x) or math.isNan(y)) {
+        @branchHint(.unlikely);
         return math.nan(T);
     }
 


### PR DESCRIPTION
NaN is an unlikely case, and a branchHint `.unlikely` would indicate this to the optimizer.