### PR TITLE
compiler_rt memcpy: avoid infinite recursion

### DIFF
--- a/lib/compiler_rt/memcpy.zig
+++ b/lib/compiler_rt/memcpy.zig
@@ -175,10 +175,11 @@ inline fn copyRange4(
     const last = len - copy_len;
     const pen = last - b;
 
-    dest[0..copy_len].* = src[0..copy_len].*;
-    dest[b..][0..copy_len].* = src[b..][0..copy_len].*;
-    dest[pen..][0..copy_len].* = src[pen..][0..copy_len].*;
-    dest[last..][0..copy_len].* = src[last..][0..copy_len].*;
+    const Int = @Type(.{ .int = .{ .signedness = .unsigned, .bits = copy_len * 8 } });
+    @as(*align(1) Int, @ptrCast(dest[0..copy_len])).* = @as(*align(1) const Int, @ptrCast(src[0..copy_len])).*;
+    @as(*align(1) Int, @ptrCast(dest[b..][0..copy_len])).* = @as(*align(1) const Int, @ptrCast(src[b..][0..copy_len])).*;
+    @as(*align(1) Int, @ptrCast(dest[pen..][0..copy_len])).* = @as(*align(1) const Int, @ptrCast(src[pen..][0..copy_len])).*;
+    @as(*align(1) Int, @ptrCast(dest[last..][0..copy_len])).* = @as(*align(1) const Int, @ptrCast(src[last..][0..copy_len])).*;
 }
 
 test "memcpy" {


### PR DESCRIPTION
when compiled in debug mode (--debug-rt)

before:

```
andy@bark ~/s/z/build-release (master)> stage3/bin/zig test ../test/behavior.zig --debug-rt
error: the following test command crashed:
/home/andy/src/zig/.zig-cache/o/d67352db25a508f21ac48aa4a6e52b3e/test --seed=0xa5e06631
```

after:

```
andy@bark ~/s/z/build-release (fix-debug-memcpy)> stage3/bin/zig test ../test/behavior.zig --debug-rt
...
1910 passed; 100 skipped; 0 failed.
```

----

This code seems broken to me either way. It's the memcpy implementation, you can't copy arbitrary unaligned lengths of bytes, even if they are power of two.

This code needs to be reworked to not be recursive. This patch has only the quality of a temporary bandage.