### PR TITLE
zig init template: add compiler version to build.zig.zon by default

### DIFF
--- a/lib/init/build.zig
+++ b/lib/init/build.zig
@@ -42,14 +42,14 @@ pub fn build(b: *std.Build) void {
     // Modules can depend on one another using the `std.Build.Module.addImport` function.
     // This is what allows Zig source code to use `@import("foo")` where 'foo' is not a
     // file path. In this case, we set up `exe_mod` to import `lib_mod`.
-    exe_mod.addImport("$_lib", lib_mod);
+    exe_mod.addImport("$root_lib", lib_mod);
 
     // Now, we will create a static library based on the module we created above.
     // This creates a `std.Build.Step.Compile`, which is the build step responsible
     // for actually invoking the compiler.
     const lib = b.addLibrary(.{
         .linkage = .static,
-        .name = "$",
+        .name = "$root",
         .root_module = lib_mod,
     });
 
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) void {
     // This creates another `std.Build.Step.Compile`, but this one builds an executable
     // rather than a static library.
     const exe = b.addExecutable(.{
-        .name = "$",
+        .name = "$root",
         .root_module = exe_mod,
     });
 

--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -6,7 +6,7 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "$",
+    .name = "$root",
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
@@ -15,7 +15,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "*",
+    .minimum_zig_version = "$version",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -15,7 +15,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    //.minimum_zig_version = "0.11.0",
+    .minimum_zig_version = "*",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/lib/init/src/main.zig
+++ b/lib/init/src/main.zig
@@ -41,4 +41,3 @@ test "fuzz example" {
     };
     try std.testing.fuzz(global.testOne, .{});
 }
-

--- a/lib/init/src/main.zig
+++ b/lib/init/src/main.zig
@@ -1,6 +1,9 @@
 //! By convention, main.zig is where your main function lives in the case that
 //! you are building an executable. If you are making a library, the convention
 //! is to delete this file and start with root.zig instead.
+const std = @import("std");
+/// This imports the separate module containing `root.zig`. Take a look in `build.zig` for details.
+const lib = @import("$root_lib");
 
 pub fn main() !void {
     // Prints to stderr (it's a shortcut based on `std.io.getStdErr()`)
@@ -39,7 +42,3 @@ test "fuzz example" {
     try std.testing.fuzz(global.testOne, .{});
 }
 
-const std = @import("std");
-
-/// This imports the separate module containing `root.zig`. Take a look in `build.zig` for details.
-const lib = @import("$_lib");

--- a/src/main.zig
+++ b/src/main.zig
@@ -7466,12 +7466,6 @@ fn loadManifest(
 const Replacement = struct {
     variable: []const u8,
     replacement: []const u8,
-
-    pub inline fn check_variable(self: *@This()) !void {
-        if (self.variable.len < 2) {
-            return error.InvalidVariable;
-        }
-    }
 };
 
 const Templates = struct {
@@ -7512,7 +7506,6 @@ const Templates = struct {
         // replace variables like $root and $version with the project name
         // and zig compiler version respectively
         while (iterator.next()) |line| {
-
             var i: usize = 0;
             while (i < line.len) : (i += 1) {
                 const c = line[i];
@@ -7522,7 +7515,9 @@ const Templates = struct {
                         var found: bool = false;
 
                         for (replace_items) |replacement| {
-                            try replacement.check_variable();
+                            if (replacement.variable.len < 2) {
+                                return error.InvalidVariable;
+                            }
 
                             if (line.len - i < replacement.variable.len) {
                                 continue;

--- a/src/main.zig
+++ b/src/main.zig
@@ -7479,13 +7479,27 @@ const Templates = struct {
         const contents = templates.dir.readFileAlloc(arena, template_path, max_bytes) catch |err| {
             fatal("unable to read template file '{s}': {s}", .{ template_path, @errorName(err) });
         };
+
         templates.buffer.clearRetainingCapacity();
         try templates.buffer.ensureUnusedCapacity(contents.len);
-        for (contents) |c| {
-            if (c == '$') {
-                try templates.buffer.appendSlice(root_name);
-            } else {
-                try templates.buffer.append(c);
+
+        if (mem.eql(u8, template_path, Package.Manifest.basename)) {
+            for (contents) |c| {
+                if (c == '$') {
+                    try templates.buffer.appendSlice(root_name);
+                } else if (c == '*') {
+                    try templates.buffer.appendSlice(build_options.version);
+                } else {
+                    try templates.buffer.append(c);
+                }
+            }
+        } else {
+            for (contents) |c| {
+                if (c == '$') {
+                    try templates.buffer.appendSlice(root_name);
+                } else {
+                    try templates.buffer.append(c);
+                }
             }
         }
 


### PR DESCRIPTION
referenced here on [ziggit](https://ziggit.dev/t/adding-a-field-to-build-zig-build-zig-zon-for-the-zig-compiler-version-and-commit-used-to-init-the-project/7413/4) which describes the problem in depth, but the gist is that this solves the problem of having to manually try many different compiler versions to attempt to build a project that is unclear what version was used. If someone uses a tagged version, its not such a big deal (still annoying) but if they used a non-tagged version, it becomes nigh impossible to pin down what zig version was used to build a project. This currently just serves as an anchor point of reference so this is easier. It could also allow zig version managers to automatically use the correct version of the zig compiler. 

Instead of parsing the zon file, I opted for using a wildcard like what is used for the '.name' field and just appending the version to the buffer that gets written.

It doesn't handle updating the version, I guess its better for the programmer to do so manually, and another simple expansion upon this could be emitting a warning when the current zig version is lower than or not equal to what is specified in the `build.zig.zon` file.