### PR TITLE
`std.zig.system`: Move CPU feature hacks after ABI detection.

### DIFF
--- a/lib/compiler_rt/memcpy.zig
+++ b/lib/compiler_rt/memcpy.zig
@@ -9,36 +9,12 @@ comptime {
     }
 }
 
-const llvm_cannot_lower = switch (builtin.cpu.arch) {
-    .arm, .armeb, .thumb, .thumbeb => builtin.zig_backend == .stage2_llvm,
-    else => false,
-};
-
 fn memcpy(noalias opt_dest: ?[*]u8, noalias opt_src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
-    if (llvm_cannot_lower) {
-        for (0..len) |i| opt_dest.?[i] = opt_src.?[i];
-        return opt_dest;
-    } else {
-        return memmove(opt_dest, opt_src, len);
-    }
+    return memmove(opt_dest, opt_src, len);
 }
 
-/// A port of https://github.com/facebook/folly/blob/1c8bc50e88804e2a7361a57cd9b551dd10f6c5fd/folly/memcpy.S
 fn memmove(opt_dest: ?[*]u8, opt_src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
-    if (llvm_cannot_lower) {
-        if (@intFromPtr(opt_dest) < @intFromPtr(opt_src)) {
-            for (0..len) |i| opt_dest.?[i] = opt_src.?[i];
-            return opt_dest;
-        } else {
-            var index = len;
-            while (index != 0) {
-                index -= 1;
-                opt_dest.?[index] = opt_src.?[index];
-            }
-            return opt_dest;
-        }
-    }
-
+    // a port of https://github.com/facebook/folly/blob/1c8bc50e88804e2a7361a57cd9b551dd10f6c5fd/folly/memcpy.S
     if (len == 0) {
         @branchHint(.unlikely);
         return opt_dest;


### PR DESCRIPTION
This was accidentally broken in #22434. See https://github.com/ziglang/zig/pull/22513#issuecomment-2599684094 for an explanation.

cc @andrewrk @Rexicon226