### PR TITLE
std.atomic: change cache line size for RISC-V from 32 to 64 bytes

### DIFF
--- a/lib/std/atomic.zig
+++ b/lib/std/atomic.zig
@@ -436,7 +436,6 @@ pub fn cacheLineForCpu(cpu: std.Target.Cpu) u16 {
         // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mips.go#L7
         // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mipsle.go#L7
         // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_mips64x.go#L9
-        // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_riscv64.go#L7
         // - https://github.com/torvalds/linux/blob/3a7e02c040b130b5545e4b115aada7bacd80a2b6/arch/sparc/include/asm/cache.h#L14
         .arm,
         .armeb,
@@ -446,8 +445,6 @@ pub fn cacheLineForCpu(cpu: std.Target.Cpu) u16 {
         .mipsel,
         .mips64,
         .mips64el,
-        .riscv32,
-        .riscv64,
         .sparc,
         .sparc64,
         => 32,
@@ -471,6 +468,7 @@ pub fn cacheLineForCpu(cpu: std.Target.Cpu) u16 {
         // - https://github.com/golang/go/blob/dda2991c2ea0c5914714469c4defc2562a907230/src/internal/cpu/cpu_x86.go#L9
         // - https://github.com/golang/go/blob/0a9321ad7f8c91e1b0c7184731257df923977eb9/src/internal/cpu/cpu_loong64.go#L11
         // - https://github.com/golang/go/blob/3dd58676054223962cd915bb0934d1f9f489d4d2/src/internal/cpu/cpu_wasm.go#L7
+        // - https://github.com/golang/go/blob/19e923182e590ae6568c2c714f20f32512aeb3e3/src/internal/cpu/cpu_riscv64.go#L7
         // - https://github.com/torvalds/linux/blob/3a7e02c040b130b5545e4b115aada7bacd80a2b6/arch/xtensa/variants/csp/include/variant/core.h#L209
         // - https://github.com/torvalds/linux/blob/3a7e02c040b130b5545e4b115aada7bacd80a2b6/arch/csky/Kconfig#L183
         // - https://www.xmos.com/download/The-XMOS-XS3-Architecture.pdf


### PR DESCRIPTION
The Golang internals referenced have since changed to specify a size of 64 bytes, not 32. RISC-V profiles for application processors since RVA22 [have mandated 64-byte cache lines](https://github.com/riscv/riscv-profiles/blob/main/src/profiles.adoc#612-rva22u64-mandatory-extensions) via the `Zic64b` extension. There aren't any other extensions defined to indicate differently-sized cache lines, indicating the RISC-V ecosystem has effectively settled on 64 bytes.