### PR TITLE
Sema: fix `is_non_null_ptr` handling for runtime-known pointers

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -4114,6 +4114,16 @@ pub fn containerTypeName(ty: Type, ip: *const InternPool) InternPool.NullTermina
     };
 }
 
+/// Returns `true` if a value of this type is always `null`.
+/// Returns `false` if a value of this type is neve `null`.
+/// Returns `null` otherwise.
+pub fn isNullFromType(ty: Type, zcu: *const Zcu) ?bool {
+    if (ty.zigTypeTag(zcu) != .optional and !ty.isCPtr(zcu)) return false;
+    const child = ty.optionalChild(zcu);
+    if (child.zigTypeTag(zcu) == .noreturn) return true; // `?noreturn` is always null
+    return null;
+}
+
 pub const @"u1": Type = .{ .ip_index = .u1_type };
 pub const @"u8": Type = .{ .ip_index = .u8_type };
 pub const @"u16": Type = .{ .ip_index = .u16_type };

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -498,6 +498,20 @@ test "optional of noreturn used with orelse" {
     try expect(val == 123);
 }
 
+test "mutable optional of noreturn" {
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+
+    var a: ?noreturn = null;
+    if (a) |*ptr| {
+        _ = ptr;
+        @compileError("bad");
+    } else {
+        // this is what we expect to hit
+        return;
+    }
+    @compileError("bad");
+}
+
 test "orelse on C pointer" {
 
     // TODO https://github.com/ziglang/zig/issues/6597

--- a/test/cases/compile_errors/branch_in_comptime_only_scope_uses_condbr_inline.zig
+++ b/test/cases/compile_errors/branch_in_comptime_only_scope_uses_condbr_inline.zig
@@ -15,11 +15,9 @@ pub export fn entry2() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :5:15: error: unable to evaluate comptime expression
 // :5:13: note: operation is runtime due to this operand
 // :4:72: note: '@shuffle' mask must be comptime-known
-// :13:11: error: unable to evaluate comptime expression
+// :13:11: error: unable to resolve comptime value
 // :12:72: note: '@shuffle' mask must be comptime-known


### PR DESCRIPTION
We can still potentially determine a comptime result based on the type, even if the pointer is runtime-known.

Also, we previously used load -> is non null instead of AIR `is_non_null_ptr` if the pointer is comptime-known, but that's a bad heuristic. Instead, we should check for the pointer to be comptime-known, *and* for the load to be comptime-known, and only in that case should we call `Sema.analyzeIsNonNull`.

Resolves: #22556