### PR TITLE
fix: allow std.os.linux.getgroups to accept null

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1674,7 +1674,7 @@ pub fn setpgid(pid: pid_t, pgid: pid_t) usize {
     return syscall2(.setpgid, @intCast(pid), @intCast(pgid));
 }
 
-pub fn getgroups(size: usize, list: *gid_t) usize {
+pub fn getgroups(size: usize, list: ?*gid_t) usize {
     if (@hasField(SYS, "getgroups32")) {
         return syscall2(.getgroups32, size, @intFromPtr(list));
     } else {


### PR DESCRIPTION
looking at `man getgroups` and `info getgroups` this is given as an example:

  ```c
       // Here's how to use ‘getgroups’ to read all the supplementary group
       // IDs:

            gid_t *
            read_all_groups (void)
            {
              int ngroups = getgroups (0, NULL);
              gid_t *groups
                = (gid_t *) xmalloc (ngroups * sizeof (gid_t));
              int val = getgroups (ngroups, groups);
              if (val < 0)
                {
                  free (groups);
                  return NULL;
                }
              return groups;
            }
  ```

getgroups(0, NULL) is used to get the count of groups so that the correct count can be used to allocate a list of gid_t. However this is not possible with the function signature `getgroups(size: usize, list: *gid_t) usize` where "list" is supposedly a pointer to the beginning of a list of unknown length.

equivalent example in Zig after the change:

  ```zig
    // get the group count
    const ngroups: usize = std.os.linux.getgroups(0, null);
    if (ngroups <= 0) {
        return error.GetGroupsError;
    }

    std.debug.print("number of groups: {d}\n", .{ngroups});
    const groups_gids: []u32 = try alloc.alloc(u32, ngroups);

    // populate an array of gid_t
    _ = std.os.linux.getgroups(ngroups, @ptrCast(groups_gids));
  ```