### PR TITLE
Add least common multiple (LCM) to math

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -235,6 +235,7 @@ pub const sinh = @import("math/sinh.zig").sinh;
 pub const cosh = @import("math/cosh.zig").cosh;
 pub const tanh = @import("math/tanh.zig").tanh;
 pub const gcd = @import("math/gcd.zig").gcd;
+pub const lcm = @import("math/lcm.zig").lcm;
 pub const gamma = @import("math/gamma.zig").gamma;
 pub const lgamma = @import("math/gamma.zig").lgamma;
 
@@ -395,6 +396,7 @@ test {
     _ = cosh;
     _ = tanh;
     _ = gcd;
+    _ = lcm;
     _ = gamma;
     _ = lgamma;
 

--- a/lib/std/math/lcm.zig
+++ b/lib/std/math/lcm.zig
@@ -1,0 +1,29 @@
+//! Least common multiple (https://mathworld.wolfram.com/LeastCommonMultiple.html)
+const std = @import("std");
+
+/// Returns the least common multiple (LCM) of two integers (`a` and `b`).
+/// For example, the LCM of `8` and `12` is `24`, that is, `lcm(8, 12) == 24`.
+/// If any of the arguments is zero, then the returned value is 0.
+pub fn lcm(a: anytype, b: anytype) @TypeOf(a, b) {
+    // Behavior from C++ and Python
+    // If an argument is zero, then the returned value is 0.
+    if (a == 0 or b == 0) return 0;
+    return @abs(b) * (@abs(a) / std.math.gcd(@abs(a), @abs(b)));
+}
+
+test lcm {
+    const expectEqual = std.testing.expectEqual;
+
+    try expectEqual(lcm(0, 0), 0);
+    try expectEqual(lcm(1, 0), 0);
+    try expectEqual(lcm(-1, 0), 0);
+    try expectEqual(lcm(0, 1), 0);
+    try expectEqual(lcm(0, -1), 0);
+    try expectEqual(lcm(7, 1), 7);
+    try expectEqual(lcm(7, -1), 7);
+    try expectEqual(lcm(8, 12), 24);
+    try expectEqual(lcm(-23, 15), 345);
+    try expectEqual(lcm(120, 84), 840);
+    try expectEqual(lcm(84, -120), 840);
+    try expectEqual(lcm(1216342683557601535506311712, 436522681849110124616458784), 16592536571065866494401400422922201534178938447014944);
+}


### PR DESCRIPTION
Fixes #22660

Then maybe in the future the individual lcm implementations (like in crypto) can use a single one from the math library?