### PR TITLE
test: Enable long calls for all `thumb`/`thumbeb` module tests.

### DIFF
--- a/test/tests.zig
+++ b/test/tests.zig
@@ -425,41 +425,23 @@ const test_targets = blk: {
             .link_libc = true,
         },
 
-        .{
-            .target = .{
-                .cpu_arch = .thumb,
-                .os_tag = .linux,
-                .abi = .eabi,
-            },
-        },
-        .{
-            .target = .{
-                .cpu_arch = .thumb,
-                .os_tag = .linux,
-                .abi = .eabihf,
-            },
-        },
-        .{
-            .target = .{
-                .cpu_arch = .thumb,
-                .os_tag = .linux,
-                .abi = .musleabi,
-            },
-            .link_libc = true,
-            .skip_modules = &.{"std"},
-        },
-        .{
-            .target = .{
-                .cpu_arch = .thumb,
-                .os_tag = .linux,
-                .abi = .musleabihf,
-            },
-            .link_libc = true,
-            .skip_modules = &.{"std"},
-        },
         // Calls are normally lowered to branch instructions that only support +/- 16 MB range when
-        // targeting Thumb. This is not sufficient for the std test binary linked statically with
-        // musl, so use long calls to avoid out-of-range relocations.
+        // targeting Thumb. This easily becomes insufficient for our test binaries, so use long
+        // calls to avoid out-of-range relocations.
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "thumb-linux-eabi",
+                .cpu_features = "baseline+long_calls",
+            }) catch unreachable,
+            .pic = false, // Long calls don't work with PIC.
+        },
+        .{
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "thumb-linux-eabihf",
+                .cpu_features = "baseline+long_calls",
+            }) catch unreachable,
+            .pic = false, // Long calls don't work with PIC.
+        },
         .{
             .target = std.Target.Query.parse(.{
                 .arch_os_abi = "thumb-linux-musleabi",
@@ -467,12 +449,6 @@ const test_targets = blk: {
             }) catch unreachable,
             .link_libc = true,
             .pic = false, // Long calls don't work with PIC.
-            .skip_modules = &.{
-                "behavior",
-                "c-import",
-                "compiler-rt",
-                "universal-libc",
-            },
         },
         .{
             .target = std.Target.Query.parse(.{
@@ -481,49 +457,22 @@ const test_targets = blk: {
             }) catch unreachable,
             .link_libc = true,
             .pic = false, // Long calls don't work with PIC.
-            .skip_modules = &.{
-                "behavior",
-                "c-import",
-                "compiler-rt",
-                "universal-libc",
-            },
         },
 
         .{
-            .target = .{
-                .cpu_arch = .thumbeb,
-                .os_tag = .linux,
-                .abi = .eabi,
-            },
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "thumbeb-linux-eabi",
+                .cpu_features = "baseline+long_calls",
+            }) catch unreachable,
+            .pic = false, // Long calls don't work with PIC.
         },
         .{
-            .target = .{
-                .cpu_arch = .thumbeb,
-                .os_tag = .linux,
-                .abi = .eabihf,
-            },
+            .target = std.Target.Query.parse(.{
+                .arch_os_abi = "thumbeb-linux-eabihf",
+                .cpu_features = "baseline+long_calls",
+            }) catch unreachable,
+            .pic = false, // Long calls don't work with PIC.
         },
-        .{
-            .target = .{
-                .cpu_arch = .thumbeb,
-                .os_tag = .linux,
-                .abi = .musleabi,
-            },
-            .link_libc = true,
-            .skip_modules = &.{"std"},
-        },
-        .{
-            .target = .{
-                .cpu_arch = .thumbeb,
-                .os_tag = .linux,
-                .abi = .musleabihf,
-            },
-            .link_libc = true,
-            .skip_modules = &.{"std"},
-        },
-        // Calls are normally lowered to branch instructions that only support +/- 16 MB range when
-        // targeting Thumb. This is not sufficient for the std test binary linked statically with
-        // musl, so use long calls to avoid out-of-range relocations.
         .{
             .target = std.Target.Query.parse(.{
                 .arch_os_abi = "thumbeb-linux-musleabi",
@@ -531,12 +480,6 @@ const test_targets = blk: {
             }) catch unreachable,
             .link_libc = true,
             .pic = false, // Long calls don't work with PIC.
-            .skip_modules = &.{
-                "behavior",
-                "c-import",
-                "compiler-rt",
-                "universal-libc",
-            },
         },
         .{
             .target = std.Target.Query.parse(.{
@@ -545,12 +488,6 @@ const test_targets = blk: {
             }) catch unreachable,
             .link_libc = true,
             .pic = false, // Long calls don't work with PIC.
-            .skip_modules = &.{
-                "behavior",
-                "c-import",
-                "compiler-rt",
-                "universal-libc",
-            },
         },
 
         .{


### PR DESCRIPTION
The relocation range issues will happen eventually as we add more code to the standard library and test suites, so we may as well just deal with this now. @MasonRemaley ran into this in #20271, for example.