### PR TITLE
autodocs: recognize lib.zig as a library root source file

### DIFF
--- a/lib/docs/wasm/main.zig
+++ b/lib/docs/wasm/main.zig
@@ -772,6 +772,7 @@ fn unpackInner(tar_bytes: []u8) !void {
                         const gop = try Walk.modules.getOrPut(gpa, pkg_name);
                         const file: Walk.File.Index = @enumFromInt(Walk.files.entries.len);
                         if (!gop.found_existing or
+                            std.mem.eql(u8, file_name[pkg_name_end..], "/lib.zig") or
                             std.mem.eql(u8, file_name[pkg_name_end..], "/root.zig") or
                             std.mem.eql(u8, file_name[pkg_name_end + 1 .. file_name.len - ".zig".len], pkg_name))
                         {

--- a/lib/fuzzer/web/main.zig
+++ b/lib/fuzzer/web/main.zig
@@ -184,6 +184,7 @@ fn unpackInner(tar_bytes: []u8) !void {
                         const gop = try Walk.modules.getOrPut(gpa, pkg_name);
                         const file: Walk.File.Index = @enumFromInt(Walk.files.entries.len);
                         if (!gop.found_existing or
+                            std.mem.eql(u8, file_name[pkg_name_end..], "/lib.zig") or
                             std.mem.eql(u8, file_name[pkg_name_end..], "/root.zig") or
                             std.mem.eql(u8, file_name[pkg_name_end + 1 .. file_name.len - ".zig".len], pkg_name))
                         {


### PR DESCRIPTION
Hi, I'd like to plead the case for `lib.zig` as a _valid_ library root source file, and moreover, to challenge the current convention of `root.zig` _being_ the library root source file.

Here're some points to consider:
- **Is This Your Root or Mine?**
Since library code can sometimes resort to inspecting users' root source files with `@import("root")`, having `root.zig` as the library root source file can be confusing, whereas `lib.zig` would avoid this confusion.
- **What in the Root Is This?**
The word _root_ (either a noun or an adjective) is objectively more likely to be encountered in other contexts across potential Zig codebases (tree-like data structures, file system hierarchies, privileged access permissions) and conflict with these other uses, compared to the word _lib_ which, being a common alias for _library_ (a noun), is much less likely to emerge beyond the compiler-related projects.
- **Is This Even a Library?**
A `lib.zig` file succeeds at being perceived as exclusively a _library_ root source file, similarly to how a `main.zig` file is seen as an _executable_ root source file, whereas `root.zig` only communicates that it's **_a_** root source file, without making it immediately apparent that it's a _library_ root source file.
- **We Want Lib!**
FWIW, querying GitHub Search with `root.zig language:Zig` gives 4.8k source code results while `lib.zig language:Zig` produces 5.1k results, which may suggest that Zig users are already slightly more biased towards `lib.zig`.

In the ~~unlikely~~ expected case that you become convinced that `lib.zig` is a better library root source file, I'd be happy to change the `zig init` template and its generation logic (the only other places where `root.zig` convention is enforced) in a follow-up PR.