### PR TITLE
Do not print the sign of NaNs

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -2233,22 +2233,16 @@ test "float.scientific.precision" {
 
 test "float.special" {
     try expectFmt("f64: nan", "f64: {}", .{math.nan(f64)});
-    // negative nan is not defined by IEE 754,
-    // and ARM thus normalizes it to positive nan
-    if (builtin.target.cpu.arch != .arm) {
-        try expectFmt("f64: -nan", "f64: {}", .{-math.nan(f64)});
-    }
+    try expectFmt("f64: nan", "f64: {}", .{-math.nan(f64)});
+
     try expectFmt("f64: inf", "f64: {}", .{math.inf(f64)});
     try expectFmt("f64: -inf", "f64: {}", .{-math.inf(f64)});
 }
 
 test "float.hexadecimal.special" {
     try expectFmt("f64: nan", "f64: {x}", .{math.nan(f64)});
-    // negative nan is not defined by IEE 754,
-    // and ARM thus normalizes it to positive nan
-    if (builtin.target.cpu.arch != .arm) {
-        try expectFmt("f64: -nan", "f64: {x}", .{-math.nan(f64)});
-    }
+    try expectFmt("f64: nan", "f64: {x}", .{-math.nan(f64)});
+
     try expectFmt("f64: inf", "f64: {x}", .{math.inf(f64)});
     try expectFmt("f64: -inf", "f64: {x}", .{-math.inf(f64)});
 

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1067,11 +1067,11 @@ pub fn formatFloatHexadecimal(
     options: FormatOptions,
     writer: anytype,
 ) !void {
-    if (math.signbit(value)) {
-        try writer.writeByte('-');
-    }
     if (math.isNan(value)) {
         return writer.writeAll("nan");
+    }
+    if (math.signbit(value)) {
+        try writer.writeByte('-');
     }
     if (math.isInf(value)) {
         return writer.writeAll("inf");

--- a/lib/std/fmt/format_float.zig
+++ b/lib/std/fmt/format_float.zig
@@ -89,13 +89,13 @@ pub fn FloatDecimal(comptime T: type) type {
 }
 
 fn copySpecialStr(buf: []u8, f: anytype) []const u8 {
-    if (f.sign) {
-        buf[0] = '-';
+    if (f.mantissa != 0) {
+        @memcpy(buf[0..3], "nan");
+        return buf[0..3];
     }
     const offset: usize = @intFromBool(f.sign);
-    if (f.mantissa != 0) {
-        @memcpy(buf[offset..][0..3], "nan");
-        return buf[0 .. 3 + offset];
+    if (f.sign) {
+        buf[0] = '-';
     }
     @memcpy(buf[offset..][0..3], "inf");
     return buf[0 .. 3 + offset];


### PR DESCRIPTION
The sign of a NaN is very much not defined, and no more meaningful than any of the other bits that may vary in its representation. Since it can change between machines (between different or identical architectures!), and LLVM messes with it arbitrarily even in debug mode, printing it only adds noise and potential for bugs.