### PR TITLE
`libunwind`: Build C files with `-fexceptions`.

### DIFF
--- a/src/libunwind.zig
+++ b/src/libunwind.zig
@@ -36,8 +36,7 @@ pub fn buildStaticLib(comp: *Compilation, prog_node: std.Progress.Node) BuildErr
         .root_optimize_mode = comp.compilerRtOptMode(),
         .root_strip = comp.compilerRtStrip(),
         .link_libc = true,
-        // Disable LTO to avoid https://github.com/llvm/llvm-project/issues/56825
-        .lto = .none,
+        .lto = comp.config.lto,
     }) catch |err| {
         comp.setMiscFailure(
             .libunwind,
@@ -102,18 +101,18 @@ pub fn buildStaticLib(comp: *Compilation, prog_node: std.Progress.Node) BuildErr
 
         switch (Compilation.classifyFileExt(unwind_src)) {
             .c => {
-                try cflags.append("-std=c17");
-            },
-            .cpp => {
-                try cflags.appendSlice(&[_][]const u8{
-                    "-std=c++17",
-                    "-fno-rtti",
+                try cflags.appendSlice(&.{
+                    "-std=c99",
+                    "-fexceptions",
                 });
             },
+            .cpp => {
+                try cflags.append("-fno-exceptions");
+                try cflags.append("-fno-rtti");
+            },
             .assembly_with_cpp => {},
-            else => unreachable, // You can see the entire list of files just above.
+            else => unreachable, // See `unwind_src_list`.
         }
-        try cflags.append("-fno-exceptions");
         try cflags.append("-I");
         try cflags.append(try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libunwind", "include" }));
         try cflags.append("-D_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS");


### PR DESCRIPTION
See: https://github.com/llvm/llvm-project/pull/121819

This fixes LTO for libunwind, so also re-enable support for that.