### PR TITLE
Sema: rewrite semantic analysis of function calls

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ const assert = std.debug.assert;
 const DevEnv = @import("src/dev.zig").Env;
 
 const zig_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0 };
-const stack_size = 32 * 1024 * 1024;
+const stack_size = 46 * 1024 * 1024;
 
 pub fn build(b: *std.Build) !void {
     const only_c = b.option(bool, "only-c", "Translate the Zig compiler to C code, with only the C backend enabled") orelse false;

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -168,6 +168,7 @@ pub fn translate(
         context.pattern_list.deinit(gpa);
     }
 
+    @setEvalBranchQuota(2000);
     inline for (@typeInfo(std.zig.c_builtins).@"struct".decls) |decl| {
         const builtin_fn = try ZigTag.pub_var_simple.create(arena, .{
             .name = decl.name,

--- a/lib/std/math/log_int.zig
+++ b/lib/std/math/log_int.zig
@@ -61,6 +61,7 @@ pub fn log_int(comptime T: type, base: T, x: T) Log2Int(T) {
 }
 
 test "log_int" {
+    @setEvalBranchQuota(2000);
     // Test all unsigned integers with 2, 3, ..., 64 bits.
     // We cannot test 0 or 1 bits since base must be > 1.
     inline for (2..64 + 1) |bits| {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1468,6 +1468,7 @@ fn mountmgrIsVolumeName(name: []const u16) bool {
 }
 
 test mountmgrIsVolumeName {
+    @setEvalBranchQuota(2000);
     const L = std.unicode.utf8ToUtf16LeStringLiteral;
     try std.testing.expect(mountmgrIsVolumeName(L("\\\\?\\Volume{383da0b0-717f-41b6-8c36-00500992b58d}")));
     try std.testing.expect(mountmgrIsVolumeName(L("\\??\\Volume{383da0b0-717f-41b6-8c36-00500992b58d}")));

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -749,6 +749,8 @@ pub const SimpleComptimeReason = enum(u32) {
     array_mul_factor,
     slice_cat_operand,
     comptime_call_target,
+    inline_call_target,
+    generic_call_target,
     wasm_memory_index,
     work_group_dim_index,
 
@@ -791,7 +793,6 @@ pub const SimpleComptimeReason = enum(u32) {
     struct_field_default_value,
     enum_field_tag_value,
     slice_single_item_ptr_bounds,
-    comptime_param_arg,
     stored_to_comptime_field,
     stored_to_comptime_var,
     casted_to_comptime_enum,
@@ -828,6 +829,8 @@ pub const SimpleComptimeReason = enum(u32) {
             .array_mul_factor     => "array multiplication factor must be comptime-known",
             .slice_cat_operand    => "slice being concatenated must be comptime-known",
             .comptime_call_target => "function being called at comptime must be comptime-known",
+            .inline_call_target   => "function being called inline must be comptime-known",
+            .generic_call_target  => "generic function being called must be comptime-known",
             .wasm_memory_index    => "wasm memory index must be comptime-known",
             .work_group_dim_index => "work group dimension index must be comptime-known",
 
@@ -865,7 +868,6 @@ pub const SimpleComptimeReason = enum(u32) {
             .struct_field_default_value   => "struct field default value must be comptime-known",
             .enum_field_tag_value         => "enum field tag value must be comptime-known",
             .slice_single_item_ptr_bounds => "slice of single-item pointer must have comptime-known bounds",
-            .comptime_param_arg           => "argument to comptime parameter must be comptime-known",
             .stored_to_comptime_field     => "value stored to a comptime field must be comptime-known",
             .stored_to_comptime_var       => "value stored to a comptime variable must be comptime-known",
             .casted_to_comptime_enum      => "value casted to enum with 'comptime_int' tag type must be comptime-known",

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -10209,9 +10209,6 @@ fn callExpr(
 
     const callee = try calleeExpr(gz, scope, ri.rl, call.ast.fn_expr);
     const modifier: std.builtin.CallModifier = blk: {
-        if (gz.is_comptime) {
-            break :blk .compile_time;
-        }
         if (call.async_token != null) {
             break :blk .async_kw;
         }

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1928,6 +1928,24 @@ pub const SrcLoc = struct {
                     },
                 }
             },
+            .func_decl_param_comptime => |param_idx| {
+                const tree = try src_loc.file_scope.getTree(gpa);
+                var buf: [1]Ast.Node.Index = undefined;
+                const full = tree.fullFnProto(&buf, src_loc.base_node).?;
+                var param_it = full.iterate(tree);
+                for (0..param_idx) |_| assert(param_it.next() != null);
+                const param = param_it.next().?;
+                return tree.tokenToSpan(param.comptime_noalias.?);
+            },
+            .func_decl_param_ty => |param_idx| {
+                const tree = try src_loc.file_scope.getTree(gpa);
+                var buf: [1]Ast.Node.Index = undefined;
+                const full = tree.fullFnProto(&buf, src_loc.base_node).?;
+                var param_it = full.iterate(tree);
+                for (0..param_idx) |_| assert(param_it.next() != null);
+                const param = param_it.next().?;
+                return tree.nodeToSpan(param.type_expr);
+            },
         }
     }
 };
@@ -2235,6 +2253,12 @@ pub const LazySrcLoc = struct {
         /// The source location points to the "tag" capture (second capture) of
         /// a specific case of a `switch`.
         switch_tag_capture: SwitchCapture,
+        /// The source location points to the `comptime` token on the given comptime parameter,
+        /// where the base node is a function declaration. The value is the parameter index.
+        func_decl_param_comptime: u32,
+        /// The source location points to the type annotation on the given function parameter,
+        /// where the base node is a function declaration. The value is the parameter index.
+        func_decl_param_ty: u32,
 
         pub const FnProtoParam = struct {
             /// The offset of the function prototype AST node.

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -160,6 +160,7 @@ pub fn translate(
         context.pattern_list.deinit(gpa);
     }
 
+    @setEvalBranchQuota(2000);
     inline for (@typeInfo(std.zig.c_builtins).@"struct".decls) |decl| {
         const builtin = try Tag.pub_var_simple.create(arena, .{
             .name = decl.name,

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -363,7 +363,7 @@ test "comptime modification of const struct field" {
 }
 
 test "refer to the type of a generic function" {
-    const Func = fn (type) void;
+    const Func = fn (comptime type) void;
     const f: Func = doNothingWithType;
     f(i32);
 }

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -427,7 +427,7 @@ test "generic function passed as comptime argument" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
 
     const S = struct {
-        fn doMath(comptime f: fn (type, i32, i32) error{Overflow}!i32, a: i32, b: i32) !void {
+        fn doMath(comptime f: fn (comptime type, i32, i32) error{Overflow}!i32, a: i32, b: i32) !void {
             const result = try f(i32, a, b);
             try expect(result == 11);
         }

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1511,7 +1511,7 @@ test "if inside struct init inside if" {
 
 test "optional generic function label struct field" {
     const Options = struct {
-        isFoo: ?fn (type) u8 = defaultIsFoo,
+        isFoo: ?fn (comptime type) u8 = defaultIsFoo,
         fn defaultIsFoo(comptime _: type) u8 {
             return 123;
         }

--- a/test/behavior/typename.zig
+++ b/test/behavior/typename.zig
@@ -238,7 +238,7 @@ test "comptime parameters not converted to anytype in function type" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
 
-    const T = fn (fn (type) void, void) void;
+    const T = fn (comptime fn (comptime type) void, void) void;
     try expectEqualStrings("fn (comptime fn (comptime type) void, void) void", @typeName(T));
 }
 

--- a/test/cases/compile_errors/arg_to_non_comptime_param_with_comptime_only_type_is_not_evaluated_at_comptime.zig
+++ b/test/cases/compile_errors/arg_to_non_comptime_param_with_comptime_only_type_is_not_evaluated_at_comptime.zig
@@ -1,0 +1,36 @@
+//! Whew, that filename is a bit of a mouthful!
+//! To maximise consistency with other parts of the language, function arguments expressions are
+//! only *evaluated* at comptime if the parameter is declared `comptime`. If the parameter type is
+//! comptime-only, but the parameter is not declared `comptime`, the evaluation happens at runtime,
+//! and the value is just comptime-resolved.
+
+export fn foo() void {
+    // This function is itself generic, with the comptime-only parameter being generic.
+    simpleGeneric(type, if (cond()) u8 else u16);
+}
+
+export fn bar() void {
+    // This function is not generic; once `Wrapper` is called, its parameter type is immediately known.
+    Wrapper(type).inner(if (cond()) u8 else u16);
+}
+
+fn simpleGeneric(comptime T: type, _: T) void {}
+
+fn Wrapper(comptime T: type) type {
+    return struct {
+        fn inner(_: T) void {}
+    };
+}
+
+fn cond() bool {
+    return true;
+}
+
+// error
+//
+// :9:25: error: value with comptime-only type 'type' depends on runtime control flow
+// :9:33: note: runtime control flow here
+// :9:25: note: types are not available at runtime
+// :14:25: error: value with comptime-only type 'type' depends on runtime control flow
+// :14:33: note: runtime control flow here
+// :14:25: note: types are not available at runtime

--- a/test/cases/compile_errors/bad_usage_of_call.zig
+++ b/test/cases/compile_errors/bad_usage_of_call.zig
@@ -42,8 +42,8 @@ noinline fn dummy2() void {}
 // :2:23: error: expected a tuple, found 'void'
 // :5:21: error: unable to perform 'never_inline' call at compile-time
 // :8:21: error: unable to perform 'never_tail' call at compile-time
-// :11:5: error: 'never_inline' call of inline function
+// :11:5: error: cannot perform inline call with 'never_inline' modifier
 // :15:26: error: modifier 'compile_time' requires a comptime-known function
-// :18:9: error: 'always_inline' call of noinline function
-// :21:9: error: 'always_inline' call of noinline function
+// :18:9: error: inline call of noinline function
+// :21:9: error: inline call of noinline function
 // :26:27: error: modifier 'always_inline' requires a comptime-known function

--- a/test/cases/compile_errors/comptime_call_of_function_pointer.zig
+++ b/test/cases/compile_errors/comptime_call_of_function_pointer.zig
@@ -4,7 +4,6 @@ export fn entry() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
-// :3:20: error: comptime call of function pointer
+// :3:14: error: unable to resolve comptime value
+// :3:14: note: function being called at comptime must be comptime-known

--- a/test/cases/compile_errors/condition_comptime_reason_explained.zig
+++ b/test/cases/compile_errors/condition_comptime_reason_explained.zig
@@ -36,11 +36,13 @@ pub export fn entry2() void {
 //
 // :8:9: error: unable to resolve comptime value
 // :19:15: note: called at comptime from here
-// :7:13: note: function with comptime-only return type 'tmp.S' is evaluated at comptime
+// :19:15: note: call to function with comptime-only return type 'tmp.S' is evaluated at comptime
+// :7:13: note: return type declared here
 // :2:12: note: struct requires comptime because of this field
 // :2:12: note: use '*const fn () void' for a function pointer type
 // :22:13: error: unable to resolve comptime value
 // :32:19: note: called at comptime from here
-// :21:17: note: function with comptime-only return type 'tmp.S' is evaluated at comptime
+// :32:19: note: call to function with comptime-only return type 'tmp.S' is evaluated at comptime
+// :21:17: note: return type declared here
 // :2:12: note: struct requires comptime because of this field
 // :2:12: note: use '*const fn () void' for a function pointer type

--- a/test/cases/compile_errors/dereference_anyopaque.zig
+++ b/test/cases/compile_errors/dereference_anyopaque.zig
@@ -1,54 +1,7 @@
-const std = @import("std");
-
-const Error = error{Something};
-
-fn next() Error!void {
-    return;
-}
-
-fn parse(comptime T: type, allocator: std.mem.Allocator) !void {
-    parseFree(T, undefined, allocator);
-    _ = (try next()) != null;
-}
-
-fn parseFree(comptime T: type, value: T, allocator: std.mem.Allocator) void {
-    switch (@typeInfo(T)) {
-        .@"struct" => |structInfo| {
-            inline for (structInfo.fields) |field| {
-                if (!field.is_comptime)
-                    parseFree(field.type, undefined, allocator);
-            }
-        },
-        .pointer => |ptrInfo| {
-            switch (ptrInfo.size) {
-                .One => {
-                    parseFree(ptrInfo.child, value.*, allocator);
-                },
-                .Slice => {
-                    for (value) |v|
-                        parseFree(ptrInfo.child, v, allocator);
-                },
-                else => unreachable,
-            }
-        },
-        else => unreachable,
-    }
-}
-
-pub export fn entry() void {
-    const allocator = std.testing.failing_allocator;
-    _ = parse(std.StringArrayHashMap(bool), allocator) catch return;
+export fn foo(ptr: *anyopaque) void {
+    _ = ptr.*;
 }
 
 // error
-// target=native
-// backend=llvm
 //
-// :11:22: error: comparison of 'void' with null
-// :25:51: error: cannot load opaque type 'anyopaque'
-// :25:51: error: values of type 'fn (*anyopaque, usize, u8, usize) ?[*]u8' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn (*anyopaque, usize, u8, usize) ?[*]u8' for a function pointer type
-// :25:51: error: values of type 'fn (*anyopaque, []u8, u8, usize, usize) bool' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn (*anyopaque, []u8, u8, usize, usize) bool' for a function pointer type
-// :25:51: error: values of type 'fn (*anyopaque, []u8, u8, usize) void' must be comptime-known, but operand value is runtime-known
-// :25:51: note: use '*const fn (*anyopaque, []u8, u8, usize) void' for a function pointer type
+// :2:12: error: cannot load opaque type 'anyopaque'

--- a/test/cases/compile_errors/explain_why_fn_is_called_at_comptime.zig
+++ b/test/cases/compile_errors/explain_why_fn_is_called_at_comptime.zig
@@ -15,6 +15,7 @@ pub export fn entry() void {
 // error
 //
 // :12:13: error: unable to resolve comptime value
-// :7:16: note: function with comptime-only return type 'tmp.S' is evaluated at comptime
+// :12:12: note: call to function with comptime-only return type 'tmp.S' is evaluated at comptime
+// :7:16: note: return type declared here
 // :2:12: note: struct requires comptime because of this field
 // :2:12: note: use '*const fn () void' for a function pointer type

--- a/test/cases/compile_errors/explain_why_generic_fn_is_called_at_comptime.zig
+++ b/test/cases/compile_errors/explain_why_generic_fn_is_called_at_comptime.zig
@@ -17,6 +17,7 @@ pub export fn entry() void {
 // error
 //
 // :15:13: error: unable to resolve comptime value
-// :9:38: note: generic function instantiated with comptime-only return type 'tmp.S(fn () void)' is evaluated at comptime
+// :15:12: note: call to generic function instantiated with comptime-only return type 'tmp.S(fn () void)' is evaluated at comptime
+// :9:38: note: return type declared here
 // :3:16: note: struct requires comptime because of this field
 // :3:16: note: use '*const fn () void' for a function pointer type

--- a/test/cases/compile_errors/generic_function_instance_with_non-constant_expression.zig
+++ b/test/cases/compile_errors/generic_function_instance_with_non-constant_expression.zig
@@ -10,8 +10,7 @@ export fn entry() usize {
 }
 
 // error
-// backend=stage2
-// target=native
 //
-// :5:16: error: runtime-known argument passed to comptime parameter
-// :1:17: note: declared comptime here
+// :5:16: error: unable to resolve comptime value
+// :5:16: note: argument to comptime parameter must be comptime-known
+// :1:8: note: parameter declared comptime here

--- a/test/cases/compile_errors/generic_function_instantiation_inherits_parent_branch_quota.zig
+++ b/test/cases/compile_errors/generic_function_instantiation_inherits_parent_branch_quota.zig
@@ -22,9 +22,8 @@ fn Type(comptime n: usize) type {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :21:16: error: evaluation exceeded 1001 backwards branches
 // :21:16: note: use @setEvalBranchQuota() to raise the branch limit from 1001
 // :16:34: note: called from here
+// :8:15: note: called from here

--- a/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
@@ -40,3 +40,4 @@ pub fn is(comptime id: std.builtin.TypeId) TraitFn {
 // target=native
 //
 // :8:48: error: expected type 'type', found 'bool'
+// :5:21: note: called from here

--- a/test/cases/compile_errors/generic_method_call_with_invalid_param.zig
+++ b/test/cases/compile_errors/generic_method_call_with_invalid_param.zig
@@ -22,12 +22,11 @@ const S = struct {
 };
 
 // error
-// backend=stage2
-// target=native
 //
 // :3:18: error: expected type 'bool', found 'void'
 // :19:43: note: parameter type declared here
 // :8:18: error: expected type 'void', found 'bool'
 // :20:43: note: parameter type declared here
-// :15:26: error: runtime-known argument passed to comptime parameter
-// :21:57: note: declared comptime here
+// :15:26: error: unable to resolve comptime value
+// :15:26: note: argument to comptime parameter must be comptime-known
+// :21:48: note: parameter declared comptime here

--- a/test/cases/compile_errors/global_variable_initializer_must_be_constant_expression.zig
+++ b/test/cases/compile_errors/global_variable_initializer_must_be_constant_expression.zig
@@ -5,7 +5,5 @@ export fn entry() i32 {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :2:14: error: comptime call of extern function

--- a/test/cases/compile_errors/inline_call_runtime_value_to_comptime_param.zig
+++ b/test/cases/compile_errors/inline_call_runtime_value_to_comptime_param.zig
@@ -10,8 +10,7 @@ pub export fn entry() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :5:18: error: unable to resolve comptime value
 // :5:18: note: argument to comptime parameter must be comptime-known
+// :1:24: note: parameter declared comptime here

--- a/test/cases/compile_errors/invalid_extern_function_call.zig
+++ b/test/cases/compile_errors/invalid_extern_function_call.zig
@@ -9,8 +9,6 @@ export fn entry1() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
-// :4:15: error: comptime call of extern function pointer
-// :8:5: error: inline call of extern function pointer
+// :4:15: error: comptime call of extern function
+// :8:5: error: inline call of extern function

--- a/test/cases/compile_errors/invalid_pointer_for_var_type.zig
+++ b/test/cases/compile_errors/invalid_pointer_for_var_type.zig
@@ -7,7 +7,5 @@ export fn f() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :2:16: error: comptime call of extern function

--- a/test/cases/compile_errors/nested_generic_function_param_type_mismatch.zig
+++ b/test/cases/compile_errors/nested_generic_function_param_type_mismatch.zig
@@ -19,6 +19,6 @@ pub export fn entry() void {
 // backend=llvm
 // target=native
 //
-// :15:28: error: expected type '*const fn (comptime type, u8, u8) u32', found '*const fn (void, u8, u8) u32'
-// :15:28: note: pointer type child 'fn (void, u8, u8) u32' cannot cast into pointer type child 'fn (comptime type, u8, u8) u32'
+// :15:28: error: expected type '*const fn (type, u8, u8) u32', found '*const fn (void, u8, u8) u32'
+// :15:28: note: pointer type child 'fn (void, u8, u8) u32' cannot cast into pointer type child 'fn (type, u8, u8) u32'
 // :15:28: note: non-generic function cannot cast into a generic function

--- a/test/cases/compile_errors/never_inline_call_of_inline_fn_with_comptime_param.zig
+++ b/test/cases/compile_errors/never_inline_call_of_inline_fn_with_comptime_param.zig
@@ -19,5 +19,5 @@ export fn entry2() void {
 
 // error
 //
-// :14:5: error: 'never_inline' call of inline function
-// :17:5: error: 'never_inline' call of inline function
+// :14:5: error: cannot perform inline call with 'never_inline' modifier
+// :17:5: error: cannot perform inline call with 'never_inline' modifier

--- a/test/cases/compile_errors/non-const_expression_in_struct_literal_outside_function.zig
+++ b/test/cases/compile_errors/non-const_expression_in_struct_literal_outside_function.zig
@@ -9,7 +9,5 @@ export fn entry() usize {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :4:27: error: comptime call of extern function

--- a/test/cases/compile_errors/non_comptime_param_in_comptime_function.zig
+++ b/test/cases/compile_errors/non_comptime_param_in_comptime_function.zig
@@ -11,5 +11,6 @@ export fn entry() void {
 // error
 //
 // :8:11: error: unable to resolve comptime value
-// :1:20: note: function with comptime-only return type 'type' is evaluated at comptime
-// :1:20: note: types are not available at runtime
+// :8:10: note: call to function with comptime-only return type 'type' is evaluated at comptime
+// :1:20: note: return type declared here
+// :8:10: note: types are not available at runtime

--- a/test/cases/compile_errors/recursive_inline_fn.zig
+++ b/test/cases/compile_errors/recursive_inline_fn.zig
@@ -29,8 +29,10 @@ pub export fn entry2() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :5:27: error: inline call is recursive
+// :12:12: note: called from here
 // :24:10: error: inline call is recursive
+// :20:10: note: called from here
+// :16:11: note: called from here
+// :28:10: note: called from here

--- a/test/cases/compile_errors/runtime_operation_in_comptime_scope.zig
+++ b/test/cases/compile_errors/runtime_operation_in_comptime_scope.zig
@@ -27,8 +27,9 @@ var rt: u32 = undefined;
 // :19:5: note: operation is runtime due to this operand
 // :14:8: note: called at comptime from here
 // :10:12: note: called at comptime from here
-// :13:10: note: function with comptime-only return type 'type' is evaluated at comptime
-// :13:10: note: types are not available at runtime
+// :10:12: note: call to function with comptime-only return type 'type' is evaluated at comptime
+// :13:10: note: return type declared here
+// :10:12: note: types are not available at runtime
 // :2:8: note: called from here
 // :19:8: error: unable to evaluate comptime expression
 // :19:5: note: operation is runtime due to this operand

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -57,8 +57,9 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
             \\}
         , &[_][]const u8{
             ":3:12: error: unable to resolve comptime value",
-            ":2:55: note: generic function instantiated with comptime-only return type '?fn () void' is evaluated at comptime",
-            ":2:55: note: use '*const fn () void' for a function pointer type",
+            ":3:19: note: call to generic function instantiated with comptime-only return type '?fn () void' is evaluated at comptime",
+            ":2:55: note: return type declared here",
+            ":3:19: note: use '*const fn () void' for a function pointer type",
         });
         case.addSourceFile("b.zig",
             \\pub const ElfDynLib = struct {
@@ -193,10 +194,12 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
             \\    import.anytypeFunction(S{ .x = x, .y = u32 });
             \\}
         , &[_][]const u8{
-            ":4:33: error: runtime-known argument passed to comptime parameter",
-            ":1:38: note: declared comptime here",
-            ":8:36: error: runtime-known argument passed to comptime parameter",
-            ":2:41: note: declared comptime here",
+            ":4:33: error: unable to resolve comptime value",
+            ":4:33: note: argument to comptime parameter must be comptime-known",
+            ":1:29: note: parameter declared comptime here",
+            ":8:36: error: unable to resolve comptime value",
+            ":8:36: note: argument to comptime parameter must be comptime-known",
+            ":2:32: note: parameter declared comptime here",
             ":13:32: error: unable to resolve comptime value",
             ":13:32: note: initializer of comptime-only struct 'tmp.callAnytypeFunctionWithRuntimeComptimeOnlyType.S' must be comptime-known",
             ":12:35: note: struct requires comptime because of this field",

--- a/test/standalone/simple/std_enums_big_enums.zig
+++ b/test/standalone/simple/std_enums_big_enums.zig
@@ -31,6 +31,7 @@ pub fn main() void {
     var bounded_multiset = std.enums.BoundedEnumMultiset(big.Big, u8).init(.{});
     _ = &bounded_multiset;
 
+    @setEvalBranchQuota(3000);
     var array = std.enums.EnumArray(big.Big, u8).init(undefined);
     array = std.enums.EnumArray(big.Big, u8).initDefault(123, .{});
 }


### PR DESCRIPTION
This rewrite improves some error messages, hugely simplifies the logic, and fixes several bugs. One of these bugs is technically a new rule which Andrew and I agreed on: if a parameter has a comptime-only type but is not declared `comptime`, then the corresponding call argument should not be *evaluated* at comptime; only resolved. Implementing this required changing how function types work a little, which in turn required allowing a new kind of function coercion for some generic use cases: function coercions are now allowed to implicitly *remove* `comptime` annotations from parameters with comptime-only types. This is okay because removing the annotation affects only the call site.

Resolves: #22262

This **is** a breaking change, because it fixes a bug relating to eval branch quota. Previously, the usage of a "child Sema" when analyzing a generic function's call site meant we accidentally "duplicated" the eval branch quota. We no longer do this (I've actually concluded that the concept of a "child Sema" isn't really coherent), so a little more eval branch quota is used up on evaluating generic parameter/return types. That's why the changes to `lib/compiler/aro_translate_c.zig` and `src/translate_c.zig` were necessary. #22410 is **not** resolved by this PR; the buggy behavior of status quo is left intact.

I was considering also reworking the ZIR for function declarations in this PR, since it's very overcomplicated. However, I decided to leave that for now, since I'm planning to start playing around with a biiiig ZIR rewrite soon.