### PR TITLE
Adds imported ZON files to the cache manifest

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -14017,15 +14017,12 @@ fn zirImport(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.
                     try pt.reportRetryableFileError(result.file_index, "unable to resolve path: {s}", .{@errorName(err)});
                     return error.AnalysisFail;
                 };
-                errdefer zcu.gpa.free(resolved_path);
-
-                const copied_resolved_path = try zcu.gpa.dupe(u8, resolved_path);
-                errdefer zcu.gpa.free(copied_resolved_path);
+                defer zcu.gpa.free(resolved_path);
 
                 whole.cache_manifest_mutex.lock();
                 defer whole.cache_manifest_mutex.unlock();
 
-                man.addFilePost(copied_resolved_path) catch |err| {
+                man.addFilePost(resolved_path) catch |err| {
                     // TODO: these errors are file system errors; make sure an update() will
                     // retry this and not cache the file system error, which may be transient.
                     return sema.fail(block, operand_src, "unable to open '{s}': {s}", .{ operand, @errorName(err) });


### PR DESCRIPTION
fixes #22746 

Someone more familiar with the way caching works than me should probably take a quick look at this before it's merged, I only just looked at this part of the codebase for the first time while writing this.

In particular:

1. I'm using `addFilePost`. I picked this because it's the most similar to what embed file does but doesn't require the file contents, but maybe it's not the right option.

2. I'm unsure about the way I handle the errors that `addFilePost` can return. Other places in this file seem to have a TODO and just call sema.fail in similar circumstances, so I've done that here, but I feel a little bad proliferating the TODO without understanding it.