### PR TITLE
behavior: referencing an extern means depending on it

### DIFF
--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -381,6 +381,11 @@ test "extern function used as generic parameter" {
             };
         }
     };
+    const E = struct {
+        export fn usedAsGenericParameterFoo() void {}
+        export fn usedAsGenericParameterBar() void {}
+    };
+    _ = E;
     try expect(S.usedAsGenericParameterBaz(S.usedAsGenericParameterFoo) !=
         S.usedAsGenericParameterBaz(S.usedAsGenericParameterBar));
 }

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -359,6 +359,30 @@ extern fn c_fputs([*c]const u8, noalias [*c]FILE) c_int;
 extern fn c_ftell([*c]FILE) c_long;
 extern fn c_fopen([*c]const u8, [*c]const u8) [*c]FILE;
 
+const exp = struct {
+    export fn c_printf(a: [*c]const u8) c_int {
+        _ = a;
+        unreachable;
+    }
+    export fn c_fputs(a: [*c]const u8, noalias b: [*c]FILE) c_int {
+        _ = a;
+        _ = b;
+        unreachable;
+    }
+    export fn c_ftell(a: [*c]FILE) c_long {
+        _ = a;
+        unreachable;
+    }
+    export fn c_fopen(a: [*c]const u8, b: [*c]const u8) [*c]FILE {
+        _ = a;
+        _ = b;
+        unreachable;
+    }
+};
+comptime {
+    _ = exp;
+}
+
 test "Extern function calls in @TypeOf" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
 
@@ -367,6 +391,14 @@ test "Extern function calls in @TypeOf" {
 
         extern fn s_do_thing([*c]const @This(), b: c_int) c_short;
     };
+    const E = struct {
+        export fn s_do_thing(a: [*c]const @This(), b: c_int) c_short {
+            _ = a;
+            _ = b;
+            unreachable;
+        }
+    };
+    _ = E;
 
     const Test = struct {
         fn test_fn_1(a: anytype, b: anytype) @TypeOf(c_printf("%d %s\n", a, b)) {

--- a/test/behavior/type_info.zig
+++ b/test/behavior/type_info.zig
@@ -357,6 +357,15 @@ test "type info: function type info" {
 }
 
 fn testFunction() !void {
+    const S = struct {
+        export fn typeInfoFoo() callconv(.c) usize {
+            unreachable;
+        }
+        export fn typeInfoFooAligned() callconv(.c) usize {
+            unreachable;
+        }
+    };
+    _ = S;
     const foo_fn_type = @TypeOf(typeInfoFoo);
     const foo_fn_info = @typeInfo(foo_fn_type);
     try expect(foo_fn_info.@"fn".calling_convention.eql(.c));


### PR DESCRIPTION
Relax the behavior tests so that the following language rule can be implemented without breaking the behavior tests:

The reference to `foo` here creates an external dependency on symbol `foo` even if not called.

```zig
extern fn foo() callconv(.c) void;
comptime {
    _ = foo;
}
```

Acceptance testing for this language rule is not implemented yet.