### PR TITLE
std.c: Fix definition of stack_t on OpenBSD

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -5971,7 +5971,7 @@ pub const IFNAMESIZE = switch (native_os) {
 pub const stack_t = switch (native_os) {
     .linux => linux.stack_t,
     .emscripten => emscripten.stack_t,
-    .freebsd => extern struct {
+    .freebsd, .openbsd => extern struct {
         /// Signal stack base.
         sp: *anyopaque,
         /// Signal stack length.


### PR DESCRIPTION
The size field is not supposed to be signed. See: https://man.openbsd.org/sigaltstack.2