### PR TITLE
fix backtraces produced by standard library under Wine

### DIFF
--- a/lib/std/debug/SelfInfo.zig
+++ b/lib/std/debug/SelfInfo.zig
@@ -1003,7 +1003,7 @@ fn readCoffDebugInfo(allocator: Allocator, coff_obj: *coff.Coff) !Module {
             di.dwarf = dwarf;
         }
 
-        const raw_path = try coff_obj.getPdbPath() orelse return di;
+        const raw_path = (coff_obj.getPdbPath() catch return error.InvalidDebugInfo) orelse return di;
         const path = blk: {
             if (fs.path.isAbsolute(raw_path)) {
                 break :blk raw_path;

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -1353,7 +1353,7 @@ pub fn realpathW(self: Dir, pathname: []const u16, out_buffer: []u8) RealPathErr
     defer w.CloseHandle(h_file);
 
     var wide_buf: [w.PATH_MAX_WIDE]u16 = undefined;
-    const wide_slice = try w.GetFinalPathNameByHandle(h_file, .{}, &wide_buf);
+    const wide_slice = try w.GetFinalPathNameByHandle(h_file, .{ .volume_name = .Nt }, &wide_buf);
     var big_out_buf: [fs.max_path_bytes]u8 = undefined;
     const end_index = std.unicode.wtf16LeToWtf8(&big_out_buf, wide_slice);
     if (end_index > out_buffer.len)


### PR DESCRIPTION
Quick Zig program to test changes (at `~/code/zig/build/example-dump-stacktrace/main.zig`):

```zig
pub const std = @import("std");

pub fn main() !void {
    var arena_allocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    defer arena_allocator.deinit();
    const allocator = arena_allocator.allocator();

    // Raw value from wine indicating location of the executable
    const image_path_name_unicode_string = std.os.windows.peb().ProcessParameters.ImagePathName;
    const image_path_name = image_path_name_unicode_string.Buffer.?[0 .. image_path_name_unicode_string.Length / @sizeOf(u16) :0];
    std.log.debug("{s}:{} PEB.ProcessParameters.ImagePathName = {}", .{ @src().file, @src().line, std.unicode.fmtUtf16Le(image_path_name) });

    const pathname_w = try std.os.windows.wToPrefixedFileW(null, image_path_name);
    std.log.info("{s}:{} wToPrefixedFileW() = {s}", .{ @src().file, @src().line, std.unicode.fmtUtf16Le(pathname_w.span()) });

    std.debug.dumpCurrentStackTrace(null);

    const self_path = try std.fs.selfExePathAlloc(allocator);
    std.log.info("{s}:{} self path = {s}", .{ @src().file, @src().line, self_path });
}
```

Before these changes:

```
~/code/zig/build/example-dump-stacktrace> ../stage3/bin/zig build-exe -target x86_64-windows-msvc ./main.zig; wine ./main.exe
00c8:err:ntoskrnl:ZwLoadDriver failed to create driver L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\winebth": c0000135
003c:fixme:service:scmdatabase_autostart_services Auto-start service L"winebth" failed to start: 126
debug: main.zig:11 PEB.ProcessParameters.ImagePathName = Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
info: main.zig:14 wToPrefixedFileW() = \??\Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
Unable to dump stack trace: Unexpected
error: Unexpected
Unable to dump stack trace: Unexpected
```

After commit 64ba10d0f7b0fbf783e983fdda733e7ed2fac451:

```
~/code/zig/build/example-dump-stacktrace> ../stage3/bin/zig build-exe -target x86_64-windows-msvc ./main.zig; wine ./main.exe
00c8:err:ntoskrnl:ZwLoadDriver failed to create driver L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\winebth": c0000135
003c:fixme:service:scmdatabase_autostart_services Auto-start service L"winebth" failed to start: 126
debug: main.zig:11 PEB.ProcessParameters.ImagePathName = Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
info: main.zig:14 wToPrefixedFileW() = \??\Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
/home/geemili/code/zig/lib/std/debug.zig:198:31: 0x140003b07 in dumpCurrentStackTrace (main.exe.obj)
        writeCurrentStackTrace(stderr, debug_info, io.tty.detectConfig(io.getStdErr()), start_addr) catch |err| {
                              ^
/main.zig:16:36: 0x1400019f5 in main (main.exe.obj)
/home/geemili/code/zig/lib/std/start.zig:475:53: 0x140003f47 in WinStartup (main.exe.obj)
    std.os.windows.ntdll.RtlExitUserProcess(callMain());
                                                    ^
Unable to dump stack trace: InvalidDebugDirectory
info: main.zig:19 self path = \??\Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
```

After commit 21a3b43d39f68d6ab3c7bf971ade4aec502df97c:

```
~/code/zig/build/example-dump-stacktrace> ../stage3/bin/zig build-exe -target x86_64-windows-msvc ./main.zig; wine ./main.exe
00c8:err:ntoskrnl:ZwLoadDriver failed to create driver L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\winebth": c0000135
003c:fixme:service:scmdatabase_autostart_services Auto-start service L"winebth" failed to start: 126
debug: main.zig:11 PEB.ProcessParameters.ImagePathName = Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
info: main.zig:14 wToPrefixedFileW() = \??\Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
/home/geemili/code/zig/lib/std/debug.zig:198:31: 0x140003b07 in dumpCurrentStackTrace (main.exe.obj)
        writeCurrentStackTrace(stderr, debug_info, io.tty.detectConfig(io.getStdErr()), start_addr) catch |err| {
                              ^
/main.zig:16:36: 0x1400019f5 in main (main.exe.obj)
/home/geemili/code/zig/lib/std/start.zig:475:53: 0x140003f47 in WinStartup (main.exe.obj)
    std.os.windows.ntdll.RtlExitUserProcess(callMain());
                                                    ^
???:?:?: 0x6fffffa547f8 in ??? (kernel32.dll)
???:?:?: 0x6fffffc2f93a in ??? (ntdll.dll)
info: main.zig:19 self path = \??\Z:\home\geemili\code\zig\build\example-dump-stacktrace\main.exe
```

These changes have not been tested on an actual windows machine yet, only under wine.