### PR TITLE
compiler-rt: re-enable memcpy runtime safety in tests

### DIFF
--- a/lib/compiler_rt/memcpy.zig
+++ b/lib/compiler_rt/memcpy.zig
@@ -12,9 +12,9 @@ comptime {
         };
 
         if (builtin.mode == .ReleaseSmall)
-            @export(&memcpySmall, export_options)
+            @export(&impl(false).memcpySmall, export_options)
         else
-            @export(&memcpyFast, export_options);
+            @export(&impl(false).memcpyFast, export_options);
     }
 }
 
@@ -33,174 +33,183 @@ comptime {
     assert(std.math.isPowerOfTwo(@sizeOf(Element)));
 }
 
-fn memcpySmall(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
-    @setRuntimeSafety(false);
+fn impl(comptime enable_safety: bool) type {
+    return struct {
+        fn memcpySmall(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
+            @setRuntimeSafety(enable_safety);
 
-    for (0..len) |i| {
-        dest.?[i] = src.?[i];
-    }
+            for (0..len) |i| {
+                dest.?[i] = src.?[i];
+            }
 
-    return dest;
-}
-
-fn memcpyFast(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
-    @setRuntimeSafety(false);
-
-    const small_limit = 2 * @sizeOf(Element);
-
-    if (copySmallLength(small_limit, dest.?, src.?, len)) return dest;
-
-    copyForwards(dest.?, src.?, len);
-
-    return dest;
-}
-
-inline fn copySmallLength(
-    comptime small_limit: comptime_int,
-    dest: [*]u8,
-    src: [*]const u8,
-    len: usize,
-) bool {
-    if (len < 16) {
-        copyLessThan16(dest, src, len);
-        return true;
-    }
-
-    if (comptime 2 < (std.math.log2(small_limit) + 1) / 2) {
-        if (copy16ToSmallLimit(small_limit, dest, src, len)) return true;
-    }
-
-    return false;
-}
-
-inline fn copyLessThan16(
-    dest: [*]u8,
-    src: [*]const u8,
-    len: usize,
-) void {
-    @setRuntimeSafety(false);
-    if (len < 4) {
-        if (len == 0) return;
-        dest[0] = src[0];
-        dest[len / 2] = src[len / 2];
-        dest[len - 1] = src[len - 1];
-        return;
-    }
-    copyRange4(4, dest, src, len);
-}
-
-inline fn copy16ToSmallLimit(
-    comptime small_limit: comptime_int,
-    dest: [*]u8,
-    src: [*]const u8,
-    len: usize,
-) bool {
-    @setRuntimeSafety(false);
-    inline for (2..(std.math.log2(small_limit) + 1) / 2 + 1) |p| {
-        const limit = 1 << (2 * p);
-        if (len < limit) {
-            copyRange4(limit / 4, dest, src, len);
-            return true;
+            return dest;
         }
-    }
-    return false;
-}
 
-inline fn copyForwards(
-    noalias dest: [*]u8,
-    noalias src: [*]const u8,
-    len: usize,
-) void {
-    @setRuntimeSafety(false);
+        fn memcpyFast(noalias dest: ?[*]u8, noalias src: ?[*]const u8, len: usize) callconv(.C) ?[*]u8 {
+            @setRuntimeSafety(enable_safety);
 
-    copyFixedLength(dest, src, @sizeOf(Element));
-    const alignment_offset = @alignOf(Element) - @intFromPtr(src) % @alignOf(Element);
-    const n = len - alignment_offset;
-    const d = dest + alignment_offset;
-    const s = src + alignment_offset;
+            const small_limit = 2 * @sizeOf(Element);
 
-    copyBlocksAlignedSource(@ptrCast(d), @alignCast(@ptrCast(s)), n);
+            if (copySmallLength(small_limit, dest.?, src.?, len)) return dest;
 
-    // copy last `@sizeOf(Element)` bytes unconditionally, since block copy
-    // methods only copy a multiple of `@sizeOf(Element)` bytes.
-    const offset = len - @sizeOf(Element);
-    copyFixedLength(dest + offset, src + offset, @sizeOf(Element));
-}
+            copyForwards(dest.?, src.?, len);
 
-inline fn copyBlocksAlignedSource(
-    noalias dest: [*]align(1) Element,
-    noalias src: [*]const Element,
-    max_bytes: usize,
-) void {
-    copyBlocks(dest, src, max_bytes);
-}
+            return dest;
+        }
 
-/// Copies the largest multiple of `@sizeOf(T)` bytes from `src` to `dest`,
-/// that is less than `max_bytes` where `T` is the child type of `src` and
-/// `dest`.
-inline fn copyBlocks(
-    noalias dest: anytype,
-    noalias src: anytype,
-    max_bytes: usize,
-) void {
-    @setRuntimeSafety(false);
+        inline fn copySmallLength(
+            comptime small_limit: comptime_int,
+            dest: [*]u8,
+            src: [*]const u8,
+            len: usize,
+        ) bool {
+            if (len < 16) {
+                copyLessThan16(dest, src, len);
+                return true;
+            }
 
-    const T = @typeInfo(@TypeOf(dest)).pointer.child;
-    comptime assert(T == @typeInfo(@TypeOf(src)).pointer.child);
+            if (comptime 2 < (std.math.log2(small_limit) + 1) / 2) {
+                if (copy16ToSmallLimit(small_limit, dest, src, len)) return true;
+            }
 
-    const loop_count = max_bytes / @sizeOf(T);
+            return false;
+        }
 
-    for (dest[0..loop_count], src[0..loop_count]) |*d, s| {
-        d.* = s;
-    }
-}
+        inline fn copyLessThan16(
+            dest: [*]u8,
+            src: [*]const u8,
+            len: usize,
+        ) void {
+            @setRuntimeSafety(enable_safety);
+            if (len < 4) {
+                if (len == 0) return;
+                dest[0] = src[0];
+                dest[len / 2] = src[len / 2];
+                dest[len - 1] = src[len - 1];
+                return;
+            }
+            copyRange4(4, dest, src, len);
+        }
 
-inline fn copyFixedLength(
-    noalias dest: [*]u8,
-    noalias src: [*]const u8,
-    comptime len: comptime_int,
-) void {
-    @setRuntimeSafety(false);
-    comptime assert(std.math.isPowerOfTwo(len));
+        inline fn copy16ToSmallLimit(
+            comptime small_limit: comptime_int,
+            dest: [*]u8,
+            src: [*]const u8,
+            len: usize,
+        ) bool {
+            @setRuntimeSafety(enable_safety);
+            inline for (2..(std.math.log2(small_limit) + 1) / 2 + 1) |p| {
+                const limit = 1 << (2 * p);
+                if (len < limit) {
+                    copyRange4(limit / 4, dest, src, len);
+                    return true;
+                }
+            }
+            return false;
+        }
 
-    const T = if (len >= @sizeOf(Element))
-        Element
-    else if (len > @sizeOf(usize))
-        @Vector(len, u8)
-    else
-        @Type(.{ .int = .{ .signedness = .unsigned, .bits = len * 8 } });
+        inline fn copyForwards(
+            noalias dest: [*]u8,
+            noalias src: [*]const u8,
+            len: usize,
+        ) void {
+            @setRuntimeSafety(enable_safety);
+            if (enable_safety) assert(len >= 2 * @sizeOf(Element));
 
-    const loop_count = @divExact(len, @sizeOf(T));
+            copyFixedLength(dest, src, @sizeOf(Element));
+            const alignment_offset = @alignOf(Element) - @intFromPtr(src) % @alignOf(Element);
+            const n = len - alignment_offset;
+            const d = dest + alignment_offset;
+            const s = src + alignment_offset;
 
-    const d: [*]align(1) T = @ptrCast(dest);
-    const s: [*]align(1) const T = @ptrCast(src);
+            copyBlocksAlignedSource(@ptrCast(d), @alignCast(@ptrCast(s)), n);
 
-    inline for (0..loop_count) |i| {
-        d[i] = s[i];
-    }
-}
+            // copy last `@sizeOf(Element)` bytes unconditionally, since block copy
+            // methods only copy a multiple of `@sizeOf(Element)` bytes.
+            const offset = len - @sizeOf(Element);
+            copyFixedLength(dest + offset, src + offset, @sizeOf(Element));
+        }
 
-/// copy `len` bytes from `src` to `dest`; `len` must be in the range
-/// `[copy_len, 4 * copy_len)`.
-inline fn copyRange4(
-    comptime copy_len: comptime_int,
-    noalias dest: [*]u8,
-    noalias src: [*]const u8,
-    len: usize,
-) void {
-    @setRuntimeSafety(false);
-    comptime assert(std.math.isPowerOfTwo(copy_len));
+        inline fn copyBlocksAlignedSource(
+            noalias dest: [*]align(1) Element,
+            noalias src: [*]const Element,
+            max_bytes: usize,
+        ) void {
+            copyBlocks(dest, src, max_bytes);
+        }
 
-    const a = len & (copy_len * 2);
-    const b = a / 2;
+        /// Copies the largest multiple of `@sizeOf(T)` bytes from `src` to `dest`,
+        /// that is less than `max_bytes` where `T` is the child type of `src` and
+        /// `dest`.
+        inline fn copyBlocks(
+            noalias dest: anytype,
+            noalias src: anytype,
+            max_bytes: usize,
+        ) void {
+            @setRuntimeSafety(enable_safety);
 
-    const last = len - copy_len;
-    const pen = last - b;
+            const T = @typeInfo(@TypeOf(dest)).pointer.child;
+            comptime assert(T == @typeInfo(@TypeOf(src)).pointer.child);
 
-    copyFixedLength(dest, src, copy_len);
-    copyFixedLength(dest + b, src + b, copy_len);
-    copyFixedLength(dest + pen, src + pen, copy_len);
-    copyFixedLength(dest + last, src + last, copy_len);
+            const loop_count = max_bytes / @sizeOf(T);
+
+            for (dest[0..loop_count], src[0..loop_count]) |*d, s| {
+                d.* = s;
+            }
+        }
+
+        inline fn copyFixedLength(
+            noalias dest: [*]u8,
+            noalias src: [*]const u8,
+            comptime len: comptime_int,
+        ) void {
+            @setRuntimeSafety(enable_safety);
+            comptime assert(std.math.isPowerOfTwo(len));
+
+            const T = if (len >= @sizeOf(Element))
+                Element
+            else if (len > @sizeOf(usize))
+                @Vector(len, u8)
+            else
+                @Type(.{ .int = .{ .signedness = .unsigned, .bits = len * 8 } });
+
+            const loop_count = @divExact(len, @sizeOf(T));
+
+            const d: [*]align(1) T = @ptrCast(dest);
+            const s: [*]align(1) const T = @ptrCast(src);
+
+            inline for (0..loop_count) |i| {
+                d[i] = s[i];
+            }
+        }
+
+        /// copy `len` bytes from `src` to `dest`; `len` must be in the range
+        /// `[copy_len, 4 * copy_len)`.
+        inline fn copyRange4(
+            comptime copy_len: comptime_int,
+            noalias dest: [*]u8,
+            noalias src: [*]const u8,
+            len: usize,
+        ) void {
+            @setRuntimeSafety(enable_safety);
+            comptime assert(std.math.isPowerOfTwo(copy_len));
+            if (enable_safety) {
+                assert(len >= copy_len);
+                assert(len < 4 * copy_len);
+            }
+
+            const a = len & (copy_len * 2);
+            const b = a / 2;
+
+            const last = len - copy_len;
+            const pen = last - b;
+
+            copyFixedLength(dest, src, copy_len);
+            copyFixedLength(dest + b, src + b, copy_len);
+            copyFixedLength(dest + pen, src + pen, copy_len);
+            copyFixedLength(dest + last, src + last, copy_len);
+        }
+    };
 }
 
 test "memcpy" {
@@ -232,6 +241,6 @@ test "memcpy" {
         }
     };
 
-    try S.testFunc(memcpySmall);
-    try S.testFunc(memcpyFast);
+    try S.testFunc(impl(true).memcpySmall);
+    try S.testFunc(impl(true).memcpyFast);
 }


### PR DESCRIPTION
The PR re-enables runtime safety for compiler-rt `memcpy` tests. This should allow detecting logic bugs more reliably with tests.

The diff looks messy due to indentation changes, but the only actual changes are the re-inclusion of 3 asserts that were removed in #22854 and making the implementation generic based on a comptime `enable_safety: bool` parameter. This allows the tests to test the logic with `enable_safety == true` while not causing recursive calls to `memcpy`, as the `memcpy` calls made by safety code will call the version with `enable_safety == false`.

Another option would have been to have `enable_safety` be a comptime argument to all the helper functions - this makes a cleaner diff, but I think it makes the code a bit harder to read.