### PR TITLE
Document that the `ptr` field of Allocator/Random should not be compared and remove existing comparison

### DIFF
--- a/lib/std/Random.zig
+++ b/lib/std/Random.zig
@@ -29,6 +29,9 @@ pub const RomuTrio = @import("Random/RomuTrio.zig");
 pub const SplitMix64 = @import("Random/SplitMix64.zig");
 pub const ziggurat = @import("Random/ziggurat.zig");
 
+/// Any comparison of this field may result in illegal behavior, since it may be set to
+/// `undefined` in cases where the random implementation does not have any associated
+/// state.
 ptr: *anyopaque,
 fillFn: *const fn (ptr: *anyopaque, buf: []u8) void,
 

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -10,7 +10,10 @@ const builtin = @import("builtin");
 pub const Error = error{OutOfMemory};
 pub const Log2Align = math.Log2Int(usize);
 
-// The type erased pointer to the allocator implementation
+/// The type erased pointer to the allocator implementation.
+/// Any comparison of this field may result in illegal behavior, since it may be set to
+/// `undefined` in cases where the allocator implementation does not have any associated
+/// state.
 ptr: *anyopaque,
 vtable: *const VTable,
 

--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -344,15 +344,17 @@ pub const RunResult = struct {
     stderr: []u8,
 };
 
-fn fifoToOwnedArrayList(fifo: *std.io.PollFifo) std.ArrayList(u8) {
+fn writeFifoDataToArrayList(allocator: Allocator, list: *std.ArrayListUnmanaged(u8), fifo: *std.io.PollFifo) !void {
     if (fifo.head != 0) fifo.realign();
-    const result = std.ArrayList(u8){
-        .items = fifo.buf[0..fifo.count],
-        .capacity = fifo.buf.len,
-        .allocator = fifo.allocator,
-    };
-    fifo.* = std.io.PollFifo.init(fifo.allocator);
-    return result;
+    if (list.capacity == 0) {
+        list.* = .{
+            .items = fifo.buf[0..fifo.count],
+            .capacity = fifo.buf.len,
+        };
+        fifo.* = std.io.PollFifo.init(fifo.allocator);
+    } else {
+        try list.appendSlice(allocator, fifo.buf[0..fifo.count]);
+    }
 }
 
 /// Collect the output from the process's stdout and stderr. Will return once all output
@@ -362,21 +364,16 @@ fn fifoToOwnedArrayList(fifo: *std.io.PollFifo) std.ArrayList(u8) {
 /// The process must be started with stdout_behavior and stderr_behavior == .Pipe
 pub fn collectOutput(
     child: ChildProcess,
-    stdout: *std.ArrayList(u8),
-    stderr: *std.ArrayList(u8),
+    /// Used for `stdout` and `stderr`.
+    allocator: Allocator,
+    stdout: *std.ArrayListUnmanaged(u8),
+    stderr: *std.ArrayListUnmanaged(u8),
     max_output_bytes: usize,
 ) !void {
     assert(child.stdout_behavior == .Pipe);
     assert(child.stderr_behavior == .Pipe);
 
-    // we could make this work with multiple allocators but YAGNI
-    if (stdout.allocator.ptr != stderr.allocator.ptr or
-        stdout.allocator.vtable != stderr.allocator.vtable)
-    {
-        unreachable; // ChildProcess.collectOutput only supports 1 allocator
-    }
-
-    var poller = std.io.poll(stdout.allocator, enum { stdout, stderr }, .{
+    var poller = std.io.poll(allocator, enum { stdout, stderr }, .{
         .stdout = child.stdout.?,
         .stderr = child.stderr.?,
     });
@@ -389,8 +386,8 @@ pub fn collectOutput(
             return error.StderrStreamTooLong;
     }
 
-    stdout.* = fifoToOwnedArrayList(poller.fifo(.stdout));
-    stderr.* = fifoToOwnedArrayList(poller.fifo(.stderr));
+    try writeFifoDataToArrayList(allocator, stdout, poller.fifo(.stdout));
+    try writeFifoDataToArrayList(allocator, stderr, poller.fifo(.stderr));
 }
 
 pub const RunError = posix.GetCwdError || posix.ReadError || SpawnError || posix.PollError || error{
@@ -420,22 +417,20 @@ pub fn run(args: struct {
     child.expand_arg0 = args.expand_arg0;
     child.progress_node = args.progress_node;
 
-    var stdout = std.ArrayList(u8).init(args.allocator);
-    var stderr = std.ArrayList(u8).init(args.allocator);
-    errdefer {
-        stdout.deinit();
-        stderr.deinit();
-    }
+    var stdout: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer stdout.deinit(args.allocator);
+    var stderr: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer stderr.deinit(args.allocator);
 
     try child.spawn();
     errdefer {
         _ = child.kill() catch {};
     }
-    try child.collectOutput(&stdout, &stderr, args.max_output_bytes);
+    try child.collectOutput(args.allocator, &stdout, &stderr, args.max_output_bytes);
 
     return RunResult{
-        .stdout = try stdout.toOwnedSlice(),
-        .stderr = try stderr.toOwnedSlice(),
+        .stdout = try stdout.toOwnedSlice(args.allocator),
+        .stderr = try stderr.toOwnedSlice(args.allocator),
         .term = try child.wait(),
     };
 }


### PR DESCRIPTION
This is an alternative to https://github.com/ziglang/zig/pull/21760 (it's the 1st option in that PR's description):

> Codify that comparing ptr is always illegal/unsafe, and remove all existing comparisons.

(suggested for exploration here: https://github.com/ziglang/zig/pull/21760#issuecomment-2625965026)

However, I personally think this is probably not the best solution to https://github.com/ziglang/zig/issues/21756 / https://github.com/ziglang/zig/issues/17704, for a few reasons:

- A doc comment is about the best we can currently do to help unsuspecting users to avoid comparing these fields and invoking (currently unchecked, see https://github.com/ziglang/zig/issues/211) illegal behavior
- Unless I'm thinking about it wrong, in the future it seems likely that this illegal behavior would become a runtime panic at best (i.e. not a compile error) which doesn't seem ideal (you could still write library code that appears to work fine if you don't use any `Allocator` implementations that set `.ptr = undefined`)
- The solution in https://github.com/ziglang/zig/pull/21760 better communicates the intention behind setting `.ptr = undefined`, and removes the possibility of illegal behavior (and doesn't increase the field's size, so there's no real downside AFAIK)

---

If https://github.com/ziglang/zig/pull/21760 is merged, this PR could be seen as just a straightforward improvement to the API of `process.Child.collectOutput`, plus an irrelevant extra commit that could be dropped.

What I personally would like to see happen is exactly that: merge https://github.com/ziglang/zig/pull/21760 to address https://github.com/ziglang/zig/issues/21756 / https://github.com/ziglang/zig/issues/17704, and then drop the second commit from this PR and merge it too.

---

Note that the changes to `collectOutput` differ from those suggested in https://github.com/ziglang/zig/pull/21760#issuecomment-2625965026 because I realized that there's no tangible benefit to taking `ArrayList` pointers--the memory for `stdout`/`stderr` is handled via `std.io.poll` and its `LinearFifo`s, and then the result is stuffed into the ArrayList fields and returned, so doing something like calling `ensureTotalCapacity`/etc before `collectOutput` is wasted at best (or will leak memory at worst).

Instead, the `ArrayList` parameters were removed in favor of just an allocator parameter, and the ArrayList usage is now just an implementation detail (it's just used for the convenience of `toOwnedSlice`).

---

If this *is* merged *instead of* https://github.com/ziglang/zig/pull/21760, then:
- Closes https://github.com/ziglang/zig/issues/21756
- Closes https://github.com/ziglang/zig/issues/17704