### PR TITLE
std: add streamUntilEof to io

### DIFF
--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -193,11 +193,13 @@ pub fn GenericReader(
 
         pub inline fn streamUntilEof(
             self: Self,
-            array_list: *std.ArrayList(u8),
+            writer: anytype,
+            comptime buf_size: usize,
             optional_max_size: ?usize,
-        ) (NoEofError || error{StreamTooLong} || @TypeOf(array_list).Error)!void {
+        ) (NoEofError || error{StreamTooLong} || @TypeOf(writer).Error)!void {
             return @errorCast(self.any().streamUntilEof(
-                array_list,
+                writer,
+                buf_size,
                 optional_max_size,
             ));
         }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -191,6 +191,17 @@ pub fn GenericReader(
             ));
         }
 
+        pub inline fn streamUntilEof(
+            self: Self,
+            writer: anytype,
+            optional_max_size: ?usize,
+        ) (NoEofError || error{StreamTooLong} || @TypeOf(writer).Error)!void {
+            return @errorCast(self.any().streamUntilEof(
+                writer,
+                optional_max_size,
+            ));
+        }
+
         pub inline fn skipUntilDelimiterOrEof(self: Self, delimiter: u8) Error!void {
             return @errorCast(self.any().skipUntilDelimiterOrEof(delimiter));
         }

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -193,11 +193,11 @@ pub fn GenericReader(
 
         pub inline fn streamUntilEof(
             self: Self,
-            writer: anytype,
+            array_list: *std.ArrayList(u8),
             optional_max_size: ?usize,
-        ) (NoEofError || error{StreamTooLong} || @TypeOf(writer).Error)!void {
+        ) (NoEofError || error{StreamTooLong} || @TypeOf(array_list).Error)!void {
             return @errorCast(self.any().streamUntilEof(
-                writer,
+                array_list,
                 optional_max_size,
             ));
         }

--- a/lib/std/io/Reader.zig
+++ b/lib/std/io/Reader.zig
@@ -215,6 +215,31 @@ pub fn streamUntilDelimiter(
     }
 }
 
+/// Appends to the `writer` contents by reading from the stream until EOF.
+/// If `optional_max_size` is not null and amount of written bytes exceeds `optional_max_size`,
+/// returns `error.StreamTooLong` and finishes appending.
+/// If `optional_max_size` is null, appending is unbounded.
+pub fn streamUntilEof(
+    self: Self,
+    writer: anytype,
+    optional_max_size: ?usize,
+) anyerror!void {
+    if (optional_max_size) |max_size| {
+        for (0..max_size) |_| {
+            const byte: u8 = try self.readByte();
+            try writer.writeByte(byte);
+        }
+        return error.StreamTooLong;
+    } else {
+        while (true) {
+            const byte: u8 = self.readByte() catch {
+                break;
+            };
+            try writer.writeByte(byte);
+        }
+    }
+}
+
 /// Reads from the stream until specified byte is found, discarding all data,
 /// including the delimiter.
 /// If end-of-stream is found, this function succeeds.


### PR DESCRIPTION
It's currently quite inconvenient to read an entire file using the streamUntilDelimiter function, this one replicates most of the same functionality but will read until it hits EOF rather than a delimiter.