### PR TITLE
fix incorrect slicing by length detection cases

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -885,7 +885,7 @@ fn expr(gz: *GenZir, scope: *Scope, ri: ResultInfo, node: Ast.Node.Index) InnerE
             const lhs_is_slice_sentinel = lhs_tag == .slice_sentinel;
             const lhs_is_open_slice = lhs_tag == .slice_open or
                 (lhs_is_slice_sentinel and tree.fullSlice(full.ast.sliced).?.ast.end == 0);
-            if (node_tags[node] != .slice_open and
+            if (full.ast.end != 0 and
                 lhs_is_open_slice and
                 nodeIsTriviallyZero(tree, full.ast.start))
             {
@@ -897,7 +897,7 @@ fn expr(gz: *GenZir, scope: *Scope, ri: ResultInfo, node: Ast.Node.Index) InnerE
                 } else try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[full.ast.sliced].rhs);
 
                 const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
-                const len = if (full.ast.end != 0) try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, full.ast.end) else .none;
+                const len = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, full.ast.end);
                 const sentinel = if (full.ast.sentinel != 0) try expr(gz, scope, .{ .rl = .none }, full.ast.sentinel) else .none;
                 try emitDbgStmt(gz, cursor);
                 const result = try gz.addPlNode(.slice_length, node, Zir.Inst.SliceLength{

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -876,100 +876,68 @@ fn expr(gz: *GenZir, scope: *Scope, ri: ResultInfo, node: Ast.Node.Index) InnerE
 
         .for_simple, .@"for" => return forExpr(gz, scope, ri.br(), node, tree.fullFor(node).?, false),
 
-        .slice_open => {
-            const lhs = try expr(gz, scope, .{ .rl = .ref }, node_datas[node].lhs);
-
-            const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
-            const start = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[node].rhs);
-            try emitDbgStmt(gz, cursor);
-            const result = try gz.addPlNode(.slice_start, node, Zir.Inst.SliceStart{
-                .lhs = lhs,
-                .start = start,
-            });
-            return rvalue(gz, ri, result, node);
-        },
-        .slice => {
-            const extra = tree.extraData(node_datas[node].rhs, Ast.Node.Slice);
-            const lhs_node = node_datas[node].lhs;
-            const lhs_tag = node_tags[lhs_node];
+        .slice_open,
+        .slice,
+        .slice_sentinel,
+        => {
+            const full = tree.fullSlice(node).?;
+            const lhs_tag = node_tags[full.ast.sliced];
             const lhs_is_slice_sentinel = lhs_tag == .slice_sentinel;
             const lhs_is_open_slice = lhs_tag == .slice_open or
-                (lhs_is_slice_sentinel and tree.extraData(node_datas[lhs_node].rhs, Ast.Node.SliceSentinel).end == 0);
-            if (lhs_is_open_slice and nodeIsTriviallyZero(tree, extra.start)) {
-                const lhs = try expr(gz, scope, .{ .rl = .ref }, node_datas[lhs_node].lhs);
+                (lhs_is_slice_sentinel and tree.fullSlice(full.ast.sliced).?.ast.end == 0);
+            if (node_tags[node] != .slice_open and
+                lhs_is_open_slice and
+                nodeIsTriviallyZero(tree, full.ast.start))
+            {
+                const lhs = try expr(gz, scope, .{ .rl = .ref }, node_datas[full.ast.sliced].lhs);
 
                 const start = if (lhs_is_slice_sentinel) start: {
-                    const lhs_extra = tree.extraData(node_datas[lhs_node].rhs, Ast.Node.SliceSentinel);
+                    const lhs_extra = tree.extraData(node_datas[full.ast.sliced].rhs, Ast.Node.SliceSentinel);
                     break :start try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, lhs_extra.start);
-                } else try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[lhs_node].rhs);
+                } else try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[full.ast.sliced].rhs);
 
                 const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
-                const len = if (extra.end != 0) try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, extra.end) else .none;
+                const len = if (full.ast.end != 0) try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, full.ast.end) else .none;
+                const sentinel = if (full.ast.sentinel != 0) try expr(gz, scope, .{ .rl = .none }, full.ast.sentinel) else .none;
                 try emitDbgStmt(gz, cursor);
                 const result = try gz.addPlNode(.slice_length, node, Zir.Inst.SliceLength{
                     .lhs = lhs,
                     .start = start,
                     .len = len,
-                    .start_src_node_offset = gz.nodeIndexToRelative(lhs_node),
-                    .sentinel = .none,
-                });
-                return rvalue(gz, ri, result, node);
-            }
-            const lhs = try expr(gz, scope, .{ .rl = .ref }, node_datas[node].lhs);
-
-            const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
-            const start = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, extra.start);
-            const end = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, extra.end);
-            try emitDbgStmt(gz, cursor);
-            const result = try gz.addPlNode(.slice_end, node, Zir.Inst.SliceEnd{
-                .lhs = lhs,
-                .start = start,
-                .end = end,
-            });
-            return rvalue(gz, ri, result, node);
-        },
-        .slice_sentinel => {
-            const extra = tree.extraData(node_datas[node].rhs, Ast.Node.SliceSentinel);
-            const lhs_node = node_datas[node].lhs;
-            const lhs_tag = node_tags[lhs_node];
-            const lhs_is_slice_sentinel = lhs_tag == .slice_sentinel;
-            const lhs_is_open_slice = lhs_tag == .slice_open or
-                (lhs_is_slice_sentinel and tree.extraData(node_datas[lhs_node].rhs, Ast.Node.SliceSentinel).end == 0);
-            if (lhs_is_open_slice and nodeIsTriviallyZero(tree, extra.start)) {
-                const lhs = try expr(gz, scope, .{ .rl = .ref }, node_datas[lhs_node].lhs);
-
-                const start = if (lhs_is_slice_sentinel) start: {
-                    const lhs_extra = tree.extraData(node_datas[lhs_node].rhs, Ast.Node.SliceSentinel);
-                    break :start try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, lhs_extra.start);
-                } else try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, node_datas[lhs_node].rhs);
-
-                const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
-                const len = if (extra.end != 0) try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, extra.end) else .none;
-                const sentinel = try expr(gz, scope, .{ .rl = .none }, extra.sentinel);
-                try emitDbgStmt(gz, cursor);
-                const result = try gz.addPlNode(.slice_length, node, Zir.Inst.SliceLength{
-                    .lhs = lhs,
-                    .start = start,
-                    .len = len,
-                    .start_src_node_offset = gz.nodeIndexToRelative(lhs_node),
+                    .start_src_node_offset = gz.nodeIndexToRelative(full.ast.sliced),
                     .sentinel = sentinel,
                 });
                 return rvalue(gz, ri, result, node);
             }
-            const lhs = try expr(gz, scope, .{ .rl = .ref }, node_datas[node].lhs);
+            const lhs = try expr(gz, scope, .{ .rl = .ref }, full.ast.sliced);
 
             const cursor = maybeAdvanceSourceCursorToMainToken(gz, node);
-            const start = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, extra.start);
-            const end = if (extra.end != 0) try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, extra.end) else .none;
-            const sentinel = try expr(gz, scope, .{ .rl = .none }, extra.sentinel);
+            const start = try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, full.ast.start);
+            const end = if (full.ast.end != 0) try expr(gz, scope, .{ .rl = .{ .coerced_ty = .usize_type } }, full.ast.end) else .none;
+            const sentinel = if (full.ast.sentinel != 0) try expr(gz, scope, .{ .rl = .none }, full.ast.sentinel) else .none;
             try emitDbgStmt(gz, cursor);
-            const result = try gz.addPlNode(.slice_sentinel, node, Zir.Inst.SliceSentinel{
-                .lhs = lhs,
-                .start = start,
-                .end = end,
-                .sentinel = sentinel,
-            });
-            return rvalue(gz, ri, result, node);
+            if (sentinel != .none) {
+                const result = try gz.addPlNode(.slice_sentinel, node, Zir.Inst.SliceSentinel{
+                    .lhs = lhs,
+                    .start = start,
+                    .end = end,
+                    .sentinel = sentinel,
+                });
+                return rvalue(gz, ri, result, node);
+            } else if (end != .none) {
+                const result = try gz.addPlNode(.slice_end, node, Zir.Inst.SliceEnd{
+                    .lhs = lhs,
+                    .start = start,
+                    .end = end,
+                });
+                return rvalue(gz, ri, result, node);
+            } else {
+                const result = try gz.addPlNode(.slice_start, node, Zir.Inst.SliceStart{
+                    .lhs = lhs,
+                    .start = start,
+                });
+                return rvalue(gz, ri, result, node);
+            }
         },
 
         .deref => {

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -115,6 +115,23 @@ test "open slice of open slice with sentinel" {
     try expect(slice[1..][0.. :0][4] == 0);
 }
 
+test "open slice with sentinel of slice with end index" {
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    var slice: [:0]const u8 = "hello";
+    _ = &slice;
+
+    comptime assert(@TypeOf(slice[0.. :0][0..5]) == *const [5]u8);
+    try expect(slice[0.. :0][0..5].len == 5);
+    try expect(slice[0.. :0][0..5][0] == 'h');
+    try expect(slice[0.. :0][0..5][4] == 'o');
+
+    comptime assert(@TypeOf(slice[0.. :0][0..5 :0]) == *const [5:0]u8);
+    try expect(slice[0.. :0][0..5 :0].len == 5);
+    try expect(slice[0.. :0][0..5 :0][0] == 'h');
+    try expect(slice[0.. :0][0..5 :0][5] == 0);
+}
+
 test "slice of type" {
     comptime {
         var types_array = [_]type{ i32, f64, type };

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -98,6 +98,23 @@ test "comptime slice of slice preserves comptime var" {
     }
 }
 
+test "open slice of open slice with sentinel" {
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    var slice: [:0]const u8 = "hello";
+    _ = &slice;
+
+    comptime assert(@TypeOf(slice[0..][0.. :0]) == [:0]const u8);
+    try expect(slice[0..][0.. :0].len == 5);
+    try expect(slice[0..][0.. :0][0] == 'h');
+    try expect(slice[0..][0.. :0][5] == 0);
+
+    comptime assert(@TypeOf(slice[1..][0.. :0]) == [:0]const u8);
+    try expect(slice[1..][0.. :0].len == 4);
+    try expect(slice[1..][0.. :0][0] == 'e');
+    try expect(slice[1..][0.. :0][4] == 0);
+}
+
 test "slice of type" {
     comptime {
         var types_array = [_]type{ i32, f64, type };

--- a/test/cases/safety/slice by length sentinel mismatch on lhs.zig
+++ b/test/cases/safety/slice by length sentinel mismatch on lhs.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    _ = stack_trace;
+    if (std.mem.eql(u8, message, "sentinel mismatch: expected 1, found 3")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+pub fn main() !void {
+    var buf: [4:0]u8 = .{ 1, 2, 3, 4 };
+    const slice = buf[0..][0..2 :1];
+    _ = slice;
+    return error.TestFailed;
+}
+// run
+// backend=llvm
+// target=native

--- a/test/cases/safety/slice by length sentinel mismatch on rhs.zig
+++ b/test/cases/safety/slice by length sentinel mismatch on rhs.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, stack_trace: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    _ = stack_trace;
+    if (std.mem.eql(u8, message, "sentinel mismatch: expected 1, found 0")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+pub fn main() !void {
+    var buf: [4:0]u8 = .{ 1, 2, 3, 4 };
+    const slice = buf[0.. :1][0..2];
+    _ = slice;
+    return error.TestFailed;
+}
+// run
+// backend=llvm
+// target=native


### PR DESCRIPTION
I initially just wanted to simplify the code that handles the slicing syntax in AstGen.zig but then found two bugs related to the special [Slicing By Length](https://ziglang.org/download/0.11.0/release-notes.html#Slicing-By-Length) syntax:

This example will incorrectly trigger slicing by length even though no end index has been provided. It will crash the compiler.
```zig
test {
    var foo = "";
    _ = foo[0..][0.. :0];
}
```

In this example, the provided sentinel expression is never analyzed and no sentinel mismatch safety check is reported.
```zig
test {
    var foo: [2:0]u8 = .{ 1, 2 };
    _ = foo[0.. :1][0..2];
}
```

The [PR](https://github.com/ziglang/zig/pull/15519) that added the slicing by length special case has explicitly mentioned support for `s[start..:sentinel][0..len]` and `s[start..:sentinal_1][0..len:sentinel_2]` but appears to have never tested what happens if the first sentinel is invalid.

The diff as a whole is not very readable. I would recommend to look at the commits individually.

Here is a Benchmark of running ast-check on Sema.zig:

```
poop "build/stage4-fast/bin/zig ast-check src/Sema.zig" "build/stage4-sos-fast/bin/zig ast-check src/Sema.zig" -d 20000
Benchmark 1 (192 runs): build/stage4-fast/bin/zig ast-check src/Sema.zig
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           104ms ± 1.76ms     101ms …  109ms          0 ( 0%)        0%
  peak_rss           77.7MB ± 48.1KB    77.4MB … 77.8MB         24 (13%)        0%
  cpu_cycles          340M  ± 5.09M      332M  …  357M           1 ( 1%)        0%
  instructions        516M  ± 11.3       516M  …  516M           0 ( 0%)        0%
  cache_references   1.41M  ± 63.2K     1.24M  … 1.56M           7 ( 4%)        0%
  cache_misses        354K  ± 34.8K      298K  …  416K           0 ( 0%)        0%
  branch_misses      4.75M  ± 3.17K     4.75M  … 4.76M           9 ( 5%)        0%
Benchmark 2 (194 runs): build/stage4-sos-fast/bin/zig ast-check src/Sema.zig
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           103ms ± 2.37ms     101ms …  129ms          2 ( 1%)          -  0.7% ±  0.4%
  peak_rss           77.8MB ± 67.5KB    77.6MB … 77.8MB          0 ( 0%)          +  0.1% ±  0.0%
  cpu_cycles          337M  ± 6.85M      332M  …  411M           3 ( 2%)          -  0.7% ±  0.4%
  instructions        517M  ± 9.75       517M  …  517M           2 ( 1%)          +  0.1% ±  0.0%
  cache_references   1.42M  ± 58.4K     1.25M  … 1.86M           8 ( 4%)          +  0.6% ±  0.9%
  cache_misses        341K  ± 30.2K      294K  …  484K           1 ( 1%)        ⚡-  3.8% ±  1.8%
  branch_misses      4.73M  ± 3.05K     4.73M  … 4.76M           1 ( 1%)          -  0.4% ±  0.0%
```