### PR TITLE
link/Elf.zig: set build-id for dynamic libraries.

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1716,7 +1716,9 @@ fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: s
                 "-z",
                 try std.fmt.allocPrint(arena, "stack-size={d}", .{self.base.stack_size}),
             });
+        }
 
+        if (is_exe_or_dyn_lib) {
             switch (self.base.build_id) {
                 .none => {},
                 .fast, .uuid, .sha1, .md5 => {


### PR DESCRIPTION
Found this while trying to package ghostty and found that libghostty had had no build-id despite `--build-id=sha1` being explicitly passed.

This PR makes it so that `build-id` is also set for shared libraries. 