### PR TITLE
glibc: guard more function declarations

### DIFF
--- a/lib/libc/include/generic-glibc/bits/spawn_ext.h
+++ b/lib/libc/include/generic-glibc/bits/spawn_ext.h
@@ -35,6 +35,8 @@ extern int posix_spawnattr_setcgroup_np (posix_spawnattr_t *__attr,
 					 int __cgroup)
      __THROW __nonnull ((1));
 
+// zig patch: check target glibc version
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 39) || __GLIBC__ > 2
 /* Spawn a new process executing PATH with the attributes describes in *ATTRP.
    Before running the process perform the actions described in FACTS.  Return
    a PID file descriptor in PIDFD if process creation was successful and the
@@ -61,6 +63,7 @@ extern int pidfd_spawnp (int *__restrict __pidfd,
 			 char *const __argv[__restrict_arr],
 			 char *const __envp[__restrict_arr])
     __nonnull ((1, 2, 5));
+#endif /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 39) || __GLIBC__ > 2 */
 
 #endif /* __USE_MISC */
 

--- a/lib/libc/include/generic-glibc/bits/statx-generic.h
+++ b/lib/libc/include/generic-glibc/bits/statx-generic.h
@@ -25,6 +25,9 @@
 #include <bits/types/struct_statx_timestamp.h>
 #include <bits/types/struct_statx.h>
 
+// zig patch: check target glibc version
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 28) || __GLIBC__ > 2
+
 #ifndef STATX_TYPE
 # define STATX_TYPE 0x0001U
 # define STATX_MODE 0x0002U
@@ -64,3 +67,5 @@ int statx (int __dirfd, const char *__restrict __path, int __flags,
   __THROW __nonnull ((2, 5));
 
 __END_DECLS
+
+#endif /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 28) || __GLIBC__ > 2 */

--- a/lib/libc/include/generic-glibc/sys/mount.h
+++ b/lib/libc/include/generic-glibc/sys/mount.h
@@ -235,6 +235,8 @@ struct mount_attr
 #define FSPICK_NO_AUTOMOUNT     0x00000004
 #define FSPICK_EMPTY_PATH       0x00000008
 
+// zig patch: check target glibc version
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2
 
 #ifndef FSOPEN_CLOEXEC
 /* The type of fsconfig call made.   */
@@ -268,6 +270,7 @@ enum fsconfig_command
 #define OPEN_TREE_CLONE    1         /* Clone the target tree and attach the clone */
 #define OPEN_TREE_CLOEXEC  O_CLOEXEC /* Close the file on execve() */
 
+#endif
 
 __BEGIN_DECLS
 
@@ -281,6 +284,9 @@ extern int umount (const char *__special_file) __THROW;
 
 /* Unmount a filesystem.  Force unmounting if FLAGS is set to MNT_FORCE.  */
 extern int umount2 (const char *__special_file, int __flags) __THROW;
+
+// zig patch: check target glibc version
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2
 
 /* Open the filesystem referenced by FS_NAME so it can be configured for
    mouting.  */
@@ -319,6 +325,8 @@ extern int open_tree (int __dfd, const char *__filename, unsigned int __flags)
 extern int mount_setattr (int __dfd, const char *__path, unsigned int __flags,
 			  struct mount_attr *__uattr, size_t __usize)
   __THROW;
+
+#endif /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2 */
 
 __END_DECLS
 

--- a/lib/libc/include/generic-glibc/sys/pidfd.h
+++ b/lib/libc/include/generic-glibc/sys/pidfd.h
@@ -21,6 +21,9 @@
 #include <fcntl.h>
 #include <bits/types/siginfo_t.h>
 
+// zig patch: check target glibc version
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2
+
 #define PIDFD_NONBLOCK O_NONBLOCK
 #define PIDFD_THREAD O_EXCL
 
@@ -45,8 +48,15 @@ extern int pidfd_getfd (int __pidfd, int __targetfd,
 extern int pidfd_send_signal (int __pidfd, int __sig, siginfo_t *__info,
 			      unsigned int __flags) __THROW;
 
+#endif /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2 */
+
+// zig patch: check target glibc version
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 39) || __GLIBC__ > 2
+
 /* Query the process ID (PID) from process descriptor FD.  Return the PID
    or -1 in case of an error.  */
 extern pid_t pidfd_getpid (int __fd) __THROW;
+
+#endif /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 36) || __GLIBC__ > 2 */
 
 #endif /* _PIDFD_H  */

--- a/lib/libc/include/generic-glibc/unistd.h
+++ b/lib/libc/include/generic-glibc/unistd.h
@@ -1203,6 +1203,8 @@ int getentropy (void *__buffer, size_t __length) __wur
 #endif
 
 #ifdef __USE_GNU
+// zig patch: check target glibc version
+# if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 34) || __GLIBC__ > 2
 /* Close all file descriptors in the range FD up to MAX_FD.  The flag FLAGS
    are define by the CLOSE_RANGE prefix.  This function behaves like close
    on the range and gaps where the file descriptor is invalid or errors
@@ -1210,6 +1212,7 @@ int getentropy (void *__buffer, size_t __length) __wur
    successor or -1 for failure (and sets errno accordingly).  */
 extern int close_range (unsigned int __fd, unsigned int __max_fd,
 			int __flags) __THROW;
+# endif
 #endif
 
 /* Define some macros helping to catch buffer overflows.  */


### PR DESCRIPTION
Guard the declaration of:
* `close_range` (introduced in 2.34)
* `statx` (introduced in 2.28)
* `fsopen`, `fsmount`, `move_mount`, `fsconfig`, `fspick`, `open_tree`, `mount_setattr` (introduced in 2.36)
* `pidfd_open`, `pidfd_getfd`, `pidfd_send_signal` (introduced in `2.36)
* `pidfd_getpid` (introduced in 2.39)

This fixes building util-linux` while targeting glibc `2.17` (or any version prior to 2.39)