### PR TITLE
std.mem: add missing check to lastIndexOfLinear

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1396,6 +1396,7 @@ pub fn indexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize 
 /// Consider using `lastIndexOf` instead of this, which will automatically use a
 /// more sophisticated algorithm on larger inputs.
 pub fn lastIndexOfLinear(comptime T: type, haystack: []const T, needle: []const T) ?usize {
+    if (needle.len > haystack.len) return null;
     var i: usize = haystack.len - needle.len;
     while (true) : (i -= 1) {
         if (mem.eql(T, haystack[i..][0..needle.len], needle)) return i;


### PR DESCRIPTION
Passing a `needle` with a length greater than the `haystack`'s length caused an integer overflow (illigal behavior). This behavior is not documented in the docs and is inconsistent with std.mem.indexOfPosLinear, where the check is present.