### PR TITLE
Change std.testing.expectEqual to consider equivalent nans equal

### DIFF
--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -128,9 +128,7 @@ test parseFloat {
 
 test "nan and inf" {
     inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
-        const Z = std.meta.Int(.unsigned, @typeInfo(T).float.bits);
-
-        try expectEqual(@as(Z, @bitCast(try parseFloat(T, "nAn"))), @as(Z, @bitCast(std.math.nan(T))));
+        try expectEqual(try parseFloat(T, "nAn"), std.math.nan(T));
         try expectEqual(try parseFloat(T, "inF"), std.math.inf(T));
         try expectEqual(try parseFloat(T, "-INF"), -std.math.inf(T));
     }
@@ -163,9 +161,9 @@ test "hex.special" {
 
 test "hex.zero" {
     try testing.expectEqual(@as(f32, 0.0), try parseFloat(f32, "0x0"));
-    try testing.expectEqual(@as(f32, 0.0), try parseFloat(f32, "-0x0"));
+    try testing.expectEqual(@as(f32, -0.0), try parseFloat(f32, "-0x0"));
     try testing.expectEqual(@as(f32, 0.0), try parseFloat(f32, "0x0p42"));
-    try testing.expectEqual(@as(f32, 0.0), try parseFloat(f32, "-0x0.00000p42"));
+    try testing.expectEqual(@as(f32, -0.0), try parseFloat(f32, "-0x0.00000p42"));
     try testing.expectEqual(@as(f32, 0.0), try parseFloat(f32, "0x0.00000p666"));
 }
 


### PR DESCRIPTION
Consider this test:
```zig
test "divide by zero" {
    try std.testing.expectEqual(std.math.nan(f32), 0.0 / 0.0);
}
```

I would expect this test to pass, but currently it does not. This PR chnages that: floats are compared bitwise so that nans can compare equal, if both arguments are nan but they are *different* nans, the test fails and the values are printed as hex.

In case this change is controversial, my rational follows.

***

Nans do not compare equal when using `==`. However, `expectEqual` is not `==`, it's explicitly intended for checking equality in tests.

In this context, it is very reasonable to want to compare to nan. Coming up with use cases for this is easy:

Maybe you're writing a vector math library and some operations should result in your types holding nan values. You could satisfy this use case manually with `isNan`, however, you'd need to check each field manually. This is laborious, which is exactly the problem `expectEqual` is designed to solve.

Another use case, and the one that lead to me discovering the current behavior, is fuzz testing. My fuzz tests currently fail unless I restrict the fuzz parser to never return nans, since otherwise they fail my equality checks. This is unfortunate--I don't want to rule out nans from my test inputs!

On the flip side, I can't think of any motivating use cases for the current behavior. Nan not comparing equal to itself has real use cases in general as it maintains some useful invariants. None of these are relevant to expect equal. You could argue that the current behavior is less surprising, but I disagree--`expectEqual` doesn't do what `==` much of the time, I expected the behavior this PR implements.