### PR TITLE
improve error message for unterminated string and character literals

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -458,6 +458,16 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
             return stream.writeAll("for input is not captured");
         },
 
+        .unterminated_literal => {
+            return stream.print("unterminated '{s} literal'", .{
+                switch (tree.source[tree.tokens.items(.start)[parse_error.token]]) {
+                    '\'' => "character",
+                    '"' => "string",
+                    else => unreachable,
+                },
+            });
+        },
+
         .invalid_byte => {
             const tok_slice = tree.source[tree.tokens.items(.start)[parse_error.token]..];
             return stream.print("{s} contains invalid byte: '{'}'", .{
@@ -3003,6 +3013,7 @@ pub const Error = struct {
         var_const_decl,
         extra_for_capture,
         for_input_not_captured,
+        unterminated_literal,
 
         zig_style_container,
         previous_field,

--- a/test/cases/compile_errors/character_literal_with_newline.zig
+++ b/test/cases/compile_errors/character_literal_with_newline.zig
@@ -1,0 +1,8 @@
+const foo = 'a
+';
+
+// error
+// backend=stage2
+// target=native
+//
+// :1:13: error: unterminated 'character literal'

--- a/test/cases/compile_errors/normal_string_with_newline.zig
+++ b/test/cases/compile_errors/normal_string_with_newline.zig
@@ -5,4 +5,4 @@ b";
 // backend=stage2
 // target=native
 //
-// :1:15: error: string literal contains invalid byte: '\n'
+// :1:13: error: unterminated 'string literal'

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -238,6 +238,22 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
     }
 
     {
+        const case = ctx.obj("unterminated character literal eof", b.graph.host);
+
+        case.addError("const c = '", &[_][]const u8{
+            ":1:11: error: unterminated 'character literal'",
+        });
+    }
+
+    {
+        const case = ctx.obj("unterminated string literal eof", b.graph.host);
+
+        case.addError("const s = \"hello, ", &[_][]const u8{
+            ":1:11: error: unterminated 'string literal'",
+        });
+    }
+
+    {
         const case = ctx.obj("invalid byte at start of token", b.graph.host);
 
         case.addError("x = \x00Q", &[_][]const u8{


### PR DESCRIPTION
Followup to #21459 based on [this comment](https://github.com/ziglang/zig/pull/21459#pullrequestreview-2593793519).

This improves the error message for unterminated string and character literals. Instead of showing the invalid byte, the error message now indicates that the given literal is unterminated. 