### PR TITLE
std.posix.setsockopt: EOPNOTSUPP can be returned

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -6752,6 +6752,7 @@ pub const SetSockOptError = error{
     // Setting the socket option requires more elevated permissions.
     PermissionDenied,
 
+    OperationNotSupported,
     NetworkSubsystemFailed,
     FileDescriptorNotASocket,
     SocketNotBound,
@@ -6787,6 +6788,7 @@ pub fn setsockopt(fd: socket_t, level: i32, optname: u32, opt: []const u8) SetSo
             .NOBUFS => return error.SystemResources,
             .PERM => return error.PermissionDenied,
             .NODEV => return error.NoDevice,
+            .OPNOTSUPP => return error.OperationNotSupported,
             else => |err| return unexpectedErrno(err),
         }
     }


### PR DESCRIPTION
On Linux, set REUSEPORT option on an unix socket returns a EOPNOTSUPP error.
See https://github.com/torvalds/linux/commit/5b0af621c3f6ef9261cf6067812f2fd9943acb4b