### PR TITLE
compiler_rt: fix __clzsi2_thumb1 (incorrect lookup table usage)

### DIFF
--- a/lib/compiler_rt/count0bits.zig
+++ b/lib/compiler_rt/count0bits.zig
@@ -73,7 +73,7 @@ fn __clzsi2_thumb1() callconv(.Naked) void {
         \\ subs r1, #4
         \\ movs r0, r2
         \\ 1:
-        \\ ldr r3, .lut
+        \\ adr r3, .lut
         \\ ldrb r0, [r3, r0]
         \\ subs r0, r1, r0
         \\ bx lr


### PR DESCRIPTION
Originally the code loaded the (first 4 bytes of the) lookup table into r3 instead of the address of the lookup table, resulting in the memory address 02020100 (the lookup table bytes, in little endian) being dereferenced instead of the address of the lookup table.