### PR TITLE
std: fix comptime SemanticVersion expr regression

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1061,7 +1061,7 @@ pub fn DeleteFile(sub_path_w: []const u16, options: DeleteFileOptions) DeleteFil
     // us INVALID_PARAMETER.
     // The same reasoning for win10_rs5 as in os.renameatW() applies (FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE requires >= win10_rs5).
     var need_fallback = true;
-    if (builtin.target.os.version_range.windows.min.isAtLeast(.win10_rs5)) {
+    if (comptime builtin.target.os.version_range.windows.min.isAtLeast(.win10_rs5)) {
         // Deletion with posix semantics if the filesystem supports it.
         var info = FILE_DISPOSITION_INFORMATION_EX{
             .Flags = FILE_DISPOSITION_DELETE |

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -6821,7 +6821,7 @@ pub fn memfd_createZ(name: [*:0]const u8, flags: u32) MemFdCreateError!fd_t {
             }
         },
         .freebsd => {
-            if (builtin.os.version_range.semver.max.order(.{ .major = 13, .minor = 0, .patch = 0 }) == .lt)
+            if (comptime builtin.os.version_range.semver.max.order(.{ .major = 13, .minor = 0, .patch = 0 }) == .lt)
                 @compileError("memfd_create is unavailable on FreeBSD < 13.0");
             const rc = system.memfd_create(name, flags);
             switch (errno(rc)) {


### PR DESCRIPTION
- effects FreeBSD memfd and Windows DeleteFile
- regression: e5d5a8bc4ea6b27dc3540ad4800a1231ff50b33d

---

- PR tested on FreeBSD 14.1 and 12.4
- issue manifested on master, on FreeBSD 14.1:
```sh
$ zig test lib/std/std.zig
lib/std/posix.zig:6825:17: error: memfd_create is unavailable on FreeBSD < 13.0
                @compileError("memfd_create is unavailable on FreeBSD < 13.0");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```