### PR TITLE
Sema: ensure result of `block_comptime` is comptime-known

### DIFF
--- a/test/cases/compile_errors/comptime_keyword_runtime_result.zig
+++ b/test/cases/compile_errors/comptime_keyword_runtime_result.zig
@@ -1,0 +1,14 @@
+var global_rt: u8 = 123;
+
+export fn foo() void {
+    _ = comptime global_rt;
+}
+
+export fn bar(rt: ?*anyopaque) void {
+    if (rt != null) bar(comptime rt);
+}
+
+// error
+//
+// :4:18: error: unable to resolve comptime value
+// :8:34: error: unable to resolve comptime value


### PR DESCRIPTION
Also, simplify the handling of this instruction; it was previously going through a completely unnecessary runtime path. Who would write such ridiculous code?! (It was me, I wrote it)

Resolves: #22296