### PR TITLE
std.Build: add `addLibrary` function

### DIFF
--- a/lib/init/build.zig
+++ b/lib/init/build.zig
@@ -47,7 +47,8 @@ pub fn build(b: *std.Build) void {
     // Now, we will create a static library based on the module we created above.
     // This creates a `std.Build.Step.Compile`, which is the build step responsible
     // for actually invoking the compiler.
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "$",
         .root_module = lib_mod,
     });

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -873,6 +873,7 @@ pub const SharedLibraryOptions = struct {
     error_tracing: ?bool = null,
 };
 
+/// Deprecated: use `b.addLibrary(.{ ..., .linkage = .dynamic })` instead.
 pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile {
     if (options.root_module != null and options.target != null) {
         @panic("`root_module` and `target` cannot both be populated");
@@ -943,6 +944,7 @@ pub const StaticLibraryOptions = struct {
     error_tracing: ?bool = null,
 };
 
+/// Deprecated: use `b.addLibrary(.{ ..., .linkage = .static })` instead.
 pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile {
     if (options.root_module != null and options.target != null) {
         @panic("`root_module` and `target` cannot both be populated");
@@ -970,6 +972,38 @@ pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile 
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
         .zig_lib_dir = options.zig_lib_dir,
+    });
+}
+
+pub const LibraryOptions = struct {
+    linkage: std.builtin.LinkMode = .static,
+    name: []const u8,
+    root_module: *Module,
+    version: ?std.SemanticVersion = null,
+    max_rss: usize = 0,
+    use_llvm: ?bool = null,
+    use_lld: ?bool = null,
+    zig_lib_dir: ?LazyPath = null,
+    /// Embed a `.manifest` file in the compilation if the object format supports it.
+    /// https://learn.microsoft.com/en-us/windows/win32/sbscs/manifest-files-reference
+    /// Manifest files must have the extension `.manifest`.
+    /// Can be set regardless of target. The `.manifest` file will be ignored
+    /// if the target object format does not support embedded manifests.
+    win32_manifest: ?LazyPath = null,
+};
+
+pub fn addLibrary(b: *Build, options: LibraryOptions) *Step.Compile {
+    return .create(b, .{
+        .name = options.name,
+        .root_module = options.root_module,
+        .kind = .lib,
+        .linkage = options.linkage,
+        .version = options.version,
+        .max_rss = options.max_rss,
+        .use_llvm = options.use_llvm,
+        .use_lld = options.use_lld,
+        .zig_lib_dir = options.zig_lib_dir,
+        .win32_manifest = options.win32_manifest,
     });
 }
 

--- a/test/behavior/x86_64/build.zig
+++ b/test/behavior/x86_64/build.zig
@@ -6,7 +6,8 @@ pub fn build(b: *std.Build) void {
         "Skip tests that do not match any filter",
     ) orelse &[0][]const u8{};
 
-    const compiler_rt_lib = b.addStaticLibrary(.{
+    const compiler_rt_lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "compiler_rt",
         .use_llvm = false,
         .use_lld = false,

--- a/test/link/common_symbols/build.zig
+++ b/test/link/common_symbols/build.zig
@@ -11,7 +11,8 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib_a = b.addStaticLibrary(.{
+    const lib_a = b.addLibrary(.{
+        .linkage = .static,
         .name = "a",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/link/common_symbols_alignment/build.zig
+++ b/test/link/common_symbols_alignment/build.zig
@@ -11,7 +11,8 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib_a = b.addStaticLibrary(.{
+    const lib_a = b.addLibrary(.{
+        .linkage = .static,
         .name = "a",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/link/interdependent_static_c_libs/build.zig
+++ b/test/link/interdependent_static_c_libs/build.zig
@@ -11,7 +11,8 @@ pub fn build(b: *std.Build) void {
 }
 
 fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.OptimizeMode) void {
-    const lib_a = b.addStaticLibrary(.{
+    const lib_a = b.addLibrary(.{
+        .linkage = .static,
         .name = "a",
         .root_module = b.createModule(.{
             .root_source_file = null,
@@ -22,7 +23,8 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
     lib_a.root_module.addCSourceFile(.{ .file = b.path("a.c"), .flags = &[_][]const u8{} });
     lib_a.root_module.addIncludePath(b.path("."));
 
-    const lib_b = b.addStaticLibrary(.{
+    const lib_b = b.addLibrary(.{
+        .linkage = .static,
         .name = "b",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/link/link.zig
+++ b/test/link/link.zig
@@ -65,7 +65,8 @@ pub fn addObject(b: *Build, base: Options, overlay: OverlayOptions) *Compile {
 }
 
 pub fn addStaticLibrary(b: *Build, base: Options, overlay: OverlayOptions) *Compile {
-    return b.addStaticLibrary(.{
+    return b.addLibrary(.{
+        .linkage = .static,
         .name = overlay.name,
         .root_module = createModule(b, base, overlay),
         .use_llvm = base.use_llvm,
@@ -74,7 +75,8 @@ pub fn addStaticLibrary(b: *Build, base: Options, overlay: OverlayOptions) *Comp
 }
 
 pub fn addSharedLibrary(b: *Build, base: Options, overlay: OverlayOptions) *Compile {
-    return b.addSharedLibrary(.{
+    return b.addLibrary(.{
+        .linkage = .dynamic,
         .name = overlay.name,
         .root_module = createModule(b, base, overlay),
         .use_llvm = base.use_llvm,

--- a/test/link/static_libs_from_object_files/build.zig
+++ b/test/link/static_libs_from_object_files/build.zig
@@ -85,11 +85,13 @@ fn add(b: *Build, test_step: *Step, files: []const LazyPath, optimize: std.built
             mod.addCSourceFile(.{ .file = file, .flags = &flags });
         }
 
-        const lib_a = b.addStaticLibrary(.{
+        const lib_a = b.addLibrary(.{
+            .linkage = .static,
             .name = "test2_a",
             .root_module = mod_a,
         });
-        const lib_b = b.addStaticLibrary(.{
+        const lib_b = b.addLibrary(.{
+            .linkage = .static,
             .name = "test2_b",
             .root_module = mod_b,
         });
@@ -130,11 +132,13 @@ fn add(b: *Build, test_step: *Step, files: []const LazyPath, optimize: std.built
             lib_mod.addObject(obj);
         }
 
-        const lib_a = b.addStaticLibrary(.{
+        const lib_a = b.addLibrary(.{
+            .linkage = .static,
             .name = "test3_a",
             .root_module = mod_a,
         });
-        const lib_b = b.addStaticLibrary(.{
+        const lib_b = b.addLibrary(.{
+            .linkage = .static,
             .name = "test3_b",
             .root_module = mod_b,
         });

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -684,7 +684,8 @@ pub fn lowerToBuildSteps(
                 .name = case.name,
                 .root_module = mod,
             }),
-            .Lib => b.addStaticLibrary(.{
+            .Lib => b.addLibrary(.{
+                .linkage = .static,
                 .name = case.name,
                 .root_module = mod,
             }),

--- a/test/standalone/coff_dwarf/build.zig
+++ b/test/standalone/coff_dwarf/build.zig
@@ -21,7 +21,8 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = "shared_lib",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/standalone/dep_duplicate_module/build.zig
+++ b/test/standalone/dep_duplicate_module/build.zig
@@ -23,7 +23,8 @@ pub fn build(b: *std.Build) void {
     lib_mod.addImport("mod", shared_mod);
     exe_mod.addImport("mod", shared_mod);
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "lib",
         .root_module = lib_mod,
     });

--- a/test/standalone/extern/build.zig
+++ b/test/standalone/extern/build.zig
@@ -14,7 +14,8 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    const shared = b.addSharedLibrary(.{
+    const shared = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = "shared",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/standalone/global_linkage/build.zig
+++ b/test/standalone/global_linkage/build.zig
@@ -7,7 +7,8 @@ pub fn build(b: *std.Build) void {
     const optimize: std.builtin.OptimizeMode = .Debug;
     const target = b.graph.host;
 
-    const obj1 = b.addStaticLibrary(.{
+    const obj1 = b.addLibrary(.{
+        .linkage = .static,
         .name = "obj1",
         .root_module = b.createModule(.{
             .root_source_file = b.path("obj1.zig"),
@@ -16,7 +17,8 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
-    const obj2 = b.addStaticLibrary(.{
+    const obj2 = b.addLibrary(.{
+        .linkage = .static,
         .name = "obj2",
         .root_module = b.createModule(.{
             .root_source_file = b.path("obj2.zig"),

--- a/test/standalone/install_headers/build.zig
+++ b/test/standalone/install_headers/build.zig
@@ -6,7 +6,8 @@ pub fn build(b: *std.Build) void {
 
     const empty_c = b.addWriteFiles().add("empty.c", "");
 
-    const libfoo = b.addStaticLibrary(.{
+    const libfoo = b.addLibrary(.{
+        .linkage = .static,
         .name = "foo",
         .root_module = b.createModule(.{
             .root_source_file = null,
@@ -61,7 +62,8 @@ pub fn build(b: *std.Build) void {
         .FOO_CONFIG_2 = "2",
     }));
 
-    const libbar = b.addStaticLibrary(.{
+    const libbar = b.addLibrary(.{
+        .linkage = .static,
         .name = "bar",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/standalone/load_dynamic_library/build.zig
+++ b/test/standalone/load_dynamic_library/build.zig
@@ -10,7 +10,8 @@ pub fn build(b: *std.Build) void {
 
     if (builtin.os.tag == .wasi) return;
 
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = "add",
         .version = .{ .major = 1, .minor = 0, .patch = 0 },
         .root_module = b.createModule(.{

--- a/test/standalone/shared_library/build.zig
+++ b/test/standalone/shared_library/build.zig
@@ -6,7 +6,8 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
     const target = b.graph.host;
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = "mathtest",
         .version = .{ .major = 1, .minor = 0, .patch = 0 },
         .root_module = b.createModule(.{

--- a/test/standalone/stack_iterator/build.zig
+++ b/test/standalone/stack_iterator/build.zig
@@ -68,7 +68,8 @@ pub fn build(b: *std.Build) void {
     //     - x86_64: STACK_IMMD, STACK_IND
     //     - aarch64: FRAMELESS, DWARF
     {
-        const c_shared_lib = b.addSharedLibrary(.{
+        const c_shared_lib = b.addLibrary(.{
+            .linkage = .dynamic,
             .name = "c_shared_lib",
             .root_module = b.createModule(.{
                 .root_source_file = null,

--- a/test/standalone/static_c_lib/build.zig
+++ b/test/standalone/static_c_lib/build.zig
@@ -6,7 +6,8 @@ pub fn build(b: *std.Build) void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    const foo = b.addStaticLibrary(.{
+    const foo = b.addLibrary(.{
+        .linkage = .static,
         .name = "foo",
         .root_module = b.createModule(.{
             .root_source_file = null,

--- a/test/standalone/windows_argv/build.zig
+++ b/test/standalone/windows_argv/build.zig
@@ -9,7 +9,8 @@ pub fn build(b: *std.Build) !void {
 
     const optimize: std.builtin.OptimizeMode = .Debug;
 
-    const lib_gnu = b.addStaticLibrary(.{
+    const lib_gnu = b.addLibrary(.{
+        .linkage = .static,
         .name = "toargv-gnu",
         .root_module = b.createModule(.{
             .root_source_file = b.path("lib.zig"),
@@ -74,7 +75,8 @@ pub fn build(b: *std.Build) !void {
         break :has_msvc true;
     };
     if (has_msvc) {
-        const lib_msvc = b.addStaticLibrary(.{
+        const lib_msvc = b.addLibrary(.{
+            .linkage = .static,
             .name = "toargv-msvc",
             .root_module = b.createModule(.{
                 .root_source_file = b.path("lib.zig"),


### PR DESCRIPTION
Extracted as own PR as mentioned in https://github.com/ziglang/zig/pull/20388#issuecomment-2380867994 .
    
Acts as a replacement for `addSharedLibrary` and `addStaticLibrary`, but
linking mode can be changed more easily in build.zig, for example:
   
In library:
```zig
const linkage = b.option(std.builtin.LinkMode, "linkage", "Link mode for a foo_bar library") orelse .static; // or other default
    
const lib = b.addLibrary(.{
    .linkage = linkage,
    .name = "foo_bar",
    .root_module = mod,
});
```
    
In consumer:
```zig
const dep_foo_bar = b.dependency("foo_bar", .{
    .target = target,
    .optimize = optimize,
    .linkage = .dynamic // or leave for default static
});
    
mod.linkLibrary(dep_foor_bar.artifact("foo_bar"));
```
    
It also matches nicely with `linkLibrary` name.