### PR TITLE
`-fwine` should allow x64 non-Windows OSes to run x86-windows apps

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -130,7 +130,10 @@ pub fn getExternalExecutor(
             if (options.allow_wine) {
                 // x86_64 wine does not support emulating aarch64-windows and
                 // vice versa.
-                if (candidate.cpu.arch != builtin.cpu.arch) {
+                if (candidate.cpu.arch != builtin.cpu.arch and
+                    !(candidate.cpu.arch == .thumb and builtin.cpu.arch == .aarch64) and
+                    !(candidate.cpu.arch == .x86 and builtin.cpu.arch == .x86_64))
+                {
                     return bad_result;
                 }
                 switch (candidate.ptrBitWidth()) {


### PR DESCRIPTION
An ad-hoc fix hopefully fixing my issue. But I haven't tested it.