### PR TITLE
fmt: allow multiline destructuring

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -2933,6 +2933,29 @@ test "zig fmt: destructure" {
     );
 }
 
+test "zig fmt: destructure multiline" {
+    try testTransform(
+        \\test {
+        \\    const x, y,
+        \\    const z = .{ 1, 2, 3 };
+        \\    const x,
+        \\    y, const z = .{ 1, 2, 3 };
+        \\    const
+        \\    w = 1;
+        \\}
+        \\
+    ,
+        \\test {
+        \\    const x, y, const z = .{ 1, 2, 3 };
+        \\    const x,
+        \\    y,
+        \\    const z = .{ 1, 2, 3 };
+        \\    const w = 1;
+        \\}
+        \\
+    );
+}
+
 test "zig fmt: infix operators" {
     try testCanonical(
         \\test {


### PR DESCRIPTION
While unpacking is a niche feature, and you probably shouldn't unpack too many things at the same time, there _are_ cases where this is useful, and it feels easy to support.

The specific motivating example is from TigerBeetle's build system, where we need to parse cli args of a specific known shape:

```zig
pub fn main() !void {
    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    const allocator = arena.allocator();
    const args = try std.process.argsAlloc(allocator);
    if (args.len != 8) @panic();

    const title,
    const author,
    const url_prefix,
    const nav,
    const url_page_source,
    const source_file_path,
    const target_file_path = args;
```