### PR TITLE
Improve `first()` documentation for split iterators

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2903,9 +2903,10 @@ pub fn WindowIterator(comptime T: type) type {
 
         const Self = @This();
 
-        /// Returns a slice of the first window. This never fails.
+        /// Returns a slice of the first window.
         /// Call this only to get the first window and then use `next` to get
         /// all subsequent windows.
+        /// If called after iteration has begun, it will panic.
         pub fn first(self: *Self) []const T {
             assert(self.index.? == 0);
             return self.next().?;
@@ -3037,8 +3038,9 @@ pub fn SplitIterator(comptime T: type, comptime delimiter_type: DelimiterType) t
 
         const Self = @This();
 
-        /// Returns a slice of the first field. This never fails.
+        /// Returns a slice of the first field.
         /// Call this only to get the first field and then use `next` to get all subsequent fields.
+        /// If called after iteration has begun, it will panic.
         pub fn first(self: *Self) []const T {
             assert(self.index.? == 0);
             return self.next().?;
@@ -3101,8 +3103,9 @@ pub fn SplitBackwardsIterator(comptime T: type, comptime delimiter_type: Delimit
 
         const Self = @This();
 
-        /// Returns a slice of the first field. This never fails.
+        /// Returns a slice of the first field.
         /// Call this only to get the first field and then use `next` to get all subsequent fields.
+        /// If called after iteration has begun, it will panic.
         pub fn first(self: *Self) []const T {
             assert(self.index.? == self.buffer.len);
             return self.next().?;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2906,7 +2906,7 @@ pub fn WindowIterator(comptime T: type) type {
         /// Returns a slice of the first window.
         /// Call this only to get the first window and then use `next` to get
         /// all subsequent windows.
-        /// If called after iteration has begun, it will panic.
+        /// Asserts that iteration has not begun.
         pub fn first(self: *Self) []const T {
             assert(self.index.? == 0);
             return self.next().?;
@@ -3040,7 +3040,7 @@ pub fn SplitIterator(comptime T: type, comptime delimiter_type: DelimiterType) t
 
         /// Returns a slice of the first field.
         /// Call this only to get the first field and then use `next` to get all subsequent fields.
-        /// If called after iteration has begun, it will panic.
+        /// Asserts that iteration has not begun.
         pub fn first(self: *Self) []const T {
             assert(self.index.? == 0);
             return self.next().?;
@@ -3105,7 +3105,7 @@ pub fn SplitBackwardsIterator(comptime T: type, comptime delimiter_type: Delimit
 
         /// Returns a slice of the first field.
         /// Call this only to get the first field and then use `next` to get all subsequent fields.
-        /// If called after iteration has begun, it will panic.
+        /// Asserts that iteration has not begun.
         pub fn first(self: *Self) []const T {
             assert(self.index.? == self.buffer.len);
             return self.next().?;


### PR DESCRIPTION
Remove misleading `This never fails.` statement and add explicit clarification 
that first() will panic if called after iteration has already begun.

Fixes #22338 