### PR TITLE
autodocs: reflow comment to prevent it from been put in blockquote

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2844,8 +2844,8 @@ pub const Managed = struct {
         return a.toConst().orderAbs(b.toConst());
     }
 
-    /// Returns math.Order.lt, math.Order.eq, math.Order.gt if a < b, a == b or a
-    /// > b respectively.
+    /// Returns math.Order.lt, math.Order.eq, math.Order.gt if a < b, a == b or a > b
+    /// respectively.
     pub fn order(a: Managed, b: Managed) math.Order {
         return a.toConst().order(b.toConst());
     }


### PR DESCRIPTION
closes #22498

Greped for similar types of mistakes in codebase but it seems to be the only one of kind. 
Would be usefull to create a tool to find them. Like https://github.com/ziglang/zig/issues/21660 but for markdown errors instead of typos.