### PR TITLE
compiler: slightly simplify builtin decl memoization

### DIFF
--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -590,13 +590,13 @@ pub fn ensureMemoizedStateUpToDate(pt: Zcu.PerThread, stage: InternPool.Memoized
         _ = zcu.transitive_failed_analysis.swapRemove(unit);
     } else {
         if (prev_failed) return error.AnalysisFail;
-        // We use an arbitrary field to check if the state has been resolved yet.
-        const val = switch (stage) {
-            .main => zcu.builtin_decl_values.Type,
-            .panic => zcu.builtin_decl_values.Panic,
-            .va_list => zcu.builtin_decl_values.VaList,
+        // We use an arbitrary element to check if the state has been resolved yet.
+        const to_check: Zcu.BuiltinDecl = switch (stage) {
+            .main => .Type,
+            .panic => .Panic,
+            .va_list => .VaList,
         };
-        if (val != .none) return;
+        if (zcu.builtin_decl_values.get(to_check) != .none) return;
     }
 
     const any_changed: bool, const new_failed: bool = if (pt.analyzeMemoizedState(stage)) |any_changed|

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -5754,9 +5754,7 @@ pub const FuncGen = struct {
         const o = fg.ng.object;
         const zcu = o.pt.zcu;
         const ip = &zcu.intern_pool;
-        const panic_msg_val: InternPool.Index = switch (panic_id) {
-            inline else => |ct_panic_id| @field(zcu.builtin_decl_values, "Panic.messages." ++ @tagName(ct_panic_id)),
-        };
+        const panic_msg_val = zcu.builtin_decl_values.get(panic_id.toBuiltin());
         assert(panic_msg_val != .none);
         const msg_len = Value.fromInterned(panic_msg_val).typeOf(zcu).childType(zcu).arrayLen(zcu);
         const msg_ptr = try o.lowerValue(panic_msg_val);
@@ -5770,7 +5768,7 @@ pub const FuncGen = struct {
         //   ptr null,                                               ; stack trace
         //   ptr @2,                                                 ; addr (null ?usize)
         // )
-        const panic_func = zcu.funcInfo(zcu.builtin_decl_values.@"Panic.call");
+        const panic_func = zcu.funcInfo(zcu.builtin_decl_values.get(.@"Panic.call"));
         const panic_nav = ip.getNav(panic_func.owner_nav);
         const fn_info = zcu.typeToFunc(Type.fromInterned(panic_nav.typeOf(ip))).?;
         const panic_global = try o.resolveLlvmFunction(panic_func.owner_nav);


### PR DESCRIPTION
Rather than `Zcu.BuiltinDecl.Memoized` being a struct with fields, it can instead just be an array, indexed by the enum. This allows runtime indexing, avoiding a few now-unnecessary `inline` switch cases.