### PR TITLE
`musl`: Manually inline `__tls_get_addr` into s390x `__tls_get_offset`.

### DIFF
--- a/lib/libc/musl/src/thread/s390x/__tls_get_offset.s
+++ b/lib/libc/musl/src/thread/s390x/__tls_get_offset.s
@@ -1,18 +1,17 @@
 	.global __tls_get_offset
 	.type __tls_get_offset,%function
 __tls_get_offset:
-	stmg  %r14, %r15, 112(%r15)
-	aghi  %r15, -160
+	ear   %r0, %a0
+	sllg  %r0, %r0, 32
+	ear   %r0, %a1
 
-	la    %r2, 0(%r2, %r12)
-.hidden __tls_get_addr
-	brasl %r14, __tls_get_addr
+	la    %r1, 0(%r2, %r12)
 
-	ear   %r1, %a0
-	sllg  %r1, %r1, 32
-	ear   %r1, %a1
+	lg    %r3, 0(%r1)
+	sllg  %r4, %r3, 3
+	lg    %r5, 8(%r0)
+	lg    %r2, 0(%r4, %r5)
+	ag    %r2, 8(%r1)
+	sgr   %r2, %r0
 
-	sgr   %r2, %r1
-
-	lmg   %r14, %r15, 272(%r15)
 	br    %r14


### PR DESCRIPTION
See these mailing list threads:

* https://www.openwall.com/lists/musl/2024/11/23/3
* https://www.openwall.com/lists/musl/2025/01/24/1

This supplants cc73d7ad749df8d53da442faa2e7af5d69357b33.