### PR TITLE
std.posix: adding getsockopt

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4277,29 +4277,27 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
 }
 
 pub const GetSockOptError = error{
+    /// The calling process does not have the appropriate privileges.
+    AccessDenied,
+
     /// The option is not supported by the protocol.
     InvalidProtocolOption,
 
     /// Insufficient resources are available in the system to complete the call.
     SystemResources,
-
-    /// The file descriptor is not valid.
-    FileDescriptorNotValid,
-
-    // The file descriptor is not a socket.
-    FileDescriptorNotASocket,
 } || UnexpectedError;
 
 pub fn getsockopt(fd: socket_t, level: i32, optname: u32, noalias optval: ?*anyopaque, noalias optlen: *socklen_t) GetSockOptError!void {
     switch (errno(system.getsockopt(fd, level, optname, optval, optlen))) {
         .SUCCESS => {},
-        .BADF => return error.FileDescriptorNotValid,
-        .NOTSOCK => return error.FileDescriptorNotASocket,
-        .INVAL => return error.InvalidProtocolOption,
-        .FAULT => return error.InvalidProtocolOption,
+        .BADF => unreachable,
+        .NOTSOCK => unreachable,
+        .INVAL => unreachable,
+        .FAULT => unreachable,
         .NOPROTOOPT => return error.InvalidProtocolOption,
         .NOMEM => return error.SystemResources,
         .NOBUFS => return error.SystemResources,
+        .ACCES => return error.AccessDenied,
         else => |err| return unexpectedErrno(err),
     }
 }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4287,9 +4287,10 @@ pub const GetSockOptError = error{
     SystemResources,
 } || UnexpectedError;
 
-pub fn getsockopt(fd: socket_t, level: i32, optname: u32, noalias optval: ?*anyopaque, noalias optlen: *socklen_t) GetSockOptError!void {
-    switch (errno(system.getsockopt(fd, level, optname, optval, optlen))) {
-        .SUCCESS => {},
+pub fn getsockopt(fd: socket_t, level: i32, optname: u32, opt: []u8) GetSockOptError!void {
+    var len: socklen_t = undefined;
+    switch (errno(system.getsockopt(fd, level, optname, opt.ptr, &len))) {
+        .SUCCESS => { std.debug.assert(len == opt.len); },
         .BADF => unreachable,
         .NOTSOCK => unreachable,
         .INVAL => unreachable,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4276,6 +4276,34 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
     }
 }
 
+pub const GetSockOptError = error{
+    /// The option is not supported by the protocol.
+    InvalidProtocolOption,
+
+    /// Insufficient resources are available in the system to complete the call.
+    SystemResources,
+
+    /// The file descriptor is not valid.
+    FileDescriptorNotValid,
+
+    // The file descriptor is not a socket.
+    FileDescriptorNotASocket,
+} || UnexpectedError;
+
+pub fn getsockopt(fd: socket_t, level: i32, optname: u32, noalias optval: ?*anyopaque, noalias optlen: *socklen_t) GetSockOptError!void {
+    switch (errno(system.getsockopt(fd, level, optname, optval, optlen))) {
+        .SUCCESS => {},
+        .BADF => return error.FileDescriptorNotValid,
+        .NOTSOCK => return error.FileDescriptorNotASocket,
+        .INVAL => return error.InvalidProtocolOption,
+        .FAULT => return error.InvalidProtocolOption,
+        .NOPROTOOPT => return error.InvalidProtocolOption,
+        .NOMEM => return error.SystemResources,
+        .NOBUFS => return error.SystemResources,
+        else => |err| return unexpectedErrno(err),
+    }
+}
+
 pub fn getsockoptError(sockfd: fd_t) ConnectError!void {
     var err_code: i32 = undefined;
     var size: u32 = @sizeOf(u32);

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4290,7 +4290,9 @@ pub const GetSockOptError = error{
 pub fn getsockopt(fd: socket_t, level: i32, optname: u32, opt: []u8) GetSockOptError!void {
     var len: socklen_t = undefined;
     switch (errno(system.getsockopt(fd, level, optname, opt.ptr, &len))) {
-        .SUCCESS => { std.debug.assert(len == opt.len); },
+        .SUCCESS => {
+            std.debug.assert(len == opt.len);
+        },
         .BADF => unreachable,
         .NOTSOCK => unreachable,
         .INVAL => unreachable,


### PR DESCRIPTION
I noticed that ``std.posix.setsockopt`` exists but not ``std.posix.getsockopt``. 

I tried to add it, but I'm not sure if the anyopaque / optlen approach is a good one.

https://linux.die.net/man/3/getsockopt