### PR TITLE
std.crypto.tlcsprng: Fix hardcoded use of defaultRandomSeed()

### DIFF
--- a/lib/std/crypto/tlcsprng.zig
+++ b/lib/std/crypto/tlcsprng.zig
@@ -53,7 +53,7 @@ fn tlsCsprngFill(_: *anyopaque, buffer: []u8) void {
     // std.crypto.random always make an OS syscall, rather than rely on an
     // application implementation of a CSPRNG.
     if (std.options.crypto_always_getrandom) {
-        return defaultRandomSeed(buffer);
+        return std.options.cryptoRandomSeed(buffer);
     }
 
     if (wipe_mem.len == 0) {


### PR DESCRIPTION
See commit message.