### PR TITLE
`std.Build`: Use a more conservative target for the build runner.

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -66,6 +66,12 @@ pub fn main() !void {
         .handle = try std.fs.cwd().makeOpenPath(global_cache_root, .{}),
     };
 
+    // Match the behavior of `cmdBuild()`.
+    const host_query: std.Target.Query = .{
+        .cpu_model = .baseline,
+        .os_tag = builtin.target.os.tag,
+    };
+
     var graph: std.Build.Graph = .{
         .arena = arena,
         .cache = .{
@@ -77,8 +83,8 @@ pub fn main() !void {
         .global_cache_root = global_cache_directory,
         .zig_lib_directory = zig_lib_directory,
         .host = .{
-            .query = .{},
-            .result = try std.zig.system.resolveTargetQuery(.{}),
+            .query = host_query,
+            .result = try std.zig.system.resolveTargetQuery(host_query),
         },
     };
 

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -115,7 +115,9 @@ pub const Graph = struct {
     global_cache_root: Cache.Directory,
     zig_lib_directory: Cache.Directory,
     needed_lazy_dependencies: std.StringArrayHashMapUnmanaged(void) = .empty,
-    /// Information about the native target. Computed before build() is invoked.
+    /// Information about the host target. Computed before `build()` is invoked. Note that, for
+    /// build reproducibility reasons, this information is more conservative than
+    /// `@import("builtin").target`.
     host: ResolvedTarget,
     incremental: ?bool = null,
     random_seed: u32 = 0,


### PR DESCRIPTION
This prevents some subtle cases where non-`Debug` builds would not be reproducible between similar host machines if they differed in some non-obvious ways (CPU features, OS version, glibc version).

Closes #22663.