### PR TITLE
std.heap.SmpAllocator: back to simple free implementation

### DIFF
--- a/lib/std/heap/SmpAllocator.zig
+++ b/lib/std/heap/SmpAllocator.zig
@@ -51,10 +51,6 @@ const slab_len: usize = @max(std.heap.page_size_max, 64 * 1024);
 /// Because of storing free list pointers, the minimum size class is 3.
 const min_class = math.log2(@sizeOf(usize));
 const size_class_count = math.log2(slab_len) - min_class;
-/// When a freelist length exceeds this number of slabs, a `free` will rotate
-/// up to `max_free_search` times before pushing.
-const max_freelist_len = 255;
-const max_free_search = 1;
 /// Before mapping a fresh page, `alloc` will rotate this many times.
 const max_alloc_search = 1;
 
@@ -73,8 +69,6 @@ const Thread = struct {
     next_addrs: [size_class_count]usize = @splat(0),
     /// For each size class, points to the freed pointer.
     frees: [size_class_count]usize = @splat(0),
-    /// For each size class, tracks the number of items in the freelist.
-    freelist_lens: [size_class_count]u8 = @splat(0),
 
     fn lock() *Thread {
         var index = thread_index;
@@ -159,7 +153,6 @@ fn alloc(context: *anyopaque, len: usize, alignment: mem.Alignment, ra: usize) ?
             // slab alignment here ensures the % slab len earlier catches the end of slots.
             const slab = PageAllocator.map(slab_len, .fromByteUnits(slab_len)) orelse return null;
             t.next_addrs[class] = @intFromPtr(slab) + slot_size;
-            t.freelist_lens[class] = 0;
             return slab;
         }
 
@@ -213,43 +206,12 @@ fn free(context: *anyopaque, memory: []u8, alignment: mem.Alignment, ra: usize) 
     }
 
     const node: *usize = @alignCast(@ptrCast(memory.ptr));
-    var search_count: u8 = 0;
 
-    var t = Thread.lock();
+    const t = Thread.lock();
+    defer t.unlock();
 
-    outer: while (true) {
-        const freelist_len = t.freelist_lens[class];
-        if (freelist_len < max_freelist_len) {
-            @branchHint(.likely);
-            defer t.unlock();
-            t.freelist_lens[class] = freelist_len +| @intFromBool((@intFromPtr(node) % slab_len) == 0);
-            node.* = t.frees[class];
-            t.frees[class] = @intFromPtr(node);
-            return;
-        }
-
-        if (search_count >= max_free_search) {
-            defer t.unlock();
-            t.freelist_lens[class] = freelist_len +| @intFromBool((@intFromPtr(node) % slab_len) == 0);
-            node.* = t.frees[class];
-            t.frees[class] = @intFromPtr(node);
-            return;
-        }
-
-        t.unlock();
-        const cpu_count = getCpuCount();
-        assert(cpu_count != 0);
-        var index = thread_index;
-        while (true) {
-            index = (index + 1) % cpu_count;
-            t = &global.threads[index];
-            if (t.mutex.tryLock()) {
-                thread_index = index;
-                search_count += 1;
-                continue :outer;
-            }
-        }
-    }
+    node.* = t.frees[class];
+    t.frees[class] = @intFromPtr(node);
 }
 
 fn sizeClassIndex(len: usize, alignment: mem.Alignment) usize {

--- a/lib/std/heap/SmpAllocator.zig
+++ b/lib/std/heap/SmpAllocator.zig
@@ -53,7 +53,7 @@ const min_class = math.log2(@sizeOf(usize));
 const size_class_count = math.log2(slab_len) - min_class;
 /// When a freelist length exceeds this number, a `free` will rotate up to
 /// `max_free_search` times before pushing.
-const max_freelist_len: u8 = 16;
+const max_freelist_len: u8 = 255;
 const max_free_search = 1;
 /// Before mapping a fresh page, `alloc` will rotate this many times.
 const max_alloc_search = 1;
@@ -223,6 +223,7 @@ fn free(context: *anyopaque, memory: []u8, alignment: mem.Alignment, ra: usize) 
         if (freelist_len < max_freelist_len) {
             @branchHint(.likely);
             defer t.unlock();
+            t.freelist_lens[class] = freelist_len +| 1;
             node.* = t.frees[class];
             t.frees[class] = @intFromPtr(node);
             return;


### PR DESCRIPTION
I tested various combinations, and generally found bigger batches of frees to
work better.

Freelist length accounting in alloc had a negative impact, especially with the
integer type bumped up to u16, so I even tried changing the system to be based
on counting slabs rather than total allocations.

It all ended up being worse perf than the simple thing when used with the
compiler however. Also, I realized that even with the simple free logic, it's
capable of reclaiming the freelist memory because allocations can win the race.

The freelist length accounting definitely reduces peak_rss in the asymmetric
example, however, I haven't found it to matter for the real wold use case of
the Zig compiler.

## Performance Data Points

### Asymmetric Example

from [Carmen's Playground](https://github.com/andrewrk/CarmensPlayground)

```
Benchmark 1 (6 runs): master/bin/asymmetric smp
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.91s  ± 20.0ms    1.89s  … 1.95s           0 ( 0%)        0%
  peak_rss           39.0MB ± 6.75MB    27.6MB … 47.5MB          0 ( 0%)        0%
  cpu_cycles         10.0G  ± 95.0M     9.86G  … 10.1G           0 ( 0%)        0%
  instructions       14.8G  ± 3.06M     14.8G  … 14.8G           0 ( 0%)        0%
  cache_references   54.1M  ±  595K     53.5M  … 54.9M           0 ( 0%)        0%
  cache_misses       23.6M  ±  288K     23.2M  … 23.9M           0 ( 0%)        0%
  branch_misses      2.68M  ± 67.9K     2.57M  … 2.77M           0 ( 0%)        0%
Benchmark 2 (6 runs): simplefree/bin/asymmetric smp
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.87s  ± 6.97ms    1.87s  … 1.89s           0 ( 0%)          -  1.7% ±  1.0%
  peak_rss           41.3MB ± 4.72MB    33.6MB … 46.0MB          0 ( 0%)          +  5.9% ± 19.2%
  cpu_cycles         9.94G  ±  110M     9.74G  … 10.1G           0 ( 0%)          -  1.0% ±  1.3%
  instructions       14.7G  ± 3.31M     14.7G  … 14.8G           0 ( 0%)          -  0.5% ±  0.0%
  cache_references   53.6M  ±  784K     52.7M  … 54.8M           0 ( 0%)          -  0.9% ±  1.7%
  cache_misses       23.6M  ±  166K     23.3M  … 23.8M           0 ( 0%)          -  0.1% ±  1.3%
  branch_misses      2.59M  ± 33.4K     2.55M  … 2.65M           0 ( 0%)          -  3.1% ±  2.6%
```

### Symmetric Example

from [Carmen's Playground](https://github.com/andrewrk/CarmensPlayground)

```
Benchmark 1 (81 runs): master/bin/symmetric smp
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           125ms ± 3.90ms     117ms …  136ms          4 ( 5%)        0%
  peak_rss            373MB ± 8.77MB     355MB …  394MB          0 ( 0%)        0%
  cpu_cycles         6.44G  ±  204M     5.82G  … 6.81G           0 ( 0%)        0%
  instructions       14.9G  ± 1.83M     14.9G  … 14.9G           1 ( 1%)        0%
  cache_references   60.2M  ± 2.61M     54.3M  … 69.5M           5 ( 6%)        0%
  cache_misses       14.0M  ±  774K     11.8M  … 15.4M           1 ( 1%)        0%
  branch_misses      1.70M  ± 43.6K     1.59M  … 1.79M           1 ( 1%)        0%
Benchmark 2 (80 runs): simplefree/bin/symmetric smp
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           125ms ± 3.20ms     118ms …  132ms          2 ( 3%)          +  0.7% ±  0.9%
  peak_rss            376MB ± 8.58MB     356MB …  395MB          0 ( 0%)          +  0.9% ±  0.7%
  cpu_cycles         6.34G  ±  187M     5.82G  … 6.72G           1 ( 1%)          -  1.6% ±  0.9%
  instructions       14.9G  ± 1.84M     14.9G  … 14.9G           0 ( 0%)          -  0.0% ±  0.0%
  cache_references   58.6M  ± 1.82M     53.6M  … 62.7M           1 ( 1%)        ⚡-  2.7% ±  1.2%
  cache_misses       13.6M  ±  761K     11.6M  … 15.3M           1 ( 1%)          -  2.5% ±  1.7%
  branch_misses      1.71M  ± 52.0K     1.59M  … 1.88M           1 ( 1%)          +  0.7% ±  0.9%
```

### Building Zig With Itself

```
Benchmark 1 (3 runs): master/bin/zig build -Dno-lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.5s  ± 56.6ms    12.4s  … 12.5s           0 ( 0%)        0%
  peak_rss            951MB ± 11.2MB     940MB …  962MB          0 ( 0%)        0%
  cpu_cycles         90.4G  ±  154M     90.2G  … 90.5G           0 ( 0%)        0%
  instructions        181G  ±  999K      181G  …  181G           0 ( 0%)        0%
  cache_references   5.59G  ± 19.9M     5.56G  … 5.60G           0 ( 0%)        0%
  cache_misses        403M  ± 2.64M      401M  …  406M           0 ( 0%)        0%
  branch_misses       439M  ±  447K      438M  …  439M           0 ( 0%)        0%
Benchmark 2 (3 runs): simplefree/bin/zig build -Dno-lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          11.7s  ±  131ms    11.6s  … 11.9s           0 ( 0%)        ⚡-  6.1% ±  1.8%
  peak_rss            953MB ± 6.12MB     946MB …  957MB          0 ( 0%)          +  0.1% ±  2.1%
  cpu_cycles         86.7G  ±  196M     86.5G  … 86.9G           0 ( 0%)        ⚡-  4.1% ±  0.4%
  instructions        181G  ± 10.8M      181G  …  181G           0 ( 0%)          -  0.0% ±  0.0%
  cache_references   5.50G  ± 39.2M     5.47G  … 5.55G           0 ( 0%)          -  1.5% ±  1.3%
  cache_misses        388M  ± 2.60M      385M  …  390M           0 ( 0%)        ⚡-  3.9% ±  1.5%
  branch_misses       395M  ±  876K      394M  …  396M           0 ( 0%)        ⚡- 10.0% ±  0.4%
```

#### Comparison with Glibc

```
Benchmark 1 (3 runs): glibc/bin/zig build -Dno-lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.0s  ± 30.4ms    12.0s  … 12.1s           0 ( 0%)        0%
  peak_rss            993MB ±  440KB     993MB …  994MB          0 ( 0%)        0%
  cpu_cycles         88.5G  ±  125M     88.4G  … 88.7G           0 ( 0%)        0%
  instructions        188G  ±  904K      188G  …  188G           0 ( 0%)        0%
  cache_references   5.92G  ± 16.9M     5.90G  … 5.93G           0 ( 0%)        0%
  cache_misses        386M  ±  441K      386M  …  386M           0 ( 0%)        0%
  branch_misses       365M  ±  884K      364M  …  366M           0 ( 0%)        0%
Benchmark 2 (3 runs): SmpAllocator/bin/zig build -Dno-lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          11.8s  ±  158ms    11.7s  … 12.0s           0 ( 0%)          -  1.6% ±  2.2%
  peak_rss            946MB ± 14.5MB     933MB …  961MB          0 ( 0%)        ⚡-  4.8% ±  2.3%
  cpu_cycles         86.7G  ±  152M     86.5G  … 86.8G           0 ( 0%)        ⚡-  2.1% ±  0.4%
  instructions        181G  ± 3.69M      181G  …  181G           0 ( 0%)        ⚡-  3.9% ±  0.0%
  cache_references   5.50G  ± 29.5M     5.47G  … 5.53G           0 ( 0%)        ⚡-  7.0% ±  0.9%
  cache_misses        388M  ± 4.12M      384M  …  392M           0 ( 0%)          +  0.6% ±  1.7%
  branch_misses       395M  ±  394K      395M  …  396M           0 ( 0%)        💩+  8.2% ±  0.4%
```
