### PR TITLE
zon.parse: make `requiresAllocator` public

### DIFF
--- a/lib/std/zon/parse.zig
+++ b/lib/std/zon/parse.zig
@@ -397,7 +397,7 @@ pub fn free(gpa: Allocator, value: anytype) void {
     }
 }
 
-fn requiresAllocator(T: type) bool {
+pub fn requiresAllocator(T: type) bool {
     _ = valid_types;
     return switch (@typeInfo(T)) {
         .pointer => true,


### PR DESCRIPTION
The motivation for this is that it is very nice to be able to assert that the parsed value does not need to be further freed after it's been parsed.