### PR TITLE
compiler: do not propagate result type to `try` operand

### DIFF
--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -721,14 +721,6 @@ pub const Inst = struct {
         /// Result is always void.
         /// Uses the `un_node` union field. Node is the initializer. Operand is the initializer value.
         validate_const,
-        /// Given a type `T`, construct the type `E!T`, where `E` is this function's error set, to be used
-        /// as the result type of a `try` operand. Generic poison is propagated.
-        /// Uses the `un_node` union field. Node is the `try` expression. Operand is the type `T`.
-        try_operand_ty,
-        /// Given a type `*T`, construct the type `*E!T`, where `E` is this function's error set, to be used
-        /// as the result type of a `try` operand whose address is taken with `&`. Generic poison is propagated.
-        /// Uses the `un_node` union field. Node is the `try` expression. Operand is the type `*T`.
-        try_ref_operand_ty,
 
         // The following tags all relate to struct initialization expressions.
 
@@ -1304,8 +1296,6 @@ pub const Inst = struct {
                 .array_init_elem_ptr,
                 .validate_ref_ty,
                 .validate_const,
-                .try_operand_ty,
-                .try_ref_operand_ty,
                 .restore_err_ret_index_unconditional,
                 .restore_err_ret_index_fn_entry,
                 => false,
@@ -1365,8 +1355,6 @@ pub const Inst = struct {
                 .validate_ptr_array_init,
                 .validate_ref_ty,
                 .validate_const,
-                .try_operand_ty,
-                .try_ref_operand_ty,
                 => true,
 
                 .param,
@@ -1749,8 +1737,6 @@ pub const Inst = struct {
                 .coerce_ptr_elem_ty = .pl_node,
                 .validate_ref_ty = .un_tok,
                 .validate_const = .un_node,
-                .try_operand_ty = .un_node,
-                .try_ref_operand_ty = .un_node,
 
                 .int_from_ptr = .un_node,
                 .compile_error = .un_node,
@@ -4196,8 +4182,6 @@ fn findTrackableInner(
         .coerce_ptr_elem_ty,
         .validate_ref_ty,
         .validate_const,
-        .try_operand_ty,
-        .try_ref_operand_ty,
         .struct_init_empty,
         .struct_init_empty_result,
         .struct_init_empty_ref_result,

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -278,8 +278,6 @@ const Writer = struct {
             .opt_eu_base_ptr_init,
             .restore_err_ret_index_unconditional,
             .restore_err_ret_index_fn_entry,
-            .try_operand_ty,
-            .try_ref_operand_ty,
             => try self.writeUnNode(stream, inst),
 
             .ref,

--- a/test/cases/compile_errors/redundant_try.zig
+++ b/test/cases/compile_errors/redundant_try.zig
@@ -1,0 +1,52 @@
+const S = struct { x: u32 = 0 };
+const T = struct { []const u8 };
+
+fn test0() !void {
+    const x: u8 = try 1;
+    _ = x;
+}
+
+fn test1() !void {
+    const x: S = try .{};
+    _ = x;
+}
+
+fn test2() !void {
+    const x: S = try .{ .x = 123 };
+    _ = x;
+}
+
+fn test3() !void {
+    const x: S = try try .{ .x = 123 };
+    _ = x;
+}
+
+fn test4() !void {
+    const x: T = try .{"hello"};
+    _ = x;
+}
+
+fn test5() !void {
+    const x: error{Foo}!u32 = 123;
+    _ = try try x;
+}
+
+comptime {
+    _ = &test0;
+    _ = &test1;
+    _ = &test2;
+    _ = &test3;
+    _ = &test4;
+    _ = &test5;
+}
+
+// error
+//
+// :5:23: error: expected error union type, found 'comptime_int'
+// :10:23: error: expected error union type, found '@TypeOf(.{})'
+// :15:23: error: expected error union type, found 'tmp.test2__struct_493'
+// :15:23: note: struct declared here
+// :20:27: error: expected error union type, found 'tmp.test3__struct_495'
+// :20:27: note: struct declared here
+// :25:23: error: expected error union type, found 'struct { comptime *const [5:0]u8 = "hello" }'
+// :31:13: error: expected error union type, found 'u32'


### PR DESCRIPTION
This commit effectively reverts 9e683f0, and hence un-accepts #19777. While nice in theory, this proposal turned out to have a few problems.

Firstly, supplying a result type implicitly coerces the operand to this type -- that's the main point of result types! But for `try`, this is actually a bad idea; we want a redundant `try` to be a compile error, not to silently coerce the non-error value to an error union. In practice, this didn't always happen, because the implementation was buggy anyway; but when it did, it was really quite silly. For instance, `try try ... try .{ ... }` was an accepted expression, with the inner initializer being initially coerced to `E!E!...E!T`.

Secondly, the result type inference here didn't play nicely with `return`. If you write `return try`, the operand would actually receive a result type of `E!E!T`, since the `return` gave a result type of `E!T` and the `try` wrapped it in *another* error union. More generally, the problem here is that `try` doesn't know when it should or shouldn't nest error unions. This occasionally broke code which looked like it should work.

So, this commit prevents `try` from propagating result types through to its operand. A key motivation for the original proposal here was decl literals; so, as a special case, `try .foo(...)` is still an allowed syntax form, caught by AstGen and specially lowered. This does open the doors to allowing other special cases for decl literals in future, such as `.foo(...) catch ...`, but those proposals are for another time.

Resolves: #21991
Resolves: #22633

---

This is a breaking change, but it only breaks a feature implemented *after* 0.13.0, so doesn't need the "release notes" tag.

Also, closes #21319; that enhancement doesn't make sense after this change.