### PR TITLE
Autodoc: show line numbers in source code display

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -36,6 +36,15 @@
       code a {
         color: #000000;
       }
+      .source-code {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        align-items: start;
+      }
+      .source-line-numbers pre {
+        text-align: right;
+        color: #666;
+      }
       #listFields > div, #listParams > div {
         margin-bottom: 1em;
       }
@@ -400,7 +409,14 @@
     </div>
     <div id="sectSource" class="hidden">
       <h2>Source Code</h2>
-      <pre><code id="sourceText"></code></pre>
+      <div class="source-code">
+        <div class="source-line-numbers">
+          <pre><code id="sourceLineNumbers"></code></pre>
+        </div>
+        <div class="source-text">
+          <pre><code id="sourceText"></code></pre>
+        </div>
+      </div>
     </div>
     </section>
     <div id="helpDialog" class="hidden">

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -45,6 +45,7 @@
     const domSectTypes = document.getElementById("sectTypes");
     const domSectValues = document.getElementById("sectValues");
     const domSourceText = document.getElementById("sourceText");
+    const domSourceLineNumbers = document.getElementById("sourceLineNumbers");
     const domStatus = document.getElementById("status");
     const domTableFnErrors = document.getElementById("tableFnErrors");
     const domTldDocs = document.getElementById("tldDocs");
@@ -215,6 +216,7 @@
         href: location.hash,
       }]);
 
+      domSourceLineNumbers.innerHTML = declLineNumbersHtml(decl_index);
       domSourceText.innerHTML = declSourceHtml(decl_index);
 
       domSectSource.classList.remove("hidden");
@@ -366,6 +368,7 @@
       if (members.length !== 0 || fields.length !== 0) {
         renderNamespace(decl_index, members, fields);
       } else {
+        domSourceLineNumbers.innerHTML = declLineNumbersHtml(decl_index);
         domSourceText.innerHTML = declSourceHtml(decl_index);
         domSectSource.classList.remove("hidden");
       }
@@ -396,6 +399,7 @@
         renderErrorSet(base_decl, errorSetNodeList(decl_index, errorSetNode));
       }
 
+      domSourceLineNumbers.innerHTML = declLineNumbersHtml(decl_index);
       domSourceText.innerHTML = declSourceHtml(decl_index);
       domSectSource.classList.remove("hidden");
     }
@@ -410,6 +414,7 @@
         domTldDocs.classList.remove("hidden");
       }
 
+      domSourceLineNumbers.innerHTML = declLineNumbersHtml(decl_index);
       domSourceText.innerHTML = declSourceHtml(decl_index);
       domSectSource.classList.remove("hidden");
     }
@@ -888,6 +893,10 @@
 
     function declSourceHtml(decl_index) {
       return unwrapString(wasm_exports.decl_source_html(decl_index));
+    }
+
+    function declLineNumbersHtml(decl_index) {
+        return unwrapString(wasm_exports.decl_line_numbers_html(decl_index));
     }
 
     function declDoctestHtml(decl_index) {

--- a/lib/docs/wasm/html_render.zig
+++ b/lib/docs/wasm/html_render.zig
@@ -28,6 +28,20 @@ pub const Annotation = struct {
     dom_id: u32,
 };
 
+pub fn fileSourceLineNumbersHtml(
+    file_index: Walk.File.Index,
+    out: *std.ArrayListUnmanaged(u8),
+    root_node: Ast.Node.Index,
+) !void {
+    const ast = file_index.get_ast();
+    const first_token_line = ast.tokenLocation(0, ast.firstToken(root_node)).line;
+    const last_token_line = ast.tokenLocation(0, ast.lastToken(root_node)).line;
+    const writer = out.writer(gpa);
+    for (first_token_line..last_token_line + 1) |i| {
+        try std.fmt.format(writer, "<span>{d}</span>\n", .{i + 1});
+    }
+}
+
 pub fn fileSourceHtml(
     file_index: Walk.File.Index,
     out: *std.ArrayListUnmanaged(u8),

--- a/lib/docs/wasm/main.zig
+++ b/lib/docs/wasm/main.zig
@@ -7,6 +7,7 @@ const markdown = @import("markdown.zig");
 const Decl = Walk.Decl;
 
 const fileSourceHtml = @import("html_render.zig").fileSourceHtml;
+const fileSourceLineNumbersHtml = @import("html_render.zig").fileSourceLineNumbersHtml;
 const appendEscaped = @import("html_render.zig").appendEscaped;
 const resolveDeclLink = @import("html_render.zig").resolveDeclLink;
 const missing_feature_url_escape = @import("html_render.zig").missing_feature_url_escape;
@@ -515,6 +516,16 @@ export fn decl_fn_proto_html(decl_index: Decl.Index, linkify_fn_name: bool) Stri
         .fn_link = if (linkify_fn_name) decl_index else .none,
     }) catch |err| {
         fatal("unable to render source: {s}", .{@errorName(err)});
+    };
+    return String.init(string_result.items);
+}
+
+export fn decl_line_numbers_html(decl_index: Decl.Index) String {
+    const decl = decl_index.get();
+
+    string_result.clearRetainingCapacity();
+    fileSourceLineNumbersHtml(decl.file, &string_result, decl.ast_node) catch |err| {
+        fatal("unable to render source line numbers: {s}", .{@errorName(err)});
     };
     return String.init(string_result.items);
 }


### PR DESCRIPTION
This is just a small quality of life feature. 

Thanks to the autodoc using native ast, it displays correct line numbers even with a partial code snippet:
![image](https://github.com/user-attachments/assets/b6720eb9-3826-42f0-9ec3-f7285308aac5)
