### PR TITLE
Unify and fix the checks for zirDiv*()

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -15630,10 +15630,12 @@ fn divFoldZeroOrOne(
     const type_tag = scalar_type.zigTypeTag(zcu);
     const is_int = type_tag == .int or type_tag == .comptime_int;
 
-    // For integers:
+    // For integers and comptime_float:
     // If any rhs component is zero, compile error for division by zero.
     // If the rhs is undefined, compile error because there is a possible
     // value (zero) for which the division would be illegal behavior.
+    //
+    // For integers:
     // If the rhs is 1, return the lhs.
     // Otherwise, if the lhs is zero, then zero is returned regardless of rhs.
     // If the lhs is undefined:
@@ -15651,7 +15653,7 @@ fn divFoldZeroOrOne(
     //   * otherwise, the result is undefined.
 
     if (rhs_val) |rhs| {
-        if (is_int) {
+        if (is_int or type_tag == .comptime_float) {
             if (rhs.isUndef(zcu)) {
                 return sema.failWithUseOfUndef(block, rhs_src);
             }

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -1568,10 +1568,6 @@ test "comptime fixed-width float non-zero divided by zero produces signed Inf" {
     }
 }
 
-test "comptime_float zero divided by zero produces nan" {
-    try expect(math.isNan(0.0 / 0.0));
-}
-
 test "comptime float compared with runtime int" {
     const f = 10.0;
     var i: usize = 0;

--- a/test/behavior/floatop.zig
+++ b/test/behavior/floatop.zig
@@ -1568,8 +1568,8 @@ test "comptime fixed-width float non-zero divided by zero produces signed Inf" {
     }
 }
 
-test "comptime_float zero divided by zero produces zero" {
-    try expect((0.0 / 0.0) == 0.0);
+test "comptime_float zero divided by zero produces nan" {
+    try expect(math.isNan(0.0 / 0.0));
 }
 
 test "comptime float compared with runtime int" {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -699,7 +699,6 @@ fn testFloatDivision() !void {
     }
 }
 
-
 test "large integer division" {
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;


### PR DESCRIPTION
Close #22749, close #22748, close #21198, complete the "if the RHS is one, return the LHS directly" TODOs, fix a crash on `intvec{undefined} / intvec{-1}` and fix some compile errors:

* @divExact should not cause a compile error for integer undefined lhs and runtime-known rhs, because execution is completely legal when rhs == 1, and the policy on other operations has so far been to only have a compile error when illegal behavior is guaranteed to happen.
* Compile errors for float division by zero make little sense given that they are perfectly well-defined IEEE operations. The comments suggest that this was possibly made illegal intentionally, maybe in service of explicitness / "only way to do things" (so you have to use math.inf / math.nan) or as a step towards #21205. But in general, it that behavior would contradict the principle that comptime operations behave like runtime, and would add annoying special-cases to some comptime calculations. The @...Div() intrins allowed only *floating-point zero divided by zero*, which should be, if anything, *more* ill-defined than any other division by zero, and probably shouldn't result in zero.