### PR TITLE
Classify empty environment variables as unset

### DIFF
--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -700,10 +700,6 @@ pub const EnvVar = enum {
     XDG_CACHE_HOME,
     HOME,
 
-    pub fn isSet(comptime ev: EnvVar) bool {
-        return std.process.hasEnvVarConstant(@tagName(ev));
-    }
-
     pub fn get(ev: EnvVar, arena: std.mem.Allocator) !?[]u8 {
         if (std.process.getEnvVarOwned(arena, @tagName(ev))) |value| {
             return value;
@@ -715,6 +711,11 @@ pub const EnvVar = enum {
 
     pub fn getPosix(comptime ev: EnvVar) ?[:0]const u8 {
         return std.posix.getenvZ(@tagName(ev));
+    }
+
+    pub fn isSet(ev: EnvVar, arena: std.mem.Allocator) !bool {
+        const value = try ev.get(arena) orelse return false;
+        return value.len != 0;
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -816,9 +816,9 @@ fn buildOutputType(
     var listen: Listen = .none;
     var debug_compile_errors = false;
     var verbose_link = (native_os != .wasi or builtin.link_libc) and
-        EnvVar.ZIG_VERBOSE_LINK.isSet();
+        try EnvVar.ZIG_VERBOSE_LINK.isSet(arena);
     var verbose_cc = (native_os != .wasi or builtin.link_libc) and
-        EnvVar.ZIG_VERBOSE_CC.isSet();
+        try EnvVar.ZIG_VERBOSE_CC.isSet(arena);
     var verbose_air = false;
     var verbose_intern_pool = false;
     var verbose_generic_instances = false;
@@ -996,9 +996,9 @@ fn buildOutputType(
     // if set, default the color setting to .off or .on, respectively
     // explicit --color arguments will still override this setting.
     // Disable color on WASI per https://github.com/WebAssembly/WASI/issues/162
-    var color: Color = if (native_os == .wasi or EnvVar.NO_COLOR.isSet())
+    var color: Color = if (native_os == .wasi or try EnvVar.NO_COLOR.isSet(arena))
         .off
-    else if (EnvVar.CLICOLOR_FORCE.isSet())
+    else if (try EnvVar.CLICOLOR_FORCE.isSet(arena))
         .on
     else
         .auto;
@@ -4741,9 +4741,9 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     var reference_trace: ?u32 = null;
     var debug_compile_errors = false;
     var verbose_link = (native_os != .wasi or builtin.link_libc) and
-        EnvVar.ZIG_VERBOSE_LINK.isSet();
+        try EnvVar.ZIG_VERBOSE_LINK.isSet(arena);
     var verbose_cc = (native_os != .wasi or builtin.link_libc) and
-        EnvVar.ZIG_VERBOSE_CC.isSet();
+        try EnvVar.ZIG_VERBOSE_CC.isSet(arena);
     var verbose_air = false;
     var verbose_intern_pool = false;
     var verbose_generic_instances = false;
@@ -4926,7 +4926,7 @@ fn cmdBuild(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     }
 
     const work_around_btrfs_bug = native_os == .linux and
-        EnvVar.ZIG_BTRFS_WORKAROUND.isSet();
+        try EnvVar.ZIG_BTRFS_WORKAROUND.isSet(arena);
     const root_prog_node = std.Progress.start(.{
         .disable_printing = (color == .off),
         .root_name = "Compile Build Script",
@@ -5424,7 +5424,7 @@ fn jitCmd(
         fatal("unable to find self exe path: {s}", .{@errorName(err)});
     };
 
-    const optimize_mode: std.builtin.OptimizeMode = if (EnvVar.ZIG_DEBUG_CMD.isSet())
+    const optimize_mode: std.builtin.OptimizeMode = if (try EnvVar.ZIG_DEBUG_CMD.isSet(arena))
         .Debug
     else
         .ReleaseFast;
@@ -6955,7 +6955,7 @@ fn cmdFetch(
 
     const color: Color = .auto;
     const work_around_btrfs_bug = native_os == .linux and
-        EnvVar.ZIG_BTRFS_WORKAROUND.isSet();
+        try EnvVar.ZIG_BTRFS_WORKAROUND.isSet(arena);
     var opt_path_or_url: ?[]const u8 = null;
     var override_global_cache_dir: ?[]const u8 = try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(arena);
     var debug_hash: bool = false;


### PR DESCRIPTION
Modifies EnvVar.isSet() to assume empty strings are unset. This is required for correctly parsing NO_COLOR values, and ifreund suggested that all variables should follow this behavior.

Closes #22380.