### PR TITLE
fix: inc freelist len when free

### DIFF
--- a/lib/std/heap/SmpAllocator.zig
+++ b/lib/std/heap/SmpAllocator.zig
@@ -223,6 +223,7 @@ fn free(context: *anyopaque, memory: []u8, alignment: mem.Alignment, ra: usize) 
         if (freelist_len < max_freelist_len) {
             @branchHint(.likely);
             defer t.unlock();
+            t.freelist_lens[class] = freelist_len +| 1;
             node.* = t.frees[class];
             t.frees[class] = @intFromPtr(node);
             return;


### PR DESCRIPTION
In all cases, when we insert node to the freelist, its len should be incremented.