### PR TITLE
std.fs.File: limit initial_cap according to max_bytes in readToEndAllocOptions

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1156,7 +1156,7 @@ pub fn readToEndAllocOptions(
     // The file size returned by stat is used as hint to set the buffer
     // size. If the reported size is zero, as it happens on Linux for files
     // in /proc, a small buffer is allocated instead.
-    const initial_cap = (if (size > 0) size else 1024) + @intFromBool(optional_sentinel != null);
+    const initial_cap = @min((if (size > 0) size else 1024), max_bytes) + @intFromBool(optional_sentinel != null);
     var array_list = try std.ArrayListAligned(u8, alignment).initCapacity(allocator, initial_cap);
     defer array_list.deinit();
 


### PR DESCRIPTION
I don't think we need to alloc 1024 bytes if we are going to read only few bytes. e.g.: `file.readToEndAlloc(ally, 10)`

BTW maybe we can add a assertion `size_hint <= max_bytes` if `size_hint` is not null.