### PR TITLE
Sema: skip aliasing check and runtime operation for `@memcpy` of zero-bit type

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -452,6 +452,13 @@ pub fn hasRuntimeBitsIgnoreComptime(ty: Type, zcu: *const Zcu) bool {
     return hasRuntimeBitsInner(ty, true, .eager, zcu, {}) catch unreachable;
 }
 
+pub fn hasRuntimeBitsIgnoreComptimeSema(ty: Type, pt: Zcu.PerThread) SemaError!bool {
+    return hasRuntimeBitsInner(ty, true, .sema, pt.zcu, pt.tid) catch |err| switch (err) {
+        error.NeedLazy => unreachable, // this would require a resolve strat of lazy
+        else => |e| return e,
+    };
+}
+
 /// true if and only if the type takes up space in memory at runtime.
 /// There are two reasons a type will return false:
 /// * the type is a comptime-only type. For example, the type `type` itself.

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const expect = std.testing.expect;
+const assert = std.debug.assert;
 
 test "memcpy and memset intrinsics" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -98,4 +99,32 @@ comptime {
     var s = S{};
     s.set("hello");
     if (!std.mem.eql(u8, s.buffer[0..5], "hello")) @compileError("bad");
+}
+
+test "@memcpy comptime-only type" {
+    const in: [4]type = .{ u8, u16, u32, u64 };
+    comptime var out: [4]type = undefined;
+    @memcpy(&out, &in);
+
+    comptime assert(out[0] == u8);
+    comptime assert(out[1] == u16);
+    comptime assert(out[2] == u32);
+    comptime assert(out[3] == u64);
+}
+
+test "@memcpy zero-bit type with aliasing" {
+    const S = struct {
+        fn doTheTest() void {
+            var buf: [3]void = @splat({});
+            const slice: []void = &buf;
+            // These two pointers are the same, but it's still not considered aliasing because
+            // the input and output slices both correspond to zero bits of memory.
+            @memcpy(slice, slice);
+            comptime assert(buf[0] == {});
+            comptime assert(buf[1] == {});
+            comptime assert(buf[2] == {});
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
 }


### PR DESCRIPTION
Supersedes #21658.