### PR TITLE
x86_64: enable struct field reordering

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -720,7 +720,7 @@ pub inline fn backendSupportsFeature(backend: std.builtin.CompilerBackend, compt
             else => false,
         },
         .field_reordering => switch (backend) {
-            .stage2_c, .stage2_llvm => true,
+            .stage2_c, .stage2_llvm, .stage2_x86_64 => true,
             else => false,
         },
         .safety_checked_instructions => switch (backend) {


### PR DESCRIPTION
The blocker for enabling this feature was my need to debug the emitted assembly without debug info and having to manually inspect memory to determine struct contents.  However, we now have debug info!

    (lldb) v -L foo bar
    0x00007fffffffda20: (repro.repro.Foo) foo = {
    0x00007fffffffda24:   .x = 12
    0x00007fffffffda20:   .y = 34
    }
    0x00007fffffffda28: (repro.repro.Bar) bar = {
    0x00007fffffffda28:   .x = 56
    0x00007fffffffda2c:   .y = 78
    }

Updates #21530