### PR TITLE
std.Build: add build-id option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -197,12 +197,6 @@ pub fn build(b: *std.Build) !void {
     exe.pie = pie;
     exe.entitlements = entitlements;
 
-    exe.build_id = b.option(
-        std.zig.BuildId,
-        "build-id",
-        "Request creation of '.note.gnu.build-id' section",
-    );
-
     if (no_bin) {
         b.getInstallStep().dependOn(&exe.step);
     } else {

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1373,10 +1373,13 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  --zig-lib-dir [arg]          Override path to Zig lib directory
         \\  --build-runner [file]        Override path to build runner
         \\  --seed [integer]             For shuffling dependency traversal order (default: random)
-        \\  --build-id[=style]           At a minor link-time expense, coordinates stripped binaries
-        \\      fast, uuid, sha1, md5    with debug symbols via a '.note.gnu.build-id' section
-        \\      0x[hexstring]            Maximum 32 bytes
-        \\      none                     (default) Disable build-id
+        \\  --build-id[=style]           At a minor link-time expense, embeds a build ID in binaries
+        \\      fast                     8-byte non-cryptographic hash (COFF, ELF, WASM)
+        \\      sha1, tree               20-byte cryptographic hash (ELF, WASM)
+        \\      md5                      16-byte cryptographic hash (ELF)
+        \\      uuid                     16-byte random UUID (ELF, WASM)
+        \\      0x[hexstring]            Constant ID, maximum 32 bytes (ELF, WASM)
+        \\      none                     (default) No build ID
         \\  --debug-log [scope]          Enable debugging the compiler
         \\  --debug-pkg-config           Fail if unknown pkg-config flags encountered
         \\  --debug-rt                   Debug compiler runtime libraries

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -202,6 +202,15 @@ pub fn main() !void {
                         next_arg, @errorName(err),
                     });
                 };
+            } else if (mem.eql(u8, arg, "--build-id")) {
+                builder.build_id = .fast;
+            } else if (mem.startsWith(u8, arg, "--build-id=")) {
+                const style = arg["--build-id=".len..];
+                builder.build_id = std.zig.BuildId.parse(style) catch |err| {
+                    fatal("unable to parse --build-id style '{s}': {s}", .{
+                        style, @errorName(err),
+                    });
+                };
             } else if (mem.eql(u8, arg, "--debounce")) {
                 const next_arg = nextArg(args, &arg_idx) orelse
                     fatalWithHint("expected u16 after '{s}'", .{arg});
@@ -1364,6 +1373,10 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  --zig-lib-dir [arg]          Override path to Zig lib directory
         \\  --build-runner [file]        Override path to build runner
         \\  --seed [integer]             For shuffling dependency traversal order (default: random)
+        \\  --build-id[=style]           At a minor link-time expense, coordinates stripped binaries
+        \\      fast, uuid, sha1, md5    with debug symbols via a '.note.gnu.build-id' section
+        \\      0x[hexstring]            Maximum 32 bytes
+        \\      none                     (default) Disable build-id
         \\  --debug-log [scope]          Enable debugging the compiler
         \\  --debug-pkg-config           Fail if unknown pkg-config flags encountered
         \\  --debug-rt                   Debug compiler runtime libraries

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -94,6 +94,8 @@ available_deps: AvailableDeps,
 
 release_mode: ReleaseMode,
 
+build_id: ?std.zig.BuildId = null,
+
 pub const ReleaseMode = enum {
     off,
     any,

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1681,7 +1681,7 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
 
     try addFlag(&zig_args, "each-lib-rpath", compile.each_lib_rpath);
 
-    if (compile.build_id) |build_id| {
+    if (compile.build_id orelse b.build_id) |build_id| {
         try zig_args.append(switch (build_id) {
             .hexstring => |hs| b.fmt("--build-id=0x{s}", .{
                 std.fmt.fmtSliceHexLower(hs.toSlice()),

--- a/src/main.zig
+++ b/src/main.zig
@@ -570,10 +570,13 @@ const usage_build_generic =
     \\  -fno-allow-shlib-undefined     Disallows undefined symbols in shared libraries
     \\  -fallow-so-scripts             Allows .so files to be GNU ld scripts
     \\  -fno-allow-so-scripts          (default) .so files must be ELF files
-    \\  --build-id[=style]             At a minor link-time expense, coordinates stripped binaries
-    \\      fast, uuid, sha1, md5      with debug symbols via a '.note.gnu.build-id' section
-    \\      0x[hexstring]              Maximum 32 bytes
-    \\      none                       (default) Disable build-id
+    \\  --build-id[=style]             At a minor link-time expense, embeds a build ID in binaries
+    \\      fast                       8-byte non-cryptographic hash (COFF, ELF, WASM)
+    \\      sha1, tree                 20-byte cryptographic hash (ELF, WASM)
+    \\      md5                        16-byte cryptographic hash (ELF)
+    \\      uuid                       16-byte random UUID (ELF, WASM)
+    \\      0x[hexstring]              Constant ID, maximum 32 bytes (ELF, WASM)
+    \\      none                     (default) No build ID
     \\  --eh-frame-hdr                 Enable C++ exception handling by passing --eh-frame-hdr to linker
     \\  --no-eh-frame-hdr              Disable C++ exception handling by passing --no-eh-frame-hdr to linker
     \\  --emit-relocs                  Enable output of relocation sections for post build tools


### PR DESCRIPTION
adds a `build-id` option to the build runner and a `build_id` property to `std.Build`.

the value of `std.Build.build_id` is used when `std.Build.Step.Compile.build_id` has not been explicitly specified.

This is useful for distro packagers and anyone who wants to specify a build-id for a whole project unless explicitly specified in the build logic itself.

