### PR TITLE
std.testing: improve compile error on untagged union equality

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -147,7 +147,7 @@ fn expectEqualInner(comptime T: type, expected: T, actual: T) !void {
 
         .@"union" => |union_info| {
             if (union_info.tag_type == null) {
-                @compileError("Unable to compare untagged union values");
+                @compileError("Unable to compare untagged union values for type " ++ @typeName(@TypeOf(actual)));
             }
 
             const Tag = std.meta.Tag(@TypeOf(expected));
@@ -818,7 +818,7 @@ fn expectEqualDeepInner(comptime T: type, expected: T, actual: T) error{TestExpe
 
         .@"union" => |union_info| {
             if (union_info.tag_type == null) {
-                @compileError("Unable to compare untagged union values");
+                @compileError("Unable to compare untagged union values for type " ++ @typeName(@TypeOf(actual)));
             }
 
             const Tag = std.meta.Tag(@TypeOf(expected));


### PR DESCRIPTION
With a simple test like this:

```zig
const MyStruct = struct {
    foo: u32,
    bar: union {
        a: u16,
        b: f32,
    },
};

const testing = @import("std").testing;
test {
    const x: MyStruct = .{
        .foo = 1,
        .bar = .{ .a = 9 },
    };
    const y: MyStruct = .{
        .foo = 2,
        .bar = .{ .b = 1.5 },
    };

    try testing.expectEqual(x, y);
}
```

Prior to this change, the compile error would look like:

```
$ zig test ./test.zig
/.../zig/lib/std/testing.zig:150:17: error: Unable to compare untagged union values
                @compileError("Unable to compare untagged union values");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After this change, the compile error includes the name of the type containing the untagged union:

```
$ zig test ./test.zig
/.../zig/lib/std/testing.zig:150:17: error: Unable to compare untagged union values for type test.MyStruct__union_400
                @compileError("Unable to compare untagged union values for type " ++ @typeName(@TypeOf(actual)));
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This particular compile error took me a little time to track down in a real world project; I would have saved a few minutes if the error message told me exactly what type to check.

I'm not sure if there is an existing pattern to add tests for compile errors in the standard library like this. I'm happy to add another commit with a test if anyone can point me at an example of the pattern to follow.