### PR TITLE
Fix compiler errors in std.process and std.Build.Step.Compile

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -601,7 +601,7 @@ pub fn forceUndefinedSymbol(compile: *Compile, symbol_name: []const u8) void {
 
 /// Returns whether the library, executable, or object depends on a particular system library.
 /// Includes transitive dependencies.
-pub fn dependsOnSystemLibrary(compile: *const Compile, name: []const u8) bool {
+pub fn dependsOnSystemLibrary(compile: *Compile, name: []const u8) bool {
     var is_linking_libc = false;
     var is_linking_libcpp = false;
 
@@ -613,8 +613,8 @@ pub fn dependsOnSystemLibrary(compile: *const Compile, name: []const u8) bool {
                     else => {},
                 }
             }
-            if (mod.link_libc) is_linking_libc = true;
-            if (mod.link_libcpp) is_linking_libcpp = true;
+            if (mod.link_libc orelse false) is_linking_libc = true;
+            if (mod.link_libcpp orelse false) is_linking_libcpp = true;
         }
     }
 

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -15,7 +15,7 @@ pub const Child = @import("process/Child.zig");
 pub const abort = posix.abort;
 pub const exit = posix.exit;
 pub const changeCurDir = posix.chdir;
-pub const changeCurDirC = posix.chdirC;
+pub const changeCurDirZ = posix.chdirZ;
 
 pub const GetCwdError = posix.GetCwdError;
 


### PR DESCRIPTION
Fixes
```zig
_ = &std.process.changeCurDirC;
_ = &std.Build.Step.Compile.dependsOnSystemLibrary;
```
from #20505.

Looks like `chdirC` was renamed `chdirZ` but that wasn't reflected in the `std.process` alias. I'm not sure if this alias is even needed, I couldn't find any references to `changeCurDir` in std.

For `dependsOnSystemLibrary`, it looks like because of the way it finds dependency libraries, `compile` can't be a `*const Compile`. And since `Module::link_libc` returns a `?bool` with `null` meaning "doesn't matter", I used best judgement and assigned it to false based on how `is_linking_libc` is being used.