### PR TITLE
Update the documentation comment in arena_allocator.zig to be more accurate

### DIFF
--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -3,8 +3,9 @@ const assert = std.debug.assert;
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 
-/// This allocator takes an existing allocator, wraps it, and provides an interface
-/// where you can allocate without freeing, and then free it all together.
+/// This allocator takes an existing allocator, wraps it, and provides an interface where
+/// you can allocate and then free it all together. You can only free an individual item
+/// if it was the last thing allocated, otherwise freeing individual items does nothing.
 pub const ArenaAllocator = struct {
     child_allocator: Allocator,
     state: State,

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -4,8 +4,9 @@ const mem = std.mem;
 const Allocator = std.mem.Allocator;
 
 /// This allocator takes an existing allocator, wraps it, and provides an interface where
-/// you can allocate and then free it all together. You can only free an individual item
-/// if it was the most recent allocation, otherwise calls to free do nothing.
+/// you can allocate and then free it all together. Calls to free an individual item only
+/// free the item if it was the most recent allocation, otherwise calls to free do
+/// nothing.
 pub const ArenaAllocator = struct {
     child_allocator: Allocator,
     state: State,

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -5,7 +5,7 @@ const Allocator = std.mem.Allocator;
 
 /// This allocator takes an existing allocator, wraps it, and provides an interface where
 /// you can allocate and then free it all together. You can only free an individual item
-/// if it was the last thing allocated, otherwise freeing individual items does nothing.
+/// if it was the most recent allocation, otherwise calls to free do nothing.
 pub const ArenaAllocator = struct {
     child_allocator: Allocator,
     state: State,


### PR DESCRIPTION
This PR updates the documentation comment to fit with my understanding of how freeing in the arena allocator implemented by `arena_allocator.zig` works - memory allocated with an arena allocator can be freed individually as long as it is the last thing that was allocated. Please correct my understanding if this is not how it works since I am new to zig. My understanding is as follows:
- [The function which creates the allocator object for `arena_allocator.zig`](https://ziglang.org/documentation/master/std/#std.heap.arena_allocator.ArenaAllocator.allocator) sets the `vtable.free` property of the struct to [the `ArenaAllocator.free` function](https://ziglang.org/documentation/master/std/#std.heap.arena_allocator.ArenaAllocator.free)
- The `ArenaAllocator.free` function frees the memory if it was the last thing allocated by the arena allocator
- When a user calls [allocator.free](https://ziglang.org/documentation/master/std/#std.mem.Allocator.free), that calls [allocator.rawFree](https://ziglang.org/documentation/master/std/#std.mem.Allocator.rawFree), which calls the function at `vtable.free` (the `ArenaAllocator.free` function), cuasing data to be freed individually if it was the last thing allocated

*(Side note)*: What's the maximum line width in zig std library code? (maybe adding a note [here](https://github.com/ziglang/zig/wiki/Contributing) would be useful?)