### PR TITLE
std.os.linux: use `isize` to more accurately reflect mmap offset semantics

### DIFF
--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -297,7 +297,7 @@ pub const ElfDynLib = struct {
                                 prot,
                                 .{ .TYPE = .PRIVATE, .FIXED = true },
                                 fd,
-                                ph.p_offset - extra_bytes,
+                                @intCast(ph.p_offset - extra_bytes),
                             );
                         } else {
                             const sect_mem = try posix.mmap(

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -890,7 +890,7 @@ pub fn umount2(special: [*:0]const u8, flags: u32) usize {
     return syscall2(.umount2, @intFromPtr(special), flags);
 }
 
-pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, offset: i64) usize {
+pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, offset: isize) usize {
     if (@hasField(SYS, "mmap2")) {
         // Make sure the offset is also specified in multiples of page size
         if ((offset & (MMAP2_UNIT - 1)) != 0)
@@ -903,7 +903,7 @@ pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, of
             prot,
             @as(u32, @bitCast(flags)),
             @bitCast(@as(isize, fd)),
-            @truncate(@as(u64, @bitCast(offset)) / MMAP2_UNIT),
+            @truncate(@as(usize, @bitCast(offset)) / MMAP2_UNIT),
         );
     } else {
         // The s390x mmap() syscall existed before Linux supported syscalls with 5+ parameters, so
@@ -916,7 +916,7 @@ pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, of
                 prot,
                 @as(u32, @bitCast(flags)),
                 @bitCast(@as(isize, fd)),
-                @truncate(@as(u64, @bitCast(offset))),
+                @as(usize, @bitCast(offset)),
             }),
         ) else syscall6(
             .mmap,
@@ -925,7 +925,7 @@ pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, of
             prot,
             @as(u32, @bitCast(flags)),
             @bitCast(@as(isize, fd)),
-            @truncate(@as(u64, @bitCast(offset))),
+            @as(usize, @bitCast(offset)),
         );
     }
 }

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -916,7 +916,7 @@ pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, of
                 prot,
                 @as(u32, @bitCast(flags)),
                 @bitCast(@as(isize, fd)),
-                @as(u64, @bitCast(offset)),
+                @truncate(@as(u64, @bitCast(offset))),
             }),
         ) else syscall6(
             .mmap,
@@ -925,7 +925,7 @@ pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, of
             prot,
             @as(u32, @bitCast(flags)),
             @bitCast(@as(isize, fd)),
-            @as(u64, @bitCast(offset)),
+            @truncate(@as(u64, @bitCast(offset))),
         );
     }
 }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4764,10 +4764,10 @@ pub fn mmap(
     prot: u32,
     flags: system.MAP,
     fd: fd_t,
-    offset: i64,
+    offset: isize,
 ) MMapError![]align(mem.page_size) u8 {
-    const mmap_sym = if (lfs64_abi) system.mmap64 else system.mmap;
-    const rc = mmap_sym(ptr, length, prot, @bitCast(flags), fd, @intCast(offset));
+    const mmap_sym = if (lfs64_abi and @bitSizeOf(isize) == 64) system.mmap64 else system.mmap;
+    const rc = mmap_sym(ptr, length, prot, @bitCast(flags), fd, offset);
     const err: E = if (builtin.link_libc) blk: {
         if (rc != std.c.MAP_FAILED) return @as([*]align(mem.page_size) u8, @ptrCast(@alignCast(rc)))[0..length];
         break :blk @enumFromInt(system._errno().*);

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4764,10 +4764,10 @@ pub fn mmap(
     prot: u32,
     flags: system.MAP,
     fd: fd_t,
-    offset: u64,
+    offset: i64,
 ) MMapError![]align(mem.page_size) u8 {
     const mmap_sym = if (lfs64_abi) system.mmap64 else system.mmap;
-    const rc = mmap_sym(ptr, length, prot, @bitCast(flags), fd, @bitCast(offset));
+    const rc = mmap_sym(ptr, length, prot, @bitCast(flags), fd, @intCast(offset));
     const err: E = if (builtin.link_libc) blk: {
         if (rc != std.c.MAP_FAILED) return @as([*]align(mem.page_size) u8, @ptrCast(@alignCast(rc)))[0..length];
         break :blk @enumFromInt(system._errno().*);


### PR DESCRIPTION
Resolves #22464.