### PR TITLE
fix typo of anytype to type

### DIFF
--- a/lib/std/compress.zig
+++ b/lib/std/compress.zig
@@ -10,10 +10,7 @@ pub const lzma2 = @import("compress/lzma2.zig");
 pub const xz = @import("compress/xz.zig");
 pub const zstd = @import("compress/zstandard.zig");
 
-pub fn HashedReader(
-    comptime ReaderType: anytype,
-    comptime HasherType: anytype,
-) type {
+pub fn HashedReader(ReaderType: type, HasherType: type) type {
     return struct {
         child_reader: ReaderType,
         hasher: HasherType,
@@ -40,10 +37,7 @@ pub fn hashedReader(
     return .{ .child_reader = reader, .hasher = hasher };
 }
 
-pub fn HashedWriter(
-    comptime WriterType: anytype,
-    comptime HasherType: anytype,
-) type {
+pub fn HashedWriter(WriterType: type, HasherType: type) type {
     return struct {
         child_writer: WriterType,
         hasher: HasherType,


### PR DESCRIPTION
This seems like a simple typo.  The values are immediately used in a struct as types, so there's no reason to use anytype here, afaik.