### PR TITLE
std: add bit_set.findLastSet()

### DIFF
--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -547,8 +547,8 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
         pub fn findLastSet(self: Self) ?usize {
             if (self.bit_length == 0) return null;
             const bs = @bitSizeOf(MaskInt);
-            var len = self.bit_length / bs;
-            if (self.bit_length % bs != 0) len += 1;
+            var len = bit_length / bs;
+            if (bit_length % bs != 0) len += 1;
             var offset: usize = len * bs;
             var idx: usize = len - 1;
             while (self.masks[idx] == 0) : (idx -= 1) {

--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -184,6 +184,14 @@ pub fn IntegerBitSet(comptime size: u16) type {
             return @ctz(mask);
         }
 
+        /// Finds the index of the last set bit.
+        /// If no bits are set, returns null.
+        pub fn findLastSet(self: Self) ?usize {
+            const mask = self.mask;
+            if (mask == 0) return null;
+            return bit_length - @clz(mask) - 1;
+        }
+
         /// Finds the index of the first set bit, and unsets it.
         /// If no bits are set, returns null.
         pub fn toggleFirstSet(self: *Self) ?usize {
@@ -545,7 +553,7 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
         /// Finds the index of the last set bit.
         /// If no bits are set, returns null.
         pub fn findLastSet(self: Self) ?usize {
-            if (self.bit_length == 0) return null;
+            if (bit_length == 0) return null;
             const bs = @bitSizeOf(MaskInt);
             var len = bit_length / bs;
             if (bit_length % bs != 0) len += 1;

--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -184,6 +184,14 @@ pub fn IntegerBitSet(comptime size: u16) type {
             return @ctz(mask);
         }
 
+        /// Finds the index of the last set bit.
+        /// If no bits are set, returns null.
+        pub fn findLastSet(self: Self) ?usize {
+            const mask = self.mask;
+            if (mask == 0) return null;
+            return @clz(mask);
+        }
+
         /// Finds the index of the first set bit, and unsets it.
         /// If no bits are set, returns null.
         pub fn toggleFirstSet(self: *Self) ?usize {
@@ -540,6 +548,24 @@ pub fn ArrayBitSet(comptime MaskIntType: type, comptime size: usize) type {
                 offset += @bitSizeOf(MaskInt);
             } else return null;
             return offset + @ctz(mask);
+        }
+
+        /// Finds the index of the last set bit.
+        /// If no bits are set, returns null.
+        pub fn findLastSet(self: Self) ?usize {
+            if (self.bit_length == 0) return null;
+            const bs = @bitSizeOf(MaskInt);
+            var len = self.bit_length / bs;
+            if (self.bit_length % bs != 0) len += 1;
+            var offset: usize = len * bs;
+            var idx: usize = len - 1;
+            while (self.masks[idx] == 0) : (idx -= 1) {
+                offset -= bs;
+                if (idx == 0) return null;
+            }
+            offset -= @clz(self.masks[idx]);
+            offset -= 1;
+            return offset;
         }
 
         /// Finds the index of the first set bit, and unsets it.
@@ -941,6 +967,24 @@ pub const DynamicBitSetUnmanaged = struct {
         return offset + @ctz(mask[0]);
     }
 
+    /// Finds the index of the last set bit.
+    /// If no bits are set, returns null.
+    pub fn findLastSet(self: Self) ?usize {
+        if (self.bit_length == 0) return null;
+        const bs = @bitSizeOf(MaskInt);
+        var len = self.bit_length / bs;
+        if (self.bit_length % bs != 0) len += 1;
+        var offset: usize = len * bs;
+        var idx: usize = len - 1;
+        while (self.masks[idx] == 0) : (idx -= 1) {
+            offset -= bs;
+            if (idx == 0) return null;
+        }
+        offset -= @clz(self.masks[idx]);
+        offset -= 1;
+        return offset;
+    }
+
     /// Finds the index of the first set bit, and unsets it.
     /// If no bits are set, returns null.
     pub fn toggleFirstSet(self: *Self) ?usize {
@@ -1158,6 +1202,12 @@ pub const DynamicBitSet = struct {
     /// If no bits are set, returns null.
     pub fn findFirstSet(self: Self) ?usize {
         return self.unmanaged.findFirstSet();
+    }
+
+    /// Finds the index of the last set bit.
+    /// If no bits are set, returns null.
+    pub fn findLastSet(self: Self) ?usize {
+        return self.unmanaged.findLastSet();
     }
 
     /// Finds the index of the first set bit, and unsets it.
@@ -1514,8 +1564,10 @@ fn testBitSet(a: anytype, b: anytype, len: usize) !void {
         }
     }
     try testing.expectEqual(@as(?usize, null), a.findFirstSet());
+    try testing.expectEqual(@as(?usize, null), a.findLastSet());
     try testing.expectEqual(@as(?usize, null), a.toggleFirstSet());
     try testing.expectEqual(@as(?usize, null), a.findFirstSet());
+    try testing.expectEqual(@as(?usize, null), a.findLastSet());
     try testing.expectEqual(@as(?usize, null), a.toggleFirstSet());
     try testing.expectEqual(@as(usize, 0), a.count());
 

--- a/lib/std/bit_set.zig
+++ b/lib/std/bit_set.zig
@@ -184,14 +184,6 @@ pub fn IntegerBitSet(comptime size: u16) type {
             return @ctz(mask);
         }
 
-        /// Finds the index of the last set bit.
-        /// If no bits are set, returns null.
-        pub fn findLastSet(self: Self) ?usize {
-            const mask = self.mask;
-            if (mask == 0) return null;
-            return @clz(mask);
-        }
-
         /// Finds the index of the first set bit, and unsets it.
         /// If no bits are set, returns null.
         pub fn toggleFirstSet(self: *Self) ?usize {


### PR DESCRIPTION
pairs well as the opposite to `.findFirstSet()`

discovered api mismatch in https://github.com/nektro/zig-UrlValues/commit/e7a258f24ff0d760c6bfdb107b575ecead0a4e6b