### PR TITLE
std.os.linux: adding recvmmsg()

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1878,6 +1878,17 @@ pub fn recvmsg(fd: i32, msg: *msghdr, flags: u32) usize {
     }
 }
 
+pub fn recvmmsg(fd: i32, msgvec: [*]mmsghdr, vlen: u32, flags: u32, timeout: *timespec) usize {
+    return syscall5(
+        .recvmmsg,
+        @as(usize, @bitCast(@as(isize, fd))),
+        @intFromPtr(msgvec),
+        vlen,
+        flags,
+        @intFromPtr(timeout),
+    );
+}
+
 pub fn recvfrom(
     fd: i32,
     noalias buf: [*]u8,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1878,7 +1878,7 @@ pub fn recvmsg(fd: i32, msg: *msghdr, flags: u32) usize {
     }
 }
 
-pub fn recvmmsg(fd: i32, msgvec: [*]mmsghdr, vlen: u32, flags: u32, timeout: *timespec) usize {
+pub fn recvmmsg(fd: i32, msgvec: ?[*]mmsghdr, vlen: u32, flags: u32, timeout: ?*timespec) usize {
     return syscall5(
         .recvmmsg,
         @as(usize, @bitCast(@as(isize, fd))),


### PR DESCRIPTION
Adding the ``recvmmsg()`` syscall.

There are a couple of items to consider before this is ready:

1) should ``timeout`` be a ``?*timespec`` because it can be called with ``null``?

2) the return value from ``recvmmsg()`` is an ``int``, i'm not sure if this is wrong to return a ``usize``, and it would need to be passed to ``E.init(r)`` for errno purposes.

3) I noticed ``recvmsg`` has ``if (native_arch == .x86) { return socketcall(...); }``, perhaps we want that also for ``recvmmsg``? But ``sendmmsg`` doesn't use ``socketcall``?