### PR TITLE
Module: keep frame pointer in ReleaseSmall on x86

### DIFF
--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -205,7 +205,12 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
     const omit_frame_pointer = b: {
         if (options.inherited.omit_frame_pointer) |x| break :b x;
         if (options.parent) |p| break :b p.omit_frame_pointer;
-        if (optimize_mode == .ReleaseSmall) break :b true;
+        if (optimize_mode == .ReleaseSmall) {
+            // On x86, in most cases, keeping the frame pointer usually results in smaller binary size.
+            // This has to do with how instructions for memory access via the stack base pointer register (when keeping the frame pointer)
+            // are smaller than instructions for memory access via the stack pointer register (when omitting the frame pointer).
+            break :b !target.cpu.arch.isX86();
+        }
         break :b false;
     };
 


### PR DESCRIPTION
On x86 and x86_64 keeping the frame pointer usually reduces binary size, even for simple programs:

```
~$ cat x.zig
pub fn main() void {
    @import("std").debug.print("hello", .{});
}
~$ zig build-exe x.zig -target x86_64-linux -OReleaseSmall -fno-omit-frame-pointer && wc -c x
5168 x
~$ zig build-exe x.zig -target x86_64-linux -OReleaseSmall -fomit-frame-pointer && wc -c x
5216 x
```
```
~$ cat x.zig
pub fn main() void {
    @import("std").debug.print("hello", .{});
}
~$ zig build-exe x.zig -target x86-linux -OReleaseSmall -fno-omit-frame-pointer && wc -c x
3400 x
~$ zig build-exe x.zig -target x86-linux -OReleaseSmall -fomit-frame-pointer && wc -c x
3556 x
```

A bigger benchmark is the Zig compiler:

With no changes to anything on master branch:
```
$ zig build -Dno-lib -Dno-langref --zig-lib-dir lib -Doptimize=ReleaseSmall
$ wc -c zig-out/bin/zig
10698792 zig-out/bin/zig
```
Adding `.omit_frame_pointer = false` in `addCompilerStep` in `build.zig`:
```
$ zig build -Dno-lib -Dno-langref --zig-lib-dir lib -Doptimize=ReleaseSmall
$ wc -c zig-out/bin/zig
10155744 zig-out/bin/zig
```

x86 seems to be a bit of a special case. I couldn't find any other architecture where this reduces binary size.

Progress towards #22270