### PR TITLE
Improve `std.sort.binarySearch`'s return type, fix `std.sort` functions to adhere to their documentation

### DIFF
--- a/lib/compiler/aro/aro/Preprocessor.zig
+++ b/lib/compiler/aro/aro/Preprocessor.zig
@@ -270,13 +270,14 @@ fn clearBuffers(pp: *Preprocessor) void {
 
 pub fn expansionSlice(pp: *Preprocessor, tok: Tree.TokenIndex) []Source.Location {
     const S = struct {
-        fn orderTokenIndex(context: Tree.TokenIndex, item: Tree.TokenIndex) std.math.Order {
-            return std.math.order(context, item);
+        fn order(probed: Tree.TokenIndex, context: Tree.TokenIndex) std.math.Order {
+            return std.math.order(probed, context);
         }
     };
 
     const indices = pp.expansion_entries.items(.idx);
-    const idx = std.sort.binarySearch(Tree.TokenIndex, indices, tok, S.orderTokenIndex) orelse return &.{};
+    const idx, const found = std.sort.binarySearch(Tree.TokenIndex, indices, tok, S.order);
+    if (!found) return &.{};
     const locs = pp.expansion_entries.items(.locs)[idx];
     var i: usize = 0;
     while (locs[i].id != .unused) : (i += 1) {}

--- a/lib/std/debug/Coverage.zig
+++ b/lib/std/debug/Coverage.zig
@@ -195,8 +195,8 @@ pub fn resolveAddressesDwarf(
             const slc = &cu.src_loc_cache.?;
             const table_addrs = slc.line_table.keys();
             line_table_i = std.sort.upperBound(u64, table_addrs, pc, struct {
-                fn order(context: u64, item: u64) std.math.Order {
-                    return std.math.order(context, item);
+                fn order(probed: u64, context: u64) std.math.Order {
+                    return std.math.order(probed, context);
                 }
             }.order);
         }

--- a/lib/std/debug/Dwarf.zig
+++ b/lib/std/debug/Dwarf.zig
@@ -183,8 +183,8 @@ pub const CompileUnit = struct {
 
         pub fn findSource(slc: *const SrcLocCache, address: u64) !LineEntry {
             const index = std.sort.upperBound(u64, slc.line_table.keys(), address, struct {
-                fn order(context: u64, item: u64) std.math.Order {
-                    return std.math.order(context, item);
+                fn order(probed: u64, context: u64) std.math.Order {
+                    return std.math.order(probed, context);
                 }
             }.order);
             if (index == 0) return missing();


### PR DESCRIPTION
This PR includes a couple of changes in `std.sort`, for the binary search functions family:

`std.sort.binarySearch`'s return type has been changed from `?usize` to `struct { usize, bool }` - that is because there is still meaningful information to return to the caller, even if no acceptable item was found, namely: the index where an acceptable item *could be inserted*, while preserving the input slice's order (such index is unique).

The other changes made are to correct the implementations of the search functions that accept a trisection callback; those were out of sync with their documentation ever since #21373 was implemented:

Trisection callbacks are expected to classify the slice's values as either too large (`.gt`), too small (`.lt`), or within target (`.eq`). This formulation is independent of any concrete key that may or may not exist and be compared against, and so is the most reasonable formulation in the generic case. This has been exemplified in the documentation since #20927:
```
`items` must be sorted in ascending order with respect to `compareFn`:

[0]                                                   [len]
┌───┬───┬─/ /─┬───┬───┬───┬─/ /─┬───┬───┬───┬─/ /─┬───┐
│.lt│.lt│ \ \ │.lt│.eq│.eq│ \ \ │.eq│.gt│.gt│ \ \ │.gt│
└───┴───┴─/ /─┴───┴───┴───┴─/ /─┴───┴───┴───┴─/ /─┴───┘
├─────────────────┼─────────────────┼─────────────────┤
 ↳ zero or more    ↳ zero or more    ↳ zero or more
```

However, #20927's formulation turned out to be quite confusing for the most common, specific case, where in fact there is a concrete key to compare the items to, passed via the `context` argument that the trisection callbacks accept. Forwarding the arguments to `std.math.order` to get an ascending order will require them to be swapped, making it appear like the values' relation is backwards.

#21373 introduced changes to the functions' implementations, like adding `.invert()` calls to `lowerBound` and `upperBound`'s generated predicates - these superficially fixed the issues, and indeed resolved the confusion around concrete-key use cases; however, the changes also broke the generic case, making it expect inverted inputs. The proper solution is to maintain the internal logic of the functions, and instead swap the `T` and `context` arguments in the trisection callbacks (This was not originally done in #20927 as the precedent for callbacks is to take `context` as the first argument. Retrospectively, the confusion this led to vastly outweighs the consistency benefit).

The changes in this PR mean that:
- No changes will have to be done for most calls, those that treat `context` as a key (the changes to such calls in this PR only rename arguments).
- Complex calls to the search functions (those that return `std.math.Order` values directly, instead of forwarding to `std.math.order`) will have to switch `.lt`s and `.gt`s around, again making their behaviour consistent with the functions' documentation and intent.

The PR also tweaks the doc comments somewhat, explaining the functions' main goals and preconditions in the head sentence. `compareFn` is renamed to `trisectFn` for cases where a comparison, implying an order, is not the most natural way to think of the sections (e.g. three sections for *red*, *green*, and *blue* values). The type annotations of `trisectFn` get a `probed:` argument name, to instil that the first argument is now the one taken from the slice, in case the types themselves weren't an obvious indication.