### PR TITLE
Update LDR_DATA_TABLE_ENTRY struct

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -4803,14 +4803,14 @@ pub const PEB_LDR_DATA = extern struct {
 ///  - https://docs.microsoft.com/en-us/windows/win32/api/winternl/ns-winternl-peb_ldr_data
 ///  - https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntldr/ldr_data_table_entry.htm
 pub const LDR_DATA_TABLE_ENTRY = extern struct {
-    Reserved1: [2]PVOID,
+    InLoadOrderLinks: LIST_ENTRY,
     InMemoryOrderLinks: LIST_ENTRY,
-    Reserved2: [2]PVOID,
+    InInitializationOrderLinks: LIST_ENTRY,
     DllBase: PVOID,
     EntryPoint: PVOID,
     SizeOfImage: ULONG,
     FullDllName: UNICODE_STRING,
-    Reserved4: [8]BYTE,
+    BaseDllName: UNICODE_STRING,
     Reserved5: [3]PVOID,
     DUMMYUNIONNAME: extern union {
         CheckSum: ULONG,


### PR DESCRIPTION
The current implementation of the `LDR_DATA_TABLE_ENTRY` struct is using reserved fields for `InLoadOrderMemoryLinks`, `InInitializationOrderLinks`, and `BaseDllName` among a few other fields, but they are not as relevant. I've updated those fields in this PR, but I'm happy to discuss or look into this further if a more verbose struct definition would be applicable here.

Additionally, the complete `LDR_DATA_TABLE_ENTRY` struct definition can be found at the following links for Vista and W10, respectively:
https://www.nirsoft.net/kernel_struct/vista/LDR_DATA_TABLE_ENTRY.html
https://www.vergiliusproject.com/kernels/x64/windows-10/1909/_LDR_DATA_TABLE_ENTRY