### PR TITLE
std.Build: add support for adding specific global search paths

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2140,9 +2140,13 @@ pub const SearchMethod = union(enum) {
 };
 
 pub fn addSearchPrefix(b: *Build, search_prefix: []const u8) void {
-    b.search_methods.append(b.allocator, .{
+    b.addSearchMethod(.{
         .prefix = .{ .cwd_relative = b.dupePath(search_prefix) },
-    }) catch @panic("OOM");
+    });
+}
+
+pub fn addSearchMethod(b: *Build, search_method: SearchMethod) void {
+    b.search_methods.append(b.allocator, search_method) catch @panic("OOM");
 }
 
 pub fn getInstallPath(b: *Build, dir: InstallDir, dest_rel_path: []const u8) []const u8 {


### PR DESCRIPTION
This allows more granularity when adding search paths, complementing
`--search-prefix` for more specific use-cases.

## Multi-arch library layout

On systems with multilib support (e.g. Gentoo with 32-bit and 64-bit
libraries in `/usr/lib` and `/usr/lib64` respectively), using
`--search-prefix` option can cause incorrect library selected.

For example, if I want to link system `libcurl` library when building
Zig program for non-native or explicit native-compatible target,
I can try using `--search-prefix /usr`, which will automatically add:
 * `/usr/bin` as search path for binaries (fine),
 * `/usr/lib` as search path for libraries (incorrect),
 * `/usr/include` as search path for includes (fine),

In my case it will find 32-bit libraries for 64-bit target, causing
linker errors:

```console
$ zig build -Dtarget=x86_64-linux-gnu.2.35 --search-prefix /usr

error: ld.lld: /usr/lib/libcurl.so is incompatible with elf_x86_64
```

New `--search-paths` option allows to add search paths explicitly,
using passed ZON file as a specification. You can repeat multiple
times to add many different search paths if needed.

```zig
.{
    .binaries = "/usr/bin"
    .libraries = "/usr/lib64",
    .includes = "/usr/include",
}
```

## Other layouts (GCC or Android NDK etc.)

Another use-case is when binaries, libraries and includes are
distributed across different hierarchies. Suppose I want to correctly
find `gcc` binary and link `gccjit` library for my project:

```zig
.{
    .binaries = "/usr/x86_64-pc-linux-gnu/gcc-bin/14/",
    .libraries = "/usr/lib/gcc/x86_64-pc-linux-gnu/14",
    .includes = "/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/",
}
```

Or use Android NDK:

```zig
.{
    // you can omit fields or set `null` if you don't want to search them.
    // .binaries = null,

    .libraries = "/path_to_ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/35",
    .includes = "/path_to_ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include",
}
```

```zig
.{
    .libraries = "/path_to_ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android",
}
```