### PR TITLE
compiler: analyze type and value of global declarations separately

### DIFF
--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -1868,10 +1868,6 @@ pub const Inst = struct {
     /// Rarer instructions are here; ones that do not fit in the 8-bit `Tag` enum.
     /// `noreturn` instructions may not go here; they must be part of the main `Tag` enum.
     pub const Extended = enum(u16) {
-        /// Declares a global variable.
-        /// `operand` is payload index to `ExtendedVar`.
-        /// `small` is `ExtendedVar.Small`.
-        variable,
         /// A struct type definition. Contains references to ZIR instructions for
         /// the field types, defaults, and alignments.
         /// `operand` is payload index to `StructDecl`.
@@ -2493,26 +2489,25 @@ pub const Inst = struct {
     };
 
     /// Trailing:
-    /// 0. lib_name: NullTerminatedString, // null terminated string index, if has_lib_name is set
     /// if (has_cc_ref and !has_cc_body) {
-    ///   1. cc: Ref,
+    ///   0. cc: Ref,
     /// }
     /// if (has_cc_body) {
-    ///   2. cc_body_len: u32
-    ///   3. cc_body: u32 // for each cc_body_len
+    ///   1. cc_body_len: u32
+    ///   2. cc_body: u32 // for each cc_body_len
     /// }
     /// if (has_ret_ty_ref and !has_ret_ty_body) {
-    ///   4. ret_ty: Ref,
+    ///   3. ret_ty: Ref,
     /// }
     /// if (has_ret_ty_body) {
-    ///   5. ret_ty_body_len: u32
-    ///   6. ret_ty_body: u32 // for each ret_ty_body_len
+    ///   4. ret_ty_body_len: u32
+    ///   5. ret_ty_body: u32 // for each ret_ty_body_len
     /// }
-    /// 7. noalias_bits: u32 // if has_any_noalias
+    /// 6. noalias_bits: u32 // if has_any_noalias
     ///    - each bit starting with LSB corresponds to parameter indexes
-    /// 8. body: Index // for each body_len
-    /// 9. src_locs: Func.SrcLocs // if body_len != 0
-    /// 10. proto_hash: std.zig.SrcHash // if body_len != 0; hash of function prototype
+    /// 7. body: Index // for each body_len
+    /// 8. src_locs: Func.SrcLocs // if body_len != 0
+    /// 9. proto_hash: std.zig.SrcHash // if body_len != 0; hash of function prototype
     pub const FuncFancy = struct {
         /// Points to the block that contains the param instructions for this function.
         /// If this is a `declaration`, it refers to the declaration's value body.
@@ -2522,38 +2517,16 @@ pub const Inst = struct {
 
         /// If both has_cc_ref and has_cc_body are false, it means auto calling convention.
         /// If both has_ret_ty_ref and has_ret_ty_body are false, it means void return type.
-        pub const Bits = packed struct {
+        pub const Bits = packed struct(u32) {
             is_var_args: bool,
             is_inferred_error: bool,
-            is_test: bool,
-            is_extern: bool,
             is_noinline: bool,
             has_cc_ref: bool,
             has_cc_body: bool,
             has_ret_ty_ref: bool,
             has_ret_ty_body: bool,
-            has_lib_name: bool,
             has_any_noalias: bool,
-            _: u21 = undefined,
-        };
-    };
-
-    /// Trailing:
-    /// 0. lib_name: NullTerminatedString, // null terminated string index, if has_lib_name is set
-    /// 1. align: Ref, // if has_align is set
-    /// 2. init: Ref // if has_init is set
-    /// The source node is obtained from the containing `block_inline`.
-    pub const ExtendedVar = struct {
-        var_type: Ref,
-
-        pub const Small = packed struct {
-            has_lib_name: bool,
-            has_align: bool,
-            has_init: bool,
-            is_extern: bool,
-            is_const: bool,
-            is_threadlocal: bool,
-            _: u10 = undefined,
+            _: u24 = undefined,
         };
     };
 
@@ -2582,39 +2555,301 @@ pub const Inst = struct {
     };
 
     /// Trailing:
-    /// 0. align_body_len: u32       // if `has_align_linksection_addrspace`; 0 means no `align`
-    /// 1. linksection_body_len: u32 // if `has_align_linksection_addrspace`; 0 means no `linksection`
-    /// 2. addrspace_body_len: u32   // if `has_align_linksection_addrspace`; 0 means no `addrspace`
-    /// 3. value_body_inst: Zir.Inst.Index
-    ///    - for each `value_body_len`
+    /// 0. name: NullTerminatedString      // if `flags.id.hasName()`
+    /// 1. lib_name: NullTerminatedString  // if `flags.id.hasLibName()`
+    /// 2. type_body_len: u32              // if `flags.id.hasTypeBody()`
+    /// 3. align_body_len: u32             // if `flags.id.hasSpecialBodies()`
+    /// 4. linksection_body_len: u32       // if `flags.id.hasSpecialBodies()`
+    /// 5. addrspace_body_len: u32         // if `flags.id.hasSpecialBodies()`
+    /// 6. value_body_len: u32             // if `flags.id.hasValueBody()`
+    /// 7. type_body_inst: Zir.Inst.Index
+    ///    - for each `type_body_len`
     ///    - body to be exited via `break_inline` to this `declaration` instruction
-    /// 4. align_body_inst: Zir.Inst.Index
+    /// 8. align_body_inst: Zir.Inst.Index
     ///    - for each `align_body_len`
     ///    - body to be exited via `break_inline` to this `declaration` instruction
-    /// 5. linksection_body_inst: Zir.Inst.Index
+    /// 9. linksection_body_inst: Zir.Inst.Index
     ///    - for each `linksection_body_len`
     ///    - body to be exited via `break_inline` to this `declaration` instruction
-    /// 6. addrspace_body_inst: Zir.Inst.Index
+    /// 10. addrspace_body_inst: Zir.Inst.Index
     ///    - for each `addrspace_body_len`
     ///    - body to be exited via `break_inline` to this `declaration` instruction
+    /// 11. value_body_inst: Zir.Inst.Index
+    ///    - for each `value_body_len`
+    ///    - body to be exited via `break_inline` to this `declaration` instruction
+    ///    - within this body, the `declaration` instruction refers to the resolved type from the type body
     pub const Declaration = struct {
         // These fields should be concatenated and reinterpreted as a `std.zig.SrcHash`.
         src_hash_0: u32,
         src_hash_1: u32,
         src_hash_2: u32,
         src_hash_3: u32,
-        /// The name of this `Decl`. Also indicates whether it is a test, comptime block, etc.
-        name: Name,
-        src_line: u32,
-        src_column: u32,
-        flags: Flags,
+        // These fields should be concatenated and reinterpreted as a `Flags`.
+        flags_0: u32,
+        flags_1: u32,
 
-        pub const Flags = packed struct(u32) {
-            value_body_len: u28,
+        pub const Unwrapped = struct {
+            pub const Kind = enum {
+                unnamed_test,
+                @"test",
+                decltest,
+                @"comptime",
+                @"usingnamespace",
+                @"const",
+                @"var",
+            };
+
+            pub const Linkage = enum {
+                normal,
+                @"extern",
+                @"export",
+            };
+
+            src_node: Ast.Node.Index,
+
+            src_line: u32,
+            src_column: u32,
+
+            kind: Kind,
+            /// Always `.empty` for `kind` of `unnamed_test`, `.@"comptime"`, `.@"usingnamespace"`.
+            name: NullTerminatedString,
+            /// Always `false` for `kind` of `unnamed_test`, `.@"test"`, `.decltest`, `.@"comptime"`.
             is_pub: bool,
-            is_export: bool,
-            test_is_decltest: bool,
-            has_align_linksection_addrspace: bool,
+            /// Always `false` for `kind != .@"var"`.
+            is_threadlocal: bool,
+            /// Always `.normal` for `kind != .@"const" and kind != .@"var"`.
+            linkage: Linkage,
+            /// Always `.empty` for `linkage != .@"extern"`.
+            lib_name: NullTerminatedString,
+
+            /// Always populated for `linkage == .@"extern".
+            type_body: ?[]const Inst.Index,
+            align_body: ?[]const Inst.Index,
+            linksection_body: ?[]const Inst.Index,
+            addrspace_body: ?[]const Inst.Index,
+            /// Always populated for `linkage != .@"extern".
+            value_body: ?[]const Inst.Index,
+        };
+
+        pub const Flags = packed struct(u64) {
+            src_line: u30,
+            src_column: u29,
+            id: Id,
+
+            pub const Id = enum(u5) {
+                unnamed_test,
+                @"test",
+                decltest,
+                @"comptime",
+
+                @"usingnamespace",
+                pub_usingnamespace,
+
+                const_simple,
+                const_typed,
+                @"const",
+                pub_const_simple,
+                pub_const_typed,
+                pub_const,
+
+                extern_const_simple,
+                extern_const,
+                pub_extern_const_simple,
+                pub_extern_const,
+
+                export_const,
+                pub_export_const,
+
+                var_simple,
+                @"var",
+                var_threadlocal,
+                pub_var_simple,
+                pub_var,
+                pub_var_threadlocal,
+
+                extern_var,
+                extern_var_threadlocal,
+                pub_extern_var,
+                pub_extern_var_threadlocal,
+
+                export_var,
+                export_var_threadlocal,
+                pub_export_var,
+                pub_export_var_threadlocal,
+
+                pub fn hasName(id: Id) bool {
+                    return switch (id) {
+                        .unnamed_test,
+                        .@"comptime",
+                        .@"usingnamespace",
+                        .pub_usingnamespace,
+                        => false,
+                        else => true,
+                    };
+                }
+
+                pub fn hasLibName(id: Id) bool {
+                    return switch (id) {
+                        .extern_const,
+                        .pub_extern_const,
+                        .extern_var,
+                        .extern_var_threadlocal,
+                        .pub_extern_var,
+                        .pub_extern_var_threadlocal,
+                        => true,
+                        else => false,
+                    };
+                }
+
+                pub fn hasTypeBody(id: Id) bool {
+                    return switch (id) {
+                        .unnamed_test,
+                        .@"test",
+                        .decltest,
+                        .@"comptime",
+                        .@"usingnamespace",
+                        .pub_usingnamespace,
+                        => false, // these constructs are untyped
+                        .const_simple,
+                        .pub_const_simple,
+                        .var_simple,
+                        .pub_var_simple,
+                        => false, // these reprs omit type bodies
+                        else => true,
+                    };
+                }
+
+                pub fn hasValueBody(id: Id) bool {
+                    return switch (id) {
+                        .extern_const_simple,
+                        .extern_const,
+                        .pub_extern_const_simple,
+                        .pub_extern_const,
+                        .extern_var,
+                        .extern_var_threadlocal,
+                        .pub_extern_var,
+                        .pub_extern_var_threadlocal,
+                        => false, // externs do not have values
+                        else => true,
+                    };
+                }
+
+                pub fn hasSpecialBodies(id: Id) bool {
+                    return switch (id) {
+                        .unnamed_test,
+                        .@"test",
+                        .decltest,
+                        .@"comptime",
+                        .@"usingnamespace",
+                        .pub_usingnamespace,
+                        => false, // these constructs are untyped
+                        .const_simple,
+                        .const_typed,
+                        .pub_const_simple,
+                        .pub_const_typed,
+                        .extern_const_simple,
+                        .pub_extern_const_simple,
+                        .var_simple,
+                        .pub_var_simple,
+                        => false, // these reprs omit special bodies
+                        else => true,
+                    };
+                }
+
+                pub fn linkage(id: Id) Declaration.Unwrapped.Linkage {
+                    return switch (id) {
+                        .extern_const_simple,
+                        .extern_const,
+                        .pub_extern_const_simple,
+                        .pub_extern_const,
+                        .extern_var,
+                        .extern_var_threadlocal,
+                        .pub_extern_var,
+                        .pub_extern_var_threadlocal,
+                        => .@"extern",
+                        .export_const,
+                        .pub_export_const,
+                        .export_var,
+                        .export_var_threadlocal,
+                        .pub_export_var,
+                        .pub_export_var_threadlocal,
+                        => .@"export",
+                        else => .normal,
+                    };
+                }
+
+                pub fn kind(id: Id) Declaration.Unwrapped.Kind {
+                    return switch (id) {
+                        .unnamed_test => .unnamed_test,
+                        .@"test" => .@"test",
+                        .decltest => .decltest,
+                        .@"comptime" => .@"comptime",
+                        .@"usingnamespace", .pub_usingnamespace => .@"usingnamespace",
+                        .const_simple,
+                        .const_typed,
+                        .@"const",
+                        .pub_const_simple,
+                        .pub_const_typed,
+                        .pub_const,
+                        .extern_const_simple,
+                        .extern_const,
+                        .pub_extern_const_simple,
+                        .pub_extern_const,
+                        .export_const,
+                        .pub_export_const,
+                        => .@"const",
+                        .var_simple,
+                        .@"var",
+                        .var_threadlocal,
+                        .pub_var_simple,
+                        .pub_var,
+                        .pub_var_threadlocal,
+                        .extern_var,
+                        .extern_var_threadlocal,
+                        .pub_extern_var,
+                        .pub_extern_var_threadlocal,
+                        .export_var,
+                        .export_var_threadlocal,
+                        .pub_export_var,
+                        .pub_export_var_threadlocal,
+                        => .@"var",
+                    };
+                }
+
+                pub fn isPub(id: Id) bool {
+                    return switch (id) {
+                        .pub_usingnamespace,
+                        .pub_const_simple,
+                        .pub_const_typed,
+                        .pub_const,
+                        .pub_extern_const_simple,
+                        .pub_extern_const,
+                        .pub_export_const,
+                        .pub_var_simple,
+                        .pub_var,
+                        .pub_var_threadlocal,
+                        .pub_extern_var,
+                        .pub_extern_var_threadlocal,
+                        .pub_export_var,
+                        .pub_export_var_threadlocal,
+                        => true,
+                        else => false,
+                    };
+                }
+
+                pub fn isThreadlocal(id: Id) bool {
+                    return switch (id) {
+                        .var_threadlocal,
+                        .pub_var_threadlocal,
+                        .extern_var_threadlocal,
+                        .pub_extern_var_threadlocal,
+                        .export_var_threadlocal,
+                        .pub_export_var_threadlocal,
+                        => true,
+                        else => false,
+                    };
+                }
+            };
         };
 
         pub const Name = enum(u32) {
@@ -2647,17 +2882,24 @@ pub const Inst = struct {
         };
 
         pub const Bodies = struct {
-            value_body: []const Index,
+            type_body: ?[]const Index,
             align_body: ?[]const Index,
             linksection_body: ?[]const Index,
             addrspace_body: ?[]const Index,
+            value_body: ?[]const Index,
         };
 
         pub fn getBodies(declaration: Declaration, extra_end: u32, zir: Zir) Bodies {
             var extra_index: u32 = extra_end;
-            const value_body_len = declaration.flags.value_body_len;
+            const value_body_len = declaration.value_body_len;
+            const type_body_len: u32 = len: {
+                if (!declaration.flags().kind.hasTypeBody()) break :len 0;
+                const len = zir.extra[extra_index];
+                extra_index += 1;
+                break :len len;
+            };
             const align_body_len, const linksection_body_len, const addrspace_body_len = lens: {
-                if (!declaration.flags.has_align_linksection_addrspace) {
+                if (!declaration.flags.kind.hasSpecialBodies()) {
                     break :lens .{ 0, 0, 0 };
                 }
                 const lens = zir.extra[extra_index..][0..3].*;
@@ -2665,21 +2907,30 @@ pub const Inst = struct {
                 break :lens lens;
             };
             return .{
-                .value_body = b: {
-                    defer extra_index += value_body_len;
-                    break :b zir.bodySlice(extra_index, value_body_len);
+                .type_body = if (type_body_len == 0) null else b: {
+                    const b = zir.bodySlice(extra_index, type_body_len);
+                    extra_index += type_body_len;
+                    break :b b;
                 },
                 .align_body = if (align_body_len == 0) null else b: {
-                    defer extra_index += align_body_len;
-                    break :b zir.bodySlice(extra_index, align_body_len);
+                    const b = zir.bodySlice(extra_index, align_body_len);
+                    extra_index += align_body_len;
+                    break :b b;
                 },
                 .linksection_body = if (linksection_body_len == 0) null else b: {
-                    defer extra_index += linksection_body_len;
-                    break :b zir.bodySlice(extra_index, linksection_body_len);
+                    const b = zir.bodySlice(extra_index, linksection_body_len);
+                    extra_index += linksection_body_len;
+                    break :b b;
                 },
                 .addrspace_body = if (addrspace_body_len == 0) null else b: {
-                    defer extra_index += addrspace_body_len;
-                    break :b zir.bodySlice(extra_index, addrspace_body_len);
+                    const b = zir.bodySlice(extra_index, addrspace_body_len);
+                    extra_index += addrspace_body_len;
+                    break :b b;
+                },
+                .value_body = if (value_body_len == 0) null else b: {
+                    const b = zir.bodySlice(extra_index, value_body_len);
+                    extra_index += value_body_len;
+                    break :b b;
                 },
             };
         }
@@ -3711,18 +3962,18 @@ pub const DeclContents = struct {
 pub fn findTrackable(zir: Zir, gpa: Allocator, contents: *DeclContents, decl_inst: Zir.Inst.Index) !void {
     contents.clear();
 
-    const declaration, const extra_end = zir.getDeclaration(decl_inst);
-    const bodies = declaration.getBodies(extra_end, zir);
+    const decl = zir.getDeclaration(decl_inst);
 
     // `defer` instructions duplicate the same body arbitrarily many times, but we only want to traverse
     // their contents once per defer. So, we store the extra index of the body here to deduplicate.
     var found_defers: std.AutoHashMapUnmanaged(u32, void) = .empty;
     defer found_defers.deinit(gpa);
 
-    try zir.findTrackableBody(gpa, contents, &found_defers, bodies.value_body);
-    if (bodies.align_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
-    if (bodies.linksection_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
-    if (bodies.addrspace_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
+    if (decl.type_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
+    if (decl.align_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
+    if (decl.linksection_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
+    if (decl.addrspace_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
+    if (decl.value_body) |b| try zir.findTrackableBody(gpa, contents, &found_defers, b);
 }
 
 /// Like `findTrackable`, but only considers the `main_struct_inst` instruction. This may return more than
@@ -3991,7 +4242,6 @@ fn findTrackableInner(
                 .value_placeholder => unreachable,
 
                 // Once again, we start with the boring tags.
-                .variable,
                 .this,
                 .ret_addr,
                 .builtin_src,
@@ -4237,7 +4487,6 @@ fn findTrackableInner(
             const inst_data = datas[@intFromEnum(inst)].pl_node;
             const extra = zir.extraData(Inst.FuncFancy, inst_data.payload_index);
             var extra_index: usize = extra.end;
-            extra_index += @intFromBool(extra.data.bits.has_lib_name);
 
             if (extra.data.bits.has_cc_body) {
                 const body_len = zir.extra[extra_index];
@@ -4470,8 +4719,7 @@ pub fn getParamBody(zir: Zir, fn_inst: Inst.Index) []const Zir.Inst.Index {
             return zir.bodySlice(param_block.end, param_block.data.body_len);
         },
         .declaration => {
-            const decl, const extra_end = zir.getDeclaration(param_block_index);
-            return decl.getBodies(extra_end, zir).value_body;
+            return zir.getDeclaration(param_block_index).value_body.?;
         },
         else => unreachable,
     }
@@ -4526,7 +4774,6 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
             var ret_ty_ref: Inst.Ref = .void_type;
             var ret_ty_body: []const Inst.Index = &.{};
 
-            extra_index += @intFromBool(extra.data.bits.has_lib_name);
             if (extra.data.bits.has_cc_body) {
                 extra_index += zir.extra[extra_index] + 1;
             } else if (extra.data.bits.has_cc_ref) {
@@ -4555,17 +4802,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
         },
         else => unreachable,
     };
-    const param_body = switch (tags[@intFromEnum(info.param_block)]) {
-        .block, .block_comptime, .block_inline => param_body: {
-            const param_block = zir.extraData(Inst.Block, datas[@intFromEnum(info.param_block)].pl_node.payload_index);
-            break :param_body zir.bodySlice(param_block.end, param_block.data.body_len);
-        },
-        .declaration => param_body: {
-            const decl, const extra_end = zir.getDeclaration(info.param_block);
-            break :param_body decl.getBodies(extra_end, zir).value_body;
-        },
-        else => unreachable,
-    };
+    const param_body = zir.getParamBody(fn_inst);
     var total_params_len: u32 = 0;
     for (param_body) |inst| {
         switch (tags[@intFromEnum(inst)]) {
@@ -4585,13 +4822,74 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
     };
 }
 
-pub fn getDeclaration(zir: Zir, inst: Zir.Inst.Index) struct { Inst.Declaration, u32 } {
+pub fn getDeclaration(zir: Zir, inst: Zir.Inst.Index) Inst.Declaration.Unwrapped {
     assert(zir.instructions.items(.tag)[@intFromEnum(inst)] == .declaration);
     const pl_node = zir.instructions.items(.data)[@intFromEnum(inst)].declaration;
     const extra = zir.extraData(Inst.Declaration, pl_node.payload_index);
+
+    const flags_vals: [2]u32 = .{ extra.data.flags_0, extra.data.flags_1 };
+    const flags: Inst.Declaration.Flags = @bitCast(flags_vals);
+
+    var extra_index = extra.end;
+
+    const name: NullTerminatedString = if (flags.id.hasName()) name: {
+        const name = zir.extra[extra_index];
+        extra_index += 1;
+        break :name @enumFromInt(name);
+    } else .empty;
+
+    const lib_name: NullTerminatedString = if (flags.id.hasLibName()) lib_name: {
+        const lib_name = zir.extra[extra_index];
+        extra_index += 1;
+        break :lib_name @enumFromInt(lib_name);
+    } else .empty;
+
+    const type_body_len: u32 = if (flags.id.hasTypeBody()) len: {
+        const len = zir.extra[extra_index];
+        extra_index += 1;
+        break :len len;
+    } else 0;
+    const align_body_len: u32, const linksection_body_len: u32, const addrspace_body_len: u32 = lens: {
+        if (!flags.id.hasSpecialBodies()) break :lens .{ 0, 0, 0 };
+        const lens = zir.extra[extra_index..][0..3].*;
+        extra_index += 3;
+        break :lens lens;
+    };
+    const value_body_len: u32 = if (flags.id.hasValueBody()) len: {
+        const len = zir.extra[extra_index];
+        extra_index += 1;
+        break :len len;
+    } else 0;
+
+    const type_body = zir.bodySlice(extra_index, type_body_len);
+    extra_index += type_body_len;
+    const align_body = zir.bodySlice(extra_index, align_body_len);
+    extra_index += align_body_len;
+    const linksection_body = zir.bodySlice(extra_index, linksection_body_len);
+    extra_index += linksection_body_len;
+    const addrspace_body = zir.bodySlice(extra_index, addrspace_body_len);
+    extra_index += addrspace_body_len;
+    const value_body = zir.bodySlice(extra_index, value_body_len);
+    extra_index += value_body_len;
+
     return .{
-        extra.data,
-        @intCast(extra.end),
+        .src_node = pl_node.src_node,
+
+        .src_line = flags.src_line,
+        .src_column = flags.src_column,
+
+        .kind = flags.id.kind(),
+        .name = name,
+        .is_pub = flags.id.isPub(),
+        .is_threadlocal = flags.id.isThreadlocal(),
+        .linkage = flags.id.linkage(),
+        .lib_name = lib_name,
+
+        .type_body = if (type_body_len == 0) null else type_body,
+        .align_body = if (align_body_len == 0) null else align_body,
+        .linksection_body = if (linksection_body_len == 0) null else linksection_body,
+        .addrspace_body = if (addrspace_body_len == 0) null else addrspace_body,
+        .value_body = if (value_body_len == 0) null else value_body,
     };
 }
 
@@ -4636,7 +4934,6 @@ pub fn getAssociatedSrcHash(zir: Zir, inst: Zir.Inst.Index) ?std.zig.SrcHash {
             }
             const bits = extra.data.bits;
             var extra_index = extra.end;
-            extra_index += @intFromBool(bits.has_lib_name);
             if (bits.has_cc_body) {
                 const body_len = zir.extra[extra_index];
                 extra_index += 1 + body_len;

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -348,12 +348,15 @@ const Job = union(enum) {
     /// Corresponds to the task in `link.Task`.
     /// Only needed for backends that haven't yet been updated to not race against Sema.
     codegen_type: InternPool.Index,
-    /// The `Cau` must be semantically analyzed (and possibly export itself).
+    /// The `AnalUnit`, which is *not* a `func`, must be semantically analyzed.
     /// This may be its first time being analyzed, or it may be outdated.
-    analyze_cau: InternPool.Cau.Index,
-    /// Analyze the body of a runtime function.
+    /// If the unit is a function, a `codegen_func` job will then be queued.
+    analyze_comptime_unit: InternPool.AnalUnit,
+    /// This function must be semantically analyzed.
+    /// This may be its first time being analyzed, or it may be outdated.
     /// After analysis, a `codegen_func` job will be queued.
     /// These must be separate jobs to ensure any needed type resolution occurs *before* codegen.
+    /// This job is separate from `analyze_comptime_unit` because it has a different priority.
     analyze_func: InternPool.Index,
     /// The main source file for the module needs to be analyzed.
     analyze_mod: *Package.Module,
@@ -3141,8 +3144,10 @@ pub fn getAllErrorsAlloc(comp: *Compilation) !ErrorBundle {
             }
 
             const file_index = switch (anal_unit.unwrap()) {
-                .cau => |cau| zcu.namespacePtr(ip.getCau(cau).namespace).file_scope,
-                .func => |ip_index| (zcu.funcInfo(ip_index).zir_body_inst.resolveFull(ip) orelse continue).file,
+                .@"comptime" => |cu| ip.getComptimeUnit(cu).zir_index.resolveFile(ip),
+                .nav_val => |nav| ip.getNav(nav).analysis.?.zir_index.resolveFile(ip),
+                .type => |ty| Type.fromInterned(ty).typeDeclInst(zcu).?.resolveFile(ip),
+                .func => |ip_index| zcu.funcInfo(ip_index).zir_body_inst.resolveFile(ip),
             };
 
             // Skip errors for AnalUnits within files that had a parse failure.
@@ -3374,11 +3379,9 @@ pub fn addModuleErrorMsg(
                 const rt_file_path = try src.file_scope.fullPath(gpa);
                 defer gpa.free(rt_file_path);
                 const name = switch (ref.referencer.unwrap()) {
-                    .cau => |cau| switch (ip.getCau(cau).owner.unwrap()) {
-                        .nav => |nav| ip.getNav(nav).name.toSlice(ip),
-                        .type => |ty| Type.fromInterned(ty).containerTypeName(ip).toSlice(ip),
-                        .none => "comptime",
-                    },
+                    .@"comptime" => "comptime",
+                    .nav_val => |nav| ip.getNav(nav).name.toSlice(ip),
+                    .type => |ty| Type.fromInterned(ty).containerTypeName(ip).toSlice(ip),
                     .func => |f| ip.getNav(zcu.funcInfo(f).owner_nav).name.toSlice(ip),
                 };
                 try ref_traces.append(gpa, .{
@@ -3641,10 +3644,13 @@ fn performAllTheWorkInner(
             // If there's no work queued, check if there's anything outdated
             // which we need to work on, and queue it if so.
             if (try zcu.findOutdatedToAnalyze()) |outdated| {
-                switch (outdated.unwrap()) {
-                    .cau => |cau| try comp.queueJob(.{ .analyze_cau = cau }),
-                    .func => |func| try comp.queueJob(.{ .analyze_func = func }),
-                }
+                try comp.queueJob(switch (outdated.unwrap()) {
+                    .func => |f| .{ .analyze_func = f },
+                    .@"comptime",
+                    .nav_val,
+                    .type,
+                    => .{ .analyze_comptime_unit = outdated },
+                });
                 continue;
             }
         }
@@ -3667,8 +3673,8 @@ fn processOneJob(tid: usize, comp: *Compilation, job: Job, prog_node: std.Progre
         .codegen_nav => |nav_index| {
             const zcu = comp.zcu.?;
             const nav = zcu.intern_pool.getNav(nav_index);
-            if (nav.analysis_owner.unwrap()) |cau| {
-                const unit = InternPool.AnalUnit.wrap(.{ .cau = cau });
+            if (nav.analysis != null) {
+                const unit: InternPool.AnalUnit = .wrap(.{ .nav_val = nav_index });
                 if (zcu.failed_analysis.contains(unit) or zcu.transitive_failed_analysis.contains(unit)) {
                     return;
                 }
@@ -3688,36 +3694,47 @@ fn processOneJob(tid: usize, comp: *Compilation, job: Job, prog_node: std.Progre
 
             const pt: Zcu.PerThread = .activate(comp.zcu.?, @enumFromInt(tid));
             defer pt.deactivate();
-            pt.ensureFuncBodyAnalyzed(func) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
+
+            pt.ensureFuncBodyUpToDate(func) catch |err| switch (err) {
+                error.OutOfMemory => |e| return e,
                 error.AnalysisFail => return,
             };
         },
-        .analyze_cau => |cau_index| {
+        .analyze_comptime_unit => |unit| {
+            const named_frame = tracy.namedFrame("analyze_comptime_unit");
+            defer named_frame.end();
+
             const pt: Zcu.PerThread = .activate(comp.zcu.?, @enumFromInt(tid));
             defer pt.deactivate();
-            pt.ensureCauAnalyzed(cau_index) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
+
+            const maybe_err: Zcu.SemaError!void = switch (unit.unwrap()) {
+                .@"comptime" => |cu| pt.ensureComptimeUnitUpToDate(cu),
+                .nav_val => |nav| pt.ensureNavValUpToDate(nav),
+                .type => |ty| if (pt.ensureTypeUpToDate(ty)) |_| {} else |err| err,
+                .func => unreachable,
+            };
+            maybe_err catch |err| switch (err) {
+                error.OutOfMemory => |e| return e,
                 error.AnalysisFail => return,
             };
+
             queue_test_analysis: {
                 if (!comp.config.is_test) break :queue_test_analysis;
+                const nav = switch (unit.unwrap()) {
+                    .nav_val => |nav| nav,
+                    else => break :queue_test_analysis,
+                };
 
                 // Check if this is a test function.
                 const ip = &pt.zcu.intern_pool;
-                const cau = ip.getCau(cau_index);
-                const nav_index = switch (cau.owner.unwrap()) {
-                    .none, .type => break :queue_test_analysis,
-                    .nav => |nav| nav,
-                };
-                if (!pt.zcu.test_functions.contains(nav_index)) {
+                if (!pt.zcu.test_functions.contains(nav)) {
                     break :queue_test_analysis;
                 }
 
                 // Tests are always emitted in test binaries. The decl_refs are created by
                 // Zcu.populateTestFunctions, but this will not queue body analysis, so do
                 // that now.
-                try pt.zcu.ensureFuncBodyAnalysisQueued(ip.getNav(nav_index).status.resolved.val);
+                try pt.zcu.ensureFuncBodyAnalysisQueued(ip.getNav(nav).status.resolved.val);
             }
         },
         .resolve_type_fully => |ty| {

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -363,33 +363,53 @@ pub fn rehashTrackedInsts(
 }
 
 /// Analysis Unit. Represents a single entity which undergoes semantic analysis.
-/// This is either a `Cau` or a runtime function.
-/// The LSB is used as a tag bit.
 /// This is the "source" of an incremental dependency edge.
-pub const AnalUnit = packed struct(u32) {
-    kind: enum(u1) { cau, func },
-    index: u31,
-    pub const Unwrapped = union(enum) {
-        cau: Cau.Index,
+pub const AnalUnit = packed struct(u64) {
+    kind: Kind,
+    id: u32,
+
+    pub const Kind = enum(u32) {
+        @"comptime",
+        nav_val,
+        type,
+        func,
+    };
+
+    pub const Unwrapped = union(Kind) {
+        /// This `AnalUnit` analyzes the body of the given `comptime` declaration.
+        @"comptime": ComptimeUnit.Id,
+        /// This `AnalUnit` resolves the value of the given `Nav`.
+        nav_val: Nav.Index,
+        /// This `AnalUnit` resolves the given `struct`/`union`/`enum` type.
+        /// Generated tag enums are never used here (they do not undergo type resolution).
+        type: InternPool.Index,
+        /// This `AnalUnit` analyzes the body of the given runtime function.
         func: InternPool.Index,
     };
-    pub fn unwrap(as: AnalUnit) Unwrapped {
-        return switch (as.kind) {
-            .cau => .{ .cau = @enumFromInt(as.index) },
-            .func => .{ .func = @enumFromInt(as.index) },
+
+    pub fn unwrap(au: AnalUnit) Unwrapped {
+        return switch (au.kind) {
+            inline else => |tag| @unionInit(
+                Unwrapped,
+                @tagName(tag),
+                @enumFromInt(au.id),
+            ),
         };
     }
     pub fn wrap(raw: Unwrapped) AnalUnit {
         return switch (raw) {
-            .cau => |cau| .{ .kind = .cau, .index = @intCast(@intFromEnum(cau)) },
-            .func => |func| .{ .kind = .func, .index = @intCast(@intFromEnum(func)) },
+            inline else => |id, tag| .{
+                .kind = tag,
+                .id = @intFromEnum(id),
+            },
         };
     }
+
     pub fn toOptional(as: AnalUnit) Optional {
-        return @enumFromInt(@as(u32, @bitCast(as)));
+        return @enumFromInt(@as(u64, @bitCast(as)));
     }
-    pub const Optional = enum(u32) {
-        none = std.math.maxInt(u32),
+    pub const Optional = enum(u64) {
+        none = std.math.maxInt(u64),
         _,
         pub fn unwrap(opt: Optional) ?AnalUnit {
             return switch (opt) {
@@ -400,97 +420,30 @@ pub const AnalUnit = packed struct(u32) {
     };
 };
 
-/// Comptime Analysis Unit. This is the "subject" of semantic analysis where the root context is
-/// comptime; every `Sema` is owned by either a `Cau` or a runtime function (see `AnalUnit`).
-/// The state stored here is immutable.
-///
-/// * Every ZIR `declaration` has a `Cau` (post-instantiation) to analyze the declaration body.
-/// * Every `struct`, `union`, and `enum` has a `Cau` for type resolution.
-///
-/// The analysis status of a `Cau` is known only from state in `Zcu`.
-/// An entry in `Zcu.failed_analysis` indicates an analysis failure with associated error message.
-/// An entry in `Zcu.transitive_failed_analysis` indicates a transitive analysis failure.
-///
-/// 12 bytes.
-pub const Cau = struct {
-    /// The `declaration`, `struct_decl`, `enum_decl`, or `union_decl` instruction which this `Cau` analyzes.
+pub const ComptimeUnit = extern struct {
     zir_index: TrackedInst.Index,
-    /// The namespace which this `Cau` should be analyzed within.
     namespace: NamespaceIndex,
-    /// This field essentially tells us what to do with the information resulting from
-    /// semantic analysis. See `Owner.Unwrapped` for details.
-    owner: Owner,
 
-    /// See `Owner.Unwrapped` for details. In terms of representation, the `InternPool.Index`
-    /// or `Nav.Index` is cast to a `u31` and stored in `index`. As a special case, if
-    /// `@as(u32, @bitCast(owner)) == 0xFFFF_FFFF`, then the value is treated as `.none`.
-    pub const Owner = packed struct(u32) {
-        kind: enum(u1) { type, nav },
-        index: u31,
+    comptime {
+        assert(std.meta.hasUniqueRepresentation(ComptimeUnit));
+    }
 
-        pub const Unwrapped = union(enum) {
-            /// This `Cau` exists in isolation. It is a global `comptime` declaration, or (TODO ANYTHING ELSE?).
-            /// After semantic analysis completes, the result is discarded.
-            none,
-            /// This `Cau` is owned by the given type for type resolution.
-            /// This is a `struct`, `union`, or `enum` type.
-            type: InternPool.Index,
-            /// This `Cau` is owned by the given `Nav` to resolve its value.
-            /// When analyzing the `Cau`, the resulting value is stored as the value of this `Nav`.
-            nav: Nav.Index,
-        };
-
-        pub fn unwrap(owner: Owner) Unwrapped {
-            if (@as(u32, @bitCast(owner)) == std.math.maxInt(u32)) {
-                return .none;
-            }
-            return switch (owner.kind) {
-                .type => .{ .type = @enumFromInt(owner.index) },
-                .nav => .{ .nav = @enumFromInt(owner.index) },
-            };
-        }
-
-        fn wrap(raw: Unwrapped) Owner {
-            return switch (raw) {
-                .none => @bitCast(@as(u32, std.math.maxInt(u32))),
-                .type => |ty| .{ .kind = .type, .index = @intCast(@intFromEnum(ty)) },
-                .nav => |nav| .{ .kind = .nav, .index = @intCast(@intFromEnum(nav)) },
-            };
-        }
-    };
-
-    pub const Index = enum(u32) {
+    pub const Id = enum(u32) {
         _,
-        pub const Optional = enum(u32) {
-            none = std.math.maxInt(u32),
-            _,
-            pub fn unwrap(opt: Optional) ?Cau.Index {
-                return switch (opt) {
-                    .none => null,
-                    _ => @enumFromInt(@intFromEnum(opt)),
-                };
-            }
-
-            const debug_state = InternPool.debug_state;
-        };
-        pub fn toOptional(i: Cau.Index) Optional {
-            return @enumFromInt(@intFromEnum(i));
-        }
         const Unwrapped = struct {
             tid: Zcu.PerThread.Id,
             index: u32,
-
-            fn wrap(unwrapped: Unwrapped, ip: *const InternPool) Cau.Index {
+            fn wrap(unwrapped: Unwrapped, ip: *const InternPool) ComptimeUnit.Id {
                 assert(@intFromEnum(unwrapped.tid) <= ip.getTidMask());
-                assert(unwrapped.index <= ip.getIndexMask(u31));
-                return @enumFromInt(@as(u32, @intFromEnum(unwrapped.tid)) << ip.tid_shift_31 |
+                assert(unwrapped.index <= ip.getIndexMask(u32));
+                return @enumFromInt(@as(u32, @intFromEnum(unwrapped.tid)) << ip.tid_shift_32 |
                     unwrapped.index);
             }
         };
-        fn unwrap(cau_index: Cau.Index, ip: *const InternPool) Unwrapped {
+        fn unwrap(id: Id, ip: *const InternPool) Unwrapped {
             return .{
-                .tid = @enumFromInt(@intFromEnum(cau_index) >> ip.tid_shift_31 & ip.getTidMask()),
-                .index = @intFromEnum(cau_index) & ip.getIndexMask(u31),
+                .tid = @enumFromInt(@intFromEnum(id) >> ip.tid_shift_32 & ip.getTidMask()),
+                .index = @intFromEnum(id) & ip.getIndexMask(u31),
             };
         }
 
@@ -507,6 +460,11 @@ pub const Cau = struct {
 /// * Generic instances have a `Nav` corresponding to the instantiated function.
 /// * `@extern` calls create a `Nav` whose value is a `.@"extern"`.
 ///
+/// This data structure is optimized for the `analysis_info != null` case, because this is much more
+/// common in practice; the other case is used only for externs and for generic instances. At the time
+/// of writing, in the compiler itself, around 74% of all `Nav`s have `analysis_info != null`.
+/// (Specifically, 104225 / 140923)
+///
 /// `Nav.Repr` is the in-memory representation.
 pub const Nav = struct {
     /// The unqualified name of this `Nav`. Namespace lookups use this name, and error messages may use it.
@@ -514,13 +472,16 @@ pub const Nav = struct {
     name: NullTerminatedString,
     /// The fully-qualified name of this `Nav`.
     fqn: NullTerminatedString,
-    /// If the value of this `Nav` is resolved by semantic analysis, it is within this `Cau`.
-    /// If this is `.none`, then `status == .resolved` always.
-    analysis_owner: Cau.Index.Optional,
+    /// This field is populated iff this `Nav` is resolved by semantic analysis.
+    /// If this is `null`, then `status == .resolved` always.
+    analysis: ?struct {
+        namespace: NamespaceIndex,
+        zir_index: TrackedInst.Index,
+    },
     /// TODO: this is a hack! If #20663 isn't accepted, let's figure out something a bit better.
     is_usingnamespace: bool,
     status: union(enum) {
-        /// This `Nav` is pending semantic analysis through `analysis_owner`.
+        /// This `Nav` is pending semantic analysis.
         unresolved,
         /// The value of this `Nav` is resolved.
         resolved: struct {
@@ -544,17 +505,16 @@ pub const Nav = struct {
     /// Get the ZIR instruction corresponding to this `Nav`, used to resolve source locations.
     /// This is a `declaration`.
     pub fn srcInst(nav: Nav, ip: *const InternPool) TrackedInst.Index {
-        if (nav.analysis_owner.unwrap()) |cau| {
-            return ip.getCau(cau).zir_index;
+        if (nav.analysis) |a| {
+            return a.zir_index;
         }
-        // A `Nav` with no corresponding `Cau` always has a resolved value.
+        // A `Nav` which does not undergo analysis always has a resolved value.
         return switch (ip.indexToKey(nav.status.resolved.val)) {
             .func => |func| {
-                // Since there was no `analysis_owner`, this must be an instantiation.
-                // Go up to the generic owner and consult *its* `analysis_owner`.
+                // Since `analysis` was not populated, this must be an instantiation.
+                // Go up to the generic owner and consult *its* `analysis` field.
                 const go_nav = ip.getNav(ip.indexToKey(func.generic_owner).func.owner_nav);
-                const go_cau = ip.getCau(go_nav.analysis_owner.unwrap().?);
-                return go_cau.zir_index;
+                return go_nav.analysis.?.zir_index;
             },
             .@"extern" => |@"extern"| @"extern".zir_index, // extern / @extern
             else => unreachable,
@@ -600,11 +560,13 @@ pub const Nav = struct {
     };
 
     /// The compact in-memory representation of a `Nav`.
-    /// 18 bytes.
+    /// 26 bytes.
     const Repr = struct {
         name: NullTerminatedString,
         fqn: NullTerminatedString,
-        analysis_owner: Cau.Index.Optional,
+        // The following 1 fields are either both populated, or both `.none`.
+        analysis_namespace: OptionalNamespaceIndex,
+        analysis_zir_index: TrackedInst.Index.Optional,
         /// Populated only if `bits.status == .resolved`.
         val: InternPool.Index,
         /// Populated only if `bits.status == .resolved`.
@@ -625,7 +587,13 @@ pub const Nav = struct {
             return .{
                 .name = repr.name,
                 .fqn = repr.fqn,
-                .analysis_owner = repr.analysis_owner,
+                .analysis = if (repr.analysis_namespace.unwrap()) |namespace| .{
+                    .namespace = namespace,
+                    .zir_index = repr.analysis_zir_index.unwrap().?,
+                } else a: {
+                    assert(repr.analysis_zir_index == .none);
+                    break :a null;
+                },
                 .is_usingnamespace = repr.bits.is_usingnamespace,
                 .status = switch (repr.bits.status) {
                     .unresolved => .unresolved,
@@ -646,7 +614,8 @@ pub const Nav = struct {
         return .{
             .name = nav.name,
             .fqn = nav.fqn,
-            .analysis_owner = nav.analysis_owner,
+            .analysis_namespace = if (nav.analysis) |a| a.namespace.toOptional() else .none,
+            .analysis_zir_index = if (nav.analysis) |a| a.zir_index.toOptional() else .none,
             .val = switch (nav.status) {
                 .unresolved => .none,
                 .resolved => |r| r.val,
@@ -862,8 +831,8 @@ const Local = struct {
         tracked_insts: ListMutate,
         files: ListMutate,
         maps: ListMutate,
-        caus: ListMutate,
         navs: ListMutate,
+        comptime_units: ListMutate,
 
         namespaces: BucketListMutate,
     } align(std.atomic.cache_line),
@@ -876,8 +845,8 @@ const Local = struct {
         tracked_insts: TrackedInsts,
         files: List(File),
         maps: Maps,
-        caus: Caus,
         navs: Navs,
+        comptime_units: ComptimeUnits,
 
         namespaces: Namespaces,
 
@@ -899,8 +868,8 @@ const Local = struct {
     const Strings = List(struct { u8 });
     const TrackedInsts = List(struct { TrackedInst.MaybeLost });
     const Maps = List(struct { FieldMap });
-    const Caus = List(struct { Cau });
     const Navs = List(Nav.Repr);
+    const ComptimeUnits = List(struct { ComptimeUnit });
 
     const namespaces_bucket_width = 8;
     const namespaces_bucket_mask = (1 << namespaces_bucket_width) - 1;
@@ -1275,21 +1244,21 @@ const Local = struct {
         };
     }
 
-    pub fn getMutableCaus(local: *Local, gpa: Allocator) Caus.Mutable {
-        return .{
-            .gpa = gpa,
-            .arena = &local.mutate.arena,
-            .mutate = &local.mutate.caus,
-            .list = &local.shared.caus,
-        };
-    }
-
     pub fn getMutableNavs(local: *Local, gpa: Allocator) Navs.Mutable {
         return .{
             .gpa = gpa,
             .arena = &local.mutate.arena,
             .mutate = &local.mutate.navs,
             .list = &local.shared.navs,
+        };
+    }
+
+    pub fn getMutableComptimeUnits(local: *Local, gpa: Allocator) ComptimeUnits.Mutable {
+        return .{
+            .gpa = gpa,
+            .arena = &local.mutate.arena,
+            .mutate = &local.mutate.comptime_units,
+            .list = &local.shared.comptime_units,
         };
     }
 
@@ -3052,8 +3021,6 @@ pub const LoadedUnionType = struct {
     // TODO: the non-fqn will be needed by the new dwarf structure
     /// The name of this union type.
     name: NullTerminatedString,
-    /// The `Cau` within which type resolution occurs.
-    cau: Cau.Index,
     /// Represents the declarations inside this union.
     namespace: NamespaceIndex,
     /// The enum tag type.
@@ -3370,7 +3337,6 @@ pub fn loadUnionType(ip: *const InternPool, index: Index) LoadedUnionType {
         .tid = unwrapped_index.tid,
         .extra_index = data,
         .name = type_union.data.name,
-        .cau = type_union.data.cau,
         .namespace = type_union.data.namespace,
         .enum_tag_ty = type_union.data.tag_ty,
         .field_types = field_types,
@@ -3387,8 +3353,6 @@ pub const LoadedStructType = struct {
     // TODO: the non-fqn will be needed by the new dwarf structure
     /// The name of this struct type.
     name: NullTerminatedString,
-    /// The `Cau` within which type resolution occurs.
-    cau: Cau.Index,
     namespace: NamespaceIndex,
     /// Index of the `struct_decl` or `reify` ZIR instruction.
     zir_index: TrackedInst.Index,
@@ -3979,7 +3943,6 @@ pub fn loadStructType(ip: *const InternPool, index: Index) LoadedStructType {
     switch (item.tag) {
         .type_struct => {
             const name: NullTerminatedString = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStruct, "name").?]);
-            const cau: Cau.Index = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStruct, "cau").?]);
             const namespace: NamespaceIndex = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStruct, "namespace").?]);
             const zir_index: TrackedInst.Index = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStruct, "zir_index").?]);
             const fields_len = extra_items[item.data + std.meta.fieldIndex(Tag.TypeStruct, "fields_len").?];
@@ -4066,7 +4029,6 @@ pub fn loadStructType(ip: *const InternPool, index: Index) LoadedStructType {
                 .tid = unwrapped_index.tid,
                 .extra_index = item.data,
                 .name = name,
-                .cau = cau,
                 .namespace = namespace,
                 .zir_index = zir_index,
                 .layout = if (flags.is_extern) .@"extern" else .auto,
@@ -4083,7 +4045,6 @@ pub fn loadStructType(ip: *const InternPool, index: Index) LoadedStructType {
         },
         .type_struct_packed, .type_struct_packed_inits => {
             const name: NullTerminatedString = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStructPacked, "name").?]);
-            const cau: Cau.Index = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStructPacked, "cau").?]);
             const zir_index: TrackedInst.Index = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStructPacked, "zir_index").?]);
             const fields_len = extra_items[item.data + std.meta.fieldIndex(Tag.TypeStructPacked, "fields_len").?];
             const namespace: NamespaceIndex = @enumFromInt(extra_items[item.data + std.meta.fieldIndex(Tag.TypeStructPacked, "namespace").?]);
@@ -4130,7 +4091,6 @@ pub fn loadStructType(ip: *const InternPool, index: Index) LoadedStructType {
                 .tid = unwrapped_index.tid,
                 .extra_index = item.data,
                 .name = name,
-                .cau = cau,
                 .namespace = namespace,
                 .zir_index = zir_index,
                 .layout = .@"packed",
@@ -4153,9 +4113,6 @@ pub const LoadedEnumType = struct {
     // TODO: the non-fqn will be needed by the new dwarf structure
     /// The name of this enum type.
     name: NullTerminatedString,
-    /// The `Cau` within which type resolution occurs.
-    /// `null` if this is a generated tag type.
-    cau: Cau.Index.Optional,
     /// Represents the declarations inside this enum.
     namespace: NamespaceIndex,
     /// An integer type which is used for the numerical value of the enum.
@@ -4232,21 +4189,15 @@ pub fn loadEnumType(ip: *const InternPool, index: Index) LoadedEnumType {
         .type_enum_auto => {
             const extra = extraDataTrail(extra_list, EnumAuto, item.data);
             var extra_index: u32 = @intCast(extra.end);
-            const cau: Cau.Index.Optional = if (extra.data.zir_index == .none) cau: {
+            if (extra.data.zir_index == .none) {
                 extra_index += 1; // owner_union
-                break :cau .none;
-            } else cau: {
-                const cau: Cau.Index = @enumFromInt(extra_list.view().items(.@"0")[extra_index]);
-                extra_index += 1; // cau
-                break :cau cau.toOptional();
-            };
+            }
             const captures_len = if (extra.data.captures_len == std.math.maxInt(u32)) c: {
                 extra_index += 2; // type_hash: PackedU64
                 break :c 0;
             } else extra.data.captures_len;
             return .{
                 .name = extra.data.name,
-                .cau = cau,
                 .namespace = extra.data.namespace,
                 .tag_ty = extra.data.int_tag_type,
                 .names = .{
@@ -4272,21 +4223,15 @@ pub fn loadEnumType(ip: *const InternPool, index: Index) LoadedEnumType {
     };
     const extra = extraDataTrail(extra_list, EnumExplicit, item.data);
     var extra_index: u32 = @intCast(extra.end);
-    const cau: Cau.Index.Optional = if (extra.data.zir_index == .none) cau: {
+    if (extra.data.zir_index == .none) {
         extra_index += 1; // owner_union
-        break :cau .none;
-    } else cau: {
-        const cau: Cau.Index = @enumFromInt(extra_list.view().items(.@"0")[extra_index]);
-        extra_index += 1; // cau
-        break :cau cau.toOptional();
-    };
+    }
     const captures_len = if (extra.data.captures_len == std.math.maxInt(u32)) c: {
         extra_index += 2; // type_hash: PackedU64
         break :c 0;
     } else extra.data.captures_len;
     return .{
         .name = extra.data.name,
-        .cau = cau,
         .namespace = extra.data.namespace,
         .tag_ty = extra.data.int_tag_type,
         .names = .{
@@ -5256,7 +5201,6 @@ pub const Tag = enum(u8) {
         .payload = EnumExplicit,
         .trailing = struct {
             owner_union: Index,
-            cau: ?Cau.Index,
             captures: ?[]CaptureValue,
             type_hash: ?u64,
             field_names: []NullTerminatedString,
@@ -5302,7 +5246,6 @@ pub const Tag = enum(u8) {
             .payload = EnumAuto,
             .trailing = struct {
                 owner_union: ?Index,
-                cau: ?Cau.Index,
                 captures: ?[]CaptureValue,
                 type_hash: ?u64,
                 field_names: []NullTerminatedString,
@@ -5679,7 +5622,6 @@ pub const Tag = enum(u8) {
         size: u32,
         /// Only valid after .have_layout
         padding: u32,
-        cau: Cau.Index,
         namespace: NamespaceIndex,
         /// The enum that provides the list of field names and values.
         tag_ty: Index,
@@ -5710,7 +5652,6 @@ pub const Tag = enum(u8) {
     /// 5. init: Index for each fields_len // if tag is type_struct_packed_inits
     pub const TypeStructPacked = struct {
         name: NullTerminatedString,
-        cau: Cau.Index,
         zir_index: TrackedInst.Index,
         fields_len: u32,
         namespace: NamespaceIndex,
@@ -5758,7 +5699,6 @@ pub const Tag = enum(u8) {
     /// 8. field_offset: u32 // for each field in declared order, undef until layout_resolved
     pub const TypeStruct = struct {
         name: NullTerminatedString,
-        cau: Cau.Index,
         zir_index: TrackedInst.Index,
         namespace: NamespaceIndex,
         fields_len: u32,
@@ -6088,11 +6028,10 @@ pub const Array = struct {
 
 /// Trailing:
 /// 0. owner_union: Index // if `zir_index == .none`
-/// 1. cau: Cau.Index // if `zir_index != .none`
-/// 2. capture: CaptureValue // for each `captures_len`
-/// 3. type_hash: PackedU64 // if reified (`captures_len == std.math.maxInt(u32)`)
-/// 4. field name: NullTerminatedString for each fields_len; declaration order
-/// 5. tag value: Index for each fields_len; declaration order
+/// 1. capture: CaptureValue // for each `captures_len`
+/// 2. type_hash: PackedU64 // if reified (`captures_len == std.math.maxInt(u32)`)
+/// 3. field name: NullTerminatedString for each fields_len; declaration order
+/// 4. tag value: Index for each fields_len; declaration order
 pub const EnumExplicit = struct {
     name: NullTerminatedString,
     /// `std.math.maxInt(u32)` indicates this type is reified.
@@ -6115,10 +6054,9 @@ pub const EnumExplicit = struct {
 
 /// Trailing:
 /// 0. owner_union: Index // if `zir_index == .none`
-/// 1. cau: Cau.Index // if `zir_index != .none`
-/// 2. capture: CaptureValue // for each `captures_len`
-/// 3. type_hash: PackedU64 // if reified (`captures_len == std.math.maxInt(u32)`)
-/// 4. field name: NullTerminatedString for each fields_len; declaration order
+/// 1. capture: CaptureValue // for each `captures_len`
+/// 2. type_hash: PackedU64 // if reified (`captures_len == std.math.maxInt(u32)`)
+/// 3. field name: NullTerminatedString for each fields_len; declaration order
 pub const EnumAuto = struct {
     name: NullTerminatedString,
     /// `std.math.maxInt(u32)` indicates this type is reified.
@@ -6408,32 +6346,32 @@ pub fn init(ip: *InternPool, gpa: Allocator, available_threads: usize) !void {
     ip.locals = try gpa.alloc(Local, used_threads);
     @memset(ip.locals, .{
         .shared = .{
-            .items = Local.List(Item).empty,
-            .extra = Local.Extra.empty,
-            .limbs = Local.Limbs.empty,
-            .strings = Local.Strings.empty,
-            .tracked_insts = Local.TrackedInsts.empty,
-            .files = Local.List(File).empty,
-            .maps = Local.Maps.empty,
-            .caus = Local.Caus.empty,
-            .navs = Local.Navs.empty,
+            .items = .empty,
+            .extra = .empty,
+            .limbs = .empty,
+            .strings = .empty,
+            .tracked_insts = .empty,
+            .files = .empty,
+            .maps = .empty,
+            .navs = .empty,
+            .comptime_units = .empty,
 
-            .namespaces = Local.Namespaces.empty,
+            .namespaces = .empty,
         },
         .mutate = .{
             .arena = .{},
 
-            .items = Local.ListMutate.empty,
-            .extra = Local.ListMutate.empty,
-            .limbs = Local.ListMutate.empty,
-            .strings = Local.ListMutate.empty,
-            .tracked_insts = Local.ListMutate.empty,
-            .files = Local.ListMutate.empty,
-            .maps = Local.ListMutate.empty,
-            .caus = Local.ListMutate.empty,
-            .navs = Local.ListMutate.empty,
+            .items = .empty,
+            .extra = .empty,
+            .limbs = .empty,
+            .strings = .empty,
+            .tracked_insts = .empty,
+            .files = .empty,
+            .maps = .empty,
+            .navs = .empty,
+            .comptime_units = .empty,
 
-            .namespaces = Local.BucketListMutate.empty,
+            .namespaces = .empty,
         },
     });
 
@@ -6506,7 +6444,8 @@ pub fn deinit(ip: *InternPool, gpa: Allocator) void {
                 namespace.priv_decls.deinit(gpa);
                 namespace.pub_usingnamespace.deinit(gpa);
                 namespace.priv_usingnamespace.deinit(gpa);
-                namespace.other_decls.deinit(gpa);
+                namespace.comptime_decls.deinit(gpa);
+                namespace.test_decls.deinit(gpa);
             }
         };
         const maps = local.getMutableMaps(gpa);
@@ -6525,8 +6464,6 @@ pub fn activate(ip: *const InternPool) void {
     _ = OptionalString.debug_state;
     _ = NullTerminatedString.debug_state;
     _ = OptionalNullTerminatedString.debug_state;
-    _ = Cau.Index.debug_state;
-    _ = Cau.Index.Optional.debug_state;
     _ = Nav.Index.debug_state;
     _ = Nav.Index.Optional.debug_state;
     std.debug.assert(debug_state.intern_pool == null);
@@ -6711,14 +6648,14 @@ pub fn indexToKey(ip: *const InternPool, index: Index) Key {
             if (extra.data.captures_len == std.math.maxInt(u32)) {
                 break :ns .{ .reified = .{
                     .zir_index = zir_index,
-                    .type_hash = extraData(extra_list, PackedU64, extra.end + 1).get(),
+                    .type_hash = extraData(extra_list, PackedU64, extra.end).get(),
                 } };
             }
             break :ns .{ .declared = .{
                 .zir_index = zir_index,
                 .captures = .{ .owned = .{
                     .tid = unwrapped_index.tid,
-                    .start = extra.end + 1,
+                    .start = extra.end,
                     .len = extra.data.captures_len,
                 } },
             } };
@@ -6735,14 +6672,14 @@ pub fn indexToKey(ip: *const InternPool, index: Index) Key {
             if (extra.data.captures_len == std.math.maxInt(u32)) {
                 break :ns .{ .reified = .{
                     .zir_index = zir_index,
-                    .type_hash = extraData(extra_list, PackedU64, extra.end + 1).get(),
+                    .type_hash = extraData(extra_list, PackedU64, extra.end).get(),
                 } };
             }
             break :ns .{ .declared = .{
                 .zir_index = zir_index,
                 .captures = .{ .owned = .{
                     .tid = unwrapped_index.tid,
-                    .start = extra.end + 1,
+                    .start = extra.end,
                     .len = extra.data.captures_len,
                 } },
             } };
@@ -8323,7 +8260,6 @@ pub fn getUnionType(
         .size = std.math.maxInt(u32),
         .padding = std.math.maxInt(u32),
         .name = undefined, // set by `finish`
-        .cau = undefined, // set by `finish`
         .namespace = undefined, // set by `finish`
         .tag_ty = ini.enum_tag_ty,
         .zir_index = switch (ini.key) {
@@ -8375,7 +8311,6 @@ pub fn getUnionType(
         .tid = tid,
         .index = gop.put(),
         .type_name_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeUnion, "name").?,
-        .cau_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeUnion, "cau").?,
         .namespace_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeUnion, "namespace").?,
     } };
 }
@@ -8384,7 +8319,6 @@ pub const WipNamespaceType = struct {
     tid: Zcu.PerThread.Id,
     index: Index,
     type_name_extra_index: u32,
-    cau_extra_index: ?u32,
     namespace_extra_index: u32,
 
     pub fn setName(
@@ -8400,17 +8334,10 @@ pub const WipNamespaceType = struct {
     pub fn finish(
         wip: WipNamespaceType,
         ip: *InternPool,
-        analysis_owner: Cau.Index.Optional,
         namespace: NamespaceIndex,
     ) Index {
         const extra = ip.getLocalShared(wip.tid).extra.acquire();
         const extra_items = extra.view().items(.@"0");
-
-        if (wip.cau_extra_index) |i| {
-            extra_items[i] = @intFromEnum(analysis_owner.unwrap().?);
-        } else {
-            assert(analysis_owner == .none);
-        }
 
         extra_items[wip.namespace_extra_index] = @intFromEnum(namespace);
 
@@ -8510,7 +8437,6 @@ pub fn getStructType(
                 ini.fields_len); // inits
             const extra_index = addExtraAssumeCapacity(extra, Tag.TypeStructPacked{
                 .name = undefined, // set by `finish`
-                .cau = undefined, // set by `finish`
                 .zir_index = zir_index,
                 .fields_len = ini.fields_len,
                 .namespace = undefined, // set by `finish`
@@ -8555,7 +8481,6 @@ pub fn getStructType(
                 .tid = tid,
                 .index = gop.put(),
                 .type_name_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeStructPacked, "name").?,
-                .cau_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeStructPacked, "cau").?,
                 .namespace_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeStructPacked, "namespace").?,
             } };
         },
@@ -8578,7 +8503,6 @@ pub fn getStructType(
         1); // names_map
     const extra_index = addExtraAssumeCapacity(extra, Tag.TypeStruct{
         .name = undefined, // set by `finish`
-        .cau = undefined, // set by `finish`
         .zir_index = zir_index,
         .namespace = undefined, // set by `finish`
         .fields_len = ini.fields_len,
@@ -8647,7 +8571,6 @@ pub fn getStructType(
         .tid = tid,
         .index = gop.put(),
         .type_name_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeStruct, "name").?,
-        .cau_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeStruct, "cau").?,
         .namespace_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeStruct, "namespace").?,
     } };
 }
@@ -9383,7 +9306,7 @@ fn finishFuncInstance(
     func_extra_index: u32,
 ) Allocator.Error!void {
     const fn_owner_nav = ip.getNav(ip.funcDeclInfo(generic_owner).owner_nav);
-    const fn_namespace = ip.getCau(fn_owner_nav.analysis_owner.unwrap().?).namespace;
+    const fn_namespace = fn_owner_nav.analysis.?.namespace;
 
     // TODO: improve this name
     const nav_name = try ip.getOrPutStringFmt(gpa, tid, "{}__anon_{d}", .{
@@ -9429,7 +9352,6 @@ pub const WipEnumType = struct {
     index: Index,
     tag_ty_index: u32,
     type_name_extra_index: u32,
-    cau_extra_index: u32,
     namespace_extra_index: u32,
     names_map: MapIndex,
     names_start: u32,
@@ -9449,13 +9371,11 @@ pub const WipEnumType = struct {
     pub fn prepare(
         wip: WipEnumType,
         ip: *InternPool,
-        analysis_owner: Cau.Index,
         namespace: NamespaceIndex,
     ) void {
         const extra = ip.getLocalShared(wip.tid).extra.acquire();
         const extra_items = extra.view().items(.@"0");
 
-        extra_items[wip.cau_extra_index] = @intFromEnum(analysis_owner);
         extra_items[wip.namespace_extra_index] = @intFromEnum(namespace);
     }
 
@@ -9556,7 +9476,6 @@ pub fn getEnumType(
                     .reified => 2, // type_hash: PackedU64
                 } +
                 // zig fmt: on
-                1 + // cau
                 ini.fields_len); // field types
 
             const extra_index = addExtraAssumeCapacity(extra, EnumAuto{
@@ -9577,8 +9496,6 @@ pub fn getEnumType(
                 .tag = .type_enum_auto,
                 .data = extra_index,
             });
-            const cau_extra_index = extra.view().len;
-            extra.appendAssumeCapacity(undefined); // `cau` will be set by `finish`
             switch (ini.key) {
                 .declared => |d| extra.appendSliceAssumeCapacity(.{@ptrCast(d.captures)}),
                 .declared_owned_captures => |d| extra.appendSliceAssumeCapacity(.{@ptrCast(d.captures.get(ip))}),
@@ -9591,7 +9508,6 @@ pub fn getEnumType(
                 .index = gop.put(),
                 .tag_ty_index = extra_index + std.meta.fieldIndex(EnumAuto, "int_tag_type").?,
                 .type_name_extra_index = extra_index + std.meta.fieldIndex(EnumAuto, "name").?,
-                .cau_extra_index = @intCast(cau_extra_index),
                 .namespace_extra_index = extra_index + std.meta.fieldIndex(EnumAuto, "namespace").?,
                 .names_map = names_map,
                 .names_start = @intCast(names_start),
@@ -9616,7 +9532,6 @@ pub fn getEnumType(
                     .reified => 2, // type_hash: PackedU64
                 } +
                 // zig fmt: on
-                1 + // cau
                 ini.fields_len + // field types
                 ini.fields_len * @intFromBool(ini.has_values)); // field values
 
@@ -9643,8 +9558,6 @@ pub fn getEnumType(
                 },
                 .data = extra_index,
             });
-            const cau_extra_index = extra.view().len;
-            extra.appendAssumeCapacity(undefined); // `cau` will be set by `finish`
             switch (ini.key) {
                 .declared => |d| extra.appendSliceAssumeCapacity(.{@ptrCast(d.captures)}),
                 .declared_owned_captures => |d| extra.appendSliceAssumeCapacity(.{@ptrCast(d.captures.get(ip))}),
@@ -9661,7 +9574,6 @@ pub fn getEnumType(
                 .index = gop.put(),
                 .tag_ty_index = extra_index + std.meta.fieldIndex(EnumExplicit, "int_tag_type").?,
                 .type_name_extra_index = extra_index + std.meta.fieldIndex(EnumExplicit, "name").?,
-                .cau_extra_index = @intCast(cau_extra_index),
                 .namespace_extra_index = extra_index + std.meta.fieldIndex(EnumExplicit, "namespace").?,
                 .names_map = names_map,
                 .names_start = @intCast(names_start),
@@ -9858,7 +9770,6 @@ pub fn getOpaqueType(
             .tid = tid,
             .index = gop.put(),
             .type_name_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeOpaque, "name").?,
-            .cau_extra_index = null, // opaques do not undergo type resolution
             .namespace_extra_index = extra_index + std.meta.fieldIndex(Tag.TypeOpaque, "namespace").?,
         },
     };
@@ -9974,7 +9885,6 @@ fn addExtraAssumeCapacity(extra: Local.Extra.Mutable, item: anytype) u32 {
     inline for (@typeInfo(@TypeOf(item)).@"struct".fields) |field| {
         extra.appendAssumeCapacity(.{switch (field.type) {
             Index,
-            Cau.Index,
             Nav.Index,
             NamespaceIndex,
             OptionalNamespaceIndex,
@@ -10037,7 +9947,6 @@ fn extraDataTrail(extra: Local.Extra, comptime T: type, index: u32) struct { dat
         const extra_item = extra_items[extra_index];
         @field(result, field.name) = switch (field.type) {
             Index,
-            Cau.Index,
             Nav.Index,
             NamespaceIndex,
             OptionalNamespaceIndex,
@@ -11058,12 +10967,6 @@ pub fn dumpGenericInstancesFallible(ip: *const InternPool, allocator: Allocator)
     try bw.flush();
 }
 
-pub fn getCau(ip: *const InternPool, index: Cau.Index) Cau {
-    const unwrapped = index.unwrap(ip);
-    const caus = ip.getLocalShared(unwrapped.tid).caus.acquire();
-    return caus.view().items(.@"0")[unwrapped.index];
-}
-
 pub fn getNav(ip: *const InternPool, index: Nav.Index) Nav {
     const unwrapped = index.unwrap(ip);
     const navs = ip.getLocalShared(unwrapped.tid).navs.acquire();
@@ -11077,51 +10980,34 @@ pub fn namespacePtr(ip: *InternPool, namespace_index: NamespaceIndex) *Zcu.Names
     return &namespaces_bucket[unwrapped_namespace_index.index];
 }
 
-/// Create a `Cau` associated with the type at the given `InternPool.Index`.
-pub fn createTypeCau(
+/// Create a `ComptimeUnit`, forming an `AnalUnit` for a `comptime` declaration.
+pub fn createComptimeUnit(
     ip: *InternPool,
     gpa: Allocator,
     tid: Zcu.PerThread.Id,
     zir_index: TrackedInst.Index,
     namespace: NamespaceIndex,
-    owner_type: InternPool.Index,
-) Allocator.Error!Cau.Index {
-    const caus = ip.getLocal(tid).getMutableCaus(gpa);
-    const index_unwrapped: Cau.Index.Unwrapped = .{
+) Allocator.Error!ComptimeUnit.Id {
+    const comptime_units = ip.getLocal(tid).getMutableComptimeUnits(gpa);
+    const id_unwrapped: ComptimeUnit.Id.Unwrapped = .{
         .tid = tid,
-        .index = caus.mutate.len,
+        .index = comptime_units.mutate.len,
     };
-    try caus.append(.{.{
+    try comptime_units.append(.{.{
         .zir_index = zir_index,
         .namespace = namespace,
-        .owner = Cau.Owner.wrap(.{ .type = owner_type }),
     }});
-    return index_unwrapped.wrap(ip);
+    return id_unwrapped.wrap(ip);
 }
 
-/// Create a `Cau` for a `comptime` declaration.
-pub fn createComptimeCau(
-    ip: *InternPool,
-    gpa: Allocator,
-    tid: Zcu.PerThread.Id,
-    zir_index: TrackedInst.Index,
-    namespace: NamespaceIndex,
-) Allocator.Error!Cau.Index {
-    const caus = ip.getLocal(tid).getMutableCaus(gpa);
-    const index_unwrapped: Cau.Index.Unwrapped = .{
-        .tid = tid,
-        .index = caus.mutate.len,
-    };
-    try caus.append(.{.{
-        .zir_index = zir_index,
-        .namespace = namespace,
-        .owner = Cau.Owner.wrap(.none),
-    }});
-    return index_unwrapped.wrap(ip);
+pub fn getComptimeUnit(ip: *const InternPool, id: ComptimeUnit.Id) ComptimeUnit {
+    const unwrapped = id.unwrap(ip);
+    const comptime_units = ip.getLocalShared(unwrapped.tid).comptime_units.acquire();
+    return comptime_units.view().items(.@"0")[unwrapped.index];
 }
 
-/// Create a `Nav` not associated with any `Cau`.
-/// Since there is no analysis owner, the `Nav`'s value must be known at creation time.
+/// Create a `Nav` which does not undergo semantic analysis.
+/// Since it is never analyzed, the `Nav`'s value must be known at creation time.
 pub fn createNav(
     ip: *InternPool,
     gpa: Allocator,
@@ -11143,7 +11029,7 @@ pub fn createNav(
     try navs.append(Nav.pack(.{
         .name = opts.name,
         .fqn = opts.fqn,
-        .analysis_owner = .none,
+        .analysis = null,
         .status = .{ .resolved = .{
             .val = opts.val,
             .alignment = opts.alignment,
@@ -11155,10 +11041,9 @@ pub fn createNav(
     return index_unwrapped.wrap(ip);
 }
 
-/// Create a `Cau` and `Nav` which are paired. The value of the `Nav` is
-/// determined by semantic analysis of the `Cau`. The value of the `Nav`
-/// is initially unresolved.
-pub fn createPairedCauNav(
+/// Create a `Nav` which undergoes semantic analysis because it corresponds to a source declaration.
+/// The value of the `Nav` is initially unresolved.
+pub fn createDeclNav(
     ip: *InternPool,
     gpa: Allocator,
     tid: Zcu.PerThread.Id,
@@ -11168,36 +11053,28 @@ pub fn createPairedCauNav(
     namespace: NamespaceIndex,
     /// TODO: this is hacky! See `Nav.is_usingnamespace`.
     is_usingnamespace: bool,
-) Allocator.Error!struct { Cau.Index, Nav.Index } {
-    const caus = ip.getLocal(tid).getMutableCaus(gpa);
+) Allocator.Error!Nav.Index {
     const navs = ip.getLocal(tid).getMutableNavs(gpa);
 
-    try caus.ensureUnusedCapacity(1);
     try navs.ensureUnusedCapacity(1);
 
-    const cau = Cau.Index.Unwrapped.wrap(.{
-        .tid = tid,
-        .index = caus.mutate.len,
-    }, ip);
     const nav = Nav.Index.Unwrapped.wrap(.{
         .tid = tid,
         .index = navs.mutate.len,
     }, ip);
 
-    caus.appendAssumeCapacity(.{.{
-        .zir_index = zir_index,
-        .namespace = namespace,
-        .owner = Cau.Owner.wrap(.{ .nav = nav }),
-    }});
     navs.appendAssumeCapacity(Nav.pack(.{
         .name = name,
         .fqn = fqn,
-        .analysis_owner = cau.toOptional(),
+        .analysis = .{
+            .namespace = namespace,
+            .zir_index = zir_index,
+        },
         .status = .unresolved,
         .is_usingnamespace = is_usingnamespace,
     }));
 
-    return .{ cau, nav };
+    return nav;
 }
 
 /// Resolve the value of a `Nav` with an analysis owner.
@@ -11220,12 +11097,14 @@ pub fn resolveNavValue(
 
     const navs = local.shared.navs.view();
 
-    const nav_analysis_owners = navs.items(.analysis_owner);
+    const nav_analysis_namespace = navs.items(.analysis_namespace);
+    const nav_analysis_zir_index = navs.items(.analysis_zir_index);
     const nav_vals = navs.items(.val);
     const nav_linksections = navs.items(.@"linksection");
     const nav_bits = navs.items(.bits);
 
-    assert(nav_analysis_owners[unwrapped.index] != .none);
+    assert(nav_analysis_namespace[unwrapped.index] != .none);
+    assert(nav_analysis_zir_index[unwrapped.index] != .none);
 
     @atomicStore(InternPool.Index, &nav_vals[unwrapped.index], resolved.val, .release);
     @atomicStore(OptionalNullTerminatedString, &nav_linksections[unwrapped.index], resolved.@"linksection", .release);

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -2018,7 +2018,6 @@ pub const Key = union(enum) {
         ty: Index,
         init: Index,
         owner_nav: Nav.Index,
-        lib_name: OptionalNullTerminatedString,
         is_threadlocal: bool,
         is_weak_linkage: bool,
     };
@@ -2741,7 +2740,6 @@ pub const Key = union(enum) {
                 return a_info.owner_nav == b_info.owner_nav and
                     a_info.ty == b_info.ty and
                     a_info.init == b_info.init and
-                    a_info.lib_name == b_info.lib_name and
                     a_info.is_threadlocal == b_info.is_threadlocal and
                     a_info.is_weak_linkage == b_info.is_weak_linkage;
             },
@@ -5573,9 +5571,6 @@ pub const Tag = enum(u8) {
         /// May be `none`.
         init: Index,
         owner_nav: Nav.Index,
-        /// Library name if specified.
-        /// For example `extern "c" var stderrp = ...` would have 'c' as library name.
-        lib_name: OptionalNullTerminatedString,
         flags: Flags,
 
         pub const Flags = packed struct(u32) {
@@ -6928,7 +6923,6 @@ pub fn indexToKey(ip: *const InternPool, index: Index) Key {
                 .ty = extra.ty,
                 .init = extra.init,
                 .owner_nav = extra.owner_nav,
-                .lib_name = extra.lib_name,
                 .is_threadlocal = extra.flags.is_threadlocal,
                 .is_weak_linkage = extra.flags.is_weak_linkage,
             } };
@@ -7575,7 +7569,6 @@ pub fn get(ip: *InternPool, gpa: Allocator, tid: Zcu.PerThread.Id, key: Key) All
                     .ty = variable.ty,
                     .init = variable.init,
                     .owner_nav = variable.owner_nav,
-                    .lib_name = variable.lib_name,
                     .flags = .{
                         .is_const = false,
                         .is_threadlocal = variable.is_threadlocal,

--- a/src/Sema/comptime_ptr_access.zig
+++ b/src/Sema/comptime_ptr_access.zig
@@ -219,9 +219,8 @@ fn loadComptimePtrInner(
 
     const base_val: MutableValue = switch (ptr.base_addr) {
         .nav => |nav| val: {
-            try sema.declareDependency(.{ .nav_val = nav });
-            try sema.ensureNavResolved(src, nav);
-            const val = ip.getNav(nav).status.resolved.val;
+            try sema.ensureNavResolved(src, nav, .fully);
+            const val = ip.getNav(nav).status.fully_resolved.val;
             switch (ip.indexToKey(val)) {
                 .variable => return .runtime_load,
                 // We let `.@"extern"` through here if it's a function.

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -3851,7 +3851,7 @@ fn resolveStructInner(
     const gpa = zcu.gpa;
 
     const struct_obj = zcu.typeToStruct(ty).?;
-    const owner = InternPool.AnalUnit.wrap(.{ .cau = struct_obj.cau });
+    const owner: InternPool.AnalUnit = .wrap(.{ .type = ty.toIntern() });
 
     if (zcu.failed_analysis.contains(owner) or zcu.transitive_failed_analysis.contains(owner)) {
         return error.AnalysisFail;
@@ -3905,7 +3905,7 @@ fn resolveUnionInner(
     const gpa = zcu.gpa;
 
     const union_obj = zcu.typeToUnion(ty).?;
-    const owner = InternPool.AnalUnit.wrap(.{ .cau = union_obj.cau });
+    const owner: InternPool.AnalUnit = .wrap(.{ .type = ty.toIntern() });
 
     if (zcu.failed_analysis.contains(owner) or zcu.transitive_failed_analysis.contains(owner)) {
         return error.AnalysisFail;

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -1343,7 +1343,12 @@ pub fn isLazySize(val: Value, zcu: *Zcu) bool {
 pub fn isPtrRuntimeValue(val: Value, zcu: *Zcu) bool {
     const ip = &zcu.intern_pool;
     const nav = ip.getBackingNav(val.toIntern()).unwrap() orelse return false;
-    return switch (ip.indexToKey(ip.getNav(nav).status.resolved.val)) {
+    const nav_val = switch (ip.getNav(nav).status) {
+        .unresolved => unreachable,
+        .type_resolved => |r| return r.is_threadlocal,
+        .fully_resolved => |r| r.val,
+    };
+    return switch (ip.indexToKey(nav_val)) {
         .@"extern" => |e| e.is_threadlocal or e.is_dll_import,
         .variable => |v| v.is_threadlocal,
         else => false,

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -545,117 +545,270 @@ pub fn updateZirRefs(pt: Zcu.PerThread) Allocator.Error!void {
 pub fn ensureFileAnalyzed(pt: Zcu.PerThread, file_index: Zcu.File.Index) Zcu.SemaError!void {
     const file_root_type = pt.zcu.fileRootType(file_index);
     if (file_root_type != .none) {
-        _ = try pt.ensureTypeUpToDate(file_root_type, false);
+        _ = try pt.ensureTypeUpToDate(file_root_type);
     } else {
         return pt.semaFile(file_index);
     }
 }
 
-/// This ensures that the state of the `Cau`, and of its corresponding `Nav` or type,
-/// is fully up-to-date. Note that the type of the `Nav` may not be fully resolved.
-/// Returns `error.AnalysisFail` if the `Cau` has an error.
-pub fn ensureCauAnalyzed(pt: Zcu.PerThread, cau_index: InternPool.Cau.Index) Zcu.SemaError!void {
+/// Ensures that the state of the given `ComptimeUnit` is fully up-to-date, performing re-analysis
+/// if necessary. Returns `error.AnalysisFail` if an analysis error is encountered; the caller is
+/// free to ignore this, since the error is already registered.
+pub fn ensureComptimeUnitUpToDate(pt: Zcu.PerThread, cu_id: InternPool.ComptimeUnit.Id) Zcu.SemaError!void {
     const tracy = trace(@src());
     defer tracy.end();
 
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
-    const ip = &zcu.intern_pool;
 
-    const anal_unit = AnalUnit.wrap(.{ .cau = cau_index });
-    const cau = ip.getCau(cau_index);
+    const anal_unit: AnalUnit = .wrap(.{ .@"comptime" = cu_id });
 
-    log.debug("ensureCauAnalyzed {}", .{zcu.fmtAnalUnit(anal_unit)});
+    log.debug("ensureComptimeUnitUpToDate {}", .{zcu.fmtAnalUnit(anal_unit)});
 
     assert(!zcu.analysis_in_progress.contains(anal_unit));
 
-    // Determine whether or not this Cau is outdated, i.e. requires re-analysis
-    // even if `complete`. If a Cau is PO, we pessismistically assume that it
-    // *does* require re-analysis, to ensure that the Cau is definitely
-    // up-to-date when this function returns.
+    // Determine whether or not this `ComptimeUnit` is outdated. For this kind of `AnalUnit`, that's
+    // the only indicator as to whether or not analysis is required; when a `ComptimeUnit` is first
+    // created, it's marked as outdated.
+    //
+    // Note that if the unit is PO, we pessimistically assume that it *does* require re-analysis, to
+    // ensure that the unit is definitely up-to-date when this function returns. This mechanism could
+    // result in over-analysis if analysis occurs in a poor order; we do our best to avoid this by
+    // carefully choosing which units to re-analyze. See `Zcu.findOutdatedToAnalyze`.
 
-    // If analysis occurs in a poor order, this could result in over-analysis.
-    // We do our best to avoid this by the other dependency logic in this file
-    // which tries to limit re-analysis to Caus whose previously listed
-    // dependencies are all up-to-date.
-
-    const cau_outdated = zcu.outdated.swapRemove(anal_unit) or
+    const was_outdated = zcu.outdated.swapRemove(anal_unit) or
         zcu.potentially_outdated.swapRemove(anal_unit);
 
-    const prev_failed = zcu.failed_analysis.contains(anal_unit) or zcu.transitive_failed_analysis.contains(anal_unit);
-
-    if (cau_outdated) {
+    if (was_outdated) {
         _ = zcu.outdated_ready.swapRemove(anal_unit);
+        // `was_outdated` can be true in the initial update for comptime units, so this isn't a `dev.check`.
+        if (dev.env.supports(.incremental)) {
+            zcu.deleteUnitExports(anal_unit);
+            zcu.deleteUnitReferences(anal_unit);
+            if (zcu.failed_analysis.fetchSwapRemove(anal_unit)) |kv| {
+                kv.value.destroy(gpa);
+            }
+            _ = zcu.transitive_failed_analysis.swapRemove(anal_unit);
+        }
     } else {
-        // We can trust the current information about this `Cau`.
-        if (prev_failed) {
-            return error.AnalysisFail;
-        }
-        // If it wasn't failed and wasn't marked outdated, then either...
-        // * it is a type and is up-to-date, or
-        // * it is a `comptime` decl and is up-to-date, or
-        // * it is another decl and is EITHER up-to-date OR never-referenced (so unresolved)
-        // We just need to check for that last case.
-        switch (cau.owner.unwrap()) {
-            .type, .none => return,
-            .nav => |nav| if (ip.getNav(nav).status == .resolved) return,
-        }
+        // We can trust the current information about this unit.
+        if (zcu.failed_analysis.contains(anal_unit)) return error.AnalysisFail;
+        if (zcu.transitive_failed_analysis.contains(anal_unit)) return error.AnalysisFail;
+        return;
     }
 
-    const sema_result: SemaCauResult, const analysis_fail = if (pt.ensureCauAnalyzedInner(cau_index, cau_outdated)) |result|
-        // This `Cau` has gone from failed to success, so even if the value of the owner `Nav` didn't actually
-        // change, we need to invalidate the dependencies anyway.
-        .{ .{
-            .invalidate_decl_val = result.invalidate_decl_val or prev_failed,
-            .invalidate_decl_ref = result.invalidate_decl_ref or prev_failed,
-        }, false }
-    else |err| switch (err) {
-        error.AnalysisFail => res: {
+    const unit_prog_node = zcu.sema_prog_node.start("comptime", 0);
+    defer unit_prog_node.end();
+
+    return pt.analyzeComptimeUnit(cu_id) catch |err| switch (err) {
+        error.AnalysisFail => {
             if (!zcu.failed_analysis.contains(anal_unit)) {
-                // If this `Cau` caused the error, it would have an entry in `failed_analysis`.
+                // If this unit caused the error, it would have an entry in `failed_analysis`.
                 // Since it does not, this must be a transitive failure.
                 try zcu.transitive_failed_analysis.put(gpa, anal_unit, {});
                 log.debug("mark transitive analysis failure for {}", .{zcu.fmtAnalUnit(anal_unit)});
             }
-            // We consider this `Cau` to be outdated if:
-            // * Previous analysis succeeded; in this case, we need to re-analyze dependants to ensure
-            //   they hit a transitive error here, rather than reporting a different error later (which
-            //   may now be invalid).
-            // * The `Cau` is a type; in this case, the declaration site may require re-analysis to
-            //   construct a valid type.
-            const outdated = !prev_failed or cau.owner.unwrap() == .type;
+            return error.AnalysisFail;
+        },
+        error.OutOfMemory => {
+            // TODO: it's unclear how to gracefully handle this.
+            // To report the error cleanly, we need to add a message to `failed_analysis` and a
+            // corresponding entry to `retryable_failures`; but either of these things is quite
+            // likely to OOM at this point.
+            // If that happens, what do we do? Perhaps we could have a special field on `Zcu`
+            // for reporting OOM errors without allocating.
+            return error.OutOfMemory;
+        },
+        error.GenericPoison => unreachable,
+        error.ComptimeReturn => unreachable,
+        error.ComptimeBreak => unreachable,
+    };
+}
+
+/// Re-analyzes a `ComptimeUnit`. The unit has already been determined to be out-of-date, and old
+/// side effects (exports/references/etc) have been dropped. If semantic analysis fails, this
+/// function will return `error.AnalysisFail`, and it is the caller's reponsibility to add an entry
+/// to `transitive_failed_analysis` if necessary.
+fn analyzeComptimeUnit(pt: Zcu.PerThread, cu_id: InternPool.ComptimeUnit.Id) Zcu.CompileError!void {
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
+    const ip = &zcu.intern_pool;
+
+    const anal_unit: AnalUnit = .wrap(.{ .@"comptime" = cu_id });
+    const comptime_unit = ip.getComptimeUnit(cu_id);
+
+    log.debug("analyzeComptimeUnit {}", .{zcu.fmtAnalUnit(anal_unit)});
+
+    const inst_resolved = comptime_unit.zir_index.resolveFull(ip) orelse return error.AnalysisFail;
+    const file = zcu.fileByIndex(inst_resolved.file);
+    // TODO: stop the compiler ever reaching Sema if there are failed files. That way, this check is
+    // unnecessary, and we can move the below `removeDependenciesForDepender` call up with its friends
+    // in `ensureComptimeUnitUpToDate`.
+    if (file.status != .success_zir) return error.AnalysisFail;
+    const zir = file.zir;
+
+    // We are about to re-analyze this unit; drop its depenndencies.
+    zcu.intern_pool.removeDependenciesForDepender(gpa, anal_unit);
+
+    try zcu.analysis_in_progress.put(gpa, anal_unit, {});
+    defer assert(zcu.analysis_in_progress.swapRemove(anal_unit));
+
+    var analysis_arena: std.heap.ArenaAllocator = .init(gpa);
+    defer analysis_arena.deinit();
+
+    var comptime_err_ret_trace: std.ArrayList(Zcu.LazySrcLoc) = .init(gpa);
+    defer comptime_err_ret_trace.deinit();
+
+    var sema: Sema = .{
+        .pt = pt,
+        .gpa = gpa,
+        .arena = analysis_arena.allocator(),
+        .code = zir,
+        .owner = anal_unit,
+        .func_index = .none,
+        .func_is_naked = false,
+        .fn_ret_ty = .void,
+        .fn_ret_ty_ies = null,
+        .comptime_err_ret_trace = &comptime_err_ret_trace,
+    };
+    defer sema.deinit();
+
+    // The comptime unit declares on the source of the corresponding `comptime` declaration.
+    try sema.declareDependency(.{ .src_hash = comptime_unit.zir_index });
+
+    var block: Sema.Block = .{
+        .parent = null,
+        .sema = &sema,
+        .namespace = comptime_unit.namespace,
+        .instructions = .{},
+        .inlining = null,
+        .is_comptime = true,
+        .src_base_inst = comptime_unit.zir_index,
+        .type_name_ctx = try ip.getOrPutStringFmt(gpa, pt.tid, "{}.comptime", .{
+            Type.fromInterned(zcu.namespacePtr(comptime_unit.namespace).owner_type).containerTypeName(ip).fmt(ip),
+        }, .no_embedded_nulls),
+    };
+    defer block.instructions.deinit(gpa);
+
+    const zir_decl = zir.getDeclaration(inst_resolved.inst);
+    assert(zir_decl.kind == .@"comptime");
+    assert(zir_decl.type_body == null);
+    assert(zir_decl.align_body == null);
+    assert(zir_decl.linksection_body == null);
+    assert(zir_decl.addrspace_body == null);
+    const value_body = zir_decl.value_body.?;
+
+    const result_ref = try sema.resolveInlineBody(&block, value_body, inst_resolved.inst);
+    assert(result_ref == .void_value); // AstGen should always uphold this
+
+    // Nothing else to do -- for a comptime decl, all we care about are the side effects.
+    // Just make sure to `flushExports`.
+    try sema.flushExports();
+}
+
+/// Ensures that the resolved value of the given `Nav` is fully up-to-date, performing re-analysis
+/// if necessary. Returns `error.AnalysisFail` if an analysis error is encountered; the caller is
+/// free to ignore this, since the error is already registered.
+pub fn ensureNavValUpToDate(pt: Zcu.PerThread, nav_id: InternPool.Nav.Index) Zcu.SemaError!void {
+    const tracy = trace(@src());
+    defer tracy.end();
+
+    // TODO: document this elsewhere mlugg!
+    // For my own benefit, here's how a namespace update for a normal (non-file-root) type works:
+    // `const S = struct { ... };`
+    // We are adding or removing a declaration within this `struct`.
+    // * `S` registers a dependency on `.{ .src_hash = (declaration of S) }`
+    // * Any change to the `struct` body -- including changing a declaration -- invalidates this
+    // * `S` is re-analyzed, but notes:
+    //   * there is an existing struct instance (at this `TrackedInst` with these captures)
+    //   * the struct's resolution is up-to-date (because nothing about the fields changed)
+    // * so, it uses the same `struct`
+    // * but this doesn't stop it from updating the namespace!
+    //   * we basically do `scanDecls`, updating the namespace as needed
+    // * so everyone lived happily ever after
+
+    const zcu = pt.zcu;
+    const gpa = zcu.gpa;
+    const ip = &zcu.intern_pool;
+
+    const anal_unit: AnalUnit = .wrap(.{ .nav_val = nav_id });
+    const nav = ip.getNav(nav_id);
+
+    log.debug("ensureNavUpToDate {}", .{zcu.fmtAnalUnit(anal_unit)});
+
+    // Determine whether or not this `Nav`'s value is outdated. This also includes checking if the
+    // status is `.unresolved`, which indicates that the value is outdated because it has *never*
+    // been analyzed so far.
+    //
+    // Note that if the unit is PO, we pessimistically assume that it *does* require re-analysis, to
+    // ensure that the unit is definitely up-to-date when this function returns. This mechanism could
+    // result in over-analysis if analysis occurs in a poor order; we do our best to avoid this by
+    // carefully choosing which units to re-analyze. See `Zcu.findOutdatedToAnalyze`.
+
+    const was_outdated = zcu.outdated.swapRemove(anal_unit) or
+        zcu.potentially_outdated.swapRemove(anal_unit);
+
+    const prev_failed = zcu.failed_analysis.contains(anal_unit) or
+        zcu.transitive_failed_analysis.contains(anal_unit);
+
+    if (was_outdated) {
+        dev.check(.incremental);
+        _ = zcu.outdated_ready.swapRemove(anal_unit);
+        zcu.deleteUnitExports(anal_unit);
+        zcu.deleteUnitReferences(anal_unit);
+        if (zcu.failed_analysis.fetchSwapRemove(anal_unit)) |kv| {
+            kv.value.destroy(gpa);
+        }
+        _ = zcu.transitive_failed_analysis.swapRemove(anal_unit);
+    } else {
+        // We can trust the current information about this unit.
+        if (prev_failed) return error.AnalysisFail;
+        if (nav.status == .resolved) return;
+    }
+
+    const unit_prog_node = zcu.sema_prog_node.start(nav.fqn.toSlice(ip), 0);
+    defer unit_prog_node.end();
+
+    const sema_result: SemaNavResult, const new_failed: bool = if (pt.analyzeNavVal(nav_id)) |result| res: {
+        break :res .{
+            .{
+                // If the unit has gone from failed to success, we still need to invalidate the dependencies.
+                .invalidate_nav_val = result.invalidate_nav_val or prev_failed,
+                .invalidate_nav_ref = result.invalidate_nav_ref or prev_failed,
+            },
+            false,
+        };
+    } else |err| switch (err) {
+        error.AnalysisFail => res: {
+            if (!zcu.failed_analysis.contains(anal_unit)) {
+                // If this unit caused the error, it would have an entry in `failed_analysis`.
+                // Since it does not, this must be a transitive failure.
+                try zcu.transitive_failed_analysis.put(gpa, anal_unit, {});
+                log.debug("mark transitive analysis failure for {}", .{zcu.fmtAnalUnit(anal_unit)});
+            }
             break :res .{ .{
-                .invalidate_decl_val = outdated,
-                .invalidate_decl_ref = outdated,
+                .invalidate_nav_val = !prev_failed,
+                .invalidate_nav_ref = !prev_failed,
             }, true };
         },
-        error.OutOfMemory => res: {
-            try zcu.failed_analysis.ensureUnusedCapacity(gpa, 1);
-            try zcu.retryable_failures.ensureUnusedCapacity(gpa, 1);
-            const msg = try Zcu.ErrorMsg.create(
-                gpa,
-                .{ .base_node_inst = cau.zir_index, .offset = Zcu.LazySrcLoc.Offset.nodeOffset(0) },
-                "unable to analyze: OutOfMemory",
-                .{},
-            );
-            zcu.retryable_failures.appendAssumeCapacity(anal_unit);
-            zcu.failed_analysis.putAssumeCapacityNoClobber(anal_unit, msg);
-            break :res .{ .{
-                .invalidate_decl_val = true,
-                .invalidate_decl_ref = true,
-            }, true };
+        error.OutOfMemory => {
+            // TODO: it's unclear how to gracefully handle this.
+            // To report the error cleanly, we need to add a message to `failed_analysis` and a
+            // corresponding entry to `retryable_failures`; but either of these things is quite
+            // likely to OOM at this point.
+            // If that happens, what do we do? Perhaps we could have a special field on `Zcu`
+            // for reporting OOM errors without allocating.
+            return error.OutOfMemory;
         },
+        error.GenericPoison => unreachable,
+        error.ComptimeReturn => unreachable,
+        error.ComptimeBreak => unreachable,
     };
 
-    if (cau_outdated) {
-        // TODO: we do not yet have separate dependencies for decl values vs types.
-        const invalidate = sema_result.invalidate_decl_val or sema_result.invalidate_decl_ref;
-        const dependee: InternPool.Dependee = switch (cau.owner.unwrap()) {
-            .none => return, // there are no dependencies on a `comptime` decl!
-            .nav => |nav_index| .{ .nav_val = nav_index },
-            .type => |ty| .{ .interned = ty },
-        };
-
+    if (was_outdated) {
+        // TODO: we do not yet have separate dependencies for Nav values vs types.
+        const invalidate = sema_result.invalidate_nav_val or sema_result.invalidate_nav_ref;
+        const dependee: InternPool.Dependee = .{ .nav_val = nav_id };
         if (invalidate) {
             // This dependency was marked as PO, meaning dependees were waiting
             // on its analysis result, and it has turned out to be outdated.
@@ -668,67 +821,320 @@ pub fn ensureCauAnalyzed(pt: Zcu.PerThread, cau_index: InternPool.Cau.Index) Zcu
         }
     }
 
-    if (analysis_fail) return error.AnalysisFail;
+    if (new_failed) return error.AnalysisFail;
 }
 
-fn ensureCauAnalyzedInner(
-    pt: Zcu.PerThread,
-    cau_index: InternPool.Cau.Index,
-    cau_outdated: bool,
-) Zcu.SemaError!SemaCauResult {
+const SemaNavResult = packed struct {
+    /// Whether the value of a `decl_val` of the corresponding Nav changed.
+    invalidate_nav_val: bool,
+    /// Whether the type of a `decl_ref` of the corresponding Nav changed.
+    invalidate_nav_ref: bool,
+};
+
+fn analyzeNavVal(pt: Zcu.PerThread, nav_id: InternPool.Nav.Index) Zcu.CompileError!SemaNavResult {
     const zcu = pt.zcu;
+    const gpa = zcu.gpa;
     const ip = &zcu.intern_pool;
 
-    const cau = ip.getCau(cau_index);
-    const anal_unit = AnalUnit.wrap(.{ .cau = cau_index });
+    const anal_unit: AnalUnit = .wrap(.{ .nav_val = nav_id });
+    const old_nav = ip.getNav(nav_id);
 
-    const inst_info = cau.zir_index.resolveFull(ip) orelse return error.AnalysisFail;
+    log.debug("analyzeNavVal {}", .{zcu.fmtAnalUnit(anal_unit)});
 
-    // TODO: document this elsewhere mlugg!
-    // For my own benefit, here's how a namespace update for a normal (non-file-root) type works:
-    // `const S = struct { ... };`
-    // We are adding or removing a declaration within this `struct`.
-    // * `S` registers a dependency on `.{ .src_hash = (declaration of S) }`
-    // * Any change to the `struct` body -- including changing a declaration -- invalidates this
-    // * `S` is re-analyzed, but notes:
-    //   * there is an existing struct instance (at this `TrackedInst` with these captures)
-    //   * the struct's `Cau` is up-to-date (because nothing about the fields changed)
-    // * so, it uses the same `struct`
-    // * but this doesn't stop it from updating the namespace!
-    //   * we basically do `scanDecls`, updating the namespace as needed
-    // * so everyone lived happily ever after
+    const inst_resolved = old_nav.analysis.?.zir_index.resolveFull(ip) orelse return error.AnalysisFail;
+    const file = zcu.fileByIndex(inst_resolved.file);
+    // TODO: stop the compiler ever reaching Sema if there are failed files. That way, this check is
+    // unnecessary, and we can move the below `removeDependenciesForDepender` call up with its friends
+    // in `ensureComptimeUnitUpToDate`.
+    if (file.status != .success_zir) return error.AnalysisFail;
+    const zir = file.zir;
 
-    if (zcu.fileByIndex(inst_info.file).status != .success_zir) {
-        return error.AnalysisFail;
-    }
+    // We are about to re-analyze this unit; drop its depenndencies.
+    zcu.intern_pool.removeDependenciesForDepender(gpa, anal_unit);
 
-    // `cau_outdated` can be true in the initial update for `comptime` declarations,
-    // so this isn't a `dev.check`.
-    if (cau_outdated and dev.env.supports(.incremental)) {
-        // The exports this `Cau` performs will be re-discovered, so we remove them here
-        // prior to re-analysis.
-        zcu.deleteUnitExports(anal_unit);
-        zcu.deleteUnitReferences(anal_unit);
-        if (zcu.failed_analysis.fetchSwapRemove(anal_unit)) |kv| {
-            kv.value.destroy(zcu.gpa);
-        }
-        _ = zcu.transitive_failed_analysis.swapRemove(anal_unit);
-    }
+    try zcu.analysis_in_progress.put(gpa, anal_unit, {});
+    errdefer _ = zcu.analysis_in_progress.swapRemove(anal_unit);
 
-    const decl_prog_node = zcu.sema_prog_node.start(switch (cau.owner.unwrap()) {
-        .nav => |nav| ip.getNav(nav).fqn.toSlice(ip),
-        .type => |ty| Type.fromInterned(ty).containerTypeName(ip).toSlice(ip),
-        .none => "comptime",
-    }, 0);
-    defer decl_prog_node.end();
+    var analysis_arena: std.heap.ArenaAllocator = .init(gpa);
+    defer analysis_arena.deinit();
 
-    return pt.semaCau(cau_index) catch |err| switch (err) {
-        error.GenericPoison, error.ComptimeBreak, error.ComptimeReturn => unreachable,
-        error.AnalysisFail, error.OutOfMemory => |e| return e,
+    var comptime_err_ret_trace: std.ArrayList(Zcu.LazySrcLoc) = .init(gpa);
+    defer comptime_err_ret_trace.deinit();
+
+    var sema: Sema = .{
+        .pt = pt,
+        .gpa = gpa,
+        .arena = analysis_arena.allocator(),
+        .code = zir,
+        .owner = anal_unit,
+        .func_index = .none,
+        .func_is_naked = false,
+        .fn_ret_ty = .void,
+        .fn_ret_ty_ies = null,
+        .comptime_err_ret_trace = &comptime_err_ret_trace,
     };
+    defer sema.deinit();
+
+    // The comptime unit declares on the source of the corresponding declaration.
+    try sema.declareDependency(.{ .src_hash = old_nav.analysis.?.zir_index });
+
+    var block: Sema.Block = .{
+        .parent = null,
+        .sema = &sema,
+        .namespace = old_nav.analysis.?.namespace,
+        .instructions = .{},
+        .inlining = null,
+        .is_comptime = true,
+        .src_base_inst = old_nav.analysis.?.zir_index,
+        .type_name_ctx = old_nav.fqn,
+    };
+    defer block.instructions.deinit(gpa);
+
+    const zir_decl = zir.getDeclaration(inst_resolved.inst);
+
+    assert(old_nav.is_usingnamespace == (zir_decl.kind == .@"usingnamespace"));
+
+    const align_src = block.src(.{ .node_offset_var_decl_align = 0 });
+    const section_src = block.src(.{ .node_offset_var_decl_section = 0 });
+    const addrspace_src = block.src(.{ .node_offset_var_decl_addrspace = 0 });
+    const ty_src = block.src(.{ .node_offset_var_decl_ty = 0 });
+    const init_src = block.src(.{ .node_offset_var_decl_init = 0 });
+
+    // First, we must resolve the declaration's type. To do this, we analyze the type body if available,
+    // or otherwise, we analyze the value body, populating `early_val` in the process.
+
+    const nav_ty: Type, const early_val: ?Value = if (zir_decl.type_body) |type_body| ty: {
+        // We evaluate only the type now; no need for the value yet.
+        const uncoerced_type_ref = try sema.resolveInlineBody(&block, type_body, inst_resolved.inst);
+        const type_ref = try sema.coerce(&block, .type, uncoerced_type_ref, ty_src);
+        break :ty .{ .fromInterned(type_ref.toInterned().?), null };
+    } else ty: {
+        // We don't have a type body, so we need to evaluate the value immediately.
+        const value_body = zir_decl.value_body.?;
+        const result_ref = try sema.resolveInlineBody(&block, value_body, inst_resolved.inst);
+        const val = try sema.resolveFinalDeclValue(&block, init_src, result_ref);
+        break :ty .{ val.typeOf(zcu), val };
+    };
+
+    switch (zir_decl.kind) {
+        .@"comptime" => unreachable, // this is not a Nav
+        .unnamed_test, .@"test", .decltest => assert(nav_ty.zigTypeTag(zcu) == .@"fn"),
+        .@"usingnamespace" => {},
+        .@"const" => {},
+        .@"var" => try sema.validateVarType(
+            &block,
+            if (zir_decl.type_body != null) ty_src else init_src,
+            nav_ty,
+            zir_decl.linkage == .@"extern",
+        ),
+    }
+
+    // Now that we know the type, we can evaluate the alignment, linksection, and addrspace, to determine
+    // the full pointer type of this declaration.
+
+    const alignment: InternPool.Alignment = a: {
+        const align_body = zir_decl.align_body orelse break :a .none;
+        const align_ref = try sema.resolveInlineBody(&block, align_body, inst_resolved.inst);
+        break :a try sema.analyzeAsAlign(&block, align_src, align_ref);
+    };
+
+    const @"linksection": InternPool.OptionalNullTerminatedString = ls: {
+        const linksection_body = zir_decl.linksection_body orelse break :ls .none;
+        const linksection_ref = try sema.resolveInlineBody(&block, linksection_body, inst_resolved.inst);
+        const bytes = try sema.toConstString(&block, section_src, linksection_ref, .{
+            .needed_comptime_reason = "linksection must be comptime-known",
+        });
+        if (std.mem.indexOfScalar(u8, bytes, 0) != null) {
+            return sema.fail(&block, section_src, "linksection cannot contain null bytes", .{});
+        } else if (bytes.len == 0) {
+            return sema.fail(&block, section_src, "linksection cannot be empty", .{});
+        }
+        break :ls try ip.getOrPutStringOpt(gpa, pt.tid, bytes, .no_embedded_nulls);
+    };
+
+    const @"addrspace": std.builtin.AddressSpace = as: {
+        const addrspace_ctx: Sema.AddressSpaceContext = switch (zir_decl.kind) {
+            .@"var" => .variable,
+            else => switch (nav_ty.zigTypeTag(zcu)) {
+                .@"fn" => .function,
+                else => .constant,
+            },
+        };
+        const target = zcu.getTarget();
+        const addrspace_body = zir_decl.addrspace_body orelse break :as switch (addrspace_ctx) {
+            .function => target_util.defaultAddressSpace(target, .function),
+            .variable => target_util.defaultAddressSpace(target, .global_mutable),
+            .constant => target_util.defaultAddressSpace(target, .global_constant),
+            else => unreachable,
+        };
+        const addrspace_ref = try sema.resolveInlineBody(&block, addrspace_body, inst_resolved.inst);
+        break :as try sema.analyzeAsAddressSpace(&block, addrspace_src, addrspace_ref, addrspace_ctx);
+    };
+
+    // Lastly, we must evaluate the value if we have not already done so. Note, however, that extern declarations
+    // don't have an associated value body.
+
+    const final_val: ?Value = early_val orelse if (zir_decl.value_body) |value_body| val: {
+        // Put the resolved type into `inst_map` to be used as the result type of the init.
+        try sema.inst_map.ensureSpaceForInstructions(gpa, &.{inst_resolved.inst});
+        sema.inst_map.putAssumeCapacity(inst_resolved.inst, Air.internedToRef(nav_ty.toIntern()));
+        const uncoerced_result_ref = try sema.resolveInlineBody(&block, value_body, inst_resolved.inst);
+        assert(sema.inst_map.remove(inst_resolved.inst));
+
+        const result_ref = try sema.coerce(&block, nav_ty, uncoerced_result_ref, init_src);
+        break :val try sema.resolveFinalDeclValue(&block, init_src, result_ref);
+    } else null;
+
+    const nav_val: Value = switch (zir_decl.linkage) {
+        .normal, .@"export" => switch (zir_decl.kind) {
+            .@"var" => .fromInterned(try pt.intern(.{ .variable = .{
+                .ty = nav_ty.toIntern(),
+                .init = final_val.?.toIntern(),
+                .owner_nav = nav_id,
+                .is_threadlocal = zir_decl.is_threadlocal,
+                .is_weak_linkage = false,
+            } })),
+            else => final_val.?,
+        },
+        .@"extern" => val: {
+            assert(final_val == null); // extern decls do not have a value body
+            const lib_name: ?[]const u8 = if (zir_decl.lib_name != .empty) l: {
+                break :l zir.nullTerminatedString(zir_decl.lib_name);
+            } else null;
+            if (lib_name) |l| {
+                const lib_name_src = block.src(.{ .node_offset_lib_name = 0 });
+                try sema.handleExternLibName(&block, lib_name_src, l);
+            }
+            break :val .fromInterned(try pt.getExtern(.{
+                .name = old_nav.name,
+                .ty = nav_ty.toIntern(),
+                .lib_name = try ip.getOrPutStringOpt(gpa, pt.tid, lib_name, .no_embedded_nulls),
+                .is_const = zir_decl.kind == .@"const",
+                .is_threadlocal = zir_decl.is_threadlocal,
+                .is_weak_linkage = false,
+                .is_dll_import = false,
+                .alignment = alignment,
+                .@"addrspace" = @"addrspace",
+                .zir_index = old_nav.analysis.?.zir_index, // `declaration` instruction
+                .owner_nav = undefined, // ignored by `getExtern`
+            }));
+        },
+    };
+
+    switch (nav_val.toIntern()) {
+        .generic_poison => unreachable, // assertion failure
+        .unreachable_value => unreachable, // assertion failure
+        else => {},
+    }
+
+    // This resolves the type of the resolved value, not that value itself. If `nav_val` is a struct type,
+    // this resolves the type `type` (which needs no resolution), not the struct itself.
+    try nav_ty.resolveLayout(pt);
+
+    // TODO: this is jank. If #20663 is rejected, let's think about how to better model `usingnamespace`.
+    if (zir_decl.kind == .@"usingnamespace") {
+        if (nav_ty.toIntern() != .type_type) {
+            return sema.fail(&block, ty_src, "expected type, found {}", .{nav_ty.fmt(pt)});
+        }
+        if (nav_val.toType().getNamespace(zcu) == .none) {
+            return sema.fail(&block, ty_src, "type {} has no namespace", .{nav_val.toType().fmt(pt)});
+        }
+        ip.resolveNavValue(nav_id, .{
+            .val = nav_val.toIntern(),
+            .alignment = .none,
+            .@"linksection" = .none,
+            .@"addrspace" = .generic,
+        });
+        // TODO: usingnamespace cannot participate in incremental compilation
+        assert(zcu.analysis_in_progress.swapRemove(anal_unit));
+        return .{
+            .invalidate_nav_val = true,
+            .invalidate_nav_ref = true,
+        };
+    }
+
+    const queue_linker_work, const is_owned_fn = switch (ip.indexToKey(nav_val.toIntern())) {
+        .func => |f| .{ true, f.owner_nav == nav_id }, // note that this lets function aliases reach codegen
+        .variable => |v| .{ v.owner_nav == nav_id, false },
+        .@"extern" => |e| .{
+            false,
+            Type.fromInterned(e.ty).zigTypeTag(zcu) == .@"fn" and zir_decl.linkage == .@"extern",
+        },
+        else => .{ true, false },
+    };
+
+    if (is_owned_fn) {
+        // linksection etc are legal, except some targets do not support function alignment.
+        if (zir_decl.align_body != null and !target_util.supportsFunctionAlignment(zcu.getTarget())) {
+            return sema.fail(&block, align_src, "target does not support function alignment", .{});
+        }
+    } else if (try nav_ty.comptimeOnlySema(pt)) {
+        // alignment, linksection, addrspace annotations are not allowed for comptime-only types.
+        const reason: []const u8 = switch (ip.indexToKey(nav_val.toIntern())) {
+            .func => "function alias", // slightly clearer message, since you *can* specify these on function *declarations*
+            else => "comptime-only type",
+        };
+        if (zir_decl.align_body != null) {
+            return sema.fail(&block, align_src, "cannot specify alignment of {s}", .{reason});
+        }
+        if (zir_decl.linksection_body != null) {
+            return sema.fail(&block, section_src, "cannot specify linksection of {s}", .{reason});
+        }
+        if (zir_decl.addrspace_body != null) {
+            return sema.fail(&block, addrspace_src, "cannot specify addrspace of {s}", .{reason});
+        }
+    }
+
+    ip.resolveNavValue(nav_id, .{
+        .val = nav_val.toIntern(),
+        .alignment = alignment,
+        .@"linksection" = @"linksection",
+        .@"addrspace" = @"addrspace",
+    });
+
+    // Mark the unit as completed before evaluating the export!
+    assert(zcu.analysis_in_progress.swapRemove(anal_unit));
+
+    if (zir_decl.linkage == .@"export") {
+        const export_src = block.src(.{ .token_offset = @intFromBool(zir_decl.is_pub) });
+        const name_slice = zir.nullTerminatedString(zir_decl.name);
+        const name_ip = try ip.getOrPutString(gpa, pt.tid, name_slice, .no_embedded_nulls);
+        try sema.analyzeExport(&block, export_src, .{ .name = name_ip }, nav_id);
+    }
+
+    try sema.flushExports();
+
+    queue_codegen: {
+        if (!queue_linker_work) break :queue_codegen;
+
+        if (!try nav_ty.hasRuntimeBitsSema(pt)) {
+            if (zcu.comp.config.use_llvm) break :queue_codegen;
+            if (file.mod.strip) break :queue_codegen;
+        }
+
+        // This job depends on any resolve_type_fully jobs queued up before it.
+        try zcu.comp.queueJob(.{ .codegen_nav = nav_id });
+    }
+
+    switch (old_nav.status) {
+        .unresolved => return .{
+            .invalidate_nav_val = true,
+            .invalidate_nav_ref = true,
+        },
+        .resolved => |old| {
+            const new = ip.getNav(nav_id).status.resolved;
+            return .{
+                .invalidate_nav_val = new.val != old.val,
+                .invalidate_nav_ref = ip.typeOf(new.val) != ip.typeOf(old.val) or
+                    new.alignment != old.alignment or
+                    new.@"linksection" != old.@"linksection" or
+                    new.@"addrspace" != old.@"addrspace",
+            };
+        },
+    }
 }
 
-pub fn ensureFuncBodyAnalyzed(pt: Zcu.PerThread, maybe_coerced_func_index: InternPool.Index) Zcu.SemaError!void {
+pub fn ensureFuncBodyUpToDate(pt: Zcu.PerThread, maybe_coerced_func_index: InternPool.Index) Zcu.SemaError!void {
     dev.check(.sema);
 
     const tracy = trace(@src());
@@ -740,19 +1146,26 @@ pub fn ensureFuncBodyAnalyzed(pt: Zcu.PerThread, maybe_coerced_func_index: Inter
 
     // We only care about the uncoerced function.
     const func_index = ip.unwrapCoercedFunc(maybe_coerced_func_index);
-    const anal_unit = AnalUnit.wrap(.{ .func = func_index });
+    const anal_unit: AnalUnit = .wrap(.{ .func = func_index });
 
-    log.debug("ensureFuncBodyAnalyzed {}", .{zcu.fmtAnalUnit(anal_unit)});
+    log.debug("ensureFuncBodyUpToDate {}", .{zcu.fmtAnalUnit(anal_unit)});
 
     const func = zcu.funcInfo(maybe_coerced_func_index);
 
-    const func_outdated = zcu.outdated.swapRemove(anal_unit) or
+    const was_outdated = zcu.outdated.swapRemove(anal_unit) or
         zcu.potentially_outdated.swapRemove(anal_unit);
 
     const prev_failed = zcu.failed_analysis.contains(anal_unit) or zcu.transitive_failed_analysis.contains(anal_unit);
 
-    if (func_outdated) {
+    if (was_outdated) {
+        dev.check(.incremental);
         _ = zcu.outdated_ready.swapRemove(anal_unit);
+        zcu.deleteUnitExports(anal_unit);
+        zcu.deleteUnitReferences(anal_unit);
+        if (zcu.failed_analysis.fetchSwapRemove(anal_unit)) |kv| {
+            kv.value.destroy(gpa);
+        }
+        _ = zcu.transitive_failed_analysis.swapRemove(anal_unit);
     } else {
         // We can trust the current information about this function.
         if (prev_failed) {
@@ -765,8 +1178,11 @@ pub fn ensureFuncBodyAnalyzed(pt: Zcu.PerThread, maybe_coerced_func_index: Inter
         }
     }
 
-    const ies_outdated, const analysis_fail = if (pt.ensureFuncBodyAnalyzedInner(func_index, func_outdated)) |result|
-        .{ result.ies_outdated, false }
+    const func_prog_node = zcu.sema_prog_node.start(ip.getNav(func.owner_nav).fqn.toSlice(ip), 0);
+    defer func_prog_node.end();
+
+    const ies_outdated, const new_failed = if (pt.analyzeFuncBody(func_index)) |result|
+        .{ prev_failed or result.ies_outdated, false }
     else |err| switch (err) {
         error.AnalysisFail => res: {
             if (!zcu.failed_analysis.contains(anal_unit)) {
@@ -780,10 +1196,18 @@ pub fn ensureFuncBodyAnalyzed(pt: Zcu.PerThread, maybe_coerced_func_index: Inter
             // a different error later (which may now be invalid).
             break :res .{ !prev_failed, true };
         },
-        error.OutOfMemory => return error.OutOfMemory, // TODO: graceful handling like `ensureCauAnalyzed`
+        error.OutOfMemory => {
+            // TODO: it's unclear how to gracefully handle this.
+            // To report the error cleanly, we need to add a message to `failed_analysis` and a
+            // corresponding entry to `retryable_failures`; but either of these things is quite
+            // likely to OOM at this point.
+            // If that happens, what do we do? Perhaps we could have a special field on `Zcu`
+            // for reporting OOM errors without allocating.
+            return error.OutOfMemory;
+        },
     };
 
-    if (func_outdated) {
+    if (was_outdated) {
         if (ies_outdated) {
             try zcu.markDependeeOutdated(.marked_po, .{ .interned = func_index });
         } else {
@@ -791,13 +1215,12 @@ pub fn ensureFuncBodyAnalyzed(pt: Zcu.PerThread, maybe_coerced_func_index: Inter
         }
     }
 
-    if (analysis_fail) return error.AnalysisFail;
+    if (new_failed) return error.AnalysisFail;
 }
 
-fn ensureFuncBodyAnalyzedInner(
+fn analyzeFuncBody(
     pt: Zcu.PerThread,
     func_index: InternPool.Index,
-    func_outdated: bool,
 ) Zcu.SemaError!struct { ies_outdated: bool } {
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -812,7 +1235,7 @@ fn ensureFuncBodyAnalyzedInner(
 
     if (func.generic_owner == .none) {
         // Among another things, this ensures that the function's `zir_body_inst` is correct.
-        try pt.ensureCauAnalyzed(ip.getNav(func.owner_nav).analysis_owner.unwrap().?);
+        try pt.ensureNavValUpToDate(func.owner_nav);
         if (ip.getNav(func.owner_nav).status.resolved.val != func_index) {
             // This function is no longer referenced! There's no point in re-analyzing it.
             // Just mark a transitive failure and move on.
@@ -821,7 +1244,7 @@ fn ensureFuncBodyAnalyzedInner(
     } else {
         const go_nav = zcu.funcInfo(func.generic_owner).owner_nav;
         // Among another things, this ensures that the function's `zir_body_inst` is correct.
-        try pt.ensureCauAnalyzed(ip.getNav(go_nav).analysis_owner.unwrap().?);
+        try pt.ensureNavValUpToDate(go_nav);
         if (ip.getNav(go_nav).status.resolved.val != func.generic_owner) {
             // The generic owner is no longer referenced, so this function is also unreferenced.
             // There's no point in re-analyzing it. Just mark a transitive failure and move on.
@@ -836,38 +1259,13 @@ fn ensureFuncBodyAnalyzedInner(
     else
         .none;
 
-    if (func_outdated) {
-        dev.check(.incremental);
-        zcu.deleteUnitExports(anal_unit);
-        zcu.deleteUnitReferences(anal_unit);
-        if (zcu.failed_analysis.fetchSwapRemove(anal_unit)) |kv| {
-            kv.value.destroy(gpa);
-        }
-        _ = zcu.transitive_failed_analysis.swapRemove(anal_unit);
-    }
+    log.debug("analyze and generate fn body {}", .{zcu.fmtAnalUnit(anal_unit)});
 
-    if (!func_outdated) {
-        // We can trust the current information about this function.
-        if (zcu.failed_analysis.contains(anal_unit) or zcu.transitive_failed_analysis.contains(anal_unit)) {
-            return error.AnalysisFail;
-        }
-        switch (func.analysisUnordered(ip).state) {
-            .unreferenced => {}, // this is the first reference
-            .queued => {}, // we're waiting on first-time analysis
-            .analyzed => return .{ .ies_outdated = false }, // up-to-date
-        }
-    }
-
-    log.debug("analyze and generate fn body {}; reason='{s}'", .{
-        zcu.fmtAnalUnit(anal_unit),
-        if (func_outdated) "outdated" else "never analyzed",
-    });
-
-    var air = try pt.analyzeFnBody(func_index);
+    var air = try pt.analyzeFnBodyInner(func_index);
     errdefer air.deinit(gpa);
 
-    const ies_outdated = func_outdated and
-        (!func.analysisUnordered(ip).inferred_error_set or func.resolvedErrorSetUnordered(ip) != old_resolved_ies);
+    const ies_outdated = !func.analysisUnordered(ip).inferred_error_set or
+        func.resolvedErrorSetUnordered(ip) != old_resolved_ies;
 
     const comp = zcu.comp;
 
@@ -1035,12 +1433,11 @@ fn createFileRootStruct(
 
     wip_ty.setName(ip, try file.internFullyQualifiedName(pt));
     ip.namespacePtr(namespace_index).owner_type = wip_ty.index;
-    const new_cau_index = try ip.createTypeCau(gpa, pt.tid, tracked_inst, namespace_index, wip_ty.index);
 
     if (zcu.comp.incremental) {
         try ip.addDependency(
             gpa,
-            AnalUnit.wrap(.{ .cau = new_cau_index }),
+            .wrap(.{ .type = wip_ty.index }),
             .{ .src_hash = tracked_inst },
         );
     }
@@ -1054,7 +1451,7 @@ fn createFileRootStruct(
         try zcu.comp.queueJob(.{ .codegen_type = wip_ty.index });
     }
     zcu.setFileRootType(file_index, wip_ty.index);
-    return wip_ty.finish(ip, new_cau_index.toOptional(), namespace_index);
+    return wip_ty.finish(ip, namespace_index);
 }
 
 /// Re-scan the namespace of a file's root struct type on an incremental update.
@@ -1144,369 +1541,6 @@ fn semaFile(pt: Zcu.PerThread, file_index: Zcu.File.Index) Zcu.SemaError!void {
             };
         },
         .incremental => {},
-    }
-}
-
-const SemaCauResult = packed struct {
-    /// Whether the value of a `decl_val` of the corresponding Nav changed.
-    invalidate_decl_val: bool,
-    /// Whether the type of a `decl_ref` of the corresponding Nav changed.
-    invalidate_decl_ref: bool,
-};
-
-/// Performs semantic analysis on the given `Cau`, storing results to its owner `Nav` if needed.
-/// If analysis fails, returns `error.AnalysisFail`, storing an error in `zcu.failed_analysis` unless
-/// the error is transitive.
-/// On success, returns information about whether the `Nav` value changed.
-fn semaCau(pt: Zcu.PerThread, cau_index: InternPool.Cau.Index) !SemaCauResult {
-    const zcu = pt.zcu;
-    const gpa = zcu.gpa;
-    const ip = &zcu.intern_pool;
-
-    const anal_unit = AnalUnit.wrap(.{ .cau = cau_index });
-
-    const cau = ip.getCau(cau_index);
-    const inst_info = cau.zir_index.resolveFull(ip) orelse return error.AnalysisFail;
-    const file = zcu.fileByIndex(inst_info.file);
-    const zir = file.zir;
-
-    if (file.status != .success_zir) {
-        return error.AnalysisFail;
-    }
-
-    // We are about to re-analyze this `Cau`; drop its depenndencies.
-    zcu.intern_pool.removeDependenciesForDepender(gpa, anal_unit);
-
-    switch (cau.owner.unwrap()) {
-        .none => {}, // `comptime` decl -- we will re-analyze its body.
-        .nav => {}, // Other decl -- we will re-analyze its value.
-        .type => |ty| {
-            // This is an incremental update, and this type is being re-analyzed because it is outdated.
-            // Create a new type in its place, and mark the old one as outdated so that use sites will
-            // be re-analyzed and discover an up-to-date type.
-            const new_ty = try pt.ensureTypeUpToDate(ty, true);
-            assert(new_ty != ty);
-            return .{
-                .invalidate_decl_val = true,
-                .invalidate_decl_ref = true,
-            };
-        },
-    }
-
-    const is_usingnamespace = switch (cau.owner.unwrap()) {
-        .nav => |nav| ip.getNav(nav).is_usingnamespace,
-        .none, .type => false,
-    };
-
-    log.debug("semaCau {}", .{zcu.fmtAnalUnit(anal_unit)});
-
-    try zcu.analysis_in_progress.put(gpa, anal_unit, {});
-    errdefer _ = zcu.analysis_in_progress.swapRemove(anal_unit);
-
-    var analysis_arena = std.heap.ArenaAllocator.init(gpa);
-    defer analysis_arena.deinit();
-
-    var comptime_err_ret_trace = std.ArrayList(Zcu.LazySrcLoc).init(gpa);
-    defer comptime_err_ret_trace.deinit();
-
-    var sema: Sema = .{
-        .pt = pt,
-        .gpa = gpa,
-        .arena = analysis_arena.allocator(),
-        .code = zir,
-        .owner = anal_unit,
-        .func_index = .none,
-        .func_is_naked = false,
-        .fn_ret_ty = Type.void,
-        .fn_ret_ty_ies = null,
-        .comptime_err_ret_trace = &comptime_err_ret_trace,
-    };
-    defer sema.deinit();
-
-    // Every `Cau` has a dependency on the source of its own ZIR instruction.
-    try sema.declareDependency(.{ .src_hash = cau.zir_index });
-
-    var block: Sema.Block = .{
-        .parent = null,
-        .sema = &sema,
-        .namespace = cau.namespace,
-        .instructions = .{},
-        .inlining = null,
-        .is_comptime = true,
-        .src_base_inst = cau.zir_index,
-        .type_name_ctx = switch (cau.owner.unwrap()) {
-            .nav => |nav| ip.getNav(nav).fqn,
-            .type => |ty| Type.fromInterned(ty).containerTypeName(ip),
-            .none => try ip.getOrPutStringFmt(gpa, pt.tid, "{}.comptime", .{
-                Type.fromInterned(zcu.namespacePtr(cau.namespace).owner_type).containerTypeName(ip).fmt(ip),
-            }, .no_embedded_nulls),
-        },
-    };
-    defer block.instructions.deinit(gpa);
-
-    const zir_decl = zir.getDeclaration(inst_info.inst);
-
-    // We have to fetch this state before resolving the body because of the `nav_already_populated`
-    // case below. We might change the language in future so that align/linksection/etc for functions
-    // work in a way more in line with other declarations, in which case that logic will go away.
-    const old_nav_info = switch (cau.owner.unwrap()) {
-        .none, .type => undefined, // we'll never use `old_nav_info`
-        .nav => |nav| ip.getNav(nav),
-    };
-
-    const align_src = block.src(.{ .node_offset_var_decl_align = 0 });
-    const section_src = block.src(.{ .node_offset_var_decl_section = 0 });
-    const addrspace_src = block.src(.{ .node_offset_var_decl_addrspace = 0 });
-    const ty_src = block.src(.{ .node_offset_var_decl_ty = 0 });
-    const init_src = block.src(.{ .node_offset_var_decl_init = 0 });
-
-    // First, we must resolve the declaration's type. To do this, we analyze the type body if available,
-    // or otherwise, we analyze the value body, populating `early_val` in the process.
-
-    const decl_ty: Type, const early_val: ?Value = if (zir_decl.type_body) |type_body| ty: {
-        // We evaluate only the type now; no need for the value yet.
-        const uncoerced_type_ref = try sema.resolveInlineBody(&block, type_body, inst_info.inst);
-        const type_ref = try sema.coerce(&block, .type, uncoerced_type_ref, ty_src);
-        break :ty .{ .fromInterned(type_ref.toInterned().?), null };
-    } else ty: {
-        // We don't have a type body, so we need to evaluate the value immediately.
-        const value_body = zir_decl.value_body.?;
-        const result_ref = try sema.resolveInlineBody(&block, value_body, inst_info.inst);
-        const val = try sema.resolveFinalDeclValue(&block, init_src, result_ref);
-        break :ty .{ val.typeOf(zcu), val };
-    };
-
-    switch (zir_decl.kind) {
-        .unnamed_test, .@"test", .decltest => assert(decl_ty.zigTypeTag(zcu) == .@"fn"),
-        .@"comptime" => assert(decl_ty.toIntern() == .void_type),
-        .@"usingnamespace" => {},
-        .@"const" => {},
-        .@"var" => try sema.validateVarType(
-            &block,
-            if (zir_decl.type_body != null) ty_src else init_src,
-            decl_ty,
-            zir_decl.linkage == .@"extern",
-        ),
-    }
-
-    // Now that we know the type, we can evaluate the alignment, linksection, and addrspace, to determine
-    // the full pointer type of this declaration.
-
-    const alignment: InternPool.Alignment = a: {
-        const align_body = zir_decl.align_body orelse break :a .none;
-        const align_ref = try sema.resolveInlineBody(&block, align_body, inst_info.inst);
-        break :a try sema.analyzeAsAlign(&block, align_src, align_ref);
-    };
-
-    const @"linksection": InternPool.OptionalNullTerminatedString = ls: {
-        const linksection_body = zir_decl.linksection_body orelse break :ls .none;
-        const linksection_ref = try sema.resolveInlineBody(&block, linksection_body, inst_info.inst);
-        const bytes = try sema.toConstString(&block, section_src, linksection_ref, .{
-            .needed_comptime_reason = "linksection must be comptime-known",
-        });
-        if (std.mem.indexOfScalar(u8, bytes, 0) != null) {
-            return sema.fail(&block, section_src, "linksection cannot contain null bytes", .{});
-        } else if (bytes.len == 0) {
-            return sema.fail(&block, section_src, "linksection cannot be empty", .{});
-        }
-        break :ls try ip.getOrPutStringOpt(gpa, pt.tid, bytes, .no_embedded_nulls);
-    };
-
-    const @"addrspace": std.builtin.AddressSpace = as: {
-        const addrspace_ctx: Sema.AddressSpaceContext = switch (zir_decl.kind) {
-            .@"var" => .variable,
-            else => switch (decl_ty.zigTypeTag(zcu)) {
-                .@"fn" => .function,
-                else => .constant,
-            },
-        };
-        const target = zcu.getTarget();
-        const addrspace_body = zir_decl.addrspace_body orelse break :as switch (addrspace_ctx) {
-            .function => target_util.defaultAddressSpace(target, .function),
-            .variable => target_util.defaultAddressSpace(target, .global_mutable),
-            .constant => target_util.defaultAddressSpace(target, .global_constant),
-            else => unreachable,
-        };
-        const addrspace_ref = try sema.resolveInlineBody(&block, addrspace_body, inst_info.inst);
-        break :as try sema.analyzeAsAddressSpace(&block, addrspace_src, addrspace_ref, addrspace_ctx);
-    };
-
-    // Lastly, we must evaluate the value if we have not already done so. Note, however, that extern declarations
-    // don't have an associated value body.
-
-    const final_val: ?Value = early_val orelse if (zir_decl.value_body) |value_body| val: {
-        // Put the resolved type into `inst_map` to be used as the result type of the init.
-        try sema.inst_map.ensureSpaceForInstructions(gpa, &.{inst_info.inst});
-        sema.inst_map.putAssumeCapacity(inst_info.inst, Air.internedToRef(decl_ty.toIntern()));
-        const uncoerced_result_ref = try sema.resolveInlineBody(&block, value_body, inst_info.inst);
-        assert(sema.inst_map.remove(inst_info.inst));
-
-        const result_ref = try sema.coerce(&block, decl_ty, uncoerced_result_ref, init_src);
-        break :val try sema.resolveFinalDeclValue(&block, init_src, result_ref);
-    } else null;
-
-    // TODO: missing validation?
-
-    const decl_val: Value = switch (zir_decl.linkage) {
-        .normal, .@"export" => switch (zir_decl.kind) {
-            .@"var" => .fromInterned(try pt.intern(.{ .variable = .{
-                .ty = decl_ty.toIntern(),
-                .init = final_val.?.toIntern(),
-                .owner_nav = cau.owner.unwrap().nav,
-                .is_threadlocal = zir_decl.is_threadlocal,
-                .is_weak_linkage = false,
-            } })),
-            else => final_val.?,
-        },
-        .@"extern" => val: {
-            assert(final_val == null); // extern decls do not have a value body
-            const lib_name: ?[]const u8 = if (zir_decl.lib_name != .empty) l: {
-                break :l zir.nullTerminatedString(zir_decl.lib_name);
-            } else null;
-            if (lib_name) |l| {
-                const lib_name_src = block.src(.{ .node_offset_lib_name = 0 });
-                try sema.handleExternLibName(&block, lib_name_src, l);
-            }
-            break :val .fromInterned(try pt.getExtern(.{
-                .name = old_nav_info.name,
-                .ty = decl_ty.toIntern(),
-                .lib_name = try ip.getOrPutStringOpt(gpa, pt.tid, lib_name, .no_embedded_nulls),
-                .is_const = zir_decl.kind == .@"const",
-                .is_threadlocal = zir_decl.is_threadlocal,
-                .is_weak_linkage = false,
-                .is_dll_import = false,
-                .alignment = alignment,
-                .@"addrspace" = @"addrspace",
-                .zir_index = cau.zir_index, // `declaration` instruction
-                .owner_nav = undefined, // ignored by `getExtern`
-            }));
-        },
-    };
-
-    const nav_index = switch (cau.owner.unwrap()) {
-        .none => {
-            // This is a `comptime` decl, so we are done -- the side effects are all we care about.
-            // Just make sure to `flushExports`.
-            try sema.flushExports();
-            assert(zcu.analysis_in_progress.swapRemove(anal_unit));
-            return .{
-                .invalidate_decl_val = false,
-                .invalidate_decl_ref = false,
-            };
-        },
-        .nav => |nav| nav, // We will resolve this `Nav` below.
-        .type => unreachable, // Handled at top of function.
-    };
-
-    switch (decl_val.toIntern()) {
-        .generic_poison => unreachable, // assertion failure
-        .unreachable_value => unreachable, // assertion failure
-        else => {},
-    }
-
-    // This resolves the type of the resolved value, not that value itself. If `decl_val` is a struct type,
-    // this resolves the type `type` (which needs no resolution), not the struct itself.
-    try decl_ty.resolveLayout(pt);
-
-    // TODO: this is jank. If #20663 is rejected, let's think about how to better model `usingnamespace`.
-    if (is_usingnamespace) {
-        if (decl_ty.toIntern() != .type_type) {
-            return sema.fail(&block, ty_src, "expected type, found {}", .{decl_ty.fmt(pt)});
-        }
-        if (decl_val.toType().getNamespace(zcu) == .none) {
-            return sema.fail(&block, ty_src, "type {} has no namespace", .{decl_val.toType().fmt(pt)});
-        }
-        ip.resolveNavValue(nav_index, .{
-            .val = decl_val.toIntern(),
-            .alignment = .none,
-            .@"linksection" = .none,
-            .@"addrspace" = .generic,
-        });
-        // TODO: usingnamespace cannot participate in incremental compilation
-        assert(zcu.analysis_in_progress.swapRemove(anal_unit));
-        return .{
-            .invalidate_decl_val = true,
-            .invalidate_decl_ref = true,
-        };
-    }
-
-    const queue_linker_work, const is_owned_fn = switch (ip.indexToKey(decl_val.toIntern())) {
-        .func => |f| .{ true, f.owner_nav == nav_index }, // note that this lets function aliases reach codegen
-        .variable => |v| .{ v.owner_nav == nav_index, false },
-        .@"extern" => |e| .{ false, Type.fromInterned(e.ty).zigTypeTag(zcu) == .@"fn" },
-        else => .{ true, false },
-    };
-
-    // Keep in sync with logic in `Sema.zirVarExtended`.
-
-    if (is_owned_fn) {
-        // linksection etc are legal, except some targets do not support function alignment.
-        if (zir_decl.align_body != null and !target_util.supportsFunctionAlignment(zcu.getTarget())) {
-            return sema.fail(&block, align_src, "target does not support function alignment", .{});
-        }
-    } else if (try decl_ty.comptimeOnlySema(pt)) {
-        // alignment, linksection, addrspace annotations are not allowed for comptime-only types.
-        const reason: []const u8 = switch (ip.indexToKey(decl_val.toIntern())) {
-            .func => "function alias", // slightly clearer message, since you *can* specify these on function *declarations*
-            else => "comptime-only type",
-        };
-        if (zir_decl.align_body != null) {
-            return sema.fail(&block, align_src, "cannot specify alignment of {s}", .{reason});
-        }
-        if (zir_decl.linksection_body != null) {
-            return sema.fail(&block, section_src, "cannot specify linksection of {s}", .{reason});
-        }
-        if (zir_decl.addrspace_body != null) {
-            return sema.fail(&block, addrspace_src, "cannot specify addrspace of {s}", .{reason});
-        }
-    }
-
-    ip.resolveNavValue(nav_index, .{
-        .val = decl_val.toIntern(),
-        .alignment = alignment,
-        .@"linksection" = @"linksection",
-        .@"addrspace" = @"addrspace",
-    });
-
-    // Mark the `Cau` as completed before evaluating the export!
-    assert(zcu.analysis_in_progress.swapRemove(anal_unit));
-
-    if (zir_decl.linkage == .@"export") {
-        const export_src = block.src(.{ .token_offset = @intFromBool(zir_decl.is_pub) });
-        const name_slice = zir.nullTerminatedString(zir_decl.name);
-        const name_ip = try ip.getOrPutString(gpa, pt.tid, name_slice, .no_embedded_nulls);
-        try sema.analyzeExport(&block, export_src, .{ .name = name_ip }, nav_index);
-    }
-
-    try sema.flushExports();
-
-    queue_codegen: {
-        if (!queue_linker_work) break :queue_codegen;
-
-        if (!try decl_ty.hasRuntimeBitsSema(pt)) {
-            if (zcu.comp.config.use_llvm) break :queue_codegen;
-            if (file.mod.strip) break :queue_codegen;
-        }
-
-        // This job depends on any resolve_type_fully jobs queued up before it.
-        try zcu.comp.queueJob(.{ .codegen_nav = nav_index });
-    }
-
-    switch (old_nav_info.status) {
-        .unresolved => return .{
-            .invalidate_decl_val = true,
-            .invalidate_decl_ref = true,
-        },
-        .resolved => |old| {
-            const new = ip.getNav(nav_index).status.resolved;
-            return .{
-                .invalidate_decl_val = new.val != old.val,
-                .invalidate_decl_ref = ip.typeOf(new.val) != ip.typeOf(old.val) or
-                    new.alignment != old.alignment or
-                    new.@"linksection" != old.@"linksection" or
-                    new.@"addrspace" != old.@"addrspace",
-            };
-        },
     }
 }
 
@@ -1880,45 +1914,42 @@ pub fn scanNamespace(
 
     // For incremental updates, `scanDecl` wants to look up existing decls by their ZIR index rather
     // than their name. We'll build an efficient mapping now, then discard the current `decls`.
-    // We map to the `Cau`, since not every declaration has a `Nav`.
-    var existing_by_inst: std.AutoHashMapUnmanaged(InternPool.TrackedInst.Index, InternPool.Cau.Index) = .empty;
+    // We map to the `AnalUnit`, since not every declaration has a `Nav`.
+    var existing_by_inst: std.AutoHashMapUnmanaged(InternPool.TrackedInst.Index, InternPool.AnalUnit) = .empty;
     defer existing_by_inst.deinit(gpa);
 
     try existing_by_inst.ensureTotalCapacity(gpa, @intCast(
         namespace.pub_decls.count() + namespace.priv_decls.count() +
             namespace.pub_usingnamespace.items.len + namespace.priv_usingnamespace.items.len +
-            namespace.other_decls.items.len,
+            namespace.comptime_decls.items.len +
+            namespace.test_decls.items.len,
     ));
 
     for (namespace.pub_decls.keys()) |nav| {
-        const cau_index = ip.getNav(nav).analysis_owner.unwrap().?;
-        const zir_index = ip.getCau(cau_index).zir_index;
-        existing_by_inst.putAssumeCapacityNoClobber(zir_index, cau_index);
+        const zir_index = ip.getNav(nav).analysis.?.zir_index;
+        existing_by_inst.putAssumeCapacityNoClobber(zir_index, .wrap(.{ .nav_val = nav }));
     }
     for (namespace.priv_decls.keys()) |nav| {
-        const cau_index = ip.getNav(nav).analysis_owner.unwrap().?;
-        const zir_index = ip.getCau(cau_index).zir_index;
-        existing_by_inst.putAssumeCapacityNoClobber(zir_index, cau_index);
+        const zir_index = ip.getNav(nav).analysis.?.zir_index;
+        existing_by_inst.putAssumeCapacityNoClobber(zir_index, .wrap(.{ .nav_val = nav }));
     }
     for (namespace.pub_usingnamespace.items) |nav| {
-        const cau_index = ip.getNav(nav).analysis_owner.unwrap().?;
-        const zir_index = ip.getCau(cau_index).zir_index;
-        existing_by_inst.putAssumeCapacityNoClobber(zir_index, cau_index);
+        const zir_index = ip.getNav(nav).analysis.?.zir_index;
+        existing_by_inst.putAssumeCapacityNoClobber(zir_index, .wrap(.{ .nav_val = nav }));
     }
     for (namespace.priv_usingnamespace.items) |nav| {
-        const cau_index = ip.getNav(nav).analysis_owner.unwrap().?;
-        const zir_index = ip.getCau(cau_index).zir_index;
-        existing_by_inst.putAssumeCapacityNoClobber(zir_index, cau_index);
+        const zir_index = ip.getNav(nav).analysis.?.zir_index;
+        existing_by_inst.putAssumeCapacityNoClobber(zir_index, .wrap(.{ .nav_val = nav }));
     }
-    for (namespace.other_decls.items) |cau_index| {
-        const cau = ip.getCau(cau_index);
-        existing_by_inst.putAssumeCapacityNoClobber(cau.zir_index, cau_index);
-        // If this is a test, it'll be re-added to `test_functions` later on
-        // if still alive. Remove it for now.
-        switch (cau.owner.unwrap()) {
-            .none, .type => {},
-            .nav => |nav| _ = zcu.test_functions.swapRemove(nav),
-        }
+    for (namespace.comptime_decls.items) |cu| {
+        const zir_index = ip.getComptimeUnit(cu).zir_index;
+        existing_by_inst.putAssumeCapacityNoClobber(zir_index, .wrap(.{ .@"comptime" = cu }));
+    }
+    for (namespace.test_decls.items) |nav| {
+        const zir_index = ip.getNav(nav).analysis.?.zir_index;
+        existing_by_inst.putAssumeCapacityNoClobber(zir_index, .wrap(.{ .nav_val = nav }));
+        // This test will be re-added to `test_functions` later on if it's still alive. Remove it for now.
+        _ = zcu.test_functions.swapRemove(nav);
     }
 
     var seen_decls: std.AutoHashMapUnmanaged(InternPool.NullTerminatedString, void) = .empty;
@@ -1928,7 +1959,8 @@ pub fn scanNamespace(
     namespace.priv_decls.clearRetainingCapacity();
     namespace.pub_usingnamespace.clearRetainingCapacity();
     namespace.priv_usingnamespace.clearRetainingCapacity();
-    namespace.other_decls.clearRetainingCapacity();
+    namespace.comptime_decls.clearRetainingCapacity();
+    namespace.test_decls.clearRetainingCapacity();
 
     var scan_decl_iter: ScanDeclIter = .{
         .pt = pt,
@@ -1950,7 +1982,7 @@ const ScanDeclIter = struct {
     pt: Zcu.PerThread,
     namespace_index: Zcu.Namespace.Index,
     seen_decls: *std.AutoHashMapUnmanaged(InternPool.NullTerminatedString, void),
-    existing_by_inst: *const std.AutoHashMapUnmanaged(InternPool.TrackedInst.Index, InternPool.Cau.Index),
+    existing_by_inst: *const std.AutoHashMapUnmanaged(InternPool.TrackedInst.Index, InternPool.AnalUnit),
     /// Decl scanning is run in two passes, so that we can detect when a generated
     /// name would clash with an explicit name and use a different one.
     pass: enum { named, unnamed },
@@ -1988,48 +2020,30 @@ const ScanDeclIter = struct {
 
         const decl = zir.getDeclaration(decl_inst);
 
-        const Kind = enum { @"comptime", @"usingnamespace", @"test", named };
-
-        const maybe_name: InternPool.OptionalNullTerminatedString, const kind: Kind, const is_named_test: bool = switch (decl.kind) {
-            .@"comptime" => info: {
+        const maybe_name: InternPool.OptionalNullTerminatedString = switch (decl.kind) {
+            .@"comptime" => name: {
                 if (iter.pass != .unnamed) return;
-                break :info .{
-                    .none,
-                    .@"comptime",
-                    false,
-                };
+                break :name .none;
             },
-            .@"usingnamespace" => info: {
+            .@"usingnamespace" => name: {
                 if (iter.pass != .unnamed) return;
                 const i = iter.usingnamespace_index;
                 iter.usingnamespace_index += 1;
-                break :info .{
-                    (try iter.avoidNameConflict("usingnamespace_{d}", .{i})).toOptional(),
-                    .@"usingnamespace",
-                    false,
-                };
+                break :name (try iter.avoidNameConflict("usingnamespace_{d}", .{i})).toOptional();
             },
-            .unnamed_test => info: {
+            .unnamed_test => name: {
                 if (iter.pass != .unnamed) return;
                 const i = iter.unnamed_test_index;
                 iter.unnamed_test_index += 1;
-                break :info .{
-                    (try iter.avoidNameConflict("test_{d}", .{i})).toOptional(),
-                    .@"test",
-                    false,
-                };
+                break :name (try iter.avoidNameConflict("test_{d}", .{i})).toOptional();
             },
-            .@"test", .decltest => |kind| info: {
+            .@"test", .decltest => |kind| name: {
                 // We consider these to be unnamed since the decl name can be adjusted to avoid conflicts if necessary.
                 if (iter.pass != .unnamed) return;
                 const prefix = @tagName(kind);
-                break :info .{
-                    (try iter.avoidNameConflict("{s}.{s}", .{ prefix, zir.nullTerminatedString(decl.name) })).toOptional(),
-                    .@"test",
-                    true,
-                };
+                break :name (try iter.avoidNameConflict("{s}.{s}", .{ prefix, zir.nullTerminatedString(decl.name) })).toOptional();
             },
-            .@"const", .@"var" => info: {
+            .@"const", .@"var" => name: {
                 if (iter.pass != .named) return;
                 const name = try ip.getOrPutString(
                     gpa,
@@ -2038,11 +2052,7 @@ const ScanDeclIter = struct {
                     .no_embedded_nulls,
                 );
                 try iter.seen_decls.putNoClobber(gpa, name, {});
-                break :info .{
-                    name.toOptional(),
-                    .named,
-                    false,
-                };
+                break :name name.toOptional();
             },
         };
 
@@ -2051,46 +2061,44 @@ const ScanDeclIter = struct {
             .inst = decl_inst,
         });
 
-        const existing_cau = iter.existing_by_inst.get(tracked_inst);
+        const existing_unit = iter.existing_by_inst.get(tracked_inst);
 
-        const cau, const want_analysis = switch (kind) {
-            .@"comptime" => cau: {
-                const cau = existing_cau orelse try ip.createComptimeCau(gpa, pt.tid, tracked_inst, namespace_index);
+        const unit, const want_analysis = switch (decl.kind) {
+            .@"comptime" => unit: {
+                const cu = if (existing_unit) |eu|
+                    eu.unwrap().@"comptime"
+                else
+                    try ip.createComptimeUnit(gpa, pt.tid, tracked_inst, namespace_index);
 
-                try namespace.other_decls.append(gpa, cau);
+                const unit: AnalUnit = .wrap(.{ .@"comptime" = cu });
 
-                if (existing_cau == null) {
-                    // For a `comptime` declaration, whether to analyze is based solely on whether the
-                    // `Cau` is outdated. So, add this one to `outdated` and `outdated_ready` if not already.
-                    const unit = AnalUnit.wrap(.{ .cau = cau });
-                    if (zcu.potentially_outdated.fetchSwapRemove(unit)) |kv| {
-                        try zcu.outdated.ensureUnusedCapacity(gpa, 1);
-                        try zcu.outdated_ready.ensureUnusedCapacity(gpa, 1);
-                        zcu.outdated.putAssumeCapacityNoClobber(unit, kv.value);
-                        if (kv.value == 0) { // no PO deps
-                            zcu.outdated_ready.putAssumeCapacityNoClobber(unit, {});
-                        }
-                    } else if (!zcu.outdated.contains(unit)) {
-                        try zcu.outdated.ensureUnusedCapacity(gpa, 1);
-                        try zcu.outdated_ready.ensureUnusedCapacity(gpa, 1);
-                        zcu.outdated.putAssumeCapacityNoClobber(unit, 0);
-                        zcu.outdated_ready.putAssumeCapacityNoClobber(unit, {});
-                    }
+                try namespace.comptime_decls.append(gpa, cu);
+
+                if (existing_unit == null) {
+                    // For a `comptime` declaration, whether to analyze is based solely on whether the unit
+                    // is outdated. So, add this fresh one to `outdated` and `outdated_ready`.
+                    try zcu.outdated.ensureUnusedCapacity(gpa, 1);
+                    try zcu.outdated_ready.ensureUnusedCapacity(gpa, 1);
+                    zcu.outdated.putAssumeCapacityNoClobber(unit, 0);
+                    zcu.outdated_ready.putAssumeCapacityNoClobber(unit, {});
                 }
 
-                break :cau .{ cau, true };
+                break :unit .{ unit, true };
             },
-            else => cau: {
+            else => unit: {
                 const name = maybe_name.unwrap().?;
                 const fqn = try namespace.internFullyQualifiedName(ip, gpa, pt.tid, name);
-                const cau, const nav = if (existing_cau) |cau_index| cau_nav: {
-                    const nav_index = ip.getCau(cau_index).owner.unwrap().nav;
-                    const nav = ip.getNav(nav_index);
-                    assert(nav.name == name);
-                    assert(nav.fqn == fqn);
-                    break :cau_nav .{ cau_index, nav_index };
-                } else try ip.createPairedCauNav(gpa, pt.tid, name, fqn, tracked_inst, namespace_index, kind == .@"usingnamespace");
-                const want_analysis = switch (kind) {
+                const nav = if (existing_unit) |eu|
+                    eu.unwrap().nav_val
+                else
+                    try ip.createDeclNav(gpa, pt.tid, name, fqn, tracked_inst, namespace_index, decl.kind == .@"usingnamespace");
+
+                const unit: AnalUnit = .wrap(.{ .nav_val = nav });
+
+                assert(ip.getNav(nav).name == name);
+                assert(ip.getNav(nav).fqn == fqn);
+
+                const want_analysis = switch (decl.kind) {
                     .@"comptime" => unreachable,
                     .@"usingnamespace" => a: {
                         if (comp.incremental) {
@@ -2103,8 +2111,9 @@ const ScanDeclIter = struct {
                         }
                         break :a true;
                     },
-                    .@"test" => a: {
-                        try namespace.other_decls.append(gpa, cau);
+                    .unnamed_test, .@"test", .decltest => a: {
+                        const is_named = decl.kind != .unnamed_test;
+                        try namespace.test_decls.append(gpa, nav);
                         // TODO: incremental compilation!
                         // * remove from `test_functions` if no longer matching filter
                         // * add to `test_functions` if newly passing filter
@@ -2112,7 +2121,7 @@ const ScanDeclIter = struct {
                         // Perhaps we should add all test indiscriminately and filter at the end of the update.
                         if (!comp.config.is_test) break :a false;
                         if (file.mod != zcu.main_mod) break :a false;
-                        if (is_named_test and comp.test_filters.len > 0) {
+                        if (is_named and comp.test_filters.len > 0) {
                             const fqn_slice = fqn.toSlice(ip);
                             for (comp.test_filters) |test_filter| {
                                 if (std.mem.indexOf(u8, fqn_slice, test_filter) != null) break;
@@ -2121,7 +2130,7 @@ const ScanDeclIter = struct {
                         try zcu.test_functions.put(gpa, nav, {});
                         break :a true;
                     },
-                    .named => a: {
+                    .@"const", .@"var" => a: {
                         if (decl.is_pub) {
                             try namespace.pub_decls.putContext(gpa, nav, {}, .{ .zcu = zcu });
                         } else {
@@ -2130,23 +2139,23 @@ const ScanDeclIter = struct {
                         break :a false;
                     },
                 };
-                break :cau .{ cau, want_analysis };
+                break :unit .{ unit, want_analysis };
             },
         };
 
-        if (existing_cau == null and (want_analysis or decl.linkage == .@"export")) {
+        if (existing_unit == null and (want_analysis or decl.linkage == .@"export")) {
             log.debug(
-                "scanDecl queue analyze_cau file='{s}' cau_index={d}",
-                .{ namespace.fileScope(zcu).sub_file_path, cau },
+                "scanDecl queue analyze_comptime_unit file='{s}' unit={}",
+                .{ namespace.fileScope(zcu).sub_file_path, zcu.fmtAnalUnit(unit) },
             );
-            try comp.queueJob(.{ .analyze_cau = cau });
+            try comp.queueJob(.{ .analyze_comptime_unit = unit });
         }
 
         // TODO: we used to do line number updates here, but this is an inappropriate place for this logic to live.
     }
 };
 
-fn analyzeFnBody(pt: Zcu.PerThread, func_index: InternPool.Index) Zcu.SemaError!Air {
+fn analyzeFnBodyInner(pt: Zcu.PerThread, func_index: InternPool.Index) Zcu.SemaError!Air {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -2168,20 +2177,13 @@ fn analyzeFnBody(pt: Zcu.PerThread, func_index: InternPool.Index) Zcu.SemaError!
         func.setResolvedErrorSet(ip, .none);
     }
 
-    // This is the `Cau` corresponding to the `declaration` instruction which the function or its generic owner originates from.
-    const decl_cau = ip.getCau(cau: {
-        const orig_nav = if (func.generic_owner == .none)
-            func.owner_nav
-        else
-            zcu.funcInfo(func.generic_owner).owner_nav;
-
-        break :cau ip.getNav(orig_nav).analysis_owner.unwrap().?;
-    });
+    // This is the `Nau` corresponding to the `declaration` instruction which the function or its generic owner originates from.
+    const decl_nav = ip.getNav(if (func.generic_owner == .none)
+        func.owner_nav
+    else
+        zcu.funcInfo(func.generic_owner).owner_nav);
 
     const func_nav = ip.getNav(func.owner_nav);
-
-    const decl_prog_node = zcu.sema_prog_node.start(func_nav.fqn.toSlice(ip), 0);
-    defer decl_prog_node.end();
 
     zcu.intern_pool.removeDependenciesForDepender(gpa, anal_unit);
 
@@ -2216,7 +2218,7 @@ fn analyzeFnBody(pt: Zcu.PerThread, func_index: InternPool.Index) Zcu.SemaError!
 
     // Every runtime function has a dependency on the source of the Decl it originates from.
     // It also depends on the value of its owner Decl.
-    try sema.declareDependency(.{ .src_hash = decl_cau.zir_index });
+    try sema.declareDependency(.{ .src_hash = decl_nav.analysis.?.zir_index });
     try sema.declareDependency(.{ .nav_val = func.owner_nav });
 
     if (func.analysisUnordered(ip).inferred_error_set) {
@@ -2236,11 +2238,11 @@ fn analyzeFnBody(pt: Zcu.PerThread, func_index: InternPool.Index) Zcu.SemaError!
     var inner_block: Sema.Block = .{
         .parent = null,
         .sema = &sema,
-        .namespace = decl_cau.namespace,
+        .namespace = decl_nav.analysis.?.namespace,
         .instructions = .{},
         .inlining = null,
         .is_comptime = false,
-        .src_base_inst = decl_cau.zir_index,
+        .src_base_inst = decl_nav.analysis.?.zir_index,
         .type_name_ctx = func_nav.fqn,
     };
     defer inner_block.instructions.deinit(gpa);
@@ -2542,10 +2544,10 @@ fn processExportsInner(
         .nav => |nav_index| if (failed: {
             const nav = ip.getNav(nav_index);
             if (zcu.failed_codegen.contains(nav_index)) break :failed true;
-            if (nav.analysis_owner.unwrap()) |cau| {
-                const cau_unit = AnalUnit.wrap(.{ .cau = cau });
-                if (zcu.failed_analysis.contains(cau_unit)) break :failed true;
-                if (zcu.transitive_failed_analysis.contains(cau_unit)) break :failed true;
+            if (nav.analysis != null) {
+                const unit: AnalUnit = .wrap(.{ .nav_val = nav_index });
+                if (zcu.failed_analysis.contains(unit)) break :failed true;
+                if (zcu.transitive_failed_analysis.contains(unit)) break :failed true;
             }
             const val = switch (nav.status) {
                 .unresolved => break :failed true,
@@ -2593,15 +2595,14 @@ pub fn populateTestFunctions(
         Zcu.Namespace.NameAdapter{ .zcu = zcu },
     ).?;
     {
-        // We have to call `ensureCauAnalyzed` here in case `builtin.test_functions`
+        // We have to call `ensureNavValUpToDate` here in case `builtin.test_functions`
         // was not referenced by start code.
         zcu.sema_prog_node = main_progress_node.start("Semantic Analysis", 0);
         defer {
             zcu.sema_prog_node.end();
             zcu.sema_prog_node = std.Progress.Node.none;
         }
-        const cau_index = ip.getNav(nav_index).analysis_owner.unwrap().?;
-        pt.ensureCauAnalyzed(cau_index) catch |err| switch (err) {
+        pt.ensureNavValUpToDate(nav_index) catch |err| switch (err) {
             error.AnalysisFail => return,
             error.OutOfMemory => return error.OutOfMemory,
         };
@@ -2622,8 +2623,7 @@ pub fn populateTestFunctions(
             {
                 // The test declaration might have failed; if that's the case, just return, as we'll
                 // be emitting a compile error anyway.
-                const cau = test_nav.analysis_owner.unwrap().?;
-                const anal_unit: AnalUnit = .wrap(.{ .cau = cau });
+                const anal_unit: AnalUnit = .wrap(.{ .nav_val = test_nav_index });
                 if (zcu.failed_analysis.contains(anal_unit) or
                     zcu.transitive_failed_analysis.contains(anal_unit))
                 {
@@ -2748,8 +2748,8 @@ pub fn linkerUpdateNav(pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) error
                     "unable to codegen: {s}",
                     .{@errorName(err)},
                 ));
-                if (nav.analysis_owner.unwrap()) |cau| {
-                    try zcu.retryable_failures.append(zcu.gpa, AnalUnit.wrap(.{ .cau = cau }));
+                if (nav.analysis != null) {
+                    try zcu.retryable_failures.append(zcu.gpa, .wrap(.{ .nav_val = nav_index }));
                 } else {
                     // TODO: we don't have a way to indicate that this failure is retryable!
                     // Since these are really rare, we could as a cop-out retry the whole build next update.
@@ -3255,7 +3255,7 @@ pub fn getBuiltinNav(pt: Zcu.PerThread, name: []const u8) Allocator.Error!Intern
     const builtin_str = try ip.getOrPutString(gpa, pt.tid, "builtin", .no_embedded_nulls);
     const builtin_nav = std_namespace.pub_decls.getKeyAdapted(builtin_str, Zcu.Namespace.NameAdapter{ .zcu = zcu }) orelse
         @panic("lib/std.zig is corrupt and missing 'builtin'");
-    pt.ensureCauAnalyzed(ip.getNav(builtin_nav).analysis_owner.unwrap().?) catch @panic("std.builtin is corrupt");
+    pt.ensureNavValUpToDate(builtin_nav) catch @panic("std.builtin is corrupt");
     const builtin_type = Type.fromInterned(ip.getNav(builtin_nav).status.resolved.val);
     const builtin_namespace = zcu.namespacePtr(builtin_type.getNamespace(zcu).unwrap() orelse @panic("std.builtin is corrupt"));
     const name_str = try ip.getOrPutString(gpa, pt.tid, name, .no_embedded_nulls);
@@ -3307,68 +3307,45 @@ pub fn navAlignment(pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) InternPo
 /// Given a container type requiring resolution, ensures that it is up-to-date.
 /// If not, the type is recreated at a new `InternPool.Index`.
 /// The new index is returned. This is the same as the old index if the fields were up-to-date.
-/// If `already_updating` is set, assumes the type is already outdated and undergoing re-analysis rather than checking `zcu.outdated`.
-pub fn ensureTypeUpToDate(pt: Zcu.PerThread, ty: InternPool.Index, already_updating: bool) Zcu.SemaError!InternPool.Index {
+pub fn ensureTypeUpToDate(pt: Zcu.PerThread, ty: InternPool.Index) Zcu.SemaError!InternPool.Index {
     const zcu = pt.zcu;
+    const gpa = zcu.gpa;
     const ip = &zcu.intern_pool;
+
+    const anal_unit: AnalUnit = .wrap(.{ .type = ty });
+    const outdated = zcu.outdated.swapRemove(anal_unit) or
+        zcu.potentially_outdated.swapRemove(anal_unit);
+
+    if (!outdated) return ty;
+
+    // We will recreate the type at a new `InternPool.Index`.
+
+    _ = zcu.outdated_ready.swapRemove(anal_unit);
+    try zcu.markDependeeOutdated(.marked_po, .{ .interned = ty });
+
+    // Delete old state which is no longer in use. Technically, this is not necessary: these exports,
+    // references, etc, will be ignored because the type itself is unreferenced. However, it allows
+    // reusing the memory which is currently being used to track this state.
+    zcu.deleteUnitExports(anal_unit);
+    zcu.deleteUnitReferences(anal_unit);
+    if (zcu.failed_analysis.fetchSwapRemove(anal_unit)) |kv| {
+        kv.value.destroy(gpa);
+    }
+    _ = zcu.transitive_failed_analysis.swapRemove(anal_unit);
+    zcu.intern_pool.removeDependenciesForDepender(gpa, anal_unit);
+
     switch (ip.indexToKey(ty)) {
-        .struct_type => |key| {
-            const struct_obj = ip.loadStructType(ty);
-            const outdated = already_updating or o: {
-                const anal_unit = AnalUnit.wrap(.{ .cau = struct_obj.cau });
-                const o = zcu.outdated.swapRemove(anal_unit) or
-                    zcu.potentially_outdated.swapRemove(anal_unit);
-                if (o) {
-                    _ = zcu.outdated_ready.swapRemove(anal_unit);
-                    try zcu.markDependeeOutdated(.marked_po, .{ .interned = ty });
-                }
-                break :o o;
-            };
-            if (!outdated) return ty;
-            return pt.recreateStructType(key, struct_obj);
-        },
-        .union_type => |key| {
-            const union_obj = ip.loadUnionType(ty);
-            const outdated = already_updating or o: {
-                const anal_unit = AnalUnit.wrap(.{ .cau = union_obj.cau });
-                const o = zcu.outdated.swapRemove(anal_unit) or
-                    zcu.potentially_outdated.swapRemove(anal_unit);
-                if (o) {
-                    _ = zcu.outdated_ready.swapRemove(anal_unit);
-                    try zcu.markDependeeOutdated(.marked_po, .{ .interned = ty });
-                }
-                break :o o;
-            };
-            if (!outdated) return ty;
-            return pt.recreateUnionType(key, union_obj);
-        },
-        .enum_type => |key| {
-            const enum_obj = ip.loadEnumType(ty);
-            const outdated = already_updating or o: {
-                const anal_unit = AnalUnit.wrap(.{ .cau = enum_obj.cau.unwrap().? });
-                const o = zcu.outdated.swapRemove(anal_unit) or
-                    zcu.potentially_outdated.swapRemove(anal_unit);
-                if (o) {
-                    _ = zcu.outdated_ready.swapRemove(anal_unit);
-                    try zcu.markDependeeOutdated(.marked_po, .{ .interned = ty });
-                }
-                break :o o;
-            };
-            if (!outdated) return ty;
-            return pt.recreateEnumType(key, enum_obj);
-        },
-        .opaque_type => {
-            assert(!already_updating);
-            return ty;
-        },
+        .struct_type => |key| return pt.recreateStructType(ty, key),
+        .union_type => |key| return pt.recreateUnionType(ty, key),
+        .enum_type => |key| return pt.recreateEnumType(ty, key),
         else => unreachable,
     }
 }
 
 fn recreateStructType(
     pt: Zcu.PerThread,
+    old_ty: InternPool.Index,
     full_key: InternPool.Key.NamespaceType,
-    struct_obj: InternPool.LoadedStructType,
 ) Zcu.SemaError!InternPool.Index {
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -3405,8 +3382,7 @@ fn recreateStructType(
 
     if (captures_len != key.captures.owned.len) return error.AnalysisFail;
 
-    // The old type will be unused, so drop its dependency information.
-    ip.removeDependenciesForDepender(gpa, AnalUnit.wrap(.{ .cau = struct_obj.cau }));
+    const struct_obj = ip.loadStructType(old_ty);
 
     const wip_ty = switch (try ip.getStructType(gpa, pt.tid, .{
         .layout = small.layout,
@@ -3428,17 +3404,16 @@ fn recreateStructType(
     errdefer wip_ty.cancel(ip, pt.tid);
 
     wip_ty.setName(ip, struct_obj.name);
-    const new_cau_index = try ip.createTypeCau(gpa, pt.tid, key.zir_index, struct_obj.namespace, wip_ty.index);
     try ip.addDependency(
         gpa,
-        AnalUnit.wrap(.{ .cau = new_cau_index }),
+        .wrap(.{ .type = wip_ty.index }),
         .{ .src_hash = key.zir_index },
     );
     zcu.namespacePtr(struct_obj.namespace).owner_type = wip_ty.index;
     // No need to re-scan the namespace -- `zirStructDecl` will ultimately do that if the type is still alive.
     try zcu.comp.queueJob(.{ .resolve_type_fully = wip_ty.index });
 
-    const new_ty = wip_ty.finish(ip, new_cau_index.toOptional(), struct_obj.namespace);
+    const new_ty = wip_ty.finish(ip, struct_obj.namespace);
     if (inst_info.inst == .main_struct_inst) {
         // This is the root type of a file! Update the reference.
         zcu.setFileRootType(inst_info.file, new_ty);
@@ -3448,8 +3423,8 @@ fn recreateStructType(
 
 fn recreateUnionType(
     pt: Zcu.PerThread,
+    old_ty: InternPool.Index,
     full_key: InternPool.Key.NamespaceType,
-    union_obj: InternPool.LoadedUnionType,
 ) Zcu.SemaError!InternPool.Index {
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -3488,8 +3463,7 @@ fn recreateUnionType(
 
     if (captures_len != key.captures.owned.len) return error.AnalysisFail;
 
-    // The old type will be unused, so drop its dependency information.
-    ip.removeDependenciesForDepender(gpa, AnalUnit.wrap(.{ .cau = union_obj.cau }));
+    const union_obj = ip.loadUnionType(old_ty);
 
     const namespace_index = union_obj.namespace;
 
@@ -3526,22 +3500,21 @@ fn recreateUnionType(
     errdefer wip_ty.cancel(ip, pt.tid);
 
     wip_ty.setName(ip, union_obj.name);
-    const new_cau_index = try ip.createTypeCau(gpa, pt.tid, key.zir_index, namespace_index, wip_ty.index);
     try ip.addDependency(
         gpa,
-        AnalUnit.wrap(.{ .cau = new_cau_index }),
+        .wrap(.{ .type = wip_ty.index }),
         .{ .src_hash = key.zir_index },
     );
     zcu.namespacePtr(namespace_index).owner_type = wip_ty.index;
     // No need to re-scan the namespace -- `zirUnionDecl` will ultimately do that if the type is still alive.
     try zcu.comp.queueJob(.{ .resolve_type_fully = wip_ty.index });
-    return wip_ty.finish(ip, new_cau_index.toOptional(), namespace_index);
+    return wip_ty.finish(ip, namespace_index);
 }
 
 fn recreateEnumType(
     pt: Zcu.PerThread,
+    old_ty: InternPool.Index,
     full_key: InternPool.Key.NamespaceType,
-    enum_obj: InternPool.LoadedEnumType,
 ) Zcu.SemaError!InternPool.Index {
     const zcu = pt.zcu;
     const gpa = zcu.gpa;
@@ -3610,8 +3583,7 @@ fn recreateEnumType(
         if (bag != 0) break true;
     } else false;
 
-    // The old type will be unused, so drop its dependency information.
-    ip.removeDependenciesForDepender(gpa, AnalUnit.wrap(.{ .cau = enum_obj.cau.unwrap().? }));
+    const enum_obj = ip.loadEnumType(old_ty);
 
     const namespace_index = enum_obj.namespace;
 
@@ -3637,12 +3609,10 @@ fn recreateEnumType(
 
     wip_ty.setName(ip, enum_obj.name);
 
-    const new_cau_index = try ip.createTypeCau(gpa, pt.tid, key.zir_index, namespace_index, wip_ty.index);
-
     zcu.namespacePtr(namespace_index).owner_type = wip_ty.index;
     // No need to re-scan the namespace -- `zirEnumDecl` will ultimately do that if the type is still alive.
 
-    wip_ty.prepare(ip, new_cau_index, namespace_index);
+    wip_ty.prepare(ip, namespace_index);
     done = true;
 
     Sema.resolveDeclaredEnum(
@@ -3652,7 +3622,6 @@ fn recreateEnumType(
         key.zir_index,
         namespace_index,
         enum_obj.name,
-        new_cau_index,
         small,
         body,
         tag_type_ref,

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3218,15 +3218,7 @@ fn lowerNavRef(func: *CodeGen, nav_index: InternPool.Nav.Index, offset: u32) Inn
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
 
-    // check if decl is an alias to a function, in which case we
-    // want to lower the actual decl, rather than the alias itself.
-    const owner_nav = switch (ip.indexToKey(zcu.navValue(nav_index).toIntern())) {
-        .func => |function| function.owner_nav,
-        .variable => |variable| variable.owner_nav,
-        .@"extern" => |@"extern"| @"extern".owner_nav,
-        else => nav_index,
-    };
-    const nav_ty = ip.getNav(owner_nav).typeOf(ip);
+    const nav_ty = ip.getNav(nav_index).typeOf(ip);
     if (!ip.isFunctionType(nav_ty) and !Type.fromInterned(nav_ty).hasRuntimeBitsIgnoreComptime(zcu)) {
         return .{ .imm32 = 0xaaaaaaaa };
     }

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -853,7 +853,7 @@ fn genNavRef(
 
     const nav_index, const is_extern, const lib_name, const is_threadlocal = switch (ip.indexToKey(zcu.navValue(ref_nav_index).toIntern())) {
         .func => |func| .{ func.owner_nav, false, .none, false },
-        .variable => |variable| .{ variable.owner_nav, false, variable.lib_name, variable.is_threadlocal },
+        .variable => |variable| .{ variable.owner_nav, false, .none, variable.is_threadlocal },
         .@"extern" => |@"extern"| .{ @"extern".owner_nav, true, @"extern".lib_name, @"extern".is_threadlocal },
         else => .{ ref_nav_index, false, .none, false },
     };

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -817,7 +817,7 @@ fn genNavRef(
     pt: Zcu.PerThread,
     src_loc: Zcu.LazySrcLoc,
     val: Value,
-    ref_nav_index: InternPool.Nav.Index,
+    nav_index: InternPool.Nav.Index,
     target: std.Target,
 ) CodeGenError!GenResult {
     const zcu = pt.zcu;
@@ -851,14 +851,15 @@ fn genNavRef(
         }
     }
 
-    const nav_index, const is_extern, const lib_name, const is_threadlocal = switch (ip.indexToKey(zcu.navValue(ref_nav_index).toIntern())) {
-        .func => |func| .{ func.owner_nav, false, .none, false },
-        .variable => |variable| .{ variable.owner_nav, false, .none, variable.is_threadlocal },
-        .@"extern" => |@"extern"| .{ @"extern".owner_nav, true, @"extern".lib_name, @"extern".is_threadlocal },
-        else => .{ ref_nav_index, false, .none, false },
-    };
+    const nav = ip.getNav(nav_index);
+
+    const is_extern, const lib_name, const is_threadlocal = if (nav.getExtern(ip)) |e|
+        .{ true, e.lib_name, e.is_threadlocal }
+    else
+        .{ false, .none, nav.isThreadlocal(ip) };
+
     const single_threaded = zcu.navFileScope(nav_index).mod.single_threaded;
-    const name = ip.getNav(nav_index).name;
+    const name = nav.name;
     if (lf.cast(.elf)) |elf_file| {
         const zo = elf_file.zigObjectPtr().?;
         if (is_extern) {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1476,7 +1476,7 @@ pub const Object = struct {
             } }, &o.builder);
         }
 
-        if (nav.status.resolved.@"linksection".toSlice(ip)) |section|
+        if (nav.status.fully_resolved.@"linksection".toSlice(ip)) |section|
             function_index.setSection(try o.builder.string(section), &o.builder);
 
         var deinit_wip = true;
@@ -1684,7 +1684,7 @@ pub const Object = struct {
             const file = try o.getDebugFile(file_scope);
 
             const line_number = zcu.navSrcLine(func.owner_nav) + 1;
-            const is_internal_linkage = ip.indexToKey(nav.status.resolved.val) != .@"extern";
+            const is_internal_linkage = ip.indexToKey(nav.status.fully_resolved.val) != .@"extern";
             const debug_decl_type = try o.lowerDebugType(fn_ty);
 
             const subprogram = try o.builder.debugSubprogram(
@@ -2928,9 +2928,7 @@ pub const Object = struct {
         const gpa = o.gpa;
         const nav = ip.getNav(nav_index);
         const owner_mod = zcu.navFileScope(nav_index).mod;
-        const resolved = nav.status.resolved;
-        const val = Value.fromInterned(resolved.val);
-        const ty = val.typeOf(zcu);
+        const ty: Type = .fromInterned(nav.typeOf(ip));
         const gop = try o.nav_map.getOrPut(gpa, nav_index);
         if (gop.found_existing) return gop.value_ptr.ptr(&o.builder).kind.function;
 
@@ -2938,14 +2936,14 @@ pub const Object = struct {
         const target = owner_mod.resolved_target.result;
         const sret = firstParamSRet(fn_info, zcu, target);
 
-        const is_extern, const lib_name = switch (ip.indexToKey(val.toIntern())) {
-            .@"extern" => |@"extern"| .{ true, @"extern".lib_name },
-            else => .{ false, .none },
-        };
+        const is_extern, const lib_name = if (nav.getExtern(ip)) |@"extern"|
+            .{ true, @"extern".lib_name }
+        else
+            .{ false, .none };
         const function_index = try o.builder.addFunction(
             try o.lowerType(ty),
             try o.builder.strtabString((if (is_extern) nav.name else nav.fqn).toSlice(ip)),
-            toLlvmAddressSpace(resolved.@"addrspace", target),
+            toLlvmAddressSpace(nav.getAddrspace(), target),
         );
         gop.value_ptr.* = function_index.ptrConst(&o.builder).global;
 
@@ -3063,8 +3061,8 @@ pub const Object = struct {
             }
         }
 
-        if (resolved.alignment != .none)
-            function_index.setAlignment(resolved.alignment.toLlvm(), &o.builder);
+        if (nav.getAlignment() != .none)
+            function_index.setAlignment(nav.getAlignment().toLlvm(), &o.builder);
 
         // Function attributes that are independent of analysis results of the function body.
         try o.addCommonFnAttributes(
@@ -3249,17 +3247,21 @@ pub const Object = struct {
         const zcu = pt.zcu;
         const ip = &zcu.intern_pool;
         const nav = ip.getNav(nav_index);
-        const resolved = nav.status.resolved;
-        const is_extern, const is_threadlocal, const is_weak_linkage, const is_dll_import = switch (ip.indexToKey(resolved.val)) {
-            .variable => |variable| .{ false, variable.is_threadlocal, variable.is_weak_linkage, false },
-            .@"extern" => |@"extern"| .{ true, @"extern".is_threadlocal, @"extern".is_weak_linkage, @"extern".is_dll_import },
-            else => .{ false, false, false, false },
+        const is_extern, const is_threadlocal, const is_weak_linkage, const is_dll_import = switch (nav.status) {
+            .unresolved => unreachable,
+            .fully_resolved => |r| switch (ip.indexToKey(r.val)) {
+                .variable => |variable| .{ false, variable.is_threadlocal, variable.is_weak_linkage, false },
+                .@"extern" => |@"extern"| .{ true, @"extern".is_threadlocal, @"extern".is_weak_linkage, @"extern".is_dll_import },
+                else => .{ false, false, false, false },
+            },
+            // This means it's a source declaration which is not `extern`!
+            .type_resolved => |r| .{ false, r.is_threadlocal, false, false },
         };
 
         const variable_index = try o.builder.addVariable(
             try o.builder.strtabString((if (is_extern) nav.name else nav.fqn).toSlice(ip)),
             try o.lowerType(Type.fromInterned(nav.typeOf(ip))),
-            toLlvmGlobalAddressSpace(resolved.@"addrspace", zcu.getTarget()),
+            toLlvmGlobalAddressSpace(nav.getAddrspace(), zcu.getTarget()),
         );
         gop.value_ptr.* = variable_index.ptrConst(&o.builder).global;
 
@@ -4528,20 +4530,10 @@ pub const Object = struct {
         const zcu = pt.zcu;
         const ip = &zcu.intern_pool;
 
-        // In the case of something like:
-        // fn foo() void {}
-        // const bar = foo;
-        // ... &bar;
-        // `bar` is just an alias and we actually want to lower a reference to `foo`.
-        const owner_nav_index = switch (ip.indexToKey(zcu.navValue(nav_index).toIntern())) {
-            .func => |func| func.owner_nav,
-            .@"extern" => |@"extern"| @"extern".owner_nav,
-            else => nav_index,
-        };
-        const owner_nav = ip.getNav(owner_nav_index);
+        const nav = ip.getNav(nav_index);
 
-        const nav_ty = Type.fromInterned(owner_nav.typeOf(ip));
-        const ptr_ty = try pt.navPtrType(owner_nav_index);
+        const nav_ty = Type.fromInterned(nav.typeOf(ip));
+        const ptr_ty = try pt.navPtrType(nav_index);
 
         const is_fn_body = nav_ty.zigTypeTag(zcu) == .@"fn";
         if ((!is_fn_body and !nav_ty.hasRuntimeBits(zcu)) or
@@ -4551,13 +4543,13 @@ pub const Object = struct {
         }
 
         const llvm_global = if (is_fn_body)
-            (try o.resolveLlvmFunction(owner_nav_index)).ptrConst(&o.builder).global
+            (try o.resolveLlvmFunction(nav_index)).ptrConst(&o.builder).global
         else
-            (try o.resolveGlobalNav(owner_nav_index)).ptrConst(&o.builder).global;
+            (try o.resolveGlobalNav(nav_index)).ptrConst(&o.builder).global;
 
         const llvm_val = try o.builder.convConst(
             llvm_global.toConst(),
-            try o.builder.ptrType(toLlvmAddressSpace(owner_nav.status.resolved.@"addrspace", zcu.getTarget())),
+            try o.builder.ptrType(toLlvmAddressSpace(nav.getAddrspace(), zcu.getTarget())),
         );
 
         return o.builder.convConst(llvm_val, try o.lowerType(ptr_ty));
@@ -4799,7 +4791,7 @@ pub const NavGen = struct {
         const ip = &zcu.intern_pool;
         const nav_index = ng.nav_index;
         const nav = ip.getNav(nav_index);
-        const resolved = nav.status.resolved;
+        const resolved = nav.status.fully_resolved;
 
         const is_extern, const lib_name, const is_threadlocal, const is_weak_linkage, const is_dll_import, const is_const, const init_val, const owner_nav = switch (ip.indexToKey(resolved.val)) {
             .variable => |variable| .{ false, .none, variable.is_threadlocal, variable.is_weak_linkage, false, false, variable.init, variable.owner_nav },
@@ -5765,7 +5757,7 @@ pub const FuncGen = struct {
         const msg_nav_index = zcu.panic_messages[@intFromEnum(panic_id)].unwrap().?;
         const msg_nav = ip.getNav(msg_nav_index);
         const msg_len = Type.fromInterned(msg_nav.typeOf(ip)).childType(zcu).arrayLen(zcu);
-        const msg_ptr = try o.lowerValue(msg_nav.status.resolved.val);
+        const msg_ptr = try o.lowerValue(msg_nav.status.fully_resolved.val);
         const null_opt_addr_global = try fg.resolveNullOptUsize();
         const target = zcu.getTarget();
         const llvm_usize = try o.lowerType(Type.usize);

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2939,7 +2939,6 @@ pub const Object = struct {
         const sret = firstParamSRet(fn_info, zcu, target);
 
         const is_extern, const lib_name = switch (ip.indexToKey(val.toIntern())) {
-            .variable => |variable| .{ false, variable.lib_name },
             .@"extern" => |@"extern"| .{ true, @"extern".lib_name },
             else => .{ false, .none },
         };
@@ -4803,7 +4802,7 @@ pub const NavGen = struct {
         const resolved = nav.status.resolved;
 
         const is_extern, const lib_name, const is_threadlocal, const is_weak_linkage, const is_dll_import, const is_const, const init_val, const owner_nav = switch (ip.indexToKey(resolved.val)) {
-            .variable => |variable| .{ false, variable.lib_name, variable.is_threadlocal, variable.is_weak_linkage, false, false, variable.init, variable.owner_nav },
+            .variable => |variable| .{ false, .none, variable.is_threadlocal, variable.is_weak_linkage, false, false, variable.init, variable.owner_nav },
             .@"extern" => |@"extern"| .{ true, @"extern".lib_name, @"extern".is_threadlocal, @"extern".is_weak_linkage, @"extern".is_dll_import, @"extern".is_const, .none, @"extern".owner_nav },
             else => .{ false, .none, false, false, false, true, resolved.val, nav_index },
         };

--- a/src/link.zig
+++ b/src/link.zig
@@ -692,7 +692,7 @@ pub const File = struct {
     /// May be called before or after updateExports for any given Nav.
     pub fn updateNav(base: *File, pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) UpdateNavError!void {
         const nav = pt.zcu.intern_pool.getNav(nav_index);
-        assert(nav.status == .resolved);
+        assert(nav.status == .fully_resolved);
         switch (base.tag) {
             inline else => |tag| {
                 dev.check(tag.devFeature());

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -1110,6 +1110,8 @@ pub fn updateFunc(coff: *Coff, pt: Zcu.PerThread, func_index: InternPool.Index, 
     const atom_index = try coff.getOrCreateAtomForNav(func.owner_nav);
     coff.freeRelocations(atom_index);
 
+    coff.navs.getPtr(func.owner_nav).?.section = coff.text_section_index.?;
+
     var code_buffer = std.ArrayList(u8).init(gpa);
     defer code_buffer.deinit();
 
@@ -1222,6 +1224,8 @@ pub fn updateNav(
         const atom_index = try coff.getOrCreateAtomForNav(nav_index);
         coff.freeRelocations(atom_index);
         const atom = coff.getAtom(atom_index);
+
+        coff.navs.getPtr(nav_index).?.section = coff.getNavOutputSection(nav_index);
 
         var code_buffer = std.ArrayList(u8).init(gpa);
         defer code_buffer.deinit();
@@ -1342,7 +1346,8 @@ pub fn getOrCreateAtomForNav(coff: *Coff, nav_index: InternPool.Nav.Index) !Atom
     if (!gop.found_existing) {
         gop.value_ptr.* = .{
             .atom = try coff.createAtom(),
-            .section = coff.getNavOutputSection(nav_index),
+            // If necessary, this will be modified by `updateNav` or `updateFunc`.
+            .section = coff.rdata_section_index.?,
             .exports = .{},
         };
     }
@@ -1355,7 +1360,7 @@ fn getNavOutputSection(coff: *Coff, nav_index: InternPool.Nav.Index) u16 {
     const nav = ip.getNav(nav_index);
     const ty = Type.fromInterned(nav.typeOf(ip));
     const zig_ty = ty.zigTypeTag(zcu);
-    const val = Value.fromInterned(nav.status.resolved.val);
+    const val = Value.fromInterned(nav.status.fully_resolved.val);
     const index: u16 = blk: {
         if (val.isUndefDeep(zcu)) {
             // TODO in release-fast and release-small, we should put undef in .bss
@@ -2348,10 +2353,10 @@ pub fn getNavVAddr(
     const ip = &zcu.intern_pool;
     const nav = ip.getNav(nav_index);
     log.debug("getNavVAddr {}({d})", .{ nav.fqn.fmt(ip), nav_index });
-    const sym_index = switch (ip.indexToKey(nav.status.resolved.val)) {
-        .@"extern" => |@"extern"| try coff.getGlobalSymbol(nav.name.toSlice(ip), @"extern".lib_name.toSlice(ip)),
-        else => coff.getAtom(try coff.getOrCreateAtomForNav(nav_index)).getSymbolIndex().?,
-    };
+    const sym_index = if (nav.getExtern(ip)) |e|
+        try coff.getGlobalSymbol(nav.name.toSlice(ip), e.lib_name.toSlice(ip))
+    else
+        coff.getAtom(try coff.getOrCreateAtomForNav(nav_index)).getSymbolIndex().?;
     const atom_index = coff.getAtomIndexForSymbol(.{
         .sym_index = reloc_info.parent.atom_index,
         .file = null,

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2281,7 +2281,7 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
             const nav_ty = nav_val.typeOf(zcu);
             const nav_ty_reloc_index = try wip_nav.refForward();
             try wip_nav.infoExprloc(.{ .addr = .{ .sym = sym_index } });
-            try uleb128(diw, nav.status.resolved.alignment.toByteUnits() orelse
+            try uleb128(diw, nav.status.fully_resolved.alignment.toByteUnits() orelse
                 nav_ty.abiAlignment(zcu).toByteUnits().?);
             try diw.writeByte(@intFromBool(false));
             wip_nav.finishForward(nav_ty_reloc_index);
@@ -2313,7 +2313,7 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
             try wip_nav.refType(ty);
             const addr: Loc = .{ .addr = .{ .sym = sym_index } };
             try wip_nav.infoExprloc(if (variable.is_threadlocal) .{ .form_tls_address = &addr } else addr);
-            try uleb128(diw, nav.status.resolved.alignment.toByteUnits() orelse
+            try uleb128(diw, nav.status.fully_resolved.alignment.toByteUnits() orelse
                 ty.abiAlignment(zcu).toByteUnits().?);
             try diw.writeByte(@intFromBool(false));
         },
@@ -2388,7 +2388,7 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
             wip_nav.func_high_pc = @intCast(wip_nav.debug_info.items.len);
             try diw.writeInt(u32, 0, dwarf.endian);
             const target = file.mod.resolved_target.result;
-            try uleb128(diw, switch (nav.status.resolved.alignment) {
+            try uleb128(diw, switch (nav.status.fully_resolved.alignment) {
                 .none => target_info.defaultFunctionAlignment(target),
                 else => |a| a.maxStrict(target_info.minFunctionAlignment(target)),
             }.toByteUnits().?);
@@ -2952,7 +2952,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
             const nav_ty = nav_val.typeOf(zcu);
             try wip_nav.refType(nav_ty);
             try wip_nav.blockValue(nav_src_loc, nav_val);
-            try uleb128(diw, nav.status.resolved.alignment.toByteUnits() orelse
+            try uleb128(diw, nav.status.fully_resolved.alignment.toByteUnits() orelse
                 nav_ty.abiAlignment(zcu).toByteUnits().?);
             try diw.writeByte(@intFromBool(false));
         },
@@ -2977,7 +2977,7 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
             try wip_nav.strp(nav.name.toSlice(ip));
             try wip_nav.strp(nav.fqn.toSlice(ip));
             const nav_ty_reloc_index = try wip_nav.refForward();
-            try uleb128(diw, nav.status.resolved.alignment.toByteUnits() orelse
+            try uleb128(diw, nav.status.fully_resolved.alignment.toByteUnits() orelse
                 nav_ty.abiAlignment(zcu).toByteUnits().?);
             try diw.writeByte(@intFromBool(false));
             if (has_runtime_bits) try wip_nav.blockValue(nav_src_loc, nav_val);

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -2261,8 +2261,8 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
             assert(file.zir_loaded);
             const decl = file.zir.getDeclaration(inst_info.inst);
 
-            const parent_type, const accessibility: u8 = if (nav.analysis_owner.unwrap()) |cau| parent: {
-                const parent_namespace_ptr = ip.namespacePtr(ip.getCau(cau).namespace);
+            const parent_type, const accessibility: u8 = if (nav.analysis) |a| parent: {
+                const parent_namespace_ptr = ip.namespacePtr(a.namespace);
                 break :parent .{
                     parent_namespace_ptr.owner_type,
                     if (decl.is_pub) DW.ACCESS.public else DW.ACCESS.private,
@@ -2292,8 +2292,8 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
             assert(file.zir_loaded);
             const decl = file.zir.getDeclaration(inst_info.inst);
 
-            const parent_type, const accessibility: u8 = if (nav.analysis_owner.unwrap()) |cau| parent: {
-                const parent_namespace_ptr = ip.namespacePtr(ip.getCau(cau).namespace);
+            const parent_type, const accessibility: u8 = if (nav.analysis) |a| parent: {
+                const parent_namespace_ptr = ip.namespacePtr(a.namespace);
                 break :parent .{
                     parent_namespace_ptr.owner_type,
                     if (decl.is_pub) DW.ACCESS.public else DW.ACCESS.private,
@@ -2321,8 +2321,8 @@ pub fn initWipNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool.Nav.In
             assert(file.zir_loaded);
             const decl = file.zir.getDeclaration(inst_info.inst);
 
-            const parent_type, const accessibility: u8 = if (nav.analysis_owner.unwrap()) |cau| parent: {
-                const parent_namespace_ptr = ip.namespacePtr(ip.getCau(cau).namespace);
+            const parent_type, const accessibility: u8 = if (nav.analysis) |a| parent: {
+                const parent_namespace_ptr = ip.namespacePtr(a.namespace);
                 break :parent .{
                     parent_namespace_ptr.owner_type,
                     if (decl.is_pub) DW.ACCESS.public else DW.ACCESS.private,
@@ -2563,8 +2563,8 @@ pub fn updateComptimeNav(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPool
         return;
     }
 
-    const parent_type, const accessibility: u8 = if (nav.analysis_owner.unwrap()) |cau| parent: {
-        const parent_namespace_ptr = ip.namespacePtr(ip.getCau(cau).namespace);
+    const parent_type, const accessibility: u8 = if (nav.analysis) |a| parent: {
+        const parent_namespace_ptr = ip.namespacePtr(a.namespace);
         break :parent .{
             parent_namespace_ptr.owner_type,
             if (decl.is_pub) DW.ACCESS.public else DW.ACCESS.private,

--- a/src/link/Plan9.zig
+++ b/src/link/Plan9.zig
@@ -1021,7 +1021,7 @@ pub fn seeNav(self: *Plan9, pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) 
     const atom_idx = gop.value_ptr.index;
     // handle externs here because they might not get updateDecl called on them
     const nav = ip.getNav(nav_index);
-    if (ip.indexToKey(nav.status.resolved.val) == .@"extern") {
+    if (nav.getExtern(ip) != null) {
         // this is a "phantom atom" - it is never actually written to disk, just convenient for us to store stuff about externs
         if (nav.name.eqlSlice("etext", ip)) {
             self.etext_edata_end_atom_indices[0] = atom_idx;
@@ -1370,7 +1370,7 @@ pub fn getNavVAddr(
     const ip = &pt.zcu.intern_pool;
     const nav = ip.getNav(nav_index);
     log.debug("getDeclVAddr for {}", .{nav.name.fmt(ip)});
-    if (ip.indexToKey(nav.status.resolved.val) == .@"extern") {
+    if (nav.getExtern(ip) != null) {
         if (nav.name.eqlSlice("etext", ip)) {
             try self.addReloc(reloc_info.parent.atom_index, .{
                 .target = undefined,

--- a/src/link/Wasm/ZigObject.zig
+++ b/src/link/Wasm/ZigObject.zig
@@ -241,7 +241,7 @@ pub fn updateNav(
 
     const nav_val = zcu.navValue(nav_index);
     const is_extern, const lib_name, const nav_init = switch (ip.indexToKey(nav_val.toIntern())) {
-        .variable => |variable| .{ false, variable.lib_name, Value.fromInterned(variable.init) },
+        .variable => |variable| .{ false, .none, Value.fromInterned(variable.init) },
         .func => return,
         .@"extern" => |@"extern"| if (ip.isFunctionType(nav.typeOf(ip)))
             return

--- a/src/link/Wasm/ZigObject.zig
+++ b/src/link/Wasm/ZigObject.zig
@@ -734,15 +734,14 @@ pub fn getNavVAddr(
     const target_atom_index = try zig_object.getOrCreateAtomForNav(wasm, pt, nav_index);
     const target_atom = wasm.getAtom(target_atom_index);
     const target_symbol_index = @intFromEnum(target_atom.sym_index);
-    switch (ip.indexToKey(nav.status.resolved.val)) {
-        .@"extern" => |@"extern"| try zig_object.addOrUpdateImport(
+    if (nav.getExtern(ip)) |@"extern"| {
+        try zig_object.addOrUpdateImport(
             wasm,
             nav.name.toSlice(ip),
             target_atom.sym_index,
             @"extern".lib_name.toSlice(ip),
             null,
-        ),
-        else => {},
+        );
     }
 
     std.debug.assert(reloc_info.parent.atom_index != 0);
@@ -945,8 +944,8 @@ pub fn freeNav(zig_object: *ZigObject, wasm: *Wasm, nav_index: InternPool.Nav.In
         segment.name = &.{}; // Ensure no accidental double free
     }
 
-    const nav_val = zcu.navValue(nav_index).toIntern();
-    if (ip.indexToKey(nav_val) == .@"extern") {
+    const nav = ip.getNav(nav_index);
+    if (nav.getExtern(ip) != null) {
         std.debug.assert(zig_object.imports.remove(atom.sym_index));
     }
     std.debug.assert(wasm.symbol_atom.remove(atom.symbolLoc()));
@@ -960,7 +959,7 @@ pub fn freeNav(zig_object: *ZigObject, wasm: *Wasm, nav_index: InternPool.Nav.In
     if (sym.isGlobal()) {
         std.debug.assert(zig_object.global_syms.remove(atom.sym_index));
     }
-    if (ip.isFunctionType(ip.typeOf(nav_val))) {
+    if (ip.isFunctionType(nav.typeOf(ip))) {
         zig_object.functions_free_list.append(gpa, sym.index) catch {};
         std.debug.assert(zig_object.atom_types.remove(atom_index));
     } else {

--- a/test/cases/compile_errors/address_of_threadlocal_not_comptime_known.zig
+++ b/test/cases/compile_errors/address_of_threadlocal_not_comptime_known.zig
@@ -10,4 +10,5 @@ pub export fn entry() void {
 // target=native
 //
 // :2:36: error: unable to resolve comptime value
-// :2:36: note: container level variable initializers must be comptime-known
+// :2:36: note: global variable initializer must be comptime-known
+// :2:36: note: thread local and dll imported variables have runtime-known addresses

--- a/test/cases/compile_errors/self_reference_missing_const.zig
+++ b/test/cases/compile_errors/self_reference_missing_const.zig
@@ -1,0 +1,11 @@
+const S = struct { self: *S, x: u32 };
+const s: S = .{ .self = &s, .x = 123 };
+
+comptime {
+    _ = s;
+}
+
+// error
+//
+// :2:18: error: expected type '*tmp.S', found '*const tmp.S'
+// :2:18: note: cast discards const qualifier

--- a/test/cases/compile_errors/type_variables_must_be_constant.zig
+++ b/test/cases/compile_errors/type_variables_must_be_constant.zig
@@ -7,5 +7,5 @@ export fn entry() foo {
 // backend=stage2
 // target=native
 //
-// :1:5: error: variable of type 'type' must be const or comptime
-// :1:5: note: types are not available at runtime
+// :1:11: error: variable of type 'type' must be const or comptime
+// :1:11: note: types are not available at runtime

--- a/test/cases/compile_errors/use_invalid_number_literal_as_array_index.zig
+++ b/test/cases/compile_errors/use_invalid_number_literal_as_array_index.zig
@@ -8,5 +8,5 @@ export fn entry() void {
 // backend=stage2
 // target=native
 //
-// :1:5: error: variable of type 'comptime_int' must be const or comptime
-// :1:5: note: to modify this variable at runtime, it must be given an explicit fixed-size number type
+// :1:9: error: variable of type 'comptime_int' must be const or comptime
+// :1:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type


### PR DESCRIPTION
This PR performs 2 significant refactors, and then implements #131.

See commit messages for details.

The performance impact of this PR is variable, but here are two important tests:

### Build Compiler with Self-Hosted

```
Benchmark 1 (8 runs): /home/mlugg/zig/master/stage4-fast/bin/zig build-exe --stack 33554432 -fno-sanitize-thread -ODebug --dep aro --dep aro_translate_c --dep build_options -Mroot=src/main.zig -Maro=lib/compiler/aro/aro.zig --dep aro -Maro_translate_c=lib/compiler/aro_translate_c.zig -Mbuild_options=.zig-cache/c/c5119ba8c2bb22ea36039c62cc1b2325/options.zig -fno-llvm -fno-lld --cache-dir .zig-cache --global-cache-dir /home/mlugg/.cache/zig --name zig --zig-lib-dir lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.9s  ± 40.0ms    12.8s  … 13.0s           0 ( 0%)        0%
  peak_rss           1.02GB ± 30.8MB     996MB … 1.07GB          0 ( 0%)        0%
  cpu_cycles         78.6G  ±  125M     78.4G  … 78.8G           0 ( 0%)        0%
  instructions        167G  ± 2.40M      167G  …  167G           0 ( 0%)        0%
  cache_references   4.85G  ± 8.44M     4.84G  … 4.86G           1 (13%)        0%
  cache_misses        279M  ± 4.20M      274M  …  287M           0 ( 0%)        0%
  branch_misses       368M  ±  708K      366M  …  368M           1 (13%)        0%
Benchmark 2 (8 runs): /home/mlugg/zig/131/stage4-fast/bin/zig build-exe --stack 33554432 -fno-sanitize-thread -ODebug --dep aro --dep aro_translate_c --dep build_options -Mroot=src/main.zig -Maro=lib/compiler/aro/aro.zig --dep aro -Maro_translate_c=lib/compiler/aro_translate_c.zig -Mbuild_options=.zig-cache/c/c5119ba8c2bb22ea36039c62cc1b2325/options.zig -fno-llvm -fno-lld --cache-dir .zig-cache --global-cache-dir /home/mlugg/.cache/zig --name zig --zig-lib-dir lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.7s  ± 31.5ms    12.6s  … 12.7s           0 ( 0%)        ⚡-  1.8% ±  0.3%
  peak_rss           1.01GB ± 24.0MB     989MB … 1.06GB          1 (13%)          -  1.0% ±  2.9%
  cpu_cycles         78.0G  ± 74.7M     77.8G  … 78.1G           0 ( 0%)          -  0.8% ±  0.1%
  instructions        169G  ± 2.39M      169G  …  169G           0 ( 0%)        💩+  1.3% ±  0.0%
  cache_references   4.82G  ± 8.18M     4.81G  … 4.84G           0 ( 0%)          -  0.5% ±  0.2%
  cache_misses        273M  ± 4.01M      266M  …  279M           0 ( 0%)          -  2.0% ±  1.6%
  branch_misses       358M  ±  760K      357M  …  359M           0 ( 0%)        ⚡-  2.7% ±  0.2%
```

### Build `std` Tests with Self-Hosted

```
Benchmark 1 (3 runs): /home/mlugg/zig/master/stage4-fast/bin/zig test lib/std/std.zig --zig-lib-dir lib -fno-llvm -fno-lld --test-no-exec
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          10.5s  ± 34.2ms    10.4s  … 10.5s           0 ( 0%)        0%
  peak_rss            899MB ± 8.21MB     891MB …  907MB          0 ( 0%)        0%
  cpu_cycles         64.2G  ±  133M     64.1G  … 64.3G           0 ( 0%)        0%
  instructions        139G  ± 10.0M      139G  …  139G           0 ( 0%)        0%
  cache_references   4.22G  ± 19.6M     4.21G  … 4.24G           0 ( 0%)        0%
  cache_misses        147M  ± 1.63M      145M  …  148M           0 ( 0%)        0%
  branch_misses       182M  ±  320K      182M  …  182M           0 ( 0%)        0%
Benchmark 2 (3 runs): /home/mlugg/zig/131/stage4-fast/bin/zig test lib/std/std.zig --zig-lib-dir lib -fno-llvm -fno-lld --test-no-exec
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          10.7s  ± 32.3ms    10.7s  … 10.8s           0 ( 0%)        💩+  2.6% ±  0.7%
  peak_rss            896MB ± 5.18MB     891MB …  901MB          0 ( 0%)          -  0.3% ±  1.7%
  cpu_cycles         65.4G  ±  148M     65.3G  … 65.6G           0 ( 0%)        💩+  1.9% ±  0.5%
  instructions        144G  ± 1.05M      144G  …  144G           0 ( 0%)        💩+  3.5% ±  0.0%
  cache_references   4.16G  ± 12.8M     4.14G  … 4.17G           0 ( 0%)          -  1.4% ±  0.9%
  cache_misses        146M  ± 1.57M      145M  …  148M           0 ( 0%)          -  0.5% ±  2.5%
  branch_misses       179M  ±  245K      179M  …  179M           0 ( 0%)        ⚡-  2.0% ±  0.4%
```