### PR TITLE
std.fmt: remove placeholders from binary

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -99,7 +99,8 @@ pub fn format(
     @setEvalBranchQuota(2000000);
     comptime var arg_state: ArgState = .{ .args_len = fields_info.len };
     comptime var i = 0;
-    inline while (i < fmt.len) {
+    comptime var literal: []const u8 = "";
+    inline while (true) {
         const start_index = i;
 
         inline while (i < fmt.len) : (i += 1) {
@@ -121,13 +122,16 @@ pub fn format(
             i += 2;
         }
 
-        // Write out the literal
-        if (start_index != end_index) {
-            try writer.writeAll(fmt[start_index..end_index]);
-        }
+        literal = literal ++ fmt[start_index..end_index];
 
         // We've already skipped the other brace, restart the loop
         if (unescape_brace) continue;
+
+        // Write out the literal
+        if (literal.len != 0) {
+            try writer.writeAll(literal);
+            literal = "";
+        }
 
         if (i >= fmt.len) break;
 


### PR DESCRIPTION
Lets look at a little example program:

```zig
const std = @import("std");

pub fn main() void {
    std.debug.print("{{a: {d}, b: 0x{x}, c: {s}}}\n", .{ 0, 0xabc, "foo" });
}
```

When I compile this with `zig build-exe test.zig -O ReleaseSmall -femit-bin=master` the output of `strings master` includes `{{a: {d}, b: 0x{x}, c: {s}}}`.

I was wondering why the placeholders were included in the binary, since they are evaluated at compile time. This PR changes that.

After this PR the output of `strings branch` includes `{a: `, `, b: 0x`, `, c: ` and `}` instead.

Binary size changes:

```
$ du -b master branch
6320    master
6240    branch
```

`strace` changes:

```diff
@@ -1,16 +1,14 @@
-execve("./master", ["./master"], 0x7ffca0e79590 /* 52 vars */) = 0
+execve("./branch", ["./branch"], 0x7ffc85107730 /* 52 vars */) = 0
 arch_prctl(ARCH_SET_FS, 0x1006008)      = 0
 prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=16384*1024, rlim_max=RLIM64_INFINITY}) = 0
-rt_sigaction(SIGPIPE, {sa_handler=0x1001b3d, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x1001b72}, NULL, 8) = 0
-gettid()                                = 285721
-write(2, "{", 1)                        = 1
-write(2, "a: ", 3)                      = 3
+rt_sigaction(SIGPIPE, {sa_handler=0x1001aed, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x1001b22}, NULL, 8) = 0
+gettid()                                = 310545
+write(2, "{a: ", 4)                     = 4
 write(2, "0", 1)                        = 1
 write(2, ", b: 0x", 7)                  = 7
 write(2, "abc", 3)                      = 3
 write(2, ", c: ", 5)                    = 5
 write(2, "foo", 3)                      = 3
-write(2, "}", 1)                        = 1
-write(2, "\n", 1)                       = 1
+write(2, "}\n", 2)                      = 2
 exit_group(0)                           = ?
 +++ exited with 0 +++
```

Size changes of the Zig compiler compiled with `-Doptimize=ReleaseSmall` or `-Doptimize=ReleaseFast`:

```
$ du -b master-small/bin/zig branch-small/bin/zig master-fast/bin/zig branch-fast/bin/zig
11676760        master-small/bin/zig
11654968        branch-small/bin/zig
110727096       master-fast/bin/zig
110655056       branch-fast/bin/zig
```

closes #11033