### PR TITLE
Remove llvm19 branch condition from Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - llvm19
 concurrency:
   # Cancels pending runs when a PR gets updated.
   group: ${{ github.head_ref || github.run_id }}-${{ github.actor }}


### PR DESCRIPTION
Removing [deleted branch](https://github.com/ziglang/zig/tree/refs/heads/llvm19) from Github Actions