### PR TITLE
generic glibc: guard memfd_create & mlock2 declarations

### DIFF
--- a/lib/libc/include/generic-glibc/bits/mman-shared.h
+++ b/lib/libc/include/generic-glibc/bits/mman-shared.h
@@ -50,6 +50,9 @@
 
 __BEGIN_DECLS
 
+// zig patch: check target glibc version
+# if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 27) || __GLIBC__ > 2
+
 /* Create a new memory file descriptor.  NAME is a name for debugging.
    FLAGS is a combination of the MFD_* constants.  */
 int memfd_create (const char *__name, unsigned int __flags) __THROW;
@@ -57,6 +60,8 @@ int memfd_create (const char *__name, unsigned int __flags) __THROW;
 /* Lock pages from ADDR (inclusive) to ADDR + LENGTH (exclusive) into
    memory.  FLAGS is a combination of the MLOCK_* flags above.  */
 int mlock2 (const void *__addr, size_t __length, unsigned int __flags) __THROW;
+
+#endif /* if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 27) || __GLIBC__ > 2 */
 
 /* Allocate a new protection key, with the PKEY_DISABLE_* bits
    specified in ACCESS_RIGHTS.  The protection key mask for the


### PR DESCRIPTION
They were introduced in glibc 2.27