### PR TITLE
Fix invisible doccomments at the start of source files to make them visible

### DIFF
--- a/lib/std/compress/flate/Lookup.zig
+++ b/lib/std/compress/flate/Lookup.zig
@@ -1,7 +1,7 @@
-/// Lookup of the previous locations for the same 4 byte data. Works on hash of
-/// 4 bytes data. Head contains position of the first match for each hash. Chain
-/// points to the previous position of the same hash given the current location.
-///
+//! Lookup of the previous locations for the same 4 byte data. Works on hash of
+//! 4 bytes data. Head contains position of the first match for each hash. Chain
+//! points to the previous position of the same hash given the current location.
+
 const std = @import("std");
 const testing = std.testing;
 const expect = testing.expect;

--- a/lib/std/zip.zig
+++ b/lib/std/zip.zig
@@ -1,8 +1,8 @@
-/// The .ZIP File Format Specification is found here:
-///    https://pkwaredownloads.blob.core.windows.net/pem/APPNOTE.txt
-///
-/// Note that this file uses the abbreviation "cd" for "central directory"
-///
+//! The .ZIP File Format Specification is found here:
+//!    https://pkwaredownloads.blob.core.windows.net/pem/APPNOTE.txt
+
+// Note that this file uses the abbreviation "cd" for "central directory"
+
 const builtin = @import("builtin");
 const std = @import("std");
 const testing = std.testing;

--- a/lib/std/zip.zig
+++ b/lib/std/zip.zig
@@ -1,7 +1,7 @@
 //! The .ZIP File Format Specification is found here:
 //!    https://pkwaredownloads.blob.core.windows.net/pem/APPNOTE.txt
-
-// Note that this file uses the abbreviation "cd" for "central directory"
+//!
+//! Note that this file uses the abbreviation "cd" for "central directory"
 
 const builtin = @import("builtin");
 const std = @import("std");


### PR DESCRIPTION
When I was looking at [`lib/std/compress/flate/Lookup.zig`](https://ziglang.org/documentation/master/std/#std.compress.flate.Lookup) and [`lib/std/zip.zig`](https://ziglang.org/documentation/master/std/#std.zip) in <https://ziglang.org/documentation/master/std/>, I noticed that the doc comments at the start of them were not visible.

I think it would be better if these doc comments is top-level doc comments rather than doc comments. Because it is at the start of the source file. Also, given the context, I don't think these are doc comments for `const std = @import("std");` and `const builtin = @import("builtin");`. This makes these doc comments visible.

However, the last paragraph of doc comments in `lib/std/zip.zig` replaces doc comments with normal comments. This is because I thought that normal comments would be more appropriate than top-level doc comments given the context of the last paragraph.