### PR TITLE
Implement `if_nametoindex` for windows

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -752,6 +752,19 @@ fn if_nametoindex(name: []const u8) IPv6InterfaceError!u32 {
         return @as(u32, @bitCast(index));
     }
 
+    if (native_os == .windows) {
+        if (name.len >= posix.IFNAMESIZE)
+            return error.NameTooLong;
+
+        var interface_name: [posix.IFNAMESIZE:0]u8 = undefined;
+        @memcpy(interface_name[0..name.len], name);
+        interface_name[name.len] = 0;
+        const index = std.os.windows.ws2_32.if_nametoindex(@as([*:0]const u8, &interface_name));
+        if (index == 0)
+            return error.InterfaceNotFound;
+        return index;
+    }
+
     @compileError("std.net.if_nametoindex unimplemented for this OS");
 }
 

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -76,7 +76,8 @@ test "parse and render IPv6 addresses" {
     // TODO Make this test pass on other operating systems.
     if (builtin.os.tag == .linux or comptime builtin.os.tag.isDarwin() or builtin.os.tag == .windows) {
         try testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
-        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0s0s0s0s0s0s0", 0));
+        // Assumes IFNAMESIZE will always be a multiple of 2
+        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3" ++ "s0" ** @divExact(std.posix.IFNAMESIZE - 4, 2), 0));
         try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
     }
 }

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -77,7 +77,7 @@ test "parse and render IPv6 addresses" {
     if (builtin.os.tag == .linux or comptime builtin.os.tag.isDarwin() or builtin.os.tag == .windows) {
         try testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
         try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0s0s0s0s0s0s0", 0));
-        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234567890123456789012", 0));
+        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
     }
 }
 

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -76,8 +76,8 @@ test "parse and render IPv6 addresses" {
     // TODO Make this test pass on other operating systems.
     if (builtin.os.tag == .linux or comptime builtin.os.tag.isDarwin() or builtin.os.tag == .windows) {
         try testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
-        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0", 0));
-        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
+        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0s0s0s0s0s0s0", 0));
+        try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234567890123456789012", 0));
     }
 }
 

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -74,7 +74,7 @@ test "parse and render IPv6 addresses" {
     try testing.expectError(error.InvalidIpv4Mapping, net.Address.parseIp6("::123.123.123.123", 0));
     try testing.expectError(error.Incomplete, net.Address.parseIp6("1", 0));
     // TODO Make this test pass on other operating systems.
-    if (builtin.os.tag == .linux or comptime builtin.os.tag.isDarwin()) {
+    if (builtin.os.tag == .linux or comptime builtin.os.tag.isDarwin() or builtin.os.tag == .windows) {
         try testing.expectError(error.Incomplete, net.Address.resolveIp6("ff01::fb%", 0));
         try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%wlp3s0s0s0s0s0s0s0s0", 0));
         try testing.expectError(error.Overflow, net.Address.resolveIp6("ff01::fb%12345678901234", 0));
@@ -82,7 +82,7 @@ test "parse and render IPv6 addresses" {
 }
 
 test "invalid but parseable IPv6 scope ids" {
-    if (builtin.os.tag != .linux and comptime !builtin.os.tag.isDarwin()) {
+    if (builtin.os.tag != .linux and comptime !builtin.os.tag.isDarwin() and builtin.os.tag != .windows) {
         // Currently, resolveIp6 with alphanumerical scope IDs only works on Linux.
         // TODO Make this test pass on other operating systems.
         return error.SkipZigTest;
@@ -206,7 +206,7 @@ test "listen on a port, send bytes, receive bytes" {
 }
 
 test "listen on an in use port" {
-    if (builtin.os.tag != .linux and comptime !builtin.os.tag.isDarwin()) {
+    if (builtin.os.tag != .linux and comptime !builtin.os.tag.isDarwin() and builtin.os.tag != .windows) {
         // TODO build abstractions for other operating systems
         return error.SkipZigTest;
     }


### PR DESCRIPTION
This implements the `if_nametoindex` function for windows.

I noticed zig threw a compile error when trying to compile the zigdig example code for windows.
If I read the code correctly, and looking at issue #20530, this seems also hinder all IP resolution on windows, even though `if_nametoindex` is only called in the ipv4 codepath.

I pieced this code together from looking at the darwin implementation and the old std.x namespace, which also contained an implementation for windows.

This seems to pass all test, except for this one https://github.com/ziglang/zig/blob/d5db02728ce3ff3ba74a3e3f9050c3ea9ed34752/lib/std/net/test.zig#L79. As far as I understand, the `error.Overflow` case should be handled before `if_nametoindex` is even called. If someone can help me fix this case, I'd be happy for any pointers.

I'm also happy about any other pointers and things I should fix.

Fixes https://github.com/ziglang/zig/issues/20530.