### PR TITLE
implement reading for GECOS, HOME and SHELL within posixGetUserInfo

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1528,7 +1528,16 @@ pub fn posixGetUserInfo(allocator: mem.Allocator, name: []const u8) !UserInfo {
 
     const reader = file.reader();
 
-    const State = enum { Start, WaitForNextLine, SkipPassword, ReadUserId, ReadGroupId, ReadGECOS, ReadHome, ReadShell };
+    const State = enum {
+        Start,
+        WaitForNextLine,
+        SkipPassword,
+        ReadUserId,
+        ReadGroupId,
+        ReadGECOS,
+        ReadHome,
+        ReadShell
+    };
 
     var buf: [std.mem.page_size]u8 = undefined;
     var name_index: usize = 0;
@@ -1639,7 +1648,14 @@ pub fn posixGetUserInfo(allocator: mem.Allocator, name: []const u8) !UserInfo {
                 .ReadShell => switch (byte) {
                     '\n', ':' => {
                         shell = try shellByteArray.toOwnedSlice();
-                        return UserInfo{ .allocator = allocator, .uid = uid, .gid = gid, .gecos = gecos, .home = home, .shell = shell };
+                        return UserInfo{
+                            .allocator = allocator,
+                            .uid = uid,
+                            .gid = gid,
+                            .gecos = gecos,
+                            .home = home,
+                            .shell = shell
+                        };
                     },
                     else => {
                         try shellByteArray.append(byte);

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1633,7 +1633,7 @@ pub fn posixGetUserInfo(allocator: mem.Allocator, name: []const u8) !UserInfo {
                         state = .ReadHome;
                     },
                     else => {
-                        if (index >= mem.page_size) {
+                        if (index <= mem.page_size) {
                             try gecosByteArray.append(byte);
                         } else {
                             return error.CorruptPasswordFile;
@@ -1649,7 +1649,7 @@ pub fn posixGetUserInfo(allocator: mem.Allocator, name: []const u8) !UserInfo {
                         state = .ReadShell;
                     },
                     else => {
-                        if (index >= mem.page_size) {
+                        if (index <= mem.page_size) {
                             try homeByteArray.append(byte);
                         } else {
                             return error.CorruptPasswordFile;
@@ -1670,7 +1670,7 @@ pub fn posixGetUserInfo(allocator: mem.Allocator, name: []const u8) !UserInfo {
                         };
                     },
                     else => {
-                        if (index >= mem.page_size) {
+                        if (index <= mem.page_size) {
                             try shellByteArray.append(byte);
                         } else {
                             return error.CorruptPasswordFile;

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1647,7 +1647,14 @@ pub fn posixGetUserInfo(allocator: mem.Allocator, name: []const u8) !UserInfo {
                 .ReadShell => switch (byte) {
                     '\n', ':' => {
                         shell = try shellByteArray.toOwnedSlice();
-                        return UserInfo{ .allocator = allocator, .uid = uid, .gid = gid, .gecos = gecos, .home = home, .shell = shell };
+                        return UserInfo{
+                            .allocator = allocator,
+                            .uid = uid,
+                            .gid = gid,
+                            .gecos = gecos,
+                            .home = home,
+                            .shell = shell
+                        };
                     },
                     else => {
                         try shellByteArray.append(byte);

--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -229,7 +229,8 @@ pub fn init(argv: []const []const u8, allocator: mem.Allocator) ChildProcess {
 }
 
 pub fn setUserName(self: *ChildProcess, name: []const u8) !void {
-    const user_info = try process.getUserInfo(name);
+    const user_info = try process.getUserInfo(self.allocator, name);
+    defer user_info.deinit();
     self.uid = user_info.uid;
     self.gid = user_info.gid;
 }


### PR DESCRIPTION
Adds support for obtaining the GECOS (comment field), home directory and shell of a username based on /etc/passwd meant to be used in the future to handle when the HOME environment variable is not set within `lib/std/fs/get_app_data_dir.zig` (relates to the TODO look in /etc/passwd comment anchor)