### PR TITLE
std.zig.system: remove assert that inspected path is absolute

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1020,8 +1020,8 @@ fn resolveElfFileRecursively(cwd: fs.Dir, start_path: []const u8) error{UnableTo
     var buffer: [255 + 1]u8 = undefined;
     while (true) {
         // Interpreter path can be relative on Linux, but
-        // for simplicity we are asserting it is an absolute path.
-        assert(std.fs.path.isAbsolute(current_path));
+        // for simplicity we are assuming it is an absolute path.
+        // It can also be a relative path from PATH environment variable.
         const file = cwd.openFile(current_path, .{}) catch |err| switch (err) {
             error.NoSpaceLeft => unreachable,
             error.NameTooLong => unreachable,


### PR DESCRIPTION
Followup to https://github.com/ziglang/zig/pull/21540

It can also have relative path if PATH has relative path, so just run it with `cwd`. Also it can be a relative shebang path (which is not handled yet) and it's better to skip it rather than crash compiler.

Resolves #22566