### PR TITLE
Add Support for `sigdelset` in `std.os.linux`

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1759,6 +1759,14 @@ pub fn sigaddset(set: *sigset_t, sig: u6) void {
     (set.*)[@as(usize, @intCast(s)) / usize_bits] |= val;
 }
 
+pub fn sigdelset(set: *sigset_t, sig: u6) void {
+    const s = sig - 1;
+    // shift in musl: s&8*sizeof *set->__bits-1
+    const shift = @as(u5, @intCast(s & (usize_bits - 1)));
+    const val = @as(u32, @intCast(1)) << shift;
+    (set.*)[@as(usize, @intCast(s)) / usize_bits] ^= val;
+}
+
 pub fn sigismember(set: *const sigset_t, sig: u6) bool {
     const s = sig - 1;
     return ((set.*)[@as(usize, @intCast(s)) / usize_bits] & (@as(usize, @intCast(1)) << @intCast(s & (usize_bits - 1)))) != 0;

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -140,6 +140,16 @@ test "sigset_t" {
 
     try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), true);
     try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), true);
+
+    linux.sigdelset(&sigset, linux.SIG.USR1);
+
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), false);
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), true);
+
+    linux.sigdelset(&sigset, linux.SIG.USR2);
+
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), false);
+    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), false);
 }
 
 test {


### PR DESCRIPTION
This PR introduces the following changes:

- Implementation of the `sigdelset` function, which allows removing a signal from a signal set (sigset_t).
- Expansion of unit tests to include signal removal use cases (`sigdelset`).