### PR TITLE
std: do not call xcode-select or xcrun by absolute path in darwin sdk detection

### DIFF
--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -15,7 +15,7 @@ pub const macos = @import("darwin/macos.zig");
 pub fn isSdkInstalled(allocator: Allocator) bool {
     const result = std.process.Child.run(.{
         .allocator = allocator,
-        .argv = &.{ "/usr/bin/xcode-select", "--print-path" },
+        .argv = &.{ "xcode-select", "--print-path" },
     }) catch return false;
 
     defer {
@@ -48,7 +48,7 @@ pub fn getSdk(allocator: Allocator, target: Target) ?[]const u8 {
         .visionos => if (is_simulator_abi) "xrsimulator" else "xros",
         else => return null,
     };
-    const argv = &[_][]const u8{ "/usr/bin/xcrun", "--sdk", sdk, "--show-sdk-path" };
+    const argv = &[_][]const u8{ "xcrun", "--sdk", sdk, "--show-sdk-path" };
     const result = std.process.Child.run(.{ .allocator = allocator, .argv = argv }) catch return null;
     defer {
         allocator.free(result.stderr);


### PR DESCRIPTION
Closes #22600