### PR TITLE
std.os.linux: remove app_mask and block&unblock pair in raise

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5113,7 +5113,6 @@ pub const NSIG = if (is_mips) 128 else 65;
 pub const sigset_t = [1024 / 32]u32;
 
 pub const all_mask: sigset_t = [_]u32{0xffffffff} ** @typeInfo(sigset_t).array.len;
-pub const app_mask: sigset_t = [2]u32{ 0xfffffffc, 0x7fffffff } ++ [_]u32{0xffffffff} ** 30;
 
 const k_sigaction_funcs = struct {
     const handler = ?*align(1) const fn (i32) callconv(.c) void;

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -720,8 +720,18 @@ pub fn raise(sig: u8) RaiseError!void {
     }
 
     if (native_os == .linux) {
+        // https://git.musl-libc.org/cgit/musl/commit/?id=0bed7e0acfd34e3fb63ca0e4d99b7592571355a9
+        //
+        // Unlike musl, libc-less Zig std does not have any internal signals for implementation purposes, so we
+        // need to block all signals on the assumption that any of them could potentially fork() in a handler.
+        var set: sigset_t = undefined;
+        sigprocmask(SIG.BLOCK, &linux.all_mask, &set);
+
         const tid = linux.gettid();
         const rc = linux.tkill(tid, sig);
+
+        // restore signal mask
+        sigprocmask(SIG.SETMASK, &set, null);
 
         switch (errno(rc)) {
             .SUCCESS => return,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -720,15 +720,8 @@ pub fn raise(sig: u8) RaiseError!void {
     }
 
     if (native_os == .linux) {
-        var set: sigset_t = undefined;
-        // block application signals
-        sigprocmask(SIG.BLOCK, &linux.app_mask, &set);
-
         const tid = linux.gettid();
         const rc = linux.tkill(tid, sig);
-
-        // restore signal mask
-        sigprocmask(SIG.SETMASK, &set, null);
 
         switch (errno(rc)) {
             .SUCCESS => return,


### PR DESCRIPTION
I believe the order of first two u32 is wrong.

See also: https://github.com/bminor/musl/blob/master/src/signal/sigfillset.c