### PR TITLE
std.elf: Parsing an invalid ELF header might panic.

### DIFF
--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -532,17 +532,23 @@ pub const Header = struct {
         };
         const need_bswap = endian != native_endian;
 
+        comptime assert(!@typeInfo(OSABI).@"enum".is_exhaustive);
         const os_abi: OSABI = @enumFromInt(hdr32.e_ident[EI_OSABI]);
 
         // The meaning of this value depends on `os_abi` so just make it available as `u8`.
         const abi_version = hdr32.e_ident[EI_ABIVERSION];
 
-        const @"type" = if (need_bswap) blk: {
+        const @"type": ET = if (need_bswap) blk: {
+            // Converting integers to exhaustive enums using `@enumFromInt` could cause a panic.
+            comptime assert(@typeInfo(ET).@"enum".is_exhaustive);
             const value = @intFromEnum(hdr32.e_type);
-            break :blk @as(ET, @enumFromInt(@byteSwap(value)));
+            break :blk std.meta.intToEnum(ET, @byteSwap(value)) catch |err| switch (err) {
+                error.InvalidEnumTag => return error.InvalidElfType,
+            };
         } else hdr32.e_type;
 
         const machine = if (need_bswap) blk: {
+            comptime assert(!@typeInfo(EM).@"enum".is_exhaustive);
             const value = @intFromEnum(hdr32.e_machine);
             break :blk @as(EM, @enumFromInt(@byteSwap(value)));
         } else hdr32.e_machine;


### PR DESCRIPTION
When parsing an invalid (e.g., corrupted) ELF header, `@enumFromInt` can panic due to casting an unexpected integer to the [exhaustive enum](https://github.com/ziglang/zig/blob/d4c85079c5796805e6f44cadaee618468267db63/lib/std/elf.zig#L448-L476) `ET`.
This behavior was not observed in Zig 0.13.0 and was caught by [TigerBeetle's fuzzer tests](https://github.com/tigerbeetle/tigerbeetle/actions/runs/13187407323/job/36812706168?pr=2705).  

It's worth noting that the Zig compiler allows `Elf64_Ehdr.e_type` to hold an invalid integer when [reinterpreting memory](https://github.com/ziglang/zig/blob/d4c85079c5796805e6f44cadaee618468267db63/lib/std/elf.zig#L518). Even accessing the invalid value and calling `@intFromEnum(Elf64_Ehdr.e_type)` on it doesn’t trigger UB.