### PR TITLE
Revert d714cf33405486d9aa707e9aee8f103a011d06e9 (#21273)

### DIFF
--- a/lib/std/c/darwin.zig
+++ b/lib/std/c/darwin.zig
@@ -75,8 +75,6 @@ pub const EXC = enum(exception_type_t) {
         CORPSE_NOTIFY: bool = false,
         _14: u18 = 0,
 
-        _padding: u19 = 0,
-
         pub const MACHINE: MASK = @bitCast(@as(u32, 0));
 
         pub const ALL: MASK = .{


### PR DESCRIPTION
Turns out this was already fixed in #21964.

I have no idea why GitHub showed an incorrect diff in #21273, or how applying the diff to master was even possible, but here we are.