### PR TITLE
debug: fix MemoryAccessor file leak

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -775,6 +775,7 @@ pub const StackIterator = struct {
     }
 
     pub fn deinit(it: *StackIterator) void {
+        it.ma.deinit();
         if (have_ucontext and it.unwind_state != null) it.unwind_state.?.dwarf_context.deinit();
     }
 

--- a/lib/std/debug/MemoryAccessor.zig
+++ b/lib/std/debug/MemoryAccessor.zig
@@ -25,6 +25,17 @@ pub const init: MemoryAccessor = .{
     },
 };
 
+pub fn deinit(ma: *MemoryAccessor) void {
+    switch (native_os) {
+        .linux => switch (ma.mem.handle) {
+            -2, -1 => {},
+            else => ma.mem.close(),
+        },
+        else => {},
+    }
+    ma.* = undefined;
+}
+
 fn read(ma: *MemoryAccessor, address: usize, buf: []u8) bool {
     switch (native_os) {
         .linux => while (true) switch (ma.mem.handle) {


### PR DESCRIPTION
- patch authored by Jacob Young
- tested on alpine-aarch64, 3.21.0, qemu-system 9.2.0
- issue manifested on Alpine Linux aarch64 under qemu-system where zig2 fails during bootstrap: `error.ProcessFdQuotaExceeded`

Fixes #21701