### PR TITLE
`std.Thread`: Fix `wasi_thread_start()` export to use a pointer.

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -1022,7 +1022,7 @@ const WasiThreadImpl = struct {
 
     comptime {
         if (!builtin.single_threaded) {
-            @export(wasi_thread_start, .{ .name = "wasi_thread_start" });
+            @export(&wasi_thread_start, .{ .name = "wasi_thread_start" });
         }
     }
 


### PR DESCRIPTION
Closes #22518.