### PR TITLE
std.os.windows: Change to handle Windows file time as `u64` value

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -517,9 +517,9 @@ pub fn stat(self: File) StatError!Stat {
                 .directory
             else
                 .file,
-            .atime = windows.fromSysTime(info.BasicInformation.LastAccessTime),
-            .mtime = windows.fromSysTime(info.BasicInformation.LastWriteTime),
-            .ctime = windows.fromSysTime(info.BasicInformation.ChangeTime),
+            .atime = windows.fromSysTime(@bitCast(info.BasicInformation.LastAccessTime)),
+            .mtime = windows.fromSysTime(@bitCast(info.BasicInformation.LastWriteTime)),
+            .ctime = windows.fromSysTime(@bitCast(info.BasicInformation.ChangeTime)),
         };
     }
 
@@ -1055,9 +1055,9 @@ pub fn metadata(self: File) MetadataError!Metadata {
                     .attributes = info.BasicInformation.FileAttributes,
                     .reparse_tag = reparse_tag,
                     ._size = @as(u64, @bitCast(info.StandardInformation.EndOfFile)),
-                    .access_time = windows.fromSysTime(info.BasicInformation.LastAccessTime),
-                    .modified_time = windows.fromSysTime(info.BasicInformation.LastWriteTime),
-                    .creation_time = windows.fromSysTime(info.BasicInformation.CreationTime),
+                    .access_time = windows.fromSysTime(@bitCast(info.BasicInformation.LastAccessTime)),
+                    .modified_time = windows.fromSysTime(@bitCast(info.BasicInformation.LastWriteTime)),
+                    .creation_time = windows.fromSysTime(@bitCast(info.BasicInformation.CreationTime)),
                 };
             },
             .linux => blk: {


### PR DESCRIPTION
[`FILETIME`](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime) structure stores a 64-bit unsigned integer value. The maximum value for this is "+60056-05-28 05:36:10.955161500 UTC". The maximum value of the `FILETIME` that [`FileTimeToSystemTime`](https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime) function accepts is "+30828-09-14 02:48:05.477580700 UTC". This is the same as the maximum value for a 64-bit signed integer or 63-bit unsigned integer types.

I've searched on these types and the timestamp of NTFS, and I think any value before "1601-01-01 00:00:00 UTC" is invalid. So I don't think we need to accept the negative Windows file time.

The maximum value of the NTFS timestamp and `FileTimeToSystemTime` function is "+30828-09-14 02:48:05.477580700 UTC", so `u63` might be better than `u64`.