### PR TITLE
Zir: split up start and end of range in `for_len`

### DIFF
--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -526,8 +526,10 @@ pub const Inst = struct {
         /// Asserts that all the lengths provided match. Used to build a for loop.
         /// Return value is the length as a usize.
         /// Uses the `pl_node` field with payload `MultiOp`.
-        /// There is exactly one item corresponding to each AST node inside the for
-        /// loop condition. Any item may be `none`, indicating an unbounded range.
+        /// There are two items for each AST node inside the for loop condition.
+        /// If both items in a pair are `.none`, then this node is an unbounded range.
+        /// If only the second item in a pair is `.none`, then the first is an indexable.
+        /// Otherwise, the node is a bounded range `a..b`, with the items being `a` and `b`.
         /// Illegal behaviors:
         ///  * If all lengths are unbounded ranges (always a compile error).
         ///  * If any two lengths do not match each other.

--- a/test/cases/compile_errors/for.zig
+++ b/test/cases/compile_errors/for.zig
@@ -28,10 +28,11 @@ export fn d() void {
         _ = x3;
     }
 }
+export fn e() void {
+    for (123) |_| {}
+}
 
 // error
-// backend=stage2
-// target=native
 //
 // :2:5: error: non-matching for loop lengths
 // :2:11: note: length 10 here
@@ -43,3 +44,5 @@ export fn d() void {
 // :25:5: error: unbounded for loop
 // :25:10: note: type '[*]const u8' has no upper bound
 // :25:18: note: type '[*]const u8' has no upper bound
+// :32:10: error: type 'comptime_int' is not indexable and not a range
+// :32:10: note: for loop operand must be a range, array, slice, tuple, or vector


### PR DESCRIPTION
The old lowering was kind of neat, but it unintentionally allowed the syntax `for (123) |_| { ... }`, and there wasn't really a way to fix that. So, instead, we include both the start and the end of the range in the `for_len` instruction (each operand to `for` now has *two* entries in this multi-op instruction). This slightly increases the size of ZIR for loops of predominantly indexables, but the difference is small enough that it's not worth complicating ZIR to try and fix it.