### PR TITLE
`mingw`: Add upstream `RtlSecureZeroMemory` implementation.

### DIFF
--- a/lib/libc/mingw/crt/intrincs/RtlSecureZeroMemory.c
+++ b/lib/libc/mingw/crt/intrincs/RtlSecureZeroMemory.c
@@ -1,0 +1,17 @@
+#define __CRT__NO_INLINE 1
+#include <windows.h>
+
+PVOID WINAPI RtlSecureZeroMemory(PVOID ptr,SIZE_T cnt)
+{
+  volatile char *vptr = (volatile char *)ptr;
+#ifdef __x86_64
+  __stosb ((PBYTE)((DWORD64)vptr),0,cnt);
+#else
+  while (cnt != 0)
+    {
+      *vptr++ = 0;
+      cnt--;
+    }
+#endif /* __x86_64 */
+  return ptr;
+}

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -487,6 +487,7 @@ const mingw32_generic_src = [_][]const u8{
     "crt" ++ path.sep_str ++ "cxa_atexit.c",
     "crt" ++ path.sep_str ++ "cxa_thread_atexit.c",
     "crt" ++ path.sep_str ++ "tls_atexit.c",
+    "crt" ++ path.sep_str ++ "intrincs" ++ path.sep_str ++ "RtlSecureZeroMemory.c",
     // mingwex
     "cfguard" ++ path.sep_str ++ "mingw_cfguard_support.c",
     "complex" ++ path.sep_str ++ "_cabs.c",


### PR DESCRIPTION
Closes #22475.