### PR TITLE
add getDefault method to std.builtin.Type.StructField

### DIFF
--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -318,9 +318,7 @@ fn printStruct(options: *Options, out: anytype, comptime T: type, comptime val: 
             try out.print("    {p_}: {s}", .{ std.zig.fmtId(field.name), type_name });
         }
 
-        if (field.default_value != null) {
-            const default_value = @as(*field.type, @ptrCast(@alignCast(@constCast(field.default_value.?)))).*;
-
+        if (field.defaultValue()) |default_value| {
             try out.writeAll(" = ");
             switch (@typeInfo(@TypeOf(default_value))) {
                 .@"enum" => try out.print(".{s},\n", .{@tagName(default_value)}),

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -648,6 +648,13 @@ pub const Type = union(enum) {
         default_value: ?*const anyopaque,
         is_comptime: bool,
         alignment: comptime_int,
+
+        pub fn defaultValue(self: StructField) ?self.type {
+            return (self.defaultValuePtr() orelse return null).*;
+        }
+        pub fn defaultValuePtr(self: StructField) ?*const self.type {
+            return @ptrCast(@alignCast(self.default_value orelse return null));
+        }
     };
 
     /// This data structure is used by the Zig language code generation and

--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -787,12 +787,7 @@ fn sliceToEnum(comptime T: type, slice: []const u8) !T {
 fn fillDefaultStructValues(comptime T: type, r: *T, fields_seen: *[@typeInfo(T).@"struct".fields.len]bool) !void {
     inline for (@typeInfo(T).@"struct".fields, 0..) |field, i| {
         if (!fields_seen[i]) {
-            if (field.default_value) |default_ptr| {
-                const default = @as(*align(1) const field.type, @ptrCast(default_ptr)).*;
-                @field(r, field.name) = default;
-            } else {
-                return error.MissingField;
-            }
+            @field(r, field.name) = field.defaultValue() orelse return error.MissingField;
         }
     }
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -456,8 +456,7 @@ pub fn zeroInit(comptime T: type, init: anytype) T {
                                     @field(value, field.name) = @field(init, field.name);
                                 },
                             }
-                        } else if (field.default_value) |default_value_ptr| {
-                            const default_value = @as(*align(1) const field.type, @ptrCast(default_value_ptr)).*;
+                        } else if (field.defaultValue()) |default_value| {
                             @field(value, field.name) = default_value;
                         } else {
                             switch (@typeInfo(field.type)) {

--- a/test/behavior/tuple_declarations.zig
+++ b/test/behavior/tuple_declarations.zig
@@ -20,7 +20,7 @@ test "tuple declaration type info" {
 
         try expectEqualStrings(info.fields[0].name, "0");
         try expect(info.fields[0].type == u32);
-        try expect(@as(*const u32, @ptrCast(@alignCast(info.fields[0].default_value))).* == 1);
+        try expect(info.fields[0].defaultValue().? == 1);
         try expect(info.fields[0].is_comptime);
         try expect(info.fields[0].alignment == @alignOf(u32));
 


### PR DESCRIPTION
Leverages the type information in StructField to return the default value with the correct type.