### PR TITLE
`std.zig.target`: Remove some library names from `isLibCLibName()` for MinGW

### DIFF
--- a/lib/std/zig/target.zig
+++ b/lib/std/zig/target.zig
@@ -195,11 +195,7 @@ pub fn isLibCLibName(target: std.Target, name: []const u8) bool {
             return true;
         if (eqlIgnoreCase(ignore_case, name, "ksguid"))
             return true;
-        if (eqlIgnoreCase(ignore_case, name, "ksuser"))
-            return true;
         if (eqlIgnoreCase(ignore_case, name, "largeint"))
-            return true;
-        if (eqlIgnoreCase(ignore_case, name, "locationapi"))
             return true;
         if (eqlIgnoreCase(ignore_case, name, "m"))
             return true;
@@ -213,13 +209,7 @@ pub fn isLibCLibName(target: std.Target, name: []const u8) bool {
             return true;
         if (eqlIgnoreCase(ignore_case, name, "moldname"))
             return true;
-        if (eqlIgnoreCase(ignore_case, name, "msxml2"))
-            return true;
-        if (eqlIgnoreCase(ignore_case, name, "msxml6"))
-            return true;
         if (eqlIgnoreCase(ignore_case, name, "msvcrt-os"))
-            return true;
-        if (eqlIgnoreCase(ignore_case, name, "ntoskrnl"))
             return true;
         if (eqlIgnoreCase(ignore_case, name, "portabledeviceguids"))
             return true;


### PR DESCRIPTION
These are system DLLs, most of which MinGW provides `.def` files for. It just so happens that MinGW also has some static libraries by the same name which link in some GUID definitions.

The remaining non-MinGW library names represent libraries that are always statically linked, so if those are requested by the user, it makes sense to error if libc is not linked. A future enhancement could be to compile those independent of `mingw32.lib`, however.

Closes #22560.