### PR TITLE
std.meta: let containers define their own eql function

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -486,7 +486,12 @@ pub const CallingConvention = union(enum(u8)) {
     }
 
     pub fn eql(a: CallingConvention, b: CallingConvention) bool {
-        return std.meta.eql(a, b);
+        const tag_a: Tag = a;
+        const tag_b: Tag = b;
+        if (tag_a != tag_b) return false;
+        return switch (a) {
+            inline else => |val, tag| return std.meta.eql(val, @field(b, @tagName(tag))),
+        };
     }
 
     pub fn withStackAlign(cc: CallingConvention, incoming_stack_alignment: u64) CallingConvention {

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -572,11 +572,11 @@ fn PaxIterator(comptime ReaderType: type) type {
                 const value_len = length - value_start - 1; // \n separator at end
                 self.size -= length;
 
-                const kind: PaxAttributeKind = if (eql(keyword, "path"))
+                const kind: PaxAttributeKind = if (std.mem.eql(u8, keyword, "path"))
                     .path
-                else if (eql(keyword, "linkpath"))
+                else if (std.mem.eql(u8, keyword, "linkpath"))
                     .linkpath
-                else if (eql(keyword, "size"))
+                else if (std.mem.eql(u8, keyword, "size"))
                     .size
                 else {
                     try self.reader.skipBytes(value_len, .{});
@@ -600,10 +600,6 @@ fn PaxIterator(comptime ReaderType: type) type {
             var fbs = std.io.fixedBufferStream(&self.scratch);
             try self.reader.streamUntilDelimiter(fbs.writer(), delimiter, null);
             return fbs.getWritten();
-        }
-
-        fn eql(a: []const u8, b: []const u8) bool {
-            return std.mem.eql(u8, a, b);
         }
 
         fn hasNull(str: []const u8) bool {

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -6217,11 +6217,8 @@ fn parseCNumericType(c: *Context, m: *MacroCtx) ParseError!Node {
         unsigned: u8 = 0,
         signed: u8 = 0,
         complex: u8 = 0,
-
-        fn eql(self: @This(), other: @This()) bool {
-            return meta.eql(self, other);
-        }
     };
+    const eql = std.meta.eql;
 
     // Yes, these can be in *any* order
     // This still doesn't cover cases where for example volatile is intermixed
@@ -6247,58 +6244,58 @@ fn parseCNumericType(c: *Context, m: *MacroCtx) ParseError!Node {
         }
     }
 
-    if (kw.eql(.{ .int = 1 }) or kw.eql(.{ .signed = 1 }) or kw.eql(.{ .signed = 1, .int = 1 }))
+    if (eql(kw, .{ .int = 1 }) or eql(kw, .{ .signed = 1 }) or eql(kw, .{ .signed = 1, .int = 1 }))
         return Tag.type.create(c.arena, "c_int");
 
-    if (kw.eql(.{ .unsigned = 1 }) or kw.eql(.{ .unsigned = 1, .int = 1 }))
+    if (eql(kw, .{ .unsigned = 1 }) or eql(kw, .{ .unsigned = 1, .int = 1 }))
         return Tag.type.create(c.arena, "c_uint");
 
-    if (kw.eql(.{ .long = 1 }) or kw.eql(.{ .signed = 1, .long = 1 }) or kw.eql(.{ .long = 1, .int = 1 }) or kw.eql(.{ .signed = 1, .long = 1, .int = 1 }))
+    if (eql(kw, .{ .long = 1 }) or eql(kw, .{ .signed = 1, .long = 1 }) or eql(kw, .{ .long = 1, .int = 1 }) or eql(kw, .{ .signed = 1, .long = 1, .int = 1 }))
         return Tag.type.create(c.arena, "c_long");
 
-    if (kw.eql(.{ .unsigned = 1, .long = 1 }) or kw.eql(.{ .unsigned = 1, .long = 1, .int = 1 }))
+    if (eql(kw, .{ .unsigned = 1, .long = 1 }) or eql(kw, .{ .unsigned = 1, .long = 1, .int = 1 }))
         return Tag.type.create(c.arena, "c_ulong");
 
-    if (kw.eql(.{ .long = 2 }) or kw.eql(.{ .signed = 1, .long = 2 }) or kw.eql(.{ .long = 2, .int = 1 }) or kw.eql(.{ .signed = 1, .long = 2, .int = 1 }))
+    if (eql(kw, .{ .long = 2 }) or eql(kw, .{ .signed = 1, .long = 2 }) or eql(kw, .{ .long = 2, .int = 1 }) or eql(kw, .{ .signed = 1, .long = 2, .int = 1 }))
         return Tag.type.create(c.arena, "c_longlong");
 
-    if (kw.eql(.{ .unsigned = 1, .long = 2 }) or kw.eql(.{ .unsigned = 1, .long = 2, .int = 1 }))
+    if (eql(kw, .{ .unsigned = 1, .long = 2 }) or eql(kw, .{ .unsigned = 1, .long = 2, .int = 1 }))
         return Tag.type.create(c.arena, "c_ulonglong");
 
-    if (kw.eql(.{ .signed = 1, .char = 1 }))
+    if (eql(kw, .{ .signed = 1, .char = 1 }))
         return Tag.type.create(c.arena, "i8");
 
-    if (kw.eql(.{ .char = 1 }) or kw.eql(.{ .unsigned = 1, .char = 1 }))
+    if (eql(kw, .{ .char = 1 }) or eql(kw, .{ .unsigned = 1, .char = 1 }))
         return Tag.type.create(c.arena, "u8");
 
-    if (kw.eql(.{ .short = 1 }) or kw.eql(.{ .signed = 1, .short = 1 }) or kw.eql(.{ .short = 1, .int = 1 }) or kw.eql(.{ .signed = 1, .short = 1, .int = 1 }))
+    if (eql(kw, .{ .short = 1 }) or eql(kw, .{ .signed = 1, .short = 1 }) or eql(kw, .{ .short = 1, .int = 1 }) or eql(kw, .{ .signed = 1, .short = 1, .int = 1 }))
         return Tag.type.create(c.arena, "c_short");
 
-    if (kw.eql(.{ .unsigned = 1, .short = 1 }) or kw.eql(.{ .unsigned = 1, .short = 1, .int = 1 }))
+    if (eql(kw, .{ .unsigned = 1, .short = 1 }) or eql(kw, .{ .unsigned = 1, .short = 1, .int = 1 }))
         return Tag.type.create(c.arena, "c_ushort");
 
-    if (kw.eql(.{ .float = 1 }))
+    if (eql(kw, .{ .float = 1 }))
         return Tag.type.create(c.arena, "f32");
 
-    if (kw.eql(.{ .double = 1 }))
+    if (eql(kw, .{ .double = 1 }))
         return Tag.type.create(c.arena, "f64");
 
-    if (kw.eql(.{ .long = 1, .double = 1 })) {
+    if (eql(kw, .{ .long = 1, .double = 1 })) {
         try m.fail(c, "unable to translate: TODO long double", .{});
         return error.ParseError;
     }
 
-    if (kw.eql(.{ .float = 1, .complex = 1 })) {
+    if (eql(kw, .{ .float = 1, .complex = 1 })) {
         try m.fail(c, "unable to translate: TODO _Complex", .{});
         return error.ParseError;
     }
 
-    if (kw.eql(.{ .double = 1, .complex = 1 })) {
+    if (eql(kw, .{ .double = 1, .complex = 1 })) {
         try m.fail(c, "unable to translate: TODO _Complex", .{});
         return error.ParseError;
     }
 
-    if (kw.eql(.{ .long = 1, .double = 1, .complex = 1 })) {
+    if (eql(kw, .{ .long = 1, .double = 1, .complex = 1 })) {
         try m.fail(c, "unable to translate: TODO _Complex", .{});
         return error.ParseError;
     }


### PR DESCRIPTION
i've been using `std.testing` a lot more recently and having this felt very important when using `expectEqualSlices`.
particularly since slices do pointer equality in the default implementation of `std.meta.eql` which `expectEqualSlices` uses
by letting a struct define its own `eql` method, it can short circuit the equality check by only checking a select field or use value-equality in its slice fields for example