### PR TITLE
Dwarf: fix cross_section_relocs capacity

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -4576,7 +4576,7 @@ pub fn flushModule(dwarf: *Dwarf, pt: Zcu.PerThread) FlushError!void {
         );
         for (dwarf.mods.values(), dwarf.debug_line.section.units.items) |mod_info, *unit| {
             unit.clear();
-            try unit.cross_section_relocs.ensureTotalCapacity(dwarf.gpa, 2 * (1 + mod_info.files.count()));
+            try unit.cross_section_relocs.ensureTotalCapacity(dwarf.gpa, mod_info.dirs.count() + 2 * (mod_info.files.count()));
             header.clearRetainingCapacity();
             try header.ensureTotalCapacity(unit.header_len);
             const unit_len = (if (unit.next.unwrap()) |next_unit|


### PR DESCRIPTION
This ensure capacity call does not match the number of appendAssumeCapacity() calls that follow it. Fix this.

This was discovered due to hitting the assertion failure in appendAssumeCapacity() while building river.

I'm not sure how to isolate a minimal reproducer for a test.