### PR TITLE
zig init: Add step to generate documentation

### DIFF
--- a/lib/init/build.zig
+++ b/lib/init/build.zig
@@ -142,6 +142,18 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_mod_tests.step);
     test_step.dependOn(&run_exe_tests.step);
 
+    // This creates a `docs` step. It will be visible in the `zig build --help`
+    // menu, and can be selected like this: `zig build docs`
+    // This will generate the package documentation from the doc comments.
+    const docs_step = b.step("docs", "Build the package documentation");
+    const docs_obj = b.addObject(.{ .name = "_NAME", .root_module = mod });
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = docs_obj.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+    docs_step.dependOn(&install_docs.step);
+
     // Just like flags, top level steps are also listed in the `--help` menu.
     //
     // The Zig build system is entirely implemented in userland, which means

--- a/lib/init/src/root.zig
+++ b/lib/init/src/root.zig
@@ -14,10 +14,11 @@ pub fn bufferedPrint() !void {
     try stdout.flush(); // Don't forget to flush!
 }
 
+/// Returns the sum of `a` and `b`.
 pub fn add(a: i32, b: i32) i32 {
     return a + b;
 }
 
-test "basic add functionality" {
+test add {
     try std.testing.expect(add(3, 7) == 10);
 }


### PR DESCRIPTION
Add a `docs` step to `build.zig` which `zig init` generates. This step will generate the package documentation from the doc comments.

The generated package documentation can be viewed by running the following in the directory where it was generated:

```sh
python -m http.server
```

Also, add doc comments and doctests to `add` function to provide an example of these.

Closes #22644