### PR TITLE
std.ArrayList: initial capacity based on cache line size

### DIFF
--- a/lib/std/json/scanner_test.zig
+++ b/lib/std/json/scanner_test.zig
@@ -435,8 +435,13 @@ fn testEnsureStackCapacity(do_ensure: bool) !void {
     var fail_alloc = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
     const failing_allocator = fail_alloc.allocator();
 
-    const nestings = 999; // intentionally not a power of 2.
-    var scanner = JsonScanner.initCompleteInput(failing_allocator, "[" ** nestings ++ "]" ** nestings);
+    const nestings = 2049; // intentionally not a power of 2.
+    var input_string: std.ArrayListUnmanaged(u8) = .empty;
+    try input_string.appendNTimes(std.testing.allocator, '[', nestings);
+    try input_string.appendNTimes(std.testing.allocator, ']', nestings);
+    defer input_string.deinit(std.testing.allocator);
+
+    var scanner = JsonScanner.initCompleteInput(failing_allocator, input_string.items);
     defer scanner.deinit();
 
     if (do_ensure) {

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -916,7 +916,7 @@ test "parse at comptime" {
         uptime: u64,
     };
     const config = comptime x: {
-        var buf: [32]u8 = undefined;
+        var buf: [256]u8 = undefined;
         var fba = std.heap.FixedBufferAllocator.init(&buf);
         const res = parseFromSliceLeaky(Config, fba.allocator(), doc, .{});
         // Assert no error can occur since we are

--- a/lib/std/zig/string_literal.zig
+++ b/lib/std/zig/string_literal.zig
@@ -377,7 +377,7 @@ test parseAlloc {
     const expectError = std.testing.expectError;
     const eql = std.mem.eql;
 
-    var fixed_buf_mem: [64]u8 = undefined;
+    var fixed_buf_mem: [512]u8 = undefined;
     var fixed_buf_alloc = std.heap.FixedBufferAllocator.init(&fixed_buf_mem);
     const alloc = fixed_buf_alloc.allocator();
 


### PR DESCRIPTION
also std.MultiArrayList

build zig with itself (ReleaseFast, no libc)

```
Benchmark 1 (3 runs): master/bin/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.7s  ±  106ms    12.6s  … 12.8s           0 ( 0%)        0%
  peak_rss            983MB ± 25.8MB     956MB … 1.01GB          0 ( 0%)        0%
  cpu_cycles         93.7G  ± 63.0M     93.6G  … 93.7G           0 ( 0%)        0%
  instructions        197G  ± 2.72M      197G  …  197G           0 ( 0%)        0%
  cache_references   5.69G  ± 12.6M     5.67G  … 5.70G           0 ( 0%)        0%
  cache_misses        413M  ± 2.31M      411M  …  415M           0 ( 0%)        0%
  branch_misses       491M  ±  306K      491M  …  492M           0 ( 0%)        0%
Benchmark 2 (3 runs): branch/bin/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.2s  ± 34.3ms    12.1s  … 12.2s           0 ( 0%)        ⚡-  4.1% ±  1.4%
  peak_rss            940MB ± 6.92MB     935MB …  948MB          0 ( 0%)          -  4.4% ±  4.4%
  cpu_cycles         90.3G  ± 67.1M     90.3G  … 90.4G           0 ( 0%)        ⚡-  3.6% ±  0.2%
  instructions        196G  ± 6.30M      196G  …  196G           0 ( 0%)          -  0.2% ±  0.0%
  cache_references   5.57G  ± 18.0M     5.55G  … 5.59G           0 ( 0%)        ⚡-  2.2% ±  0.6%
  cache_misses        405M  ± 3.40M      401M  …  408M           0 ( 0%)          -  2.1% ±  1.6%
  branch_misses       412M  ±  512K      411M  …  412M           0 ( 0%)        ⚡- 16.1% ±  0.2%
```

similar to  #22861