### PR TITLE
link: fix ambiguous names in linker scripts

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -1891,30 +1891,69 @@ pub fn resolveInputs(
     syslib: while (unresolved_inputs.pop()) |unresolved_input| {
         const name_query: UnresolvedInput.NameQuery = switch (unresolved_input) {
             .name_query => |nq| nq,
-            .ambiguous_name => |an| an: {
-                const lib_name, const link_mode = stripLibPrefixAndSuffix(an.name, target) orelse {
-                    try resolvePathInput(gpa, arena, unresolved_inputs, resolved_inputs, &ld_script_bytes, target, .{
+            .ambiguous_name => |an| {
+                // First check the path relative to the current working directory.
+                // If the file is a library and is not found there, check the library search paths as well.
+                // This is consistent with the behavior of GNU ld.
+                if (try resolvePathInput(
+                    gpa,
+                    arena,
+                    unresolved_inputs,
+                    resolved_inputs,
+                    &ld_script_bytes,
+                    target,
+                    .{
                         .path = Path.initCwd(an.name),
                         .query = an.query,
-                    }, color);
-                    continue;
-                };
-                break :an .{
-                    .name = lib_name,
-                    .query = .{
-                        .needed = an.query.needed,
-                        .weak = an.query.weak,
-                        .reexport = an.query.reexport,
-                        .must_link = an.query.must_link,
-                        .hidden = an.query.hidden,
-                        .allow_so_scripts = an.query.allow_so_scripts,
-                        .preferred_mode = link_mode,
-                        .search_strategy = .no_fallback,
                     },
-                };
+                    color,
+                )) |lib_result| {
+                    switch (lib_result) {
+                        .ok => continue :syslib,
+                        .no_match => {
+                            for (lib_directories) |lib_directory| {
+                                switch ((try resolvePathInput(
+                                    gpa,
+                                    arena,
+                                    unresolved_inputs,
+                                    resolved_inputs,
+                                    &ld_script_bytes,
+                                    target,
+                                    .{
+                                        .path = .{
+                                            .root_dir = lib_directory,
+                                            .sub_path = an.name,
+                                        },
+                                        .query = an.query,
+                                    },
+                                    color,
+                                )).?) {
+                                    .ok => continue :syslib,
+                                    .no_match => {},
+                                }
+                            }
+                            fatal("{s}: file listed in linker script not found", .{an.name});
+                        },
+                    }
+                }
+                continue;
             },
             .path_query => |pq| {
-                try resolvePathInput(gpa, arena, unresolved_inputs, resolved_inputs, &ld_script_bytes, target, pq, color);
+                if (try resolvePathInput(
+                    gpa,
+                    arena,
+                    unresolved_inputs,
+                    resolved_inputs,
+                    &ld_script_bytes,
+                    target,
+                    pq,
+                    color,
+                )) |lib_result| {
+                    switch (lib_result) {
+                        .ok => {},
+                        .no_match => fatal("{}: file not found", .{pq.path}),
+                    }
+                }
                 continue;
             },
             .dso_exact => |dso_exact| {
@@ -2176,10 +2215,10 @@ fn resolvePathInput(
     target: std.Target,
     pq: UnresolvedInput.PathQuery,
     color: std.zig.Color,
-) Allocator.Error!void {
-    switch (switch (Compilation.classifyFileExt(pq.path.sub_path)) {
-        .static_library => try resolvePathInputLib(gpa, arena, unresolved_inputs, resolved_inputs, ld_script_bytes, target, pq, .static, color),
-        .shared_library => try resolvePathInputLib(gpa, arena, unresolved_inputs, resolved_inputs, ld_script_bytes, target, pq, .dynamic, color),
+) Allocator.Error!?ResolveLibInputResult {
+    switch (Compilation.classifyFileExt(pq.path.sub_path)) {
+        .static_library => return try resolvePathInputLib(gpa, arena, unresolved_inputs, resolved_inputs, ld_script_bytes, target, pq, .static, color),
+        .shared_library => return try resolvePathInputLib(gpa, arena, unresolved_inputs, resolved_inputs, ld_script_bytes, target, pq, .dynamic, color),
         .object => {
             var file = pq.path.root_dir.handle.openFile(pq.path.sub_path, .{}) catch |err|
                 fatal("failed to open object {}: {s}", .{ pq.path, @errorName(err) });
@@ -2190,7 +2229,7 @@ fn resolvePathInput(
                 .must_link = pq.query.must_link,
                 .hidden = pq.query.hidden,
             } });
-            return;
+            return null;
         },
         .res => {
             var file = pq.path.root_dir.handle.openFile(pq.path.sub_path, .{}) catch |err|
@@ -2200,12 +2239,9 @@ fn resolvePathInput(
                 .path = pq.path,
                 .file = file,
             } });
-            return;
+            return null;
         },
         else => fatal("{}: unrecognized file extension", .{pq.path}),
-    }) {
-        .ok => {},
-        .no_match => fatal("{}: file not found", .{pq.path}),
     }
 }
 
@@ -2226,9 +2262,11 @@ fn resolvePathInputLib(
     try resolved_inputs.ensureUnusedCapacity(gpa, 1);
 
     const test_path: Path = pq.path;
-    // In the case of .so files, they might actually be "linker scripts"
+    // In the case of shared libraries, they might actually be "linker scripts"
     // that contain references to other libraries.
-    if (pq.query.allow_so_scripts and target.ofmt == .elf and mem.endsWith(u8, test_path.sub_path, ".so")) {
+    if (pq.query.allow_so_scripts and target.ofmt == .elf and
+        Compilation.classifyFileExt(test_path.sub_path) == .shared_library)
+    {
         var file = test_path.root_dir.handle.openFile(test_path.sub_path, .{}) catch |err| switch (err) {
             error.FileNotFound => return .no_match,
             else => |e| fatal("unable to search for {s} library '{'}': {s}", .{
@@ -2352,21 +2390,6 @@ pub fn openDsoInput(diags: *Diags, path: Path, needed: bool, weak: bool, reexpor
     return .{ .dso = openDso(path, needed, weak, reexport) catch |err| {
         return diags.failParse(path, "failed to open {}: {s}", .{ path, @errorName(err) });
     } };
-}
-
-fn stripLibPrefixAndSuffix(path: []const u8, target: std.Target) ?struct { []const u8, std.builtin.LinkMode } {
-    const prefix = target.libPrefix();
-    const static_suffix = target.staticLibSuffix();
-    const dynamic_suffix = target.dynamicLibSuffix();
-    const basename = fs.path.basename(path);
-    const unlibbed = if (mem.startsWith(u8, basename, prefix)) basename[prefix.len..] else return null;
-    if (mem.endsWith(u8, unlibbed, static_suffix)) return .{
-        unlibbed[0 .. unlibbed.len - static_suffix.len], .static,
-    };
-    if (mem.endsWith(u8, unlibbed, dynamic_suffix)) return .{
-        unlibbed[0 .. unlibbed.len - dynamic_suffix.len], .dynamic,
-    };
-    return null;
 }
 
 /// Returns true if and only if there is at least one input of type object,


### PR DESCRIPTION
Currently zig fails to build while linking the system LLVM/C++ libraries
on my Chimera Linux system due to the fact that libc++.so is a linker
script with the following contents:

INPUT(libc++.so.1 -lc++abi -lunwind)

Prior to this commit, zig would try to convert "ambiguous names" in
linker scripts such as libc++.so.1 in this example into -lfoo style
flags. This fails in this case due to the so version number as zig
checks for exactly the .so suffix.

Furthermore, I do not think that this conversion is semantically correct
since converting libfoo.so to -lfoo could theoretically end up resulting
in libfoo.a getting linked which seems wrong when a different file is
specified in the linker script.

With this patch, this attempted conversion is removed. Instead, zig
always first checks if the exact file/path in the linker script exists
relative to the current working directory.

If the file is classified as a library (including versioned shared
objects such as libfoo.so.1), zig then falls back to checking if
the exact file/path in the linker script exists relative to each
directory in the library search path, selecting the first match or
erroring out if none is found.

This behavior fixes the regression that prevents building zig while
linking the system LLVM/C++ libraries on Chimera Linux.