### PR TITLE
mark std.testing.print as a public function

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -28,7 +28,7 @@ pub var log_level = std.log.Level.warn;
 // Disable printing in tests for simple backends.
 pub const backend_can_print = !(builtin.zig_backend == .stage2_spirv64 or builtin.zig_backend == .stage2_riscv64);
 
-fn print(comptime fmt: []const u8, args: anytype) void {
+pub fn print(comptime fmt: []const u8, args: anytype) void {
     if (@inComptime()) {
         @compileError(std.fmt.comptimePrint(fmt, args));
     } else if (backend_can_print) {


### PR DESCRIPTION
Zig's stdlib testing is able to print helpful error messages when attempting to validate a test. This works both during comptime, and runtime. This exposes the previously internal function to be used in any custom built test functions to produce helpful output that is similar behavior to the standard test framework.