### PR TITLE
linux: make ptid and ctid in clone() optional

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -71,9 +71,9 @@ pub fn clone(
     stack: usize,
     flags: u32,
     arg: usize,
-    ptid: *i32,
+    ptid: ?*i32,
     tp: usize, // aka tls
-    ctid: *i32,
+    ctid: ?*i32,
 ) usize {
     // Can't directly call a naked function; cast to C calling convention first.
     return @as(*const fn (
@@ -81,9 +81,9 @@ pub fn clone(
         usize,
         u32,
         usize,
-        *i32,
+        ?*i32,
         usize,
-        *i32,
+        ?*i32,
     ) callconv(.C) usize, @ptrCast(&syscall_bits.clone))(func, stack, flags, arg, ptid, tp, ctid);
 }
 


### PR DESCRIPTION
I think these arguments can accept null.