### PR TITLE
std.Build: Deprecate `Step.Compile` APIs that mutate the root module

### DIFF
--- a/doc/langref/build.zig
+++ b/doc/langref/build.zig
@@ -4,8 +4,10 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const exe = b.addExecutable(.{
         .name = "example",
-        .root_source_file = b.path("example.zig"),
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("example.zig"),
+            .optimize = optimize,
+        }),
     });
     b.default_step.dependOn(&exe.step);
 }

--- a/doc/langref/build_c.zig
+++ b/doc/langref/build_c.zig
@@ -4,15 +4,19 @@ pub fn build(b: *std.Build) void {
     const lib = b.addLibrary(.{
         .linkage = .dynamic,
         .name = "mathtest",
-        .root_source_file = b.path("mathtest.zig"),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("mathtest.zig"),
+        }),
         .version = .{ .major = 1, .minor = 0, .patch = 0 },
     });
     const exe = b.addExecutable(.{
         .name = "test",
+        .root_module = b.createModule(.{
+            .link_libc = true,
+        }),
     });
-    exe.addCSourceFile(.{ .file = b.path("test.c"), .flags = &.{"-std=c99"} });
-    exe.linkLibrary(lib);
-    exe.linkSystemLibrary("c");
+    exe.root_module.addCSourceFile(.{ .file = b.path("test.c"), .flags = &.{"-std=c99"} });
+    exe.root_module.linkLibrary(lib);
 
     b.default_step.dependOn(&exe.step);
 

--- a/doc/langref/build_object.zig
+++ b/doc/langref/build_object.zig
@@ -3,15 +3,19 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const obj = b.addObject(.{
         .name = "base64",
-        .root_source_file = b.path("base64.zig"),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("base64.zig"),
+        }),
     });
 
     const exe = b.addExecutable(.{
         .name = "test",
+        .root_module = b.createModule(.{
+            .link_libc = true,
+        }),
     });
-    exe.addCSourceFile(.{ .file = b.path("test.c"), .flags = &.{"-std=c99"} });
-    exe.addObject(obj);
-    exe.linkSystemLibrary("c");
+    exe.root_module.addCSourceFile(.{ .file = b.path("test.c"), .flags = &.{"-std=c99"} });
+    exe.root_module.addObject(obj);
     b.installArtifact(exe);
 }
 

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -681,10 +681,14 @@ pub fn producesImplib(compile: *Compile) bool {
     return compile.isDll();
 }
 
+/// Deprecated; use `compile.root_module.link_libc = true` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn linkLibC(compile: *Compile) void {
     compile.root_module.link_libc = true;
 }
 
+/// Deprecated; use `compile.root_module.link_libcpp = true` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn linkLibCpp(compile: *Compile) void {
     compile.root_module.link_libcpp = true;
 }
@@ -802,10 +806,14 @@ fn runPkgConfig(compile: *Compile, lib_name: []const u8) !PkgConfigResult {
     };
 }
 
+/// Deprecated; use `compile.root_module.linkSystemLibrary(name, .{})` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn linkSystemLibrary(compile: *Compile, name: []const u8) void {
     return compile.root_module.linkSystemLibrary(name, .{});
 }
 
+/// Deprecated; use `compile.root_module.linkSystemLibrary(name, options)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn linkSystemLibrary2(
     compile: *Compile,
     name: []const u8,
@@ -814,22 +822,26 @@ pub fn linkSystemLibrary2(
     return compile.root_module.linkSystemLibrary(name, options);
 }
 
+/// Deprecated; use `c.root_module.linkFramework(name, .{})` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn linkFramework(c: *Compile, name: []const u8) void {
     c.root_module.linkFramework(name, .{});
 }
 
-/// Handy when you have many C/C++ source files and want them all to have the same flags.
+/// Deprecated; use `compile.root_module.addCSourceFiles(options)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addCSourceFiles(compile: *Compile, options: Module.AddCSourceFilesOptions) void {
     compile.root_module.addCSourceFiles(options);
 }
 
+/// Deprecated; use `compile.root_module.addCSourceFile(source)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addCSourceFile(compile: *Compile, source: Module.CSourceFile) void {
     compile.root_module.addCSourceFile(source);
 }
 
-/// Resource files must have the extension `.rc`.
-/// Can be called regardless of target. The .rc file will be ignored
-/// if the target object format does not support embedded resources.
+/// Deprecated; use `compile.root_module.addWin32ResourceFile(source)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addWin32ResourceFile(compile: *Compile, source: Module.RcSourceFile) void {
     compile.root_module.addWin32ResourceFile(source);
 }
@@ -915,54 +927,80 @@ pub fn getEmittedLlvmBc(compile: *Compile) LazyPath {
     return compile.getEmittedFileGeneric(&compile.generated_llvm_bc);
 }
 
+/// Deprecated; use `compile.root_module.addAssemblyFile(source)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addAssemblyFile(compile: *Compile, source: LazyPath) void {
     compile.root_module.addAssemblyFile(source);
 }
 
+/// Deprecated; use `compile.root_module.addObjectFile(source)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addObjectFile(compile: *Compile, source: LazyPath) void {
     compile.root_module.addObjectFile(source);
 }
 
+/// Deprecated; use `compile.root_module.addObject(object)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addObject(compile: *Compile, object: *Compile) void {
     compile.root_module.addObject(object);
 }
 
+/// Deprecated; use `compile.root_module.linkLibrary(library)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn linkLibrary(compile: *Compile, library: *Compile) void {
     compile.root_module.linkLibrary(library);
 }
 
+/// Deprecated; use `compile.root_module.addAfterIncludePath(lazy_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addAfterIncludePath(compile: *Compile, lazy_path: LazyPath) void {
     compile.root_module.addAfterIncludePath(lazy_path);
 }
 
+/// Deprecated; use `compile.root_module.addSystemIncludePath(lazy_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addSystemIncludePath(compile: *Compile, lazy_path: LazyPath) void {
     compile.root_module.addSystemIncludePath(lazy_path);
 }
 
+/// Deprecated; use `compile.root_module.addIncludePath(lazy_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addIncludePath(compile: *Compile, lazy_path: LazyPath) void {
     compile.root_module.addIncludePath(lazy_path);
 }
 
+/// Deprecated; use `compile.root_module.addConfigHeader(config_header)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addConfigHeader(compile: *Compile, config_header: *Step.ConfigHeader) void {
     compile.root_module.addConfigHeader(config_header);
 }
 
+/// Deprecated; use `compile.root_module.addEmbedPath(lazy_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addEmbedPath(compile: *Compile, lazy_path: LazyPath) void {
     compile.root_module.addEmbedPath(lazy_path);
 }
 
+/// Deprecated; use `compile.root_module.addLibraryPath(directory_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addLibraryPath(compile: *Compile, directory_path: LazyPath) void {
     compile.root_module.addLibraryPath(directory_path);
 }
 
+/// Deprecated; use `compile.root_module.addRPath(directory_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addRPath(compile: *Compile, directory_path: LazyPath) void {
     compile.root_module.addRPath(directory_path);
 }
 
+/// Deprecated; use `compile.root_module.addSystemFrameworkPath(directory_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addSystemFrameworkPath(compile: *Compile, directory_path: LazyPath) void {
     compile.root_module.addSystemFrameworkPath(directory_path);
 }
 
+/// Deprecated; use `compile.root_module.addFrameworkPath(directory_path)` instead.
+/// To be removed after 0.15.0 is tagged.
 pub fn addFrameworkPath(compile: *Compile, directory_path: LazyPath) void {
     compile.root_module.addFrameworkPath(directory_path);
 }

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -210,8 +210,8 @@ fn testAbsSymbols(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.addObject(obj);
-    exe.linkLibC();
+    exe.root_module.addObject(obj);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -235,7 +235,7 @@ fn testAsNeeded(b: *Build, opts: Options) *Step {
         \\
         ,
     });
-    main_o.linkLibC();
+    main_o.root_module.link_libc = true;
 
     const libfoo = addSharedLibrary(b, opts, .{ .name = "foo" });
     addCSourceBytes(libfoo, "int foo() { return 42; }", &.{});
@@ -253,17 +253,17 @@ fn testAsNeeded(b: *Build, opts: Options) *Step {
         const exe = addExecutable(b, opts, .{
             .name = "test",
         });
-        exe.addObject(main_o);
-        exe.linkSystemLibrary2("foo", .{ .needed = true });
-        exe.addLibraryPath(libfoo.getEmittedBinDirectory());
-        exe.addRPath(libfoo.getEmittedBinDirectory());
-        exe.linkSystemLibrary2("bar", .{ .needed = true });
-        exe.addLibraryPath(libbar.getEmittedBinDirectory());
-        exe.addRPath(libbar.getEmittedBinDirectory());
-        exe.linkSystemLibrary2("baz", .{ .needed = true });
-        exe.addLibraryPath(libbaz.getEmittedBinDirectory());
-        exe.addRPath(libbaz.getEmittedBinDirectory());
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkSystemLibrary("foo", .{ .needed = true });
+        exe.root_module.addLibraryPath(libfoo.getEmittedBinDirectory());
+        exe.root_module.addRPath(libfoo.getEmittedBinDirectory());
+        exe.root_module.linkSystemLibrary("bar", .{ .needed = true });
+        exe.root_module.addLibraryPath(libbar.getEmittedBinDirectory());
+        exe.root_module.addRPath(libbar.getEmittedBinDirectory());
+        exe.root_module.linkSystemLibrary("baz", .{ .needed = true });
+        exe.root_module.addLibraryPath(libbaz.getEmittedBinDirectory());
+        exe.root_module.addRPath(libbaz.getEmittedBinDirectory());
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("42\n");
@@ -281,17 +281,17 @@ fn testAsNeeded(b: *Build, opts: Options) *Step {
         const exe = addExecutable(b, opts, .{
             .name = "test",
         });
-        exe.addObject(main_o);
-        exe.linkSystemLibrary2("foo", .{ .needed = false });
-        exe.addLibraryPath(libfoo.getEmittedBinDirectory());
-        exe.addRPath(libfoo.getEmittedBinDirectory());
-        exe.linkSystemLibrary2("bar", .{ .needed = false });
-        exe.addLibraryPath(libbar.getEmittedBinDirectory());
-        exe.addRPath(libbar.getEmittedBinDirectory());
-        exe.linkSystemLibrary2("baz", .{ .needed = false });
-        exe.addLibraryPath(libbaz.getEmittedBinDirectory());
-        exe.addRPath(libbaz.getEmittedBinDirectory());
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkSystemLibrary("foo", .{ .needed = false });
+        exe.root_module.addLibraryPath(libfoo.getEmittedBinDirectory());
+        exe.root_module.addRPath(libfoo.getEmittedBinDirectory());
+        exe.root_module.linkSystemLibrary("bar", .{ .needed = false });
+        exe.root_module.addLibraryPath(libbar.getEmittedBinDirectory());
+        exe.root_module.addRPath(libbar.getEmittedBinDirectory());
+        exe.root_module.linkSystemLibrary("baz", .{ .needed = false });
+        exe.root_module.addLibraryPath(libbaz.getEmittedBinDirectory());
+        exe.root_module.addRPath(libbaz.getEmittedBinDirectory());
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("42\n");
@@ -351,15 +351,15 @@ fn testCanonicalPlt(b: *Build, opts: Options) *Step {
         ,
         .pic = false,
     });
-    main_o.linkLibC();
+    main_o.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{
         .name = "main",
     });
-    exe.addObject(main_o);
-    exe.addObject(b_o);
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.addObject(main_o);
+    exe.root_module.addObject(b_o);
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
     exe.pie = false;
 
     const run = addRunArtifact(exe);
@@ -384,7 +384,7 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    a_o.linkLibCpp();
+    a_o.root_module.link_libcpp = true;
 
     const main_o = addObject(b, opts, .{
         .name = "main",
@@ -401,13 +401,13 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    main_o.linkLibCpp();
+    main_o.root_module.link_libcpp = true;
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(a_o);
-        exe.addObject(main_o);
-        exe.linkLibCpp();
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(main_o);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(
@@ -420,9 +420,9 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
-        exe.addObject(a_o);
-        exe.linkLibCpp();
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(
@@ -435,12 +435,12 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
 
     {
         const c_o = addObject(b, opts, .{ .name = "c" });
-        c_o.addObject(main_o);
-        c_o.addObject(a_o);
+        c_o.root_module.addObject(main_o);
+        c_o.root_module.addObject(a_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main3" });
-        exe.addObject(c_o);
-        exe.linkLibCpp();
+        exe.root_module.addObject(c_o);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(
@@ -453,12 +453,12 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
 
     {
         const d_o = addObject(b, opts, .{ .name = "d" });
-        d_o.addObject(a_o);
-        d_o.addObject(main_o);
+        d_o.root_module.addObject(a_o);
+        d_o.root_module.addObject(main_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main4" });
-        exe.addObject(d_o);
-        exe.linkLibCpp();
+        exe.root_module.addObject(d_o);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(
@@ -522,7 +522,7 @@ fn testCommonSymbols(b: *Build, opts: Options) *Step {
         \\  printf("%d %d %d\n", foo, bar, baz);
         \\}
     , &.{"-fcommon"});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("0 5 42\n");
@@ -549,7 +549,7 @@ fn testCommonSymbolsInArchive(b: *Build, opts: Options) *Step {
         ,
         .c_source_flags = &.{"-fcommon"},
     });
-    a_o.linkLibC();
+    a_o.root_module.link_libc = true;
 
     const b_o = addObject(b, opts, .{
         .name = "b",
@@ -575,16 +575,16 @@ fn testCommonSymbolsInArchive(b: *Build, opts: Options) *Step {
         });
 
         const lib = addStaticLibrary(b, opts, .{ .name = "lib" });
-        lib.addObject(b_o);
-        lib.addObject(c_o);
-        lib.addObject(d_o);
+        lib.root_module.addObject(b_o);
+        lib.root_module.addObject(c_o);
+        lib.root_module.addObject(d_o);
 
         const exe = addExecutable(b, opts, .{
             .name = "test",
         });
-        exe.addObject(a_o);
-        exe.linkLibrary(lib);
-        exe.linkLibC();
+        exe.root_module.addObject(a_o);
+        exe.root_module.linkLibrary(lib);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("5 0 0 -1\n");
@@ -603,15 +603,15 @@ fn testCommonSymbolsInArchive(b: *Build, opts: Options) *Step {
         });
 
         const lib = addStaticLibrary(b, opts, .{ .name = "lib" });
-        lib.addObject(b_o);
-        lib.addObject(e_o);
+        lib.root_module.addObject(b_o);
+        lib.root_module.addObject(e_o);
 
         const exe = addExecutable(b, opts, .{
             .name = "test",
         });
-        exe.addObject(a_o);
-        exe.linkLibrary(lib);
-        exe.linkLibC();
+        exe.root_module.addObject(a_o);
+        exe.root_module.linkLibrary(lib);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("5 0 7 2\n");
@@ -641,8 +641,8 @@ fn testCopyrel(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("3 5\n");
@@ -679,8 +679,8 @@ fn testCopyrelAlias(b: *Build, opts: Options) *Step {
         \\extern int bar;
         \\int *get_bar() { return &bar; }
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
     exe.pie = false;
 
     const run = addRunArtifact(exe);
@@ -712,15 +712,15 @@ fn testCopyrelAlignment(b: *Build, opts: Options) *Step {
         ,
         .pic = false,
     });
-    obj.linkLibC();
+    obj.root_module.link_libc = true;
 
     const exp_stdout = "5\n";
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(obj);
-        exe.linkLibrary(a_so);
-        exe.linkLibC();
+        exe.root_module.addObject(obj);
+        exe.root_module.linkLibrary(a_so);
+        exe.root_module.link_libc = true;
         exe.pie = false;
 
         const run = addRunArtifact(exe);
@@ -737,9 +737,9 @@ fn testCopyrelAlignment(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(obj);
-        exe.linkLibrary(b_so);
-        exe.linkLibC();
+        exe.root_module.addObject(obj);
+        exe.root_module.linkLibrary(b_so);
+        exe.root_module.link_libc = true;
         exe.pie = false;
 
         const run = addRunArtifact(exe);
@@ -756,9 +756,9 @@ fn testCopyrelAlignment(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(obj);
-        exe.linkLibrary(c_so);
-        exe.linkLibC();
+        exe.root_module.addObject(obj);
+        exe.root_module.linkLibrary(c_so);
+        exe.root_module.link_libc = true;
         exe.pie = false;
 
         const run = addRunArtifact(exe);
@@ -793,7 +793,7 @@ fn testDsoPlt(b: *Build, opts: Options) *Step {
         \\  real_hello();
         \\}
     , &.{});
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "test" });
     addCSourceBytes(exe,
@@ -806,8 +806,8 @@ fn testDsoPlt(b: *Build, opts: Options) *Step {
         \\  hello();
         \\}
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello WORLD\n");
@@ -825,7 +825,7 @@ fn testDsoUndef(b: *Build, opts: Options) *Step {
         \\int bar = 5;
         \\int baz() { return foo; }
     , &.{});
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const obj = addObject(b, opts, .{
         .name = "obj",
@@ -833,18 +833,18 @@ fn testDsoUndef(b: *Build, opts: Options) *Step {
     });
 
     const lib = addStaticLibrary(b, opts, .{ .name = "lib" });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const exe = addExecutable(b, opts, .{ .name = "test" });
-    exe.linkLibrary(dso);
-    exe.linkLibrary(lib);
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.linkLibrary(lib);
     addCSourceBytes(exe,
         \\extern int bar;
         \\int main() {
         \\  return bar - 5;
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -871,7 +871,7 @@ fn testEmitRelocatable(b: *Build, opts: Options) *Step {
         \\    std.debug.print("foo={d}\n", .{foo()});
         \\}
     });
-    a_o.linkLibC();
+    a_o.root_module.link_libc = true;
 
     const b_o = addObject(b, opts, .{ .name = "b", .c_source_bytes = 
         \\#include <stdio.h>
@@ -880,11 +880,11 @@ fn testEmitRelocatable(b: *Build, opts: Options) *Step {
         \\  fprintf(stderr, "bar=%d\n", bar);
         \\}
     });
-    b_o.linkLibC();
+    b_o.root_module.link_libc = true;
 
     const c_o = addObject(b, opts, .{ .name = "c" });
-    c_o.addObject(a_o);
-    c_o.addObject(b_o);
+    c_o.root_module.addObject(a_o);
+    c_o.root_module.addObject(b_o);
 
     const exe = addExecutable(b, opts, .{ .name = "test", .zig_source_bytes = 
         \\const std = @import("std");
@@ -895,8 +895,8 @@ fn testEmitRelocatable(b: *Build, opts: Options) *Step {
         \\    printBar();
         \\}
     });
-    exe.addObject(c_o);
-    exe.linkLibC();
+    exe.root_module.addObject(c_o);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdErrEqual(
@@ -944,9 +944,9 @@ fn testEmitStaticLib(b: *Build, opts: Options) *Step {
     });
 
     const lib = addStaticLibrary(b, opts, .{ .name = "lib" });
-    lib.addObject(obj1);
-    lib.addObject(obj2);
-    lib.addObject(obj3);
+    lib.root_module.addObject(obj1);
+    lib.root_module.addObject(obj2);
+    lib.root_module.addObject(obj3);
 
     const check = lib.checkObject();
     check.checkInArchiveSymtab();
@@ -996,7 +996,7 @@ fn testEmitStaticLibZig(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    lib.addObject(obj1);
+    lib.root_module.addObject(obj1);
 
     const exe = addExecutable(b, opts, .{
         .name = "test",
@@ -1008,7 +1008,7 @@ fn testEmitStaticLibZig(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.linkLibrary(lib);
+    exe.root_module.linkLibrary(lib);
 
     const run = addRunArtifact(exe);
     run.expectStdErrEqual("44");
@@ -1023,7 +1023,7 @@ fn testEmptyObject(b: *Build, opts: Options) *Step {
     const exe = addExecutable(b, opts, .{ .name = "test" });
     addCSourceBytes(exe, "int main() { return 0; }", &.{});
     addCSourceBytes(exe, "", &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -1052,8 +1052,8 @@ fn testEntryPoint(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
         exe.entry = .{ .symbol_name = "foo" };
 
         const check = exe.checkObject();
@@ -1068,8 +1068,8 @@ fn testEntryPoint(b: *Build, opts: Options) *Step {
         // cause an artifact collision taking the cached executable from the above
         // step instead of generating a new one.
         const exe = addExecutable(b, opts, .{ .name = "other" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
         exe.entry = .{ .symbol_name = "bar" };
 
         const check = exe.checkObject();
@@ -1113,8 +1113,8 @@ fn testExportDynamic(b: *Build, opts: Options) *Step {
         \\  return baz;
         \\}
     , &.{});
-    exe.addObject(obj);
-    exe.linkLibrary(dso);
+    exe.root_module.addObject(obj);
+    exe.root_module.linkLibrary(dso);
     exe.rdynamic = true;
 
     const check = exe.checkObject();
@@ -1152,8 +1152,8 @@ fn testExportSymbolsFromExe(b: *Build, opts: Options) *Step {
         \\  foo();
         \\}
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const check = exe.checkObject();
     check.checkInDynamicSymtab();
@@ -1181,7 +1181,7 @@ fn testFuncAddress(b: *Build, opts: Options) *Step {
         \\  assert(fn == ptr);
         \\}
     , &.{});
-    exe.linkLibrary(dso);
+    exe.root_module.linkLibrary(dso);
     exe.root_module.pic = false;
     exe.pie = false;
 
@@ -1216,15 +1216,15 @@ fn testGcSections(b: *Build, opts: Options) *Step {
     });
     obj.link_function_sections = true;
     obj.link_data_sections = true;
-    obj.linkLibC();
-    obj.linkLibCpp();
+    obj.root_module.link_libc = true;
+    obj.root_module.link_libcpp = true;
 
     {
         const exe = addExecutable(b, opts, .{ .name = "test" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = false;
-        exe.linkLibC();
-        exe.linkLibCpp();
+        exe.root_module.link_libc = true;
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("1 2\n");
@@ -1252,10 +1252,10 @@ fn testGcSections(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "test" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = true;
-        exe.linkLibC();
-        exe.linkLibCpp();
+        exe.root_module.link_libc = true;
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("1 2\n");
@@ -1321,7 +1321,7 @@ fn testGcSectionsZig(b: *Build, opts: Options) *Step {
             \\}
             ,
         });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = false;
 
         const run = addRunArtifact(exe);
@@ -1363,7 +1363,7 @@ fn testGcSectionsZig(b: *Build, opts: Options) *Step {
             \\}
             ,
         });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = true;
 
         const run = addRunArtifact(exe);
@@ -1427,7 +1427,7 @@ fn testIFuncAlias(b: *Build, opts: Options) *Step {
         \\}
     , &.{});
     exe.root_module.pic = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -1467,9 +1467,9 @@ fn testIFuncDlopen(b: *Build, opts: Options) *Step {
         \\  assert(foo == p);
         \\}
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
-    exe.linkSystemLibrary2("dl", .{});
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
+    exe.root_module.linkSystemLibrary("dl", .{});
     exe.root_module.pic = false;
     exe.pie = false;
 
@@ -1498,7 +1498,7 @@ fn testIFuncDso(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{
         .name = "main",
@@ -1509,7 +1509,7 @@ fn testIFuncDso(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.linkLibrary(dso);
+    exe.root_module.linkLibrary(dso);
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello world\n");
@@ -1540,7 +1540,7 @@ fn testIFuncDynamic(b: *Build, opts: Options) *Step {
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
         addCSourceBytes(exe, main_c, &.{});
-        exe.linkLibC();
+        exe.root_module.link_libc = true;
         exe.link_z_lazy = true;
 
         const run = addRunArtifact(exe);
@@ -1550,7 +1550,7 @@ fn testIFuncDynamic(b: *Build, opts: Options) *Step {
     {
         const exe = addExecutable(b, opts, .{ .name = "other" });
         addCSourceBytes(exe, main_c, &.{});
-        exe.linkLibC();
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("Hello world\n");
@@ -1576,7 +1576,7 @@ fn testIFuncExport(b: *Build, opts: Options) *Step {
         \\  return real_foobar;
         \\}
     , &.{});
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const check = dso.checkObject();
     check.checkInDynamicSymtab();
@@ -1613,7 +1613,7 @@ fn testIFuncFuncPtr(b: *Build, opts: Options) *Step {
         \\}
     , &.{});
     exe.root_module.pic = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("3\n");
@@ -1642,7 +1642,7 @@ fn testIFuncNoPlt(b: *Build, opts: Options) *Step {
         \\}
     , &.{"-fno-plt"});
     exe.root_module.pic = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello world\n");
@@ -1669,7 +1669,7 @@ fn testIFuncStatic(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
     exe.linkage = .static;
 
     const run = addRunArtifact(exe);
@@ -1700,7 +1700,7 @@ fn testIFuncStaticPie(b: *Build, opts: Options) *Step {
     exe.linkage = .static;
     exe.root_module.pic = true;
     exe.pie = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello world\n");
@@ -1733,7 +1733,7 @@ fn testImageBase(b: *Build, opts: Options) *Step {
             \\  return 0;
             \\}
         , &.{});
-        exe.linkLibC();
+        exe.root_module.link_libc = true;
         exe.image_base = 0x8000000;
 
         const run = addRunArtifact(exe);
@@ -1779,7 +1779,7 @@ fn testImportingDataDynamic(b: *Build, opts: Options) *Step {
         \\void printFoo() { fprintf(stderr, "lib foo=%d\n", foo); }
         ,
     });
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const main = addExecutable(b, opts, .{
         .name = "main",
@@ -1798,7 +1798,7 @@ fn testImportingDataDynamic(b: *Build, opts: Options) *Step {
         .strip = true, // TODO temp hack
     });
     main.pie = true;
-    main.linkLibrary(dso);
+    main.root_module.linkLibrary(dso);
 
     const run = addRunArtifact(main);
     run.expectStdErrEqual(
@@ -1832,7 +1832,7 @@ fn testImportingDataStatic(b: *Build, opts: Options) *Step {
     }, .{
         .name = "a",
     });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const main = addExecutable(b, opts, .{
         .name = "main",
@@ -1844,8 +1844,8 @@ fn testImportingDataStatic(b: *Build, opts: Options) *Step {
         ,
         .strip = true, // TODO temp hack
     });
-    main.linkLibrary(lib);
-    main.linkLibC();
+    main.root_module.linkLibrary(lib);
+    main.root_module.link_libc = true;
 
     const run = addRunArtifact(main);
     run.expectStdErrEqual("42\n");
@@ -1864,7 +1864,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((constructor(10000))) void init4() { printf("1"); }
         ,
     });
-    a_o.linkLibC();
+    a_o.root_module.link_libc = true;
 
     const b_o = addObject(b, opts, .{
         .name = "b",
@@ -1873,7 +1873,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((constructor(1000))) void init3() { printf("2"); }
         ,
     });
-    b_o.linkLibC();
+    b_o.root_module.link_libc = true;
 
     const c_o = addObject(b, opts, .{
         .name = "c",
@@ -1882,7 +1882,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((constructor)) void init1() { printf("3"); }
         ,
     });
-    c_o.linkLibC();
+    c_o.root_module.link_libc = true;
 
     const d_o = addObject(b, opts, .{
         .name = "d",
@@ -1891,7 +1891,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((constructor)) void init2() { printf("4"); }
         ,
     });
-    d_o.linkLibC();
+    d_o.root_module.link_libc = true;
 
     const e_o = addObject(b, opts, .{
         .name = "e",
@@ -1900,7 +1900,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((destructor(10000))) void fini4() { printf("5"); }
         ,
     });
-    e_o.linkLibC();
+    e_o.root_module.link_libc = true;
 
     const f_o = addObject(b, opts, .{
         .name = "f",
@@ -1909,7 +1909,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((destructor(1000))) void fini3() { printf("6"); }
         ,
     });
-    f_o.linkLibC();
+    f_o.root_module.link_libc = true;
 
     const g_o = addObject(b, opts, .{
         .name = "g",
@@ -1918,24 +1918,24 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
         \\__attribute__((destructor)) void fini1() { printf("7"); }
         ,
     });
-    g_o.linkLibC();
+    g_o.root_module.link_libc = true;
 
     const h_o = addObject(b, opts, .{ .name = "h", .c_source_bytes = 
         \\#include <stdio.h>
         \\__attribute__((destructor)) void fini2() { printf("8"); }
     });
-    h_o.linkLibC();
+    h_o.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe, "int main() { return 0; }", &.{});
-    exe.addObject(a_o);
-    exe.addObject(b_o);
-    exe.addObject(c_o);
-    exe.addObject(d_o);
-    exe.addObject(e_o);
-    exe.addObject(f_o);
-    exe.addObject(g_o);
-    exe.addObject(h_o);
+    exe.root_module.addObject(a_o);
+    exe.root_module.addObject(b_o);
+    exe.root_module.addObject(c_o);
+    exe.root_module.addObject(d_o);
+    exe.root_module.addObject(e_o);
+    exe.root_module.addObject(f_o);
+    exe.root_module.addObject(g_o);
+    exe.root_module.addObject(h_o);
 
     if (opts.target.result.isGnuLibC()) {
         // TODO I think we need to clarify our use of `-fPIC -fPIE` flags for different targets
@@ -1970,7 +1970,7 @@ fn testLargeAlignmentDso(b: *Build, opts: Options) *Step {
         \\}
     , &.{});
     dso.link_function_sections = true;
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const check = dso.checkObject();
     check.checkInSymtab();
@@ -1986,8 +1986,8 @@ fn testLargeAlignmentDso(b: *Build, opts: Options) *Step {
         \\void greet();
         \\int main() { greet(); }
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello world");
@@ -2021,7 +2021,7 @@ fn testLargeAlignmentExe(b: *Build, opts: Options) *Step {
         \\}
     , &.{});
     exe.link_function_sections = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const check = exe.checkObject();
     check.checkInSymtab();
@@ -2049,7 +2049,7 @@ fn testLargeBss(b: *Build, opts: Options) *Step {
         \\  return arr[2000];
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
     // Disabled to work around the ELF linker crashing.
     // Can be reproduced on a x86_64-linux host by commenting out the line below.
     exe.root_module.sanitize_c = .off;
@@ -2071,10 +2071,10 @@ fn testLinkOrder(b: *Build, opts: Options) *Step {
     });
 
     const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-    dso.addObject(obj);
+    dso.root_module.addObject(obj);
 
     const lib = addStaticLibrary(b, opts, .{ .name = "b" });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const main_o = addObject(b, opts, .{
         .name = "main",
@@ -2089,14 +2089,14 @@ fn testLinkOrder(b: *Build, opts: Options) *Step {
     // https://github.com/ziglang/zig/issues/17450
     // {
     //     const exe = addExecutable(b, opts, .{ .name = "main1"});
-    //     exe.addObject(main_o);
-    //     exe.linkSystemLibrary2("a", .{});
-    //     exe.addLibraryPath(dso.getEmittedBinDirectory());
-    //     exe.addRPath(dso.getEmittedBinDirectory());
-    //     exe.linkSystemLibrary2("b", .{});
-    //     exe.addLibraryPath(lib.getEmittedBinDirectory());
-    //     exe.addRPath(lib.getEmittedBinDirectory());
-    //     exe.linkLibC();
+    //     exe.root_module.addObject(main_o);
+    //     exe.root_module.linkSystemLibrary("a", .{});
+    //     exe.root_module.addLibraryPath(dso.getEmittedBinDirectory());
+    //     exe.root_module.addRPath(dso.getEmittedBinDirectory());
+    //     exe.root_module.linkSystemLibrary("b", .{});
+    //     exe.root_module.addLibraryPath(lib.getEmittedBinDirectory());
+    //     exe.root_module.addRPath(lib.getEmittedBinDirectory());
+    //     exe.root_module.link_libc = true;
 
     //     const check = exe.checkObject();
     //     check.checkInDynamicSection();
@@ -2106,14 +2106,14 @@ fn testLinkOrder(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
-        exe.linkSystemLibrary2("b", .{});
-        exe.addLibraryPath(lib.getEmittedBinDirectory());
-        exe.addRPath(lib.getEmittedBinDirectory());
-        exe.linkSystemLibrary2("a", .{});
-        exe.addLibraryPath(dso.getEmittedBinDirectory());
-        exe.addRPath(dso.getEmittedBinDirectory());
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkSystemLibrary("b", .{});
+        exe.root_module.addLibraryPath(lib.getEmittedBinDirectory());
+        exe.root_module.addRPath(lib.getEmittedBinDirectory());
+        exe.root_module.linkSystemLibrary("a", .{});
+        exe.root_module.addLibraryPath(dso.getEmittedBinDirectory());
+        exe.root_module.addRPath(dso.getEmittedBinDirectory());
+        exe.root_module.link_libc = true;
 
         const check = exe.checkObject();
         check.checkInDynamicSection();
@@ -2149,14 +2149,14 @@ fn testLdScript(b: *Build, opts: Options) *Step {
         \\  return bar() - baz();
         \\}
     , &.{});
-    exe.linkSystemLibrary2("a", .{});
-    exe.addLibraryPath(scripts.getDirectory());
-    exe.addLibraryPath(scripts2.getDirectory());
-    exe.addLibraryPath(bar.getEmittedBinDirectory());
-    exe.addLibraryPath(baz.getEmittedBinDirectory());
-    exe.addRPath(bar.getEmittedBinDirectory());
-    exe.addRPath(baz.getEmittedBinDirectory());
-    exe.linkLibC();
+    exe.root_module.linkSystemLibrary("a", .{});
+    exe.root_module.addLibraryPath(scripts.getDirectory());
+    exe.root_module.addLibraryPath(scripts2.getDirectory());
+    exe.root_module.addLibraryPath(bar.getEmittedBinDirectory());
+    exe.root_module.addLibraryPath(baz.getEmittedBinDirectory());
+    exe.root_module.addRPath(bar.getEmittedBinDirectory());
+    exe.root_module.addRPath(baz.getEmittedBinDirectory());
+    exe.root_module.link_libc = true;
     exe.allow_so_scripts = true;
 
     const run = addRunArtifact(exe);
@@ -2174,9 +2174,9 @@ fn testLdScriptPathError(b: *Build, opts: Options) *Step {
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe, "int main() { return 0; }", &.{});
-    exe.linkSystemLibrary2("a", .{});
-    exe.addLibraryPath(scripts.getDirectory());
-    exe.linkLibC();
+    exe.root_module.linkSystemLibrary("a", .{});
+    exe.root_module.addLibraryPath(scripts.getDirectory());
+    exe.root_module.link_libc = true;
     exe.allow_so_scripts = true;
 
     // TODO: A future enhancement could make this error message also mention
@@ -2213,8 +2213,8 @@ fn testLdScriptAllowUndefinedVersion(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.linkLibrary(so);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(so);
+    exe.root_module.link_libc = true;
     exe.allow_so_scripts = true;
 
     const run = addRunArtifact(exe);
@@ -2269,8 +2269,8 @@ fn testMismatchedCpuArchitectureError(b: *Build, opts: Options) *Step {
         \\  return foo;
         \\}
     , &.{});
-    exe.addObject(obj);
-    exe.linkLibC();
+    exe.root_module.addObject(obj);
+    exe.root_module.link_libc = true;
 
     expectLinkErrors(exe, test_step, .{ .exact = &.{
         "invalid ELF machine type: AARCH64",
@@ -2291,7 +2291,7 @@ fn testLinkingC(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello World!\n");
@@ -2320,8 +2320,8 @@ fn testLinkingCpp(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibC();
-    exe.linkLibCpp();
+    exe.root_module.link_libc = true;
+    exe.root_module.link_libcpp = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello World!\n");
@@ -2364,7 +2364,7 @@ fn testLinkingObj(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.addObject(obj);
+    exe.root_module.addObject(obj);
 
     const run = addRunArtifact(exe);
     run.expectStdErrEqual("84\n");
@@ -2389,7 +2389,7 @@ fn testLinkingStaticLib(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const exe = addExecutable(b, opts, .{
         .name = "testlib",
@@ -2402,7 +2402,7 @@ fn testLinkingStaticLib(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.linkLibrary(lib);
+    exe.root_module.linkLibrary(lib);
 
     const run = addRunArtifact(exe);
     run.expectStdErrEqual("0\n");
@@ -2452,7 +2452,7 @@ fn testMergeStrings(b: *Build, opts: Options) *Step {
         \\char16_t *utf16_1 = u"foo";
         \\char32_t *utf32_1 = U"foo";
     , &.{"-O2"});
-    obj1.linkLibC();
+    obj1.root_module.link_libc = true;
 
     const obj2 = addObject(b, opts, .{ .name = "b.o" });
     addCSourceBytes(obj2,
@@ -2481,12 +2481,12 @@ fn testMergeStrings(b: *Build, opts: Options) *Step {
         \\  assert((void*)wide1 !=   (void*)utf16_1);
         \\}
     , &.{"-O2"});
-    obj2.linkLibC();
+    obj2.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
-    exe.addObject(obj1);
-    exe.addObject(obj2);
-    exe.linkLibC();
+    exe.root_module.addObject(obj1);
+    exe.root_module.addObject(obj2);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -2520,8 +2520,8 @@ fn testMergeStrings2(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(obj1);
-        exe.addObject(obj2);
+        exe.root_module.addObject(obj1);
+        exe.root_module.addObject(obj2);
 
         const run = addRunArtifact(exe);
         run.expectExitCode(0);
@@ -2537,11 +2537,11 @@ fn testMergeStrings2(b: *Build, opts: Options) *Step {
 
     {
         const obj3 = addObject(b, opts, .{ .name = "c" });
-        obj3.addObject(obj1);
-        obj3.addObject(obj2);
+        obj3.root_module.addObject(obj1);
+        obj3.root_module.addObject(obj2);
 
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(obj3);
+        exe.root_module.addObject(obj3);
 
         const run = addRunArtifact(exe);
         run.expectExitCode(0);
@@ -2564,7 +2564,7 @@ fn testNoEhFrameHdr(b: *Build, opts: Options) *Step {
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe, "int main() { return 0; }", &.{});
     exe.link_eh_frame_hdr = false;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const check = exe.checkObject();
     check.checkInHeaders();
@@ -2586,7 +2586,7 @@ fn testPie(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
     exe.root_module.pic = true;
     exe.pie = true;
 
@@ -2617,7 +2617,7 @@ fn testPltGot(b: *Build, opts: Options) *Step {
         \\  printf("Hello world\n");
         \\}
     , &.{});
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe,
@@ -2626,9 +2626,9 @@ fn testPltGot(b: *Build, opts: Options) *Step {
         \\void foo() { ignore(hello); }
         \\int main() { hello(); }
     , &.{});
-    exe.linkLibrary(dso);
+    exe.root_module.linkLibrary(dso);
     exe.root_module.pic = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello world\n");
@@ -2647,7 +2647,7 @@ fn testPreinitArray(b: *Build, opts: Options) *Step {
         });
 
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
 
         const check = exe.checkObject();
         check.checkInDynamicSection();
@@ -2662,7 +2662,7 @@ fn testPreinitArray(b: *Build, opts: Options) *Step {
             \\__attribute__((section(".preinit_array")))
             \\void *preinit[] = { preinit_fn };
         , &.{});
-        exe.linkLibC();
+        exe.root_module.link_libc = true;
 
         const check = exe.checkObject();
         check.checkInDynamicSection();
@@ -2710,15 +2710,15 @@ fn testRelocatableArchive(b: *Build, opts: Options) *Step {
     });
 
     const lib = addStaticLibrary(b, opts, .{ .name = "lib" });
-    lib.addObject(obj1);
-    lib.addObject(obj2);
-    lib.addObject(obj3);
+    lib.root_module.addObject(obj1);
+    lib.root_module.addObject(obj2);
+    lib.root_module.addObject(obj3);
 
     const obj5 = addObject(b, opts, .{
         .name = "obj5",
     });
-    obj5.addObject(obj4);
-    obj5.linkLibrary(lib);
+    obj5.root_module.addObject(obj4);
+    obj5.root_module.linkLibrary(lib);
 
     const check = obj5.checkObject();
     check.checkInSymtab();
@@ -2744,7 +2744,7 @@ fn testRelocatableEhFrame(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    obj1.linkLibCpp();
+    obj1.root_module.link_libcpp = true;
     const obj2 = addObject(b, opts, .{
         .name = "obj2",
         .cpp_source_bytes =
@@ -2754,7 +2754,7 @@ fn testRelocatableEhFrame(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    obj2.linkLibCpp();
+    obj2.root_module.link_libcpp = true;
     const obj3 = addObject(b, opts, .{ .name = "obj3", .cpp_source_bytes = 
         \\#include <iostream>
         \\#include <stdexcept>
@@ -2768,18 +2768,18 @@ fn testRelocatableEhFrame(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     });
-    obj3.linkLibCpp();
+    obj3.root_module.link_libcpp = true;
 
     {
         const obj = addObject(b, opts, .{ .name = "obj" });
-        obj.addObject(obj1);
-        obj.addObject(obj2);
-        obj.linkLibCpp();
+        obj.root_module.addObject(obj1);
+        obj.root_module.addObject(obj2);
+        obj.root_module.link_libcpp = true;
 
         const exe = addExecutable(b, opts, .{ .name = "test1" });
-        exe.addObject(obj3);
-        exe.addObject(obj);
-        exe.linkLibCpp();
+        exe.root_module.addObject(obj3);
+        exe.root_module.addObject(obj);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("exception=Oh no!");
@@ -2788,14 +2788,14 @@ fn testRelocatableEhFrame(b: *Build, opts: Options) *Step {
     {
         // Flipping the order should not influence the end result.
         const obj = addObject(b, opts, .{ .name = "obj" });
-        obj.addObject(obj2);
-        obj.addObject(obj1);
-        obj.linkLibCpp();
+        obj.root_module.addObject(obj2);
+        obj.root_module.addObject(obj1);
+        obj.root_module.link_libcpp = true;
 
         const exe = addExecutable(b, opts, .{ .name = "test2" });
-        exe.addObject(obj3);
-        exe.addObject(obj);
-        exe.linkLibCpp();
+        exe.root_module.addObject(obj3);
+        exe.root_module.addObject(obj);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("exception=Oh no!");
@@ -2817,7 +2817,7 @@ fn testRelocatableEhFrameComdatHeavy(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    obj1.linkLibCpp();
+    obj1.root_module.link_libcpp = true;
     const obj2 = addObject(b, opts, .{
         .name = "obj2",
         .cpp_source_bytes =
@@ -2827,7 +2827,7 @@ fn testRelocatableEhFrameComdatHeavy(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    obj2.linkLibCpp();
+    obj2.root_module.link_libcpp = true;
     const obj3 = addObject(b, opts, .{
         .name = "obj3",
         .cpp_source_bytes =
@@ -2844,17 +2844,17 @@ fn testRelocatableEhFrameComdatHeavy(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    obj3.linkLibCpp();
+    obj3.root_module.link_libcpp = true;
 
     const obj = addObject(b, opts, .{ .name = "obj" });
-    obj.addObject(obj1);
-    obj.addObject(obj2);
-    obj.addObject(obj3);
-    obj.linkLibCpp();
+    obj.root_module.addObject(obj1);
+    obj.root_module.addObject(obj2);
+    obj.root_module.addObject(obj3);
+    obj.root_module.link_libcpp = true;
 
     const exe = addExecutable(b, opts, .{ .name = "test2" });
-    exe.addObject(obj);
-    exe.linkLibCpp();
+    exe.root_module.addObject(obj);
+    exe.root_module.link_libcpp = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("exception=Oh no!");
@@ -2880,7 +2880,7 @@ fn testRelocatableMergeStrings(b: *Build, opts: Options) *Step {
     });
 
     const obj2 = addObject(b, opts, .{ .name = "b" });
-    obj2.addObject(obj1);
+    obj2.root_module.addObject(obj1);
 
     const check = obj2.checkObject();
     check.dumpSection(".rodata.str1.1");
@@ -2905,7 +2905,7 @@ fn testRelocatableNoEhFrame(b: *Build, opts: Options) *Step {
     const obj2 = addObject(b, opts, .{
         .name = "obj2",
     });
-    obj2.addObject(obj1);
+    obj2.root_module.addObject(obj1);
 
     const check1 = obj1.checkObject();
     check1.checkInHeaders();
@@ -2940,12 +2940,12 @@ fn testSharedAbsSymbol(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    obj.linkLibC();
+    obj.root_module.link_libc = true;
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(obj);
-        exe.linkLibrary(dso);
+        exe.root_module.addObject(obj);
+        exe.root_module.linkLibrary(dso);
         exe.pie = true;
 
         const run = addRunArtifact(exe);
@@ -2965,8 +2965,8 @@ fn testSharedAbsSymbol(b: *Build, opts: Options) *Step {
     // https://github.com/ziglang/zig/issues/17430
     // {
     //     const exe = addExecutable(b, opts, .{ .name = "main2"});
-    //     exe.addObject(obj);
-    //     exe.linkLibrary(dso);
+    //     exe.root_module.addObject(obj);
+    //     exe.root_module.linkLibrary(dso);
     //     exe.pie = false;
 
     //     const run = addRunArtifact(exe);
@@ -2999,13 +2999,13 @@ fn testStrip(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    obj.linkLibC();
+    obj.root_module.link_libc = true;
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.root_module.strip = false;
-        exe.linkLibC();
+        exe.root_module.link_libc = true;
 
         const check = exe.checkObject();
         check.checkInHeaders();
@@ -3016,9 +3016,9 @@ fn testStrip(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.root_module.strip = true;
-        exe.linkLibC();
+        exe.root_module.link_libc = true;
 
         const check = exe.checkObject();
         check.checkInHeaders();
@@ -3074,7 +3074,7 @@ fn testTlsDfStaticTls(b: *Build, opts: Options) *Step {
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-        dso.addObject(obj);
+        dso.root_module.addObject(obj);
         // dso.link_relax = true;
 
         const check = dso.checkObject();
@@ -3086,7 +3086,7 @@ fn testTlsDfStaticTls(b: *Build, opts: Options) *Step {
     // TODO add -Wl,--no-relax
     // {
     //     const dso = addSharedLibrary(b, opts, .{ .name = "a"});
-    //     dso.addObject(obj);
+    //     dso.root_module.addObject(obj);
     //     dso.link_relax = false;
 
     //     const check = dso.checkObject();
@@ -3128,8 +3128,8 @@ fn testTlsDso(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("5 3 5 3 5 3\n");
@@ -3159,7 +3159,7 @@ fn testTlsGd(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    main_o.linkLibC();
+    main_o.root_module.link_libc = true;
 
     const a_o = addObject(b, opts, .{
         .name = "a",
@@ -3184,17 +3184,17 @@ fn testTlsGd(b: *Build, opts: Options) *Step {
     const exp_stdout = "1 2 3 4 5 6\n";
 
     const dso1 = addSharedLibrary(b, opts, .{ .name = "a" });
-    dso1.addObject(a_o);
+    dso1.root_module.addObject(a_o);
 
     const dso2 = addSharedLibrary(b, opts, .{ .name = "b" });
-    dso2.addObject(b_o);
+    dso2.root_module.addObject(b_o);
     // dso2.link_relax = false; // TODO
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
-        exe.linkLibrary(dso1);
-        exe.linkLibrary(dso2);
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkLibrary(dso1);
+        exe.root_module.linkLibrary(dso2);
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(exp_stdout);
@@ -3203,10 +3203,10 @@ fn testTlsGd(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         // exe.link_relax = false; // TODO
-        exe.linkLibrary(dso1);
-        exe.linkLibrary(dso2);
+        exe.root_module.linkLibrary(dso1);
+        exe.root_module.linkLibrary(dso2);
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(exp_stdout);
@@ -3216,9 +3216,9 @@ fn testTlsGd(b: *Build, opts: Options) *Step {
     // https://github.com/ziglang/zig/issues/17430 ??
     // {
     //     const exe = addExecutable(b, opts, .{ .name = "main3"});
-    //     exe.addObject(main_o);
-    //     exe.linkLibrary(dso1);
-    //     exe.linkLibrary(dso2);
+    //     exe.root_module.addObject(main_o);
+    //     exe.root_module.linkLibrary(dso1);
+    //     exe.root_module.linkLibrary(dso2);
     //     exe.linkage = .static;
 
     //     const run = addRunArtifact(exe);
@@ -3228,10 +3228,10 @@ fn testTlsGd(b: *Build, opts: Options) *Step {
 
     // {
     //     const exe = addExecutable(b, opts, .{ .name = "main4"});
-    //     exe.addObject(main_o);
+    //     exe.root_module.addObject(main_o);
     //     // exe.link_relax = false; // TODO
-    //     exe.linkLibrary(dso1);
-    //     exe.linkLibrary(dso2);
+    //     exe.root_module.linkLibrary(dso1);
+    //     exe.root_module.linkLibrary(dso2);
     //     exe.linkage = .static;
 
     //     const run = addRunArtifact(exe);
@@ -3265,7 +3265,7 @@ fn testTlsGdNoPlt(b: *Build, opts: Options) *Step {
         .c_source_flags = &.{"-fno-plt"},
         .pic = true,
     });
-    obj.linkLibC();
+    obj.root_module.link_libc = true;
 
     const a_so = addSharedLibrary(b, opts, .{ .name = "a" });
     addCSourceBytes(a_so,
@@ -3284,10 +3284,10 @@ fn testTlsGdNoPlt(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(obj);
-        exe.linkLibrary(a_so);
-        exe.linkLibrary(b_so);
-        exe.linkLibC();
+        exe.root_module.addObject(obj);
+        exe.root_module.linkLibrary(a_so);
+        exe.root_module.linkLibrary(b_so);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("1 2 3 4 5 6\n");
@@ -3296,10 +3296,10 @@ fn testTlsGdNoPlt(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(obj);
-        exe.linkLibrary(a_so);
-        exe.linkLibrary(b_so);
-        exe.linkLibC();
+        exe.root_module.addObject(obj);
+        exe.root_module.linkLibrary(a_so);
+        exe.root_module.linkLibrary(b_so);
+        exe.root_module.link_libc = true;
         // exe.link_relax = false; // TODO
 
         const run = addRunArtifact(exe);
@@ -3329,7 +3329,7 @@ fn testTlsGdToIe(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    a_o.linkLibC();
+    a_o.root_module.link_libc = true;
 
     const b_o = addObject(b, opts, .{
         .name = "b",
@@ -3342,12 +3342,12 @@ fn testTlsGdToIe(b: *Build, opts: Options) *Step {
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a1" });
-        dso.addObject(a_o);
+        dso.root_module.addObject(a_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(b_o);
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.addObject(b_o);
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("1 2 3\n");
@@ -3356,13 +3356,13 @@ fn testTlsGdToIe(b: *Build, opts: Options) *Step {
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a2" });
-        dso.addObject(a_o);
+        dso.root_module.addObject(a_o);
         // dso.link_relax = false; // TODO
 
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(b_o);
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.addObject(b_o);
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("1 2 3\n");
@@ -3371,12 +3371,12 @@ fn testTlsGdToIe(b: *Build, opts: Options) *Step {
 
     // {
     //     const dso = addSharedLibrary(b, opts, .{ .name = "a"});
-    //     dso.addObject(a_o);
+    //     dso.root_module.addObject(a_o);
     //     dso.link_z_nodlopen = true;
 
     //     const exe = addExecutable(b, opts, .{ .name = "main"});
-    //     exe.addObject(b_o);
-    //     exe.linkLibrary(dso);
+    //     exe.root_module.addObject(b_o);
+    //     exe.root_module.linkLibrary(dso);
 
     //     const run = addRunArtifact(exe);
     //     run.expectStdOutEqual("1 2 3\n");
@@ -3385,13 +3385,13 @@ fn testTlsGdToIe(b: *Build, opts: Options) *Step {
 
     // {
     //     const dso = addSharedLibrary(b, opts, .{ .name = "a"});
-    //     dso.addObject(a_o);
+    //     dso.root_module.addObject(a_o);
     //     dso.link_relax = false;
     //     dso.link_z_nodlopen = true;
 
     //     const exe = addExecutable(b, opts, .{ .name = "main"});
-    //     exe.addObject(b_o);
-    //     exe.linkLibrary(dso);
+    //     exe.root_module.addObject(b_o);
+    //     exe.root_module.linkLibrary(dso);
 
     //     const run = addRunArtifact(exe);
     //     run.expectStdOutEqual("1 2 3\n");
@@ -3417,7 +3417,7 @@ fn testTlsIe(b: *Build, opts: Options) *Step {
         \\  printf("%d %d ", foo, bar);
         \\}
     , &.{});
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const main_o = addObject(b, opts, .{
         .name = "main",
@@ -3435,15 +3435,15 @@ fn testTlsIe(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    main_o.linkLibC();
+    main_o.root_module.link_libc = true;
 
     const exp_stdout = "0 0 3 5 7\n";
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(exp_stdout);
@@ -3452,9 +3452,9 @@ fn testTlsIe(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
         // exe.link_relax = false; // TODO
 
         const run = addRunArtifact(exe);
@@ -3500,17 +3500,17 @@ fn testTlsLargeAlignment(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    c_o.linkLibC();
+    c_o.root_module.link_libc = true;
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-        dso.addObject(a_o);
-        dso.addObject(b_o);
+        dso.root_module.addObject(a_o);
+        dso.root_module.addObject(b_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(c_o);
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.addObject(c_o);
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("42 1 2 3\n");
@@ -3519,10 +3519,10 @@ fn testTlsLargeAlignment(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.addObject(c_o);
-        exe.linkLibC();
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(c_o);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("42 1 2 3\n");
@@ -3555,7 +3555,7 @@ fn testTlsLargeTbss(b: *Build, opts: Options) *Step {
         \\  printf("%d %d %d %d %d %d\n", x[0], x[1], x[1023], y[0], y[1], y[1023]);
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
     // Disabled to work around the ELF linker crashing.
     // Can be reproduced on a x86_64-linux host by commenting out the line below.
     exe.root_module.sanitize_c = .off;
@@ -3580,7 +3580,7 @@ fn testTlsLargeStaticImage(b: *Build, opts: Options) *Step {
         \\}
     , &.{});
     exe.root_module.pic = true;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("1 2 3 0 5\n");
@@ -3609,7 +3609,7 @@ fn testTlsLd(b: *Build, opts: Options) *Step {
         .c_source_flags = &.{"-ftls-model=local-dynamic"},
         .pic = true,
     });
-    main_o.linkLibC();
+    main_o.root_module.link_libc = true;
 
     const a_o = addObject(b, opts, .{
         .name = "a",
@@ -3622,9 +3622,9 @@ fn testTlsLd(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
-        exe.addObject(a_o);
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(exp_stdout);
@@ -3633,9 +3633,9 @@ fn testTlsLd(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
-        exe.addObject(a_o);
-        exe.linkLibC();
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.link_libc = true;
         // exe.link_relax = false; // TODO
 
         const run = addRunArtifact(exe);
@@ -3668,8 +3668,8 @@ fn testTlsLdDso(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("1 2\n");
@@ -3699,7 +3699,7 @@ fn testTlsLdNoPlt(b: *Build, opts: Options) *Step {
         .c_source_flags = &.{ "-ftls-model=local-dynamic", "-fno-plt" },
         .pic = true,
     });
-    a_o.linkLibC();
+    a_o.root_module.link_libc = true;
 
     const b_o = addObject(b, opts, .{
         .name = "b",
@@ -3710,9 +3710,9 @@ fn testTlsLdNoPlt(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.linkLibC();
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("3 5 3 5\n");
@@ -3721,9 +3721,9 @@ fn testTlsLdNoPlt(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.linkLibC();
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.link_libc = true;
         // exe.link_relax = false; // TODO
 
         const run = addRunArtifact(exe);
@@ -3756,7 +3756,7 @@ fn testTlsNoPic(b: *Build, opts: Options) *Step {
         \\__attribute__((tls_model("global-dynamic"))) _Thread_local int foo;
     , &.{});
     exe.root_module.pic = false;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("3 5 3 5\n");
@@ -3784,7 +3784,7 @@ fn testTlsOffsetAlignment(b: *Build, opts: Options) *Step {
         \\  return NULL;
         \\}
     , &.{});
-    dso.linkLibC();
+    dso.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe,
@@ -3811,8 +3811,8 @@ fn testTlsOffsetAlignment(b: *Build, opts: Options) *Step {
         \\  pthread_join(thread, NULL);
         \\}
     , &.{});
-    exe.addRPath(dso.getEmittedBinDirectory());
-    exe.linkLibC();
+    exe.root_module.addRPath(dso.getEmittedBinDirectory());
+    exe.root_module.link_libc = true;
     exe.root_module.pic = true;
 
     const run = addRunArtifact(exe);
@@ -3842,14 +3842,14 @@ fn testTlsPic(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    obj.linkLibC();
+    obj.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe,
         \\__attribute__((tls_model("global-dynamic"))) _Thread_local int foo = 3;
     , &.{});
-    exe.addObject(obj);
-    exe.linkLibC();
+    exe.root_module.addObject(obj);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("3 5 3 5\n");
@@ -3889,14 +3889,14 @@ fn testTlsSmallAlignment(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    c_o.linkLibC();
+    c_o.root_module.link_libc = true;
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.addObject(c_o);
-        exe.linkLibC();
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(c_o);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("42\n");
@@ -3905,13 +3905,13 @@ fn testTlsSmallAlignment(b: *Build, opts: Options) *Step {
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-        dso.addObject(a_o);
-        dso.addObject(b_o);
+        dso.root_module.addObject(a_o);
+        dso.root_module.addObject(b_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(c_o);
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.addObject(c_o);
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("42\n");
@@ -3939,7 +3939,7 @@ fn testTlsStatic(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual(
@@ -3969,8 +3969,8 @@ fn testUnknownFileTypeError(b: *Build, opts: Options) *Step {
         \\  return foo;
         \\}
     , &.{});
-    exe.linkLibrary(dylib);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dylib);
+    exe.root_module.link_libc = true;
 
     expectLinkErrors(exe, test_step, .{
         .contains = "error: failed to parse shared library: BadMagic",
@@ -3993,7 +3993,7 @@ fn testUnresolvedError(b: *Build, opts: Options) *Step {
         ,
         .c_source_flags = &.{"-ffunction-sections"},
     });
-    obj1.linkLibC();
+    obj1.root_module.link_libc = true;
 
     const obj2 = addObject(b, opts, .{
         .name = "b",
@@ -4007,12 +4007,12 @@ fn testUnresolvedError(b: *Build, opts: Options) *Step {
         ,
         .c_source_flags = &.{"-ffunction-sections"},
     });
-    obj2.linkLibC();
+    obj2.root_module.link_libc = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
-    exe.addObject(obj1);
-    exe.addObject(obj2);
-    exe.linkLibC();
+    exe.root_module.addObject(obj1);
+    exe.root_module.addObject(obj2);
+    exe.root_module.link_libc = true;
 
     expectLinkErrors(exe, test_step, .{ .exact = &.{
         "error: undefined symbol: foo",
@@ -4037,12 +4037,12 @@ fn testWeakExports(b: *Build, opts: Options) *Step {
         ,
         .pic = true,
     });
-    obj.linkLibC();
+    obj.root_module.link_libc = true;
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-        dso.addObject(obj);
-        dso.linkLibC();
+        dso.root_module.addObject(obj);
+        dso.root_module.link_libc = true;
 
         const check = dso.checkObject();
         check.checkInDynamicSymtab();
@@ -4052,8 +4052,8 @@ fn testWeakExports(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(obj);
-        exe.linkLibC();
+        exe.root_module.addObject(obj);
+        exe.root_module.link_libc = true;
 
         const check = exe.checkObject();
         check.checkInDynamicSymtab();
@@ -4084,8 +4084,8 @@ fn testWeakUndefsDso(b: *Build, opts: Options) *Step {
             \\int bar();
             \\int main() { printf("bar=%d\n", bar()); }
         , &.{});
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("bar=-1\n");
@@ -4100,8 +4100,8 @@ fn testWeakUndefsDso(b: *Build, opts: Options) *Step {
             \\int bar();
             \\int main() { printf("bar=%d\n", bar()); }
         , &.{});
-        exe.linkLibrary(dso);
-        exe.linkLibC();
+        exe.root_module.linkLibrary(dso);
+        exe.root_module.link_libc = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("bar=5\n");
@@ -4122,7 +4122,7 @@ fn testZNow(b: *Build, opts: Options) *Step {
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-        dso.addObject(obj);
+        dso.root_module.addObject(obj);
 
         const check = dso.checkObject();
         check.checkInDynamicSection();
@@ -4132,7 +4132,7 @@ fn testZNow(b: *Build, opts: Options) *Step {
 
     {
         const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-        dso.addObject(obj);
+        dso.root_module.addObject(obj);
         dso.link_z_lazy = true;
 
         const check = dso.checkObject();
@@ -4150,7 +4150,7 @@ fn testZStackSize(b: *Build, opts: Options) *Step {
     const exe = addExecutable(b, opts, .{ .name = "main" });
     addCSourceBytes(exe, "int main() { return 0; }", &.{});
     exe.stack_size = 0x800000;
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     const check = exe.checkObject();
     check.checkInHeaders();
@@ -4202,8 +4202,8 @@ fn testZText(b: *Build, opts: Options) *Step {
     });
 
     const dso = addSharedLibrary(b, opts, .{ .name = "a" });
-    dso.addObject(a_o);
-    dso.addObject(b_o);
+    dso.root_module.addObject(a_o);
+    dso.root_module.addObject(b_o);
     dso.link_z_notext = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
@@ -4214,8 +4214,8 @@ fn testZText(b: *Build, opts: Options) *Step {
         \\  printf("%d\n", fnn());
         \\}
     , &.{});
-    exe.linkLibrary(dso);
-    exe.linkLibC();
+    exe.root_module.linkLibrary(dso);
+    exe.root_module.link_libc = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("3\n");

--- a/test/link/link.zig
+++ b/test/link/link.zig
@@ -140,20 +140,20 @@ pub fn addRunArtifact(comp: *Compile) *Run {
 pub fn addCSourceBytes(comp: *Compile, bytes: []const u8, flags: []const []const u8) void {
     const b = comp.step.owner;
     const file = WriteFile.create(b).add("a.c", bytes);
-    comp.addCSourceFile(.{ .file = file, .flags = flags });
+    comp.root_module.addCSourceFile(.{ .file = file, .flags = flags });
 }
 
 pub fn addCppSourceBytes(comp: *Compile, bytes: []const u8, flags: []const []const u8) void {
     const b = comp.step.owner;
     const file = WriteFile.create(b).add("a.cpp", bytes);
-    comp.addCSourceFile(.{ .file = file, .flags = flags });
+    comp.root_module.addCSourceFile(.{ .file = file, .flags = flags });
 }
 
 pub fn addAsmSourceBytes(comp: *Compile, bytes: []const u8) void {
     const b = comp.step.owner;
     const actual_bytes = std.fmt.allocPrint(b.allocator, "{s}\n", .{bytes}) catch @panic("OOM");
     const file = WriteFile.create(b).add("a.s", actual_bytes);
-    comp.addAssemblyFile(file);
+    comp.root_module.addAssemblyFile(file);
 }
 
 pub fn expectLinkErrors(comp: *Compile, test_step: *Step, expected_errors: Compile.ExpectedCompileErrors) void {

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -127,7 +127,7 @@ fn testDeadStrip(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "no_dead_strip" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = false;
 
         const check = exe.checkObject();
@@ -156,7 +156,7 @@ fn testDeadStrip(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "yes_dead_strip" });
-        exe.addObject(obj);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = true;
 
         const check = exe.checkObject();
@@ -206,7 +206,7 @@ fn testDuplicateDefinitions(b: *Build, opts: Options) *Step {
         \\    strong();
         \\}
     });
-    exe.addObject(obj);
+    exe.root_module.addObject(obj);
 
     expectLinkErrors(exe, test_step, .{ .exact = &.{
         "error: duplicate symbol definition: _strong",
@@ -235,7 +235,7 @@ fn testDeadStripDylibs(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkFramework("Cocoa", .{});
 
         const check = exe.checkObject();
@@ -254,7 +254,7 @@ fn testDeadStripDylibs(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkFramework("Cocoa", .{});
         exe.dead_strip_dylibs = true;
 
@@ -350,7 +350,7 @@ fn testEmptyObject(b: *Build, opts: Options) *Step {
         \\  printf("Hello world!");
         \\}
     });
-    exe.addObject(empty);
+    exe.root_module.addObject(empty);
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("Hello world!");
@@ -451,7 +451,7 @@ fn testEntryPointDylib(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     , &.{});
-    exe.linkLibrary(dylib);
+    exe.root_module.linkLibrary(dylib);
     exe.entry = .{ .symbol_name = "_bootstrap" };
     exe.forceUndefinedSymbol("_my_main");
 
@@ -604,11 +604,11 @@ fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
     });
 
     const lib = addSharedLibrary(b, opts, .{ .name = "a" });
-    lib.addObject(obj1);
+    lib.root_module.addObject(obj1);
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1", .c_source_bytes = "int main() { return 0; }" });
-        exe.addObject(obj1);
+        exe.root_module.addObject(obj1);
 
         const check = exe.checkObject();
         check.checkInHeaders();
@@ -642,8 +642,8 @@ fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
         }
 
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.linkLibrary(lib);
-        exe.addObject(obj);
+        exe.root_module.linkLibrary(lib);
+        exe.root_module.addObject(obj);
 
         const check = exe.checkObject();
         check.checkInHeaders();
@@ -665,7 +665,7 @@ fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
             \\_main:
             \\  ret
         });
-        exe.linkLibrary(lib);
+        exe.root_module.linkLibrary(lib);
 
         const check = exe.checkObject();
         check.checkInHeaders();
@@ -910,7 +910,7 @@ fn testLinkingStaticLib(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const exe = addExecutable(b, opts, .{
         .name = "testlib",
@@ -923,7 +923,7 @@ fn testLinkingStaticLib(b: *Build, opts: Options) *Step {
         \\}
         ,
     });
-    exe.linkLibrary(lib);
+    exe.root_module.linkLibrary(lib);
 
     const run = addRunArtifact(exe);
     run.expectStdErrEqual("0\n");
@@ -1051,28 +1051,28 @@ fn testMergeLiteralsX64(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(main_o);
         runWithChecks(test_step, exe);
     }
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(b_o);
-        exe.addObject(a_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(main_o);
         runWithChecks(test_step, exe);
     }
 
     {
         const c_o = addObject(b, opts, .{ .name = "c" });
-        c_o.addObject(a_o);
-        c_o.addObject(b_o);
-        c_o.addObject(main_o);
+        c_o.root_module.addObject(a_o);
+        c_o.root_module.addObject(b_o);
+        c_o.root_module.addObject(main_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main3" });
-        exe.addObject(c_o);
+        exe.root_module.addObject(c_o);
         runWithChecks(test_step, exe);
     }
 
@@ -1167,28 +1167,28 @@ fn testMergeLiteralsArm64(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(main_o);
         runWithChecks(test_step, exe);
     }
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(b_o);
-        exe.addObject(a_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(main_o);
         runWithChecks(test_step, exe);
     }
 
     {
         const c_o = addObject(b, opts, .{ .name = "c" });
-        c_o.addObject(a_o);
-        c_o.addObject(b_o);
-        c_o.addObject(main_o);
+        c_o.root_module.addObject(a_o);
+        c_o.root_module.addObject(b_o);
+        c_o.root_module.addObject(main_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main3" });
-        exe.addObject(c_o);
+        exe.root_module.addObject(c_o);
         runWithChecks(test_step, exe);
     }
 
@@ -1259,9 +1259,9 @@ fn testMergeLiteralsArm642(b: *Build, opts: Options) *Step {
     });
 
     const exe = addExecutable(b, opts, .{ .name = "main1" });
-    exe.addObject(a_o);
-    exe.addObject(b_o);
-    exe.addObject(main_o);
+    exe.root_module.addObject(a_o);
+    exe.root_module.addObject(b_o);
+    exe.root_module.addObject(main_o);
 
     const check = exe.checkObject();
     check.dumpSection("__TEXT,__const");
@@ -1335,17 +1335,17 @@ fn testMergeLiteralsAlignment(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(a_o);
-        exe.addObject(b_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(main_o);
         runWithChecks(test_step, exe);
     }
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(b_o);
-        exe.addObject(a_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(b_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(main_o);
         runWithChecks(test_step, exe);
     }
 
@@ -1414,27 +1414,27 @@ fn testMergeLiteralsObjc(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
-        exe.addObject(a_o);
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(a_o);
         exe.root_module.linkFramework("Foundation", .{});
         runWithChecks(test_step, exe);
     }
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(a_o);
-        exe.addObject(main_o);
+        exe.root_module.addObject(a_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkFramework("Foundation", .{});
         runWithChecks(test_step, exe);
     }
 
     {
         const b_o = addObject(b, opts, .{ .name = "b" });
-        b_o.addObject(a_o);
-        b_o.addObject(main_o);
+        b_o.root_module.addObject(a_o);
+        b_o.root_module.addObject(main_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main3" });
-        exe.addObject(b_o);
+        exe.root_module.addObject(b_o);
         exe.root_module.linkFramework("Foundation", .{});
         runWithChecks(test_step, exe);
     }
@@ -1610,7 +1610,7 @@ fn testObjcpp(b: *Build, opts: Options) *Step {
         \\@end
     });
     foo_o.root_module.addIncludePath(foo_h.dirname());
-    foo_o.linkLibCpp();
+    foo_o.root_module.link_libcpp = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main", .objcpp_source_bytes = 
         \\#import "Foo.h"
@@ -1628,8 +1628,8 @@ fn testObjcpp(b: *Build, opts: Options) *Step {
         \\}
     });
     exe.root_module.addIncludePath(foo_h.dirname());
-    exe.addObject(foo_o);
-    exe.linkLibCpp();
+    exe.root_module.addObject(foo_o);
+    exe.root_module.link_libcpp = true;
     exe.root_module.linkFramework("Foundation", .{});
 
     const run = addRunArtifact(exe);
@@ -1693,7 +1693,7 @@ fn testReexportsZig(b: *Build, opts: Options) *Step {
         \\  return bar() - foo();
         \\}
     });
-    exe.linkLibrary(lib);
+    exe.root_module.linkLibrary(lib);
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -1711,7 +1711,7 @@ fn testRelocatable(b: *Build, opts: Options) *Step {
         \\  throw std::runtime_error("Oh no!");
         \\}
     });
-    a_o.linkLibCpp();
+    a_o.root_module.link_libcpp = true;
 
     const b_o = addObject(b, opts, .{ .name = "b", .cpp_source_bytes = 
         \\extern int try_me();
@@ -1733,19 +1733,19 @@ fn testRelocatable(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     });
-    main_o.linkLibCpp();
+    main_o.root_module.link_libcpp = true;
 
     const exp_stdout = "exception=Oh no!";
 
     {
         const c_o = addObject(b, opts, .{ .name = "c" });
-        c_o.addObject(a_o);
-        c_o.addObject(b_o);
+        c_o.root_module.addObject(a_o);
+        c_o.root_module.addObject(b_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
-        exe.addObject(c_o);
-        exe.linkLibCpp();
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(c_o);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(exp_stdout);
@@ -1754,13 +1754,13 @@ fn testRelocatable(b: *Build, opts: Options) *Step {
 
     {
         const d_o = addObject(b, opts, .{ .name = "d" });
-        d_o.addObject(a_o);
-        d_o.addObject(b_o);
-        d_o.addObject(main_o);
+        d_o.root_module.addObject(a_o);
+        d_o.root_module.addObject(b_o);
+        d_o.root_module.addObject(main_o);
 
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(d_o);
-        exe.linkLibCpp();
+        exe.root_module.addObject(d_o);
+        exe.root_module.link_libcpp = true;
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual(exp_stdout);
@@ -1805,12 +1805,12 @@ fn testRelocatableZig(b: *Build, opts: Options) *Step {
     });
 
     const c_o = addObject(b, opts, .{ .name = "c" });
-    c_o.addObject(a_o);
-    c_o.addObject(b_o);
-    c_o.addObject(main_o);
+    c_o.root_module.addObject(a_o);
+    c_o.root_module.addObject(b_o);
+    c_o.root_module.addObject(main_o);
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
-    exe.addObject(c_o);
+    exe.root_module.addObject(c_o);
 
     const run = addRunArtifact(exe);
     run.addCheck(.{ .expect_stderr_match = b.dupe("incrFoo=1") });
@@ -1833,10 +1833,10 @@ fn testSearchStrategy(b: *Build, opts: Options) *Step {
     });
 
     const liba = addStaticLibrary(b, opts, .{ .name = "a" });
-    liba.addObject(obj);
+    liba.root_module.addObject(obj);
 
     const dylib = addSharedLibrary(b, opts, .{ .name = "a" });
-    dylib.addObject(obj);
+    dylib.root_module.addObject(obj);
 
     const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
         \\#include<stdio.h>
@@ -1850,7 +1850,7 @@ fn testSearchStrategy(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkSystemLibrary("a", .{ .use_pkg_config = .no, .search_strategy = .mode_first });
         exe.root_module.addLibraryPath(liba.getEmittedBinDirectory());
         exe.root_module.addLibraryPath(dylib.getEmittedBinDirectory());
@@ -1869,7 +1869,7 @@ fn testSearchStrategy(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkSystemLibrary("a", .{ .use_pkg_config = .no, .search_strategy = .paths_first });
         exe.root_module.addLibraryPath(liba.getEmittedBinDirectory());
         exe.root_module.addLibraryPath(dylib.getEmittedBinDirectory());
@@ -1924,9 +1924,9 @@ fn testSectionBoundarySymbols(b: *Build, opts: Options) *Step {
         });
 
         const exe = addExecutable(b, opts, .{ .name = "test" });
-        exe.addObject(obj1);
-        exe.addObject(obj2);
-        exe.addObject(main_o);
+        exe.root_module.addObject(obj1);
+        exe.root_module.addObject(obj2);
+        exe.root_module.addObject(main_o);
 
         const run = b.addRunArtifact(exe);
         run.skip_foreign_checks = true;
@@ -1951,9 +1951,9 @@ fn testSectionBoundarySymbols(b: *Build, opts: Options) *Step {
         });
 
         const exe = addExecutable(b, opts, .{ .name = "test" });
-        exe.addObject(obj1);
-        exe.addObject(obj3);
-        exe.addObject(main_o);
+        exe.root_module.addObject(obj1);
+        exe.root_module.addObject(obj3);
+        exe.root_module.addObject(main_o);
 
         const run = b.addRunArtifact(exe);
         run.skip_foreign_checks = true;
@@ -2031,9 +2031,9 @@ fn testSegmentBoundarySymbols(b: *Build, opts: Options) *Step {
         });
 
         const exe = addExecutable(b, opts, .{ .name = "main" });
-        exe.addObject(obj1);
-        exe.addObject(obj2);
-        exe.addObject(main_o);
+        exe.root_module.addObject(obj1);
+        exe.root_module.addObject(obj2);
+        exe.root_module.addObject(main_o);
 
         const run = addRunArtifact(exe);
         run.expectStdOutEqual("All your codebase are belong to us.\n");
@@ -2054,9 +2054,9 @@ fn testSegmentBoundarySymbols(b: *Build, opts: Options) *Step {
         });
 
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(obj1);
-        exe.addObject(obj2);
-        exe.addObject(main_o);
+        exe.root_module.addObject(obj1);
+        exe.root_module.addObject(obj2);
+        exe.root_module.addObject(main_o);
 
         const check = exe.checkObject();
         check.checkInHeaders();
@@ -2102,9 +2102,9 @@ fn testSymbolStabs(b: *Build, opts: Options) *Step {
     });
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
-    exe.addObject(a_o);
-    exe.addObject(b_o);
-    exe.addObject(main_o);
+    exe.root_module.addObject(a_o);
+    exe.root_module.addObject(b_o);
+    exe.root_module.addObject(main_o);
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("foo=42,bar=24");
@@ -2299,7 +2299,7 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
         \\}
     });
     bar_o.root_module.addIncludePath(foo_h.dirname());
-    bar_o.linkLibCpp();
+    bar_o.root_module.link_libcpp = true;
 
     const baz_o = addObject(b, opts, .{ .name = "baz", .cpp_source_bytes = 
         \\#include "foo.h"
@@ -2309,7 +2309,7 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
         \\}
     });
     baz_o.root_module.addIncludePath(foo_h.dirname());
-    baz_o.linkLibCpp();
+    baz_o.root_module.link_libcpp = true;
 
     const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes = 
         \\extern int bar();
@@ -2321,13 +2321,13 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
         \\}
     });
     main_o.root_module.addIncludePath(foo_h.dirname());
-    main_o.linkLibCpp();
+    main_o.root_module.link_libcpp = true;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
-    exe.addObject(bar_o);
-    exe.addObject(baz_o);
-    exe.addObject(main_o);
-    exe.linkLibCpp();
+    exe.root_module.addObject(bar_o);
+    exe.root_module.addObject(baz_o);
+    exe.root_module.addObject(main_o);
+    exe.root_module.link_libcpp = true;
 
     const run = addRunArtifact(exe);
     run.expectExitCode(0);
@@ -2445,7 +2445,7 @@ fn testTwoLevelNamespace(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkSystemLibrary("a", .{});
         exe.root_module.linkSystemLibrary("b", .{});
         exe.root_module.addLibraryPath(liba.getEmittedBinDirectory());
@@ -2474,7 +2474,7 @@ fn testTwoLevelNamespace(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
+        exe.root_module.addObject(main_o);
         exe.root_module.linkSystemLibrary("b", .{});
         exe.root_module.linkSystemLibrary("a", .{});
         exe.root_module.addLibraryPath(liba.getEmittedBinDirectory());
@@ -2510,14 +2510,14 @@ fn testDiscardLocalSymbols(b: *Build, opts: Options) *Step {
     const obj = addObject(b, opts, .{ .name = "a", .c_source_bytes = "static int foo = 42;" });
 
     const lib = addStaticLibrary(b, opts, .{ .name = "a" });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = "int main() { return 0; }" });
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main3" });
-        exe.addObject(main_o);
-        exe.addObject(obj);
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(obj);
         exe.discard_local_symbols = true;
 
         const run = addRunArtifact(exe);
@@ -2532,8 +2532,8 @@ fn testDiscardLocalSymbols(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main4" });
-        exe.addObject(main_o);
-        exe.linkLibrary(lib);
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkLibrary(lib);
         exe.discard_local_symbols = true;
 
         const run = addRunArtifact(exe);
@@ -2555,14 +2555,14 @@ fn testUndefinedFlag(b: *Build, opts: Options) *Step {
     const obj = addObject(b, opts, .{ .name = "a", .c_source_bytes = "int foo = 42;" });
 
     const lib = addStaticLibrary(b, opts, .{ .name = "a" });
-    lib.addObject(obj);
+    lib.root_module.addObject(obj);
 
     const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = "int main() { return 0; }" });
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main1" });
-        exe.addObject(main_o);
-        exe.linkLibrary(lib);
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkLibrary(lib);
         exe.forceUndefinedSymbol("_foo");
 
         const run = addRunArtifact(exe);
@@ -2577,8 +2577,8 @@ fn testUndefinedFlag(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main2" });
-        exe.addObject(main_o);
-        exe.linkLibrary(lib);
+        exe.root_module.addObject(main_o);
+        exe.root_module.linkLibrary(lib);
         exe.forceUndefinedSymbol("_foo");
         exe.link_gc_sections = true;
 
@@ -2594,8 +2594,8 @@ fn testUndefinedFlag(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main3" });
-        exe.addObject(main_o);
-        exe.addObject(obj);
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(obj);
 
         const run = addRunArtifact(exe);
         run.expectExitCode(0);
@@ -2609,8 +2609,8 @@ fn testUndefinedFlag(b: *Build, opts: Options) *Step {
 
     {
         const exe = addExecutable(b, opts, .{ .name = "main4" });
-        exe.addObject(main_o);
-        exe.addObject(obj);
+        exe.root_module.addObject(main_o);
+        exe.root_module.addObject(obj);
         exe.link_gc_sections = true;
 
         const run = addRunArtifact(exe);
@@ -2642,7 +2642,7 @@ fn testUnresolvedError(b: *Build, opts: Options) *Step {
         \\    std.debug.print("foo() + bar() = {d}", .{foo() + bar()});
         \\}
     });
-    exe.addObject(obj);
+    exe.root_module.addObject(obj);
 
     // TODO order should match across backends if possible
     if (opts.use_llvm) {
@@ -2764,7 +2764,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
         \\}
     });
     main_o.root_module.addIncludePath(all_h.dirname());
-    main_o.linkLibCpp();
+    main_o.root_module.link_libcpp = true;
 
     const simple_string_o = addObject(b, opts, .{ .name = "simple_string", .cpp_source_bytes = 
         \\#include "all.h"
@@ -2799,7 +2799,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
         \\}
     });
     simple_string_o.root_module.addIncludePath(all_h.dirname());
-    simple_string_o.linkLibCpp();
+    simple_string_o.root_module.link_libcpp = true;
 
     const simple_string_owner_o = addObject(b, opts, .{ .name = "simple_string_owner", .cpp_source_bytes = 
         \\#include "all.h"
@@ -2816,7 +2816,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
         \\}
     });
     simple_string_owner_o.root_module.addIncludePath(all_h.dirname());
-    simple_string_owner_o.linkLibCpp();
+    simple_string_owner_o.root_module.link_libcpp = true;
 
     const exp_stdout =
         \\Constructed: a
@@ -2828,10 +2828,10 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
     ;
 
     const exe = addExecutable(b, opts, .{ .name = "main" });
-    exe.addObject(main_o);
-    exe.addObject(simple_string_o);
-    exe.addObject(simple_string_owner_o);
-    exe.linkLibCpp();
+    exe.root_module.addObject(main_o);
+    exe.root_module.addObject(simple_string_o);
+    exe.root_module.addObject(simple_string_owner_o);
+    exe.root_module.link_libcpp = true;
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual(exp_stdout);
@@ -2896,7 +2896,7 @@ fn testUnwindInfoNoSubsectionsArm64(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     });
-    exe.addObject(a_o);
+    exe.root_module.addObject(a_o);
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("4\n");
@@ -2948,7 +2948,7 @@ fn testUnwindInfoNoSubsectionsX64(b: *Build, opts: Options) *Step {
         \\  return 0;
         \\}
     });
-    exe.addObject(a_o);
+    exe.root_module.addObject(a_o);
 
     const run = addRunArtifact(exe);
     run.expectStdOutEqual("4\n");
@@ -3052,7 +3052,7 @@ fn testWeakBind(b: *Build, opts: Options) *Step {
         \\  .quad 0
         \\  .quad _weak_internal_tlv$tlv$init
     });
-    exe.linkLibrary(lib);
+    exe.root_module.linkLibrary(lib);
 
     {
         const check = exe.checkObject();

--- a/test/link/wasm/extern/build.zig
+++ b/test/link/wasm/extern/build.zig
@@ -16,7 +16,7 @@ fn add(b: *std.Build, test_step: *std.Build.Step, optimize: std.builtin.Optimize
             .target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .wasi }),
         }),
     });
-    exe.addCSourceFile(.{ .file = b.path("foo.c"), .flags = &.{} });
+    exe.root_module.addCSourceFile(.{ .file = b.path("foo.c"), .flags = &.{} });
     exe.use_llvm = false;
     exe.use_lld = false;
 

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -560,7 +560,7 @@ pub fn lowerToTranslateCSteps(
                 .root_module = translate_c.createModule(),
             });
             run_exe.step.name = b.fmt("{s} build-exe", .{annotated_case_name});
-            run_exe.linkLibC();
+            run_exe.root_module.link_libc = true;
             const run = b.addRunArtifact(run_exe);
             run.step.name = b.fmt("{s} run", .{annotated_case_name});
             run.expectStdOutEqual(output);

--- a/test/src/RunTranslatedC.zig
+++ b/test/src/RunTranslatedC.zig
@@ -89,7 +89,7 @@ pub fn addCase(self: *RunTranslatedCContext, case: *const TestCase) void {
         .root_module = translate_c.createModule(),
     });
     exe.step.name = b.fmt("{s} build-exe", .{annotated_case_name});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
     const run = b.addRunArtifact(exe);
     run.step.name = b.fmt("{s} run", .{annotated_case_name});
     if (!case.allow_warnings) {

--- a/test/standalone/c_embed_path/build.zig
+++ b/test/standalone/c_embed_path/build.zig
@@ -13,12 +13,12 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    exe.addCSourceFile(.{
+    exe.root_module.addCSourceFile(.{
         .file = b.path("test.c"),
         .flags = &.{"-std=c23"},
     });
-    exe.linkLibC();
-    exe.addEmbedPath(b.path("data"));
+    exe.root_module.link_libc = true;
+    exe.root_module.addEmbedPath(b.path("data"));
 
     const run_c_cmd = b.addRunArtifact(exe);
     run_c_cmd.expectExitCode(0);

--- a/test/standalone/extern/build.zig
+++ b/test/standalone/extern/build.zig
@@ -31,8 +31,8 @@ pub fn build(b: *std.Build) void {
         .target = b.graph.host,
         .optimize = optimize,
     }) });
-    test_exe.addObject(obj);
-    test_exe.linkLibrary(shared);
+    test_exe.root_module.addObject(obj);
+    test_exe.root_module.linkLibrary(shared);
 
     test_step.dependOn(&b.addRunArtifact(test_exe).step);
 }

--- a/test/standalone/issue_794/build.zig
+++ b/test/standalone/issue_794/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("main.zig"),
         .target = b.graph.host,
     }) });
-    test_artifact.addIncludePath(b.path("a_directory"));
+    test_artifact.root_module.addIncludePath(b.path("a_directory"));
 
     // TODO: actually check the output
     _ = test_artifact.getEmittedBin();

--- a/test/standalone/stack_iterator/build.zig
+++ b/test/standalone/stack_iterator/build.zig
@@ -109,7 +109,7 @@ pub fn build(b: *std.Build) void {
     //        .use_llvm = true,
     //    });
 
-    //    exe.linkLibrary(c_shared_lib);
+    //    exe.root_module.linkLibrary(c_shared_lib);
 
     //    const run_cmd = b.addRunArtifact(exe);
     //    test_step.dependOn(&run_cmd.step);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -2371,10 +2371,10 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         } else "";
         const use_pic = if (test_target.pic == true) "-pic" else "";
 
-        for (options.include_paths) |include_path| these_tests.addIncludePath(b.path(include_path));
+        for (options.include_paths) |include_path| these_tests.root_module.addIncludePath(b.path(include_path));
 
         if (target.os.tag == .windows) {
-            for (options.windows_libs) |lib| these_tests.linkSystemLibrary(lib);
+            for (options.windows_libs) |lib| these_tests.root_module.linkSystemLibrary(lib, .{});
         }
 
         const qualified_name = b.fmt("{s}-{s}-{s}-{s}{s}{s}{s}{s}{s}{s}", .{


### PR DESCRIPTION
Not only are `Step.Compile` methods like `linkLibC()` redundant because `Module` exposes the same APIs, it also might not be immediately obvious to users that these methods modify the underlying root module, which can be a footgun and lead to unintended results if the module is exported to package consumers or shared by multiple compile steps. For example, I personally almost ran in to this:

```zig
// module exported to package consumers, doesn't require libc
const mod = b.addModule("mymodule", .{
    .root_source_file = b.path("main.zig"),
    .target = target,
    .optimize = optimize,
});

// some unit tests require libc
const tests = b.addTest(.{ .root_module = mod });
tests.linkLibC(); // uh-oh! now the exported module requires libc!

const run_tests = b.addRunArtifact(tests);

const test_step = b.step("test", "Run tests");
test_step.dependOn(&run_tests.step);
```

Using `compile.root_module.link_libc = true` or `compile.root_module.linkLibrary(lib)` makes it more clear to users which of the compile step and the module owns which options.

Suggested release notes (if you think deprecation notices are relevant):

## Deprecated `std.Build.Step.Compile` APIs

The following `std.Build.Step.Compile` methods have been deprecated in favor of their `std.Build.Module` equivalents and are slated for removal during the next release cycle:

- `addAfterIncludePath`
- `addAssemblyFile`
- `addCSourceFile`
- `addCSourceFiles`
- `addConfigHeader`
- `addEmbedPath`
- `addFrameworkPath`
- `addIncludePath`
- `addLibraryPath`
- `addObject`
- `addObjectFile`
- `addRPath`
- `addSystemFrameworkPath`
- `addSystemIncludePath`
- `addWin32ResourceFile`
- `linkFramework`
- `linkLibC`
- `linkLibCpp`
- `linkLibrary`
- `linkSystemLibrary`
- `linkSystemLibrary2`

Upgrade guide:

```diff
 // Most uses can be migrated by inserting `root_module` before the method call
-exe.linkLibrary(lib);
+exe.root_module.linkLibrary(lib);

 // Set the corresponding field directly
-exe.linkLibC();
-exe.linkLibCpp();
+exe.root_module.link_libc = true;
+exe.root_module.link_libcpp = true;

 // Pass '.{}' as the second argument
-exe.linkSystemLibrary("foo");
+exe.root_module.linkSystemLibrary("foo", .{});

 // Omit the '2' from the method name
-exe.linkSystemLibrary2("foo", .{ .needed = false });
+exe.root_module.linkSystemLibrary("foo", .{ .needed = false });
```