### PR TITLE
std.net.listen: no REUSEPORT with unix socket

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -248,7 +248,7 @@ pub const Address = extern union {
                 posix.SO.REUSEADDR,
                 &mem.toBytes(@as(c_int, 1)),
             );
-            if (@hasDecl(posix.SO, "REUSEPORT")) {
+            if (@hasDecl(posix.SO, "REUSEPORT") and address.any.family != posix.AF.UNIX) {
                 try posix.setsockopt(
                     sockfd,
                     posix.SOL.SOCKET,

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -296,6 +296,21 @@ test "listen on a unix socket, send bytes, receive bytes" {
     try testing.expectEqualSlices(u8, "Hello world!", buf[0..n]);
 }
 
+test "listen on a unix socket with reuse_port option" {
+    if (!net.has_unix_sockets) return error.SkipZigTest;
+    // Windows doesn't implement reuse port option.
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const socket_path = try generateFileName("socket.unix");
+    defer testing.allocator.free(socket_path);
+
+    const socket_addr = try net.Address.initUnix(socket_path);
+    defer std.fs.cwd().deleteFile(socket_path) catch {};
+
+    var server = try socket_addr.listen(.{ .reuse_port = true });
+    server.deinit();
+}
+
 fn generateFileName(base_name: []const u8) ![]const u8 {
     const random_bytes_count = 12;
     const sub_path_len = comptime std.fs.base64_encoder.calcSize(random_bytes_count);


### PR DESCRIPTION
On Linux, set REUSEPORT option on an unix socket returns a EOPNOTSUPP error.
See https://github.com/torvalds/linux/commit/5b0af621c3f6ef9261cf6067812f2fd9943acb4b