### PR TITLE
[Feat] std.http.Server.RespondOptions content_type

### DIFF
--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -587,7 +587,7 @@ pub const Request = struct {
                 .@"HTTP/1.1" => if (!keep_alive) h.appendSliceAssumeCapacity("connection: close\r\n"),
             }
 
-            if (options.content_type) |content_type| {
+            if (options.respond_options.content_type) |content_type| {
                 h.fixedWriter().print("content-type: {s}\r\n", .{content_type}) catch unreachable;
             }
 

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -370,6 +370,7 @@ pub const Request = struct {
         keep_alive: bool = true,
         extra_headers: []const http.Header = &.{},
         transfer_encoding: ?http.TransferEncoding = null,
+        content_type: ?[]const u8 = null,
     };
 
     /// Send an entire HTTP response to the client, including headers and body.
@@ -428,6 +429,10 @@ pub const Request = struct {
         switch (options.version) {
             .@"HTTP/1.0" => if (keep_alive) h.appendSliceAssumeCapacity("connection: keep-alive\r\n"),
             .@"HTTP/1.1" => if (!keep_alive) h.appendSliceAssumeCapacity("connection: close\r\n"),
+        }
+
+        if (options.content_type) |content_type| {
+            h.fixedWriter().print("content-type: {s}\r\n", .{content_type}) catch unreachable;
         }
 
         if (options.transfer_encoding) |transfer_encoding| switch (transfer_encoding) {
@@ -580,6 +585,10 @@ pub const Request = struct {
             switch (o.version) {
                 .@"HTTP/1.0" => if (keep_alive) h.appendSliceAssumeCapacity("connection: keep-alive\r\n"),
                 .@"HTTP/1.1" => if (!keep_alive) h.appendSliceAssumeCapacity("connection: close\r\n"),
+            }
+
+            if (options.content_type) |content_type| {
+                h.fixedWriter().print("content-type: {s}\r\n", .{content_type}) catch unreachable;
             }
 
             if (o.transfer_encoding) |transfer_encoding| switch (transfer_encoding) {

--- a/lib/std/http/test.zig
+++ b/lib/std/http/test.zig
@@ -109,10 +109,8 @@ test "HTTP server handles a chunked transfer coding request" {
             try expect(mem.eql(u8, buf[0..n], "ABCD"));
 
             try request.respond("message from server!\n", .{
-                .extra_headers = &.{
-                    .{ .name = "content-type", .value = "text/plain" },
-                },
                 .keep_alive = false,
+                .content_type = "text/plain",
             });
         }
     });
@@ -405,9 +403,7 @@ test "general client/server API coverage" {
                     else
                         null,
                     .respond_options = .{
-                        .extra_headers = &.{
-                            .{ .name = "content-type", .value = "text/plain" },
-                        },
+                        .content_type = "text/plain",
                     },
                 });
                 const w = response.writer();

--- a/lib/std/http/test.zig
+++ b/lib/std/http/test.zig
@@ -118,7 +118,6 @@ test "HTTP server handles a chunked transfer coding request" {
 
     const request_bytes =
         "POST / HTTP/1.1\r\n" ++
-        "Content-Type: text/plain\r\n" ++
         "Transfer-Encoding: chunked\r\n" ++
         "\r\n" ++
         "1\r\n" ++
@@ -138,8 +137,8 @@ test "HTTP server handles a chunked transfer coding request" {
     const expected_response =
         "HTTP/1.1 200 OK\r\n" ++
         "connection: close\r\n" ++
-        "content-length: 21\r\n" ++
         "content-type: text/plain\r\n" ++
+        "content-length: 21\r\n" ++
         "\r\n" ++
         "message from server!\n";
     const response = try stream.reader().readAllAlloc(gpa, expected_response.len);


### PR DESCRIPTION
# Reasoning
Bring the `RespondOptions` inline with other parts of the API such as `std.http.Client.Response` and `std.http.Server.Request.Head` which include `content_type` as apart of the header.

# Notes
This is a breaking change, which will cause anyone using extra headers too no longer work as the HTTP response will be malformed with 2 content types.