### PR TITLE
cmake: use cache entry for extra build args to get the type correct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,7 +932,7 @@ set(ZIG_BUILD_ARGS
   -Dno-langref
 )
 
-option(ZIG_EXTRA_BUILD_ARGS "Extra zig build args")
+set(ZIG_EXTRA_BUILD_ARGS "" CACHE STRING "Extra zig build args")
 if(ZIG_EXTRA_BUILD_ARGS)
   list(APPEND ZIG_BUILD_ARGS ${ZIG_EXTRA_BUILD_ARGS})
 endif()


### PR DESCRIPTION
in cmake `option()` defaults the argument to a boolean type, changing it into a cache variable retains the same behavior while making sure the correct type is used.

This is mostly useful for tooling around cmake that doesn't allow type changes without a complete reconfiguration.