### PR TITLE
std.debug: fix format on ConfigurableTrace

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -1513,7 +1513,7 @@ pub fn ConfigurableTrace(comptime size: usize, comptime stack_frame_count: usize
         }
 
         pub fn format(
-            t: Trace,
+            t: @This(),
             comptime fmt: []const u8,
             options: std.fmt.FormatOptions,
             writer: anytype,


### PR DESCRIPTION
It was impossible to use format on any ConfigurableTrace which is not configured exactly like std.debug.Trace. And produced really sus results like so


This works perfectly fine.

```zig
const std = @import("std");
const builtin = @import("builtin");

const Trace = std.debug.ConfigurableTrace(2, 4, true);

pub fn main() !void {
    if (@hasDecl(Trace, "format")) {
        std.debug.print("{}\n", .{Trace.init});
    }
}
```
```sh
> zig run main.zig


```
Now if I change any number in ConfigurableTrace for example 4 -> 5
```zig
const std = @import("std");
const builtin = @import("builtin");

const Trace = std.debug.ConfigurableTrace(2, 5, true);

pub fn main() !void {
    if (@hasDecl(Trace, "format")) {
        std.debug.print("{}\n", .{Trace.init});
    }
}
```
```sh
> zig run main.zig
/home/andrewkraevskii/.zvm/master/lib/std/fmt.zig:508:25: error: no field or member function named 'format' in 'debug.ConfigurableTrace(2,5,true)'
        return try value.format(actual_fmt, options, writer);
                   ~~~~~^~~~~~~
/home/andrewkraevskii/.zvm/master/lib/std/debug.zig:1439:12: note: struct declared here
    return struct {
           ^~~~~~
/home/andrewkraevskii/.zvm/master/lib/std/debug.zig:1515:13: note: 'format' is not a member function
        pub fn format(
        ~~~~^~
referenced by:
    format__anon_3429: /home/andrewkraevskii/.zvm/master/lib/std/fmt.zig:188:23
    print__anon_2983: /home/andrewkraevskii/.zvm/master/lib/std/io/Writer.zig:24:26
    7 reference(s) hidden; use '-freference-trace=9' to see all references
```

