### PR TITLE
std.c: add `msghdr` and `msghdr_const` definitions for macos

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -3528,7 +3528,21 @@ pub const itimerspec = switch (native_os) {
 };
 pub const msghdr = switch (native_os) {
     .linux => linux.msghdr,
-    .openbsd, .emscripten, .dragonfly, .freebsd, .netbsd, .haiku, .solaris, .illumos => extern struct {
+    .openbsd,
+    .emscripten,
+    .dragonfly,
+    .freebsd,
+    .netbsd,
+    .haiku,
+    .solaris,
+    .illumos,
+    .macos,
+    .driverkit,
+    .ios,
+    .tvos,
+    .visionos,
+    .watchos,
+    => extern struct {
         /// optional address
         name: ?*sockaddr,
         /// size of address
@@ -3548,7 +3562,21 @@ pub const msghdr = switch (native_os) {
 };
 pub const msghdr_const = switch (native_os) {
     .linux => linux.msghdr_const,
-    .openbsd, .emscripten, .dragonfly, .freebsd, .netbsd, .haiku, .solaris, .illumos => extern struct {
+    .openbsd,
+    .emscripten,
+    .dragonfly,
+    .freebsd,
+    .netbsd,
+    .haiku,
+    .solaris,
+    .illumos,
+    .macos,
+    .driverkit,
+    .ios,
+    .tvos,
+    .visionos,
+    .watchos,
+    => extern struct {
         /// optional address
         name: ?*const sockaddr,
         /// size of address


### PR DESCRIPTION
cc @alexrp 
https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/recv.2.html#//apple_ref/doc/man/2/recv
https://developer.apple.com/documentation/kernel/msghdr/1499171-msg_iovlen
https://github.com/ziglang/zig/blob/master/lib/libc/include/any-macos-any/sys/socket.h#L564