### PR TITLE
make std.compress.xz.Decompress.init pub

### DIFF
--- a/lib/std/compress/xz.zig
+++ b/lib/std/compress/xz.zig
@@ -40,7 +40,7 @@ pub fn Decompress(comptime ReaderType: type) type {
         block_decoder: block.Decoder(ReaderType),
         in_reader: ReaderType,
 
-        fn init(allocator: Allocator, source: ReaderType) !Self {
+        pub fn init(allocator: Allocator, source: ReaderType) !Self {
             const magic = try source.readBytesNoEof(6);
             if (!std.mem.eql(u8, &magic, &.{ 0xFD, '7', 'z', 'X', 'Z', 0x00 }))
                 return error.BadHeader;


### PR DESCRIPTION
Currently, an xz decompressor can only be created through std.compress.
xz.decompress. I believe making the decompressor directly initializable
is useful in the case of already having a value with the decompressor
type (e.g. a union field) since it allows the use of decl literals.

Additionally, the paramaters to the functions are identical, and this
also has the benefit of consistancy with the other namespaces in std.
compress.