### PR TITLE
Type: `struct {}` does not have a well-defined layout

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -723,11 +723,7 @@ pub fn hasWellDefinedLayout(ty: Type, zcu: *const Zcu) bool {
             .generic_poison,
             => false,
         },
-        .struct_type => {
-            const struct_type = ip.loadStructType(ty.toIntern());
-            // Struct with no fields have a well-defined layout of no bits.
-            return struct_type.layout != .auto or struct_type.field_types.len == 0;
-        },
+        .struct_type => ip.loadStructType(ty.toIntern()).layout != .auto,
         .union_type => {
             const union_type = ip.loadUnionType(ty.toIntern());
             return switch (union_type.flagsUnordered(ip).runtime_tag) {

--- a/test/cases/compile_errors/dereference_bad_pointer_via_array_mul.zig
+++ b/test/cases/compile_errors/dereference_bad_pointer_via_array_mul.zig
@@ -1,0 +1,11 @@
+const A = struct {};
+const B = struct {};
+comptime {
+    const val: [1]A = .{.{}};
+    const ptr: *const [1]B = @ptrCast(&val);
+    _ = ptr ** 2;
+}
+
+// error
+//
+// :6:9: error: comptime dereference requires '[1]tmp.B' to have a well-defined layout


### PR DESCRIPTION
`Type.hasWellDefinedLayout` was in disagreement with pointer loading logic about auto-layout structs with zero fields, `struct {}`. For consistency, these types should not have a well-defined layout.

This is technically a breaking change.