### PR TITLE
fix(x86_64): Make the encoder recognize ModR/M operands

### DIFF
--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -83,6 +83,7 @@ pub fn findByMnemonic(
                         .{ @tagName(data.mode), rex_required },
                     );
                 }
+                continue :next;
             },
             else => {},
         }

--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -31,7 +31,7 @@ pub fn findByMnemonic(
     prefix: Instruction.Prefix,
     mnemonic: Mnemonic,
     ops: []const Instruction.Operand,
-    show_canditates: bool,
+    show_candidates: bool,
 ) !?Encoding {
     var input_ops = [1]Op{.none} ** 4;
     for (input_ops[0..ops.len], ops) |*input_op, op| input_op.* = Op.fromOperand(op);
@@ -62,7 +62,7 @@ pub fn findByMnemonic(
     next: for (mnemonic_to_encodings_map[@intFromEnum(mnemonic)]) |data| {
         switch (data.mode) {
             .none, .short => if (rex_required) {
-                if (show_canditates) {
+                if (show_candidates) {
                     @branchHint(.unlikely);
                     reportCandidateMismatch(
                         data,
@@ -74,7 +74,7 @@ pub fn findByMnemonic(
                 continue :next;
             },
             .rex, .rex_short => if (!rex_required) {
-                if (show_canditates) {
+                if (show_candidates) {
                     @branchHint(.unlikely);
                     reportCandidateMismatch(
                         data,
@@ -89,7 +89,7 @@ pub fn findByMnemonic(
         }
 
         for (input_ops, data.ops) |input_op, data_op| if (!input_op.isSubset(data_op)) {
-            if (show_canditates) {
+            if (show_candidates) {
                 @branchHint(.unlikely);
                 reportCandidateMismatch(
                     data,

--- a/src/arch/x86_64/encoder.zig
+++ b/src/arch/x86_64/encoder.zig
@@ -316,7 +316,7 @@ pub const Instruction = struct {
 
     pub fn new(prefix: Prefix, mnemonic: Mnemonic, ops: []const Operand) !Instruction {
         const encoding: Encoding = switch (prefix) {
-            else => (try Encoding.findByMnemonic(prefix, mnemonic, ops)) orelse {
+            else => (try Encoding.findByMnemonic(prefix, mnemonic, ops, false)) orelse {
                 log.err("no encoding found for: {s} {s} {s} {s} {s} {s}", .{
                     @tagName(prefix),
                     @tagName(mnemonic),
@@ -325,6 +325,8 @@ pub const Instruction = struct {
                     @tagName(if (ops.len > 2) Encoding.Op.fromOperand(ops[2]) else .none),
                     @tagName(if (ops.len > 3) Encoding.Op.fromOperand(ops[3]) else .none),
                 });
+                _ = try Encoding.findByMnemonic(prefix, mnemonic, ops, true);
+
                 return error.InvalidInstruction;
             },
             .directive => .{


### PR DESCRIPTION
Hello :)

Fixes [#20955](https://github.com/ziglang/zig/issues/20955), I ran into it myself. Now I'm not certain about my x86_64 encoding skills (I just tried to follow how R/Ms are placed on https://www.felixcloutier.com/x86, extrapolated the rest). The sample given in the issue does compile and run though (so does zig itself built with this branch (at least on `x86_64-linux-gnu`)).

I also took the liberty to add some logging whenever the encoder can't find an instruction based on a mnemonic. It helped me spot the issue, I hope it might be useful going forward.