### PR TITLE
x86_64: implement error set and enum safety

### DIFF
--- a/lib/compiler_rt.zig
+++ b/lib/compiler_rt.zig
@@ -230,6 +230,7 @@ comptime {
     _ = @import("compiler_rt/trunc.zig");
 
     // BigInt. Alphabetically sorted.
+    _ = @import("compiler_rt/divmodei4.zig");
     _ = @import("compiler_rt/udivmodei4.zig");
     _ = @import("compiler_rt/udivmodti4.zig");
 

--- a/lib/compiler_rt/divmodei4.zig
+++ b/lib/compiler_rt/divmodei4.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const common = @import("common.zig");
+const udivmod = @import("udivmodei4.zig").divmod;
+
+comptime {
+    @export(&__divei4, .{ .name = "__divei4", .linkage = common.linkage, .visibility = common.visibility });
+    @export(&__modei4, .{ .name = "__modei4", .linkage = common.linkage, .visibility = common.visibility });
+}
+
+const endian = builtin.cpu.arch.endian();
+
+inline fn limb(x: []u32, i: usize) *u32 {
+    return if (endian == .little) &x[i] else &x[x.len - 1 - i];
+}
+
+inline fn neg(x: []u32) void {
+    var ov: u1 = 1;
+    for (0..x.len) |limb_index| {
+        const l = limb(x, limb_index);
+        l.*, ov = @addWithOverflow(~l.*, ov);
+    }
+}
+
+/// Mutates the arguments!
+fn divmod(q: ?[]u32, r: ?[]u32, u: []u32, v: []u32) !void {
+    const u_sign: i32 = @bitCast(u[u.len - 1]);
+    const v_sign: i32 = @bitCast(v[v.len - 1]);
+    if (u_sign < 0) neg(u);
+    if (v_sign < 0) neg(v);
+    try @call(.always_inline, udivmod, .{ q, r, u, v });
+    if (q) |x| if (u_sign ^ v_sign < 0) neg(x);
+    if (r) |x| if (u_sign < 0) neg(x);
+}
+
+pub fn __divei4(r_q: [*]u32, u_p: [*]u32, v_p: [*]u32, bits: usize) callconv(.C) void {
+    @setRuntimeSafety(builtin.is_test);
+    const u = u_p[0 .. std.math.divCeil(usize, bits, 32) catch unreachable];
+    const v = v_p[0 .. std.math.divCeil(usize, bits, 32) catch unreachable];
+    const q = r_q[0 .. std.math.divCeil(usize, bits, 32) catch unreachable];
+    @call(.always_inline, divmod, .{ q, null, u, v }) catch unreachable;
+}
+
+pub fn __modei4(r_p: [*]u32, u_p: [*]u32, v_p: [*]u32, bits: usize) callconv(.C) void {
+    @setRuntimeSafety(builtin.is_test);
+    const u = u_p[0 .. std.math.divCeil(usize, bits, 32) catch unreachable];
+    const v = v_p[0 .. std.math.divCeil(usize, bits, 32) catch unreachable];
+    const r = r_p[0 .. std.math.divCeil(usize, bits, 32) catch unreachable];
+    @call(.always_inline, divmod, .{ null, r, u, v }) catch unreachable;
+}

--- a/lib/compiler_rt/udivmodei4.zig
+++ b/lib/compiler_rt/udivmodei4.zig
@@ -27,8 +27,8 @@ inline fn limb_set(x: []u32, i: usize, v: u32) void {
     }
 }
 
-// Uses Knuth's Algorithm D, 4.3.1, p. 272.
-fn divmod(q: ?[]u32, r: ?[]u32, u: []const u32, v: []const u32) !void {
+/// Uses Knuth's Algorithm D, 4.3.1, p. 272.
+pub fn divmod(q: ?[]u32, r: ?[]u32, u: []const u32, v: []const u32) !void {
     if (q) |q_| @memset(q_[0..], 0);
     if (r) |r_| @memset(r_[0..], 0);
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -8850,7 +8850,7 @@ fn zirEnumFromInt(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError
             // Use `intCast`, since it'll set up the Sema-emitted safety checks for us!
             const int_val = try sema.intCast(block, src, int_tag_ty, src, operand, src, true, true);
             const result = try block.addBitCast(dest_ty, int_val);
-            if (zcu.backendSupportsFeature(.is_named_enum_value)) {
+            if (!dest_ty.isNonexhaustiveEnum(zcu) and zcu.backendSupportsFeature(.is_named_enum_value)) {
                 const ok = try block.addUnOp(.is_named_enum_value, result);
                 try sema.addSafetyCheck(block, src, ok, .invalid_enum_value);
             }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -4190,11 +4190,11 @@ pub const @"c_longlong": Type = .{ .ip_index = .c_longlong_type };
 pub const @"c_ulonglong": Type = .{ .ip_index = .c_ulonglong_type };
 pub const @"c_longdouble": Type = .{ .ip_index = .c_longdouble_type };
 
-pub const slice_const_u8: Type = .{ .ip_index = .slice_const_u8_type };
 pub const manyptr_u8: Type = .{ .ip_index = .manyptr_u8_type };
-pub const single_const_pointer_to_comptime_int: Type = .{
-    .ip_index = .single_const_pointer_to_comptime_int_type,
-};
+pub const manyptr_const_u8: Type = .{ .ip_index = .manyptr_const_u8_type };
+pub const manyptr_const_u8_sentinel_0: Type = .{ .ip_index = .manyptr_const_u8_sentinel_0_type };
+pub const single_const_pointer_to_comptime_int: Type = .{ .ip_index = .single_const_pointer_to_comptime_int_type };
+pub const slice_const_u8: Type = .{ .ip_index = .slice_const_u8_type };
 pub const slice_const_u8_sentinel_0: Type = .{ .ip_index = .slice_const_u8_sentinel_0_type };
 
 pub const vector_16_i8: Type = .{ .ip_index = .vector_16_i8_type };

--- a/src/arch/x86_64/Encoding.zig
+++ b/src/arch/x86_64/Encoding.zig
@@ -304,20 +304,20 @@ pub const Mnemonic = enum {
     jnc, jne, jng, jnge, jnl, jnle, jno, jnp, jns, jnz, jo, jp, jpe, jpo, jrcxz, js, jz,
     lahf, lar, lea, leave, lfence, lgdt, lidt, lldt, lmsw, loop, loope, loopne,
     lods, lodsb, lodsd, lodsq, lodsw,
-    lsl, ltr, lzcnt,
+    lsl, ltr,
     mfence, mov, movbe,
     movs, movsb, movsd, movsq, movsw,
     movsx, movsxd, movzx, mul,
     neg, nop, not,
     @"or", out, outs, outsb, outsd, outsw,
-    pause, pop, popcnt, popf, popfd, popfq, push, pushfq,
+    pause, pop, popf, popfd, popfq, push, pushfq,
     rcl, rcr,
     rdfsbase, rdgsbase, rdmsr, rdpid, rdpkru, rdpmc, rdrand, rdseed, rdssd, rdssq, rdtsc, rdtscp,
-    ret, rol, ror, rorx, rsm,
-    sahf, sal, sar, sarx, sbb,
+    ret, rol, ror, rsm,
+    sahf, sal, sar, sbb,
     scas, scasb, scasd, scasq, scasw,
     senduipi, serialize,
-    shl, shld, shlx, shr, shrd, shrx,
+    shl, shld, shr, shrd,
     stac, stc, std, sti, str, stui,
     sub, swapgs, syscall, sysenter, sysexit, sysret,
     seta, setae, setb, setbe, setc, sete, setg, setge, setl, setle, setna, setnae,
@@ -433,6 +433,8 @@ pub const Mnemonic = enum {
     roundpd, roundps, roundsd, roundss,
     // SSE4.2
     crc32, pcmpgtq,
+    // ABM
+    lzcnt, popcnt,
     // PCLMUL
     pclmulqdq,
     // AES
@@ -440,7 +442,6 @@ pub const Mnemonic = enum {
     // SHA
     sha1rnds4, sha1nexte, sha1msg1, sha1msg2, sha256msg1, sha256msg2, sha256rnds2,
     // AVX
-    andn, bextr, blsi, blsmsk, blsr, bzhi, tzcnt,
     vaddpd, vaddps, vaddsd, vaddss, vaddsubpd, vaddsubps,
     vaesdec, vaesdeclast, vaesenc, vaesenclast, vaesimc, vaeskeygenassist,
     vandnpd, vandnps, vandpd, vandps,
@@ -506,6 +507,10 @@ pub const Mnemonic = enum {
     vtestpd, vtestps,
     vucomisd, vucomiss, vunpckhpd, vunpckhps, vunpcklpd, vunpcklps,
     vxorpd, vxorps,
+    // BMI
+    andn, bextr, blsi, blsmsk, blsr, tzcnt,
+    // BMI2
+    bzhi, mulx, pdep, pext, rorx, sarx, shlx, shrx,
     // F16C
     vcvtph2ps, vcvtps2ph,
     // FMA

--- a/src/arch/x86_64/Mir.zig
+++ b/src/arch/x86_64/Mir.zig
@@ -100,6 +100,8 @@ pub const Inst = struct {
         /// ___ Division
         _d,
 
+        /// ___ Without Affecting Flags
+        _x,
         /// ___ Left
         _l,
         /// ___ Left Double
@@ -483,6 +485,7 @@ pub const Inst = struct {
         /// ASCII adjust al after subtraction
         aa,
         /// Add with carry
+        /// Unsigned integer addition of two operands with carry flag
         adc,
         /// Add
         /// Add packed integers
@@ -1162,10 +1165,8 @@ pub const Inst = struct {
         fmadd231,
 
         // ADX
-        /// Unsigned integer addition of two operands with carry flag
-        adcx,
         /// Unsigned integer addition of two operands with overflow flag
-        adox,
+        ado,
 
         // AESKLE
         /// Encode 128-bit key with key locker

--- a/src/arch/x86_64/encodings.zig
+++ b/src/arch/x86_64/encodings.zig
@@ -405,9 +405,9 @@ pub const table = [_]Entry{
     .{ .jb,    .d, &.{ .rel32 }, &.{ 0x0f, 0x82 }, 0, .none,  .none     },
     .{ .jbe,   .d, &.{ .rel32 }, &.{ 0x0f, 0x86 }, 0, .none,  .none     },
     .{ .jc,    .d, &.{ .rel32 }, &.{ 0x0f, 0x82 }, 0, .none,  .none     },
-    .{ .jcxz,  .d, &.{ .rel32 }, &.{ 0xe3       }, 0, .short, .@"32bit" },
-    .{ .jecxz, .d, &.{ .rel32 }, &.{ 0xe3       }, 0, .none,  .@"32bit" },
-    .{ .jrcxz, .d, &.{ .rel32 }, &.{ 0xe3       }, 0, .none,  .@"64bit" },
+    .{ .jcxz,  .d, &.{ .rel8  }, &.{ 0xe3       }, 0, .short, .@"32bit" },
+    .{ .jecxz, .d, &.{ .rel8  }, &.{ 0xe3       }, 0, .none,  .@"32bit" },
+    .{ .jrcxz, .d, &.{ .rel8  }, &.{ 0xe3       }, 0, .none,  .@"64bit" },
     .{ .je,    .d, &.{ .rel32 }, &.{ 0x0f, 0x84 }, 0, .none,  .none     },
     .{ .jg,    .d, &.{ .rel32 }, &.{ 0x0f, 0x8f }, 0, .none,  .none     },
     .{ .jge,   .d, &.{ .rel32 }, &.{ 0x0f, 0x8d }, 0, .none,  .none     },
@@ -476,10 +476,6 @@ pub const table = [_]Entry{
     .{ .lsl, .rm, &.{ .r64, .r32_m16 }, &.{ 0x0f, 0x03 }, 0, .none, .none },
 
     .{ .ltr, .m, &.{ .rm16 }, &.{ 0x0f, 0x00 }, 3, .none, .none },
-
-    .{ .lzcnt, .rm, &.{ .r16, .rm16 }, &.{ 0xf3, 0x0f, 0xbd }, 0, .short, .lzcnt },
-    .{ .lzcnt, .rm, &.{ .r32, .rm32 }, &.{ 0xf3, 0x0f, 0xbd }, 0, .none,  .lzcnt },
-    .{ .lzcnt, .rm, &.{ .r64, .rm64 }, &.{ 0xf3, 0x0f, 0xbd }, 0, .long,  .lzcnt },
 
     .{ .mfence, .z, &.{}, &.{ 0x0f, 0xae, 0xf0 }, 0, .none, .none },
 
@@ -629,10 +625,6 @@ pub const table = [_]Entry{
     .{ .pop, .o, &.{ .r64  }, &.{ 0x58 }, 0, .none,  .none },
     .{ .pop, .m, &.{ .rm16 }, &.{ 0x8f }, 0, .short, .none },
     .{ .pop, .m, &.{ .rm64 }, &.{ 0x8f }, 0, .none,  .none },
-
-    .{ .popcnt, .rm, &.{ .r16, .rm16 }, &.{ 0xf3, 0x0f, 0xb8 }, 0, .short, .popcnt },
-    .{ .popcnt, .rm, &.{ .r32, .rm32 }, &.{ 0xf3, 0x0f, 0xb8 }, 0, .none,  .popcnt },
-    .{ .popcnt, .rm, &.{ .r64, .rm64 }, &.{ 0xf3, 0x0f, 0xb8 }, 0, .long,  .popcnt },
 
     .{ .popf,  .z, &.{}, &.{ 0x9d }, 0, .short, .none },
     .{ .popfd, .z, &.{}, &.{ 0x9d }, 0, .none,  .@"32bit" },
@@ -1738,6 +1730,15 @@ pub const table = [_]Entry{
 
     .{ .pcmpgtq, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x38, 0x37 }, 0, .none, .sse4_2 },
 
+    // ABM
+    .{ .lzcnt, .rm, &.{ .r16, .rm16 }, &.{ 0xf3, 0x0f, 0xbd }, 0, .short, .lzcnt },
+    .{ .lzcnt, .rm, &.{ .r32, .rm32 }, &.{ 0xf3, 0x0f, 0xbd }, 0, .none,  .lzcnt },
+    .{ .lzcnt, .rm, &.{ .r64, .rm64 }, &.{ 0xf3, 0x0f, 0xbd }, 0, .long,  .lzcnt },
+
+    .{ .popcnt, .rm, &.{ .r16, .rm16 }, &.{ 0xf3, 0x0f, 0xb8 }, 0, .short, .popcnt },
+    .{ .popcnt, .rm, &.{ .r32, .rm32 }, &.{ 0xf3, 0x0f, 0xb8 }, 0, .none,  .popcnt },
+    .{ .popcnt, .rm, &.{ .r64, .rm64 }, &.{ 0xf3, 0x0f, 0xb8 }, 0, .long,  .popcnt },
+
     // PCLMUL
     .{ .pclmulqdq, .rmi, &.{ .xmm, .xmm_m128, .imm8 }, &.{ 0x66, 0x0f, 0x3a, 0x44 }, 0, .none, .pclmul },
 
@@ -1771,38 +1772,6 @@ pub const table = [_]Entry{
     .{ .sha256msg2, .rm, &.{ .xmm, .xmm_m128 }, &.{ 0x0f, 0x38, 0xcd }, 0, .none, .sha },
 
     // AVX
-    .{ .andn, .rvm, &.{ .r32, .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf2 }, 0, .vex_lz_w0, .bmi },
-    .{ .andn, .rvm, &.{ .r64, .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf2 }, 0, .vex_lz_w1, .bmi },
-
-    .{ .bextr, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi },
-    .{ .bextr, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi },
-
-    .{ .blsi, .vm, &.{ .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf3 }, 3, .vex_lz_w0, .bmi },
-    .{ .blsi, .vm, &.{ .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf3 }, 3, .vex_lz_w1, .bmi },
-
-    .{ .blsmsk, .vm, &.{ .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf3 }, 2, .vex_lz_w0, .bmi },
-    .{ .blsmsk, .vm, &.{ .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf3 }, 2, .vex_lz_w1, .bmi },
-
-    .{ .blsr, .vm, &.{ .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf3 }, 1, .vex_lz_w0, .bmi },
-    .{ .blsr, .vm, &.{ .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf3 }, 1, .vex_lz_w1, .bmi },
-
-    .{ .bzhi, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w0, .bmi2 },
-    .{ .bzhi, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w1, .bmi2 },
-
-    .{ .rorx, .rmi, &.{ .r32, .rm32, .imm8 }, &.{ 0xf2, 0x0f, 0x3a }, 0, .vex_lz_w0, .bmi2 },
-    .{ .rorx, .rmi, &.{ .r64, .rm64, .imm8 }, &.{ 0xf2, 0x0f, 0x3a }, 0, .vex_lz_w1, .bmi2 },
-
-    .{ .sarx, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0xf3, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi2 },
-    .{ .shlx, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0x66, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi2 },
-    .{ .shrx, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0xf2, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi2 },
-    .{ .sarx, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0xf3, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi2 },
-    .{ .shlx, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0x66, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi2 },
-    .{ .shrx, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0xf2, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi2 },
-
-    .{ .tzcnt, .rm, &.{ .r16, .rm16 }, &.{ 0xf3, 0x0f, 0xbc }, 0, .short, .bmi },
-    .{ .tzcnt, .rm, &.{ .r32, .rm32 }, &.{ 0xf3, 0x0f, 0xbc }, 0, .none,  .bmi },
-    .{ .tzcnt, .rm, &.{ .r64, .rm64 }, &.{ 0xf3, 0x0f, 0xbc }, 0, .long,  .bmi },
-
     .{ .vaddpd, .rvm, &.{ .xmm, .xmm, .xmm_m128 }, &.{ 0x66, 0x0f, 0x58 }, 0, .vex_128_wig, .avx },
     .{ .vaddpd, .rvm, &.{ .ymm, .ymm, .ymm_m256 }, &.{ 0x66, 0x0f, 0x58 }, 0, .vex_256_wig, .avx },
 
@@ -2306,6 +2275,49 @@ pub const table = [_]Entry{
 
     .{ .vxorps, .rvm, &.{ .xmm, .xmm, .xmm_m128 }, &.{ 0x0f, 0x57 }, 0, .vex_128_wig, .avx },
     .{ .vxorps, .rvm, &.{ .ymm, .ymm, .ymm_m256 }, &.{ 0x0f, 0x57 }, 0, .vex_256_wig, .avx },
+
+    // BMI
+    .{ .andn, .rvm, &.{ .r32, .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf2 }, 0, .vex_lz_w0, .bmi },
+    .{ .andn, .rvm, &.{ .r64, .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf2 }, 0, .vex_lz_w1, .bmi },
+
+    .{ .bextr, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi },
+    .{ .bextr, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi },
+
+    .{ .blsi, .vm, &.{ .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf3 }, 3, .vex_lz_w0, .bmi },
+    .{ .blsi, .vm, &.{ .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf3 }, 3, .vex_lz_w1, .bmi },
+
+    .{ .blsmsk, .vm, &.{ .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf3 }, 2, .vex_lz_w0, .bmi },
+    .{ .blsmsk, .vm, &.{ .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf3 }, 2, .vex_lz_w1, .bmi },
+
+    .{ .blsr, .vm, &.{ .r32, .rm32 }, &.{ 0x0f, 0x38, 0xf3 }, 1, .vex_lz_w0, .bmi },
+    .{ .blsr, .vm, &.{ .r64, .rm64 }, &.{ 0x0f, 0x38, 0xf3 }, 1, .vex_lz_w1, .bmi },
+
+    .{ .tzcnt, .rm, &.{ .r16, .rm16 }, &.{ 0xf3, 0x0f, 0xbc }, 0, .short, .bmi },
+    .{ .tzcnt, .rm, &.{ .r32, .rm32 }, &.{ 0xf3, 0x0f, 0xbc }, 0, .none,  .bmi },
+    .{ .tzcnt, .rm, &.{ .r64, .rm64 }, &.{ 0xf3, 0x0f, 0xbc }, 0, .long,  .bmi },
+
+    // BMI2
+    .{ .bzhi, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .bzhi, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w1, .bmi2 },
+
+    .{ .mulx, .rvm, &.{ .r32, .r32, .rm32 }, &.{ 0xf2, 0x0f, 0x38, 0xf6 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .mulx, .rvm, &.{ .r64, .r64, .rm64 }, &.{ 0xf2, 0x0f, 0x38, 0xf6 }, 0, .vex_lz_w1, .bmi2 },
+
+    .{ .pdep, .rvm, &.{ .r32, .r32, .rm32 }, &.{ 0xf2, 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .pdep, .rvm, &.{ .r64, .r64, .rm64 }, &.{ 0xf2, 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w1, .bmi2 },
+
+    .{ .pext, .rvm, &.{ .r32, .r32, .rm32 }, &.{ 0xf3, 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .pext, .rvm, &.{ .r64, .r64, .rm64 }, &.{ 0xf3, 0x0f, 0x38, 0xf5 }, 0, .vex_lz_w1, .bmi2 },
+
+    .{ .rorx, .rmi, &.{ .r32, .rm32, .imm8 }, &.{ 0xf2, 0x0f, 0x3a }, 0, .vex_lz_w0, .bmi2 },
+    .{ .rorx, .rmi, &.{ .r64, .rm64, .imm8 }, &.{ 0xf2, 0x0f, 0x3a }, 0, .vex_lz_w1, .bmi2 },
+
+    .{ .sarx, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0xf3, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .shlx, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0x66, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .shrx, .rmv, &.{ .r32, .rm32, .r32 }, &.{ 0xf2, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w0, .bmi2 },
+    .{ .sarx, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0xf3, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi2 },
+    .{ .shlx, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0x66, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi2 },
+    .{ .shrx, .rmv, &.{ .r64, .rm64, .r64 }, &.{ 0xf2, 0x0f, 0x38, 0xf7 }, 0, .vex_lz_w1, .bmi2 },
 
     // F16C
     .{ .vcvtph2ps, .rm, &.{ .xmm, .xmm_m64  }, &.{ 0x66, 0x0f, 0x38, 0x13 }, 0, .vex_128_w0, .f16c },

--- a/src/codegen.zig
+++ b/src/codegen.zig
@@ -83,8 +83,10 @@ pub fn generateLazyFunction(
     debug_output: link.File.DebugInfoOutput,
 ) CodeGenError!void {
     const zcu = pt.zcu;
-    const file = Type.fromInterned(lazy_sym.ty).typeDeclInstAllowGeneratedTag(zcu).?.resolveFile(&zcu.intern_pool);
-    const target = zcu.fileByIndex(file).mod.resolved_target.result;
+    const target = if (Type.fromInterned(lazy_sym.ty).typeDeclInstAllowGeneratedTag(zcu)) |inst_index|
+        zcu.fileByIndex(inst_index.resolveFile(&zcu.intern_pool)).mod.resolved_target.result
+    else
+        zcu.getTarget();
     switch (target_util.zigBackend(target, false)) {
         else => unreachable,
         inline .stage2_x86_64, .stage2_riscv64 => |backend| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -39,10 +39,7 @@ test {
     _ = Package;
 }
 
-const thread_stack_size = switch (builtin.zig_backend) {
-    else => std.Thread.SpawnConfig.default_stack_size,
-    .stage2_x86_64 => 32 << 20,
-};
+const thread_stack_size = 32 << 20;
 
 pub const std_options: std.Options = .{
     .wasiCwd = wasi_cwd,

--- a/src/target.zig
+++ b/src/target.zig
@@ -726,11 +726,11 @@ pub inline fn backendSupportsFeature(backend: std.builtin.CompilerBackend, compt
             else => false,
         },
         .is_named_enum_value => switch (backend) {
-            .stage2_llvm => true,
+            .stage2_llvm, .stage2_x86_64 => true,
             else => false,
         },
         .error_set_has_value => switch (backend) {
-            .stage2_llvm, .stage2_wasm => true,
+            .stage2_llvm, .stage2_wasm, .stage2_x86_64 => true,
             else => false,
         },
         .field_reordering => switch (backend) {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -527,7 +527,7 @@ fn testIntDivision() !void {
     try expect(mod(i64, -14, 12) == 10);
     try expect(mod(i16, -2, 12) == 10);
     try expect(mod(i16, -118, 12) == 2);
-    try expect(mod(i8, -2, 12) == 10); // TODO: fails in x86_64
+    try expect(mod(i8, -2, 12) == 10);
 
     try expect(rem(i64, -118, 12) == -10);
     try expect(rem(i32, 10, 12) == 10);

--- a/test/behavior/x86_64/build.zig
+++ b/test/behavior/x86_64/build.zig
@@ -95,6 +95,11 @@ pub fn build(b: *std.Build) void {
         },
         .{
             .cpu_arch = .x86_64,
+            .cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v3 },
+            .cpu_features_add = std.Target.x86.featureSet(&.{.adx}),
+        },
+        .{
+            .cpu_arch = .x86_64,
             .cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v4 },
         },
     }) |query| {

--- a/test/behavior/x86_64/math.zig
+++ b/test/behavior/x86_64/math.zig
@@ -17978,8 +17978,8 @@ fn binary(comptime op: anytype, comptime opts: struct { compare: Compare = .rela
                 -0x12, -0x1e, 0x18, 0x6e, 0x31,  0x53,  -0x6a, -0x34, 0x13,  0x4d, 0x30, -0x7d, -0x31, 0x1e,  -0x24, 0x32,
                 -0x1e, -0x01, 0x55, 0x33, -0x75, -0x44, -0x57, 0x2b,  -0x66, 0x19, 0x7f, -0x28, -0x3f, -0x7e, -0x5d, -0x06,
             }, .{
-                0x05, -0x23, 0x43,  -0x54, -0x41, 0x7f,  -0x6a, -0x31, 0x04,  0x15, -0x7a, -0x37, 0x6d, 0x16,  0x00,  0x4a,
-                0x15, 0x55,  -0x4a, 0x16,  -0x73, -0x0c, 0x1c,  -0x26, -0x14, 0x00, 0x55,  0x7b,  0x16, -0x2e, -0x5f, -0x67,
+                0x05, -0x23, 0x43,  -0x54, -0x41, 0x7f,  -0x6a, -0x31, 0x04,  0x15,  -0x7a, -0x37, 0x6d, 0x16,  0x01,  0x4a,
+                0x15, 0x55,  -0x4a, 0x16,  -0x73, -0x0c, 0x1c,  -0x26, -0x14, -0x01, 0x55,  0x7b,  0x16, -0x2e, -0x5f, -0x67,
             });
             try testArgs(@Vector(64, i8), .{
                 -0x05, 0x76,  0x4e,  -0x5c, 0x7b,  -0x1a, -0x38, -0x2e, 0x3d,  0x36,  0x01,  0x30,  -0x02, -0x71, -0x24, 0x24,
@@ -18008,7 +18008,7 @@ fn binary(comptime op: anytype, comptime opts: struct { compare: Compare = .rela
                 0x23,  0x3b,  0x0a,  0x7a,  0x19,  0x14,  0x65,  -0x1d, 0x2b,  0x65,  0x33,  0x2a,  0x52,  -0x63, 0x57,  0x10,
                 -0x1b, 0x26,  -0x46, -0x7e, -0x25, 0x79,  -0x01, -0x0d, -0x49, -0x4d, 0x74,  0x03,  0x77,  0x16,  0x03,  -0x3d,
                 0x1c,  0x25,  0x5a,  -0x2f, -0x16, -0x5f, -0x36, -0x55, -0x44, -0x0c, -0x0f, 0x7b,  -0x15, -0x1d, 0x32,  0x31,
-                0x6e,  -0x44, -0x4a, -0x64, 0x67,  0x04,  0x47,  0x00,  0x3c,  -0x0a, -0x79, 0x3d,  0x48,  0x5a,  0x61,  -0x2c,
+                0x6e,  -0x44, -0x4a, -0x64, 0x67,  0x04,  0x47,  -0x02, 0x3c,  -0x0a, -0x79, 0x3d,  0x48,  0x5a,  0x61,  -0x2c,
                 0x6d,  -0x68, -0x71, -0x6b, -0x11, 0x44,  -0x75, -0x55, -0x67, -0x52, 0x64,  -0x3d, -0x05, -0x76, -0x6d, -0x44,
             });
 
@@ -18035,7 +18035,7 @@ fn binary(comptime op: anytype, comptime opts: struct { compare: Compare = .rela
             try testArgs(@Vector(16, u8), .{
                 0xea, 0x80, 0xbb, 0xe8, 0x74, 0x81, 0xc8, 0x66, 0x7b, 0x41, 0x90, 0xcb, 0x30, 0x70, 0x4b, 0x0f,
             }, .{
-                0x61, 0x26, 0xbe, 0x47, 0x00, 0x9c, 0x55, 0xa5, 0x59, 0xf0, 0xb2, 0x20, 0x30, 0xaf, 0x82, 0x3e,
+                0x61, 0x26, 0xbe, 0x47, 0x02, 0x9c, 0x55, 0xa5, 0x59, 0xf0, 0xb2, 0x20, 0x30, 0xaf, 0x82, 0x3e,
             });
             try testArgs(@Vector(32, u8), .{
                 0xa1, 0x88, 0xc4, 0xf4, 0x77, 0x0b, 0xf5, 0xbb, 0x09, 0x03, 0xbf, 0xf5, 0xcc, 0x7f, 0x6b, 0x2a,
@@ -18976,12 +18976,12 @@ test addUnsafe {
 inline fn subUnsafe(comptime Type: type, lhs: Type, rhs: Type) AddOneBit(Type) {
     @setRuntimeSafety(false);
     switch (@typeInfo(Scalar(Type))) {
+        else => @compileError(@typeName(Type)),
         .int => |int| switch (int.signedness) {
             .signed => {},
             .unsigned => return @as(AddOneBit(Type), @max(lhs, rhs)) - @min(lhs, rhs),
         },
         .float => {},
-        else => @compileError(@typeName(Type)),
     }
     return @as(AddOneBit(Type), lhs) - rhs;
 }
@@ -19024,42 +19024,51 @@ test divide {
     try test_divide.testFloatVectors();
 }
 
-// workaround https://github.com/ziglang/zig/issues/22748
-// TODO: @TypeOf(@divTrunc(lhs, rhs))
-inline fn divTrunc(comptime Type: type, lhs: Type, rhs: Type) @TypeOf(lhs / rhs) {
-    if (@inComptime()) {
-        // workaround https://github.com/ziglang/zig/issues/22748
-        return @trunc(lhs / rhs);
+inline fn divTrunc(comptime Type: type, lhs: Type, rhs: Type) Type {
+    switch (@typeInfo(Scalar(Type))) {
+        else => @compileError(@typeName(Type)),
+        .int => return @divTrunc(lhs, rhs),
+        .float => {
+            if (@inComptime()) {
+                // workaround https://github.com/ziglang/zig/issues/22748
+                return @trunc(lhs / rhs);
+            }
+            // workaround https://github.com/ziglang/zig/issues/22748
+            // workaround https://github.com/ziglang/zig/issues/22749
+            // TODO: return @divTrunc(lhs, rhs);
+            var rt_lhs = lhs;
+            var rt_rhs = rhs;
+            _ = .{ &rt_lhs, &rt_rhs };
+            return @divTrunc(rt_lhs, rt_rhs);
+        },
     }
-    // workaround https://github.com/ziglang/zig/issues/22748
-    // workaround https://github.com/ziglang/zig/issues/22749
-    // TODO: return @divTrunc(lhs, rhs);
-    var rt_lhs = lhs;
-    var rt_rhs = rhs;
-    _ = .{ &rt_lhs, &rt_rhs };
-    return @divTrunc(rt_lhs, rt_rhs);
 }
 test divTrunc {
     const test_div_trunc = binary(divTrunc, .{ .compare = .approx_int });
+    try test_div_trunc.testInts();
+    try test_div_trunc.testIntVectors();
     try test_div_trunc.testFloats();
     try test_div_trunc.testFloatVectors();
 }
 
-// workaround https://github.com/ziglang/zig/issues/22748
-// TODO: @TypeOf(@divFloor(lhs, rhs))
-inline fn divFloor(comptime Type: type, lhs: Type, rhs: Type) @TypeOf(lhs / rhs) {
-    if (@inComptime()) {
-        // workaround https://github.com/ziglang/zig/issues/22748
-        return @floor(lhs / rhs);
+inline fn divFloor(comptime Type: type, lhs: Type, rhs: Type) Type {
+    switch (@typeInfo(Scalar(Type))) {
+        else => @compileError(@typeName(Type)),
+        .int => return @divFloor(lhs, rhs),
+        .float => {
+            if (@inComptime()) {
+                // workaround https://github.com/ziglang/zig/issues/22748
+                return @floor(lhs / rhs);
+            }
+            // workaround https://github.com/ziglang/zig/issues/22748
+            // workaround https://github.com/ziglang/zig/issues/22749
+            // TODO: return @divFloor(lhs, rhs);
+            var rt_lhs = lhs;
+            var rt_rhs = rhs;
+            _ = .{ &rt_lhs, &rt_rhs };
+            return @divFloor(rt_lhs, rt_rhs);
+        },
     }
-    // workaround https://github.com/ziglang/zig/issues/22748
-    // workaround https://github.com/ziglang/zig/issues/22749
-    // TODO: return @divFloor(lhs, rhs);
-    var rt_lhs = lhs;
-    var rt_rhs = rhs;
-    _ = &rt_lhs;
-    _ = &rt_rhs;
-    return @divFloor(rt_lhs, rt_rhs);
 }
 test divFloor {
     const test_div_floor = binary(divFloor, .{ .compare = .approx_int });

--- a/test/behavior/x86_64/mem.zig
+++ b/test/behavior/x86_64/mem.zig
@@ -1,4 +1,4 @@
-fn access(comptime array: anytype) !void {
+fn accessSlice(comptime array: anytype) !void {
     var slice: []const @typeInfo(@TypeOf(array)).array.child = undefined;
     slice = &array;
     inline for (0.., &array) |ct_index, *elem| {
@@ -20,18 +20,153 @@ fn access(comptime array: anytype) !void {
         if (slice[rt_index] != elem.*) return error.Unexpected;
     }
 }
-test access {
-    try access([3]u8{ 0xdb, 0xef, 0xbd });
-    try access([3]u16{ 0x340e, 0x3654, 0x88d7 });
-    try access([3]u32{ 0xd424c2c0, 0x2d6ac466, 0x5a0cfaba });
-    try access([3]u64{
+test accessSlice {
+    try accessSlice([3]u8{ 0xdb, 0xef, 0xbd });
+    try accessSlice([3]u16{ 0x340e, 0x3654, 0x88d7 });
+    try accessSlice([3]u32{ 0xd424c2c0, 0x2d6ac466, 0x5a0cfaba });
+    try accessSlice([3]u64{
         0x9327a4f5221666a6,
         0x5c34d3ddd84a8b12,
         0xbae087f39f649260,
     });
-    try access([3]u128{
+    try accessSlice([3]u128{
         0x601cf010065444d4d42d5536dd9b95db,
         0xa03f592fcaa22d40af23a0c735531e3c,
         0x5da44907b31602b95c2d93f0b582ceab,
+    });
+}
+
+fn accessVector(comptime init: anytype) !void {
+    const Vector = @TypeOf(init);
+    var vector: Vector = undefined;
+    vector = init;
+    inline for (0..@typeInfo(Vector).vector.len) |ct_index| {
+        var rt_index: usize = undefined;
+        rt_index = ct_index;
+        if (&vector[rt_index] != &vector[ct_index]) return error.Unexpected;
+        if (vector[rt_index] != vector[ct_index]) return error.Unexpected;
+    }
+}
+test accessVector {
+    try accessVector(@Vector(1, bool){
+        false,
+    });
+    try accessVector(@Vector(2, bool){
+        false, true,
+    });
+    try accessVector(@Vector(3, bool){
+        true, true, false,
+    });
+    try accessVector(@Vector(5, bool){
+        true, false, true, false, true,
+    });
+    try accessVector(@Vector(7, bool){
+        true, false, true, true, true, false, true,
+    });
+    try accessVector(@Vector(8, bool){
+        false, true, false, true, false, false, false, true,
+    });
+    try accessVector(@Vector(9, bool){
+        true, true, false, true, false, false, false, false,
+        true,
+    });
+    try accessVector(@Vector(15, bool){
+        false, true, true,  true,  false, true,  false, false,
+        true,  true, false, false, true,  false, false,
+    });
+    try accessVector(@Vector(16, bool){
+        true,  true, false, true,  false, false, false, false,
+        false, true, true,  false, false, false, true,  true,
+    });
+    try accessVector(@Vector(17, bool){
+        true,  false, true, true,  false, true,  false, true,
+        true,  true,  true, false, false, false, true,  true,
+        false,
+    });
+    try accessVector(@Vector(31, bool){
+        true,  false, true,  true,  false, true,  true,  true,
+        false, true,  false, true,  false, true,  true,  true,
+        false, false, true,  false, false, false, false, true,
+        true,  true,  true,  false, false, false, false,
+    });
+    try accessVector(@Vector(32, bool){
+        true,  true,  false, false, false, true, true,  true,
+        false, true,  true,  true,  false, true, false, true,
+        false, true,  false, true,  false, true, true,  false,
+        false, false, false, false, false, true, true,  true,
+    });
+    try accessVector(@Vector(33, bool){
+        true,  false, false, false, false, true,  true,  true,
+        false, false, true,  false, true,  true,  false, true,
+        true,  true,  false, true,  true,  false, false, false,
+        false, true,  false, false, false, true,  true,  false,
+        false,
+    });
+    try accessVector(@Vector(63, bool){
+        false, false, true,  true,  true,  false, true,  true,
+        true,  false, true,  true,  true,  false, true,  false,
+        true,  true,  false, true,  false, true,  true,  true,
+        false, false, true,  false, false, false, false, true,
+        true,  true,  true,  true,  false, true,  false, true,
+        true,  true,  false, false, true,  false, false, true,
+        false, true,  false, false, false, false, true,  true,
+        false, true,  false, false, true,  true,  true,
+    });
+    try accessVector(@Vector(64, bool){
+        false, false, true,  true,  true,  false, true,  true,
+        true,  false, true,  true,  false, true,  true,  false,
+        false, false, false, false, true,  true,  false, true,
+        true,  true,  true,  true,  false, false, false, true,
+        true,  false, true,  true,  false, false, true,  false,
+        false, true,  true,  false, true,  true,  false, false,
+        true,  true,  false, true,  false, true,  true,  true,
+        false, true,  true,  false, false, false, false, false,
+    });
+    try accessVector(@Vector(65, bool){
+        false, false, true,  true,  true,  true,  true,  true,
+        true,  false, false, false, false, true,  true,  false,
+        true,  false, true,  true,  true,  false, false, false,
+        true,  false, true,  true,  false, true,  true,  true,
+        true,  true,  false, true,  true,  false, true,  false,
+        false, true,  false, true,  false, false, true,  false,
+        true,  false, true,  true,  true,  false, true,  true,
+        false, false, true,  true,  true,  true,  false, false,
+        true,
+    });
+    try accessVector(@Vector(8, u8){
+        0x60, 0xf7, 0xf4, 0xb0, 0x05, 0xd3, 0x06, 0x78,
+    });
+    try accessVector(@Vector(8, u16){
+        0x9c91, 0xfb8b, 0x7f80, 0x8304, 0x6e52, 0xd8ef, 0x37fc, 0x7851,
+    });
+    try accessVector(@Vector(8, u32){
+        0x688b88e2, 0x68e2b7a2, 0x87574680, 0xab4f0769,
+        0x75472bb5, 0xa791f2ae, 0xeb2ed416, 0x5f05ce82,
+    });
+    try accessVector(@Vector(8, u64){
+        0xdefd1ddffaedf818, 0x91c78a29d3d59890,
+        0x842aaf8fd3c7b785, 0x970a07b8f9f4a6b3,
+        0x21b2425d1a428246, 0xea50e41174a7977b,
+        0x08d0f1c4f5978b74, 0x8dc88a7fd85e0e67,
+    });
+    try accessVector(@Vector(8, u128){
+        0x6f2cbde1fb219b1e73d7f774d10f0d94,
+        0x7c1412616cda20436d7106691d8ba4cc,
+        0x4ee940b50e97675b3b35d7872a35b5ad,
+        0x6d994fb8caa1b2fac48acbb68fa2d2f1,
+        0xdee698c7ec8de9b5940903e3fc665b63,
+        0x0751491a509e4a1ce8cfa6d62fe9e74c,
+        0x3d880f0a927ce3bfc2682b72070fcd50,
+        0x82f0eec62881598699eeb93fbb456e95,
+    });
+    try accessVector(@Vector(8, u256){
+        0x6ee4f35fe624d365952f73960791238ac781bfba782abc7866a691063e43ce48,
+        0xb006491f54a9c9292458a5835b7d5f4cfa18136f175eef0a13bb8adf5c3dc061,
+        0xd6e25ca1bc5685fc52609e261b9065bc05a8662e9291660033dd7f6d98e562b3,
+        0x992c5e54e0e6331dac258996be7dae9b2a2eff323a39043ba8d2721420dc5f5c,
+        0x257313f45fb3556d0fc323d5f38c953e9a093fe2278655312b6a5b64aab9d901,
+        0x6c8ad2182b9a3b2b19c2c9b152956b383d0fee2e3fbd5b02ed72227446a7b221,
+        0xd80cafc2252b289793799675e43f97ba4a5448c7b57e1544a464687b435efc7b,
+        0xfcb480f2d70afd53c4689dd3f5db7638c24302f2a6a15f738167db090d91fb28,
     });
 }

--- a/test/cases/array_in_anon_struct.zig
+++ b/test/cases/array_in_anon_struct.zig
@@ -18,5 +18,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/compile_errors/addition_with_non_numbers.zig
+++ b/test/cases/compile_errors/addition_with_non_numbers.zig
@@ -8,7 +8,7 @@ export fn entry() usize {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :4:29: error: invalid operands to binary expression: 'struct' and 'struct'

--- a/test/cases/compile_errors/asm_at_compile_time.zig
+++ b/test/cases/compile_errors/asm_at_compile_time.zig
@@ -11,7 +11,7 @@ fn doSomeAsm() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :6:5: error: unable to evaluate comptime expression

--- a/test/cases/compile_errors/asm_output_to_const.zig
+++ b/test/cases/compile_errors/asm_output_to_const.zig
@@ -8,7 +8,7 @@ export fn foo() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :4:5: error: asm cannot output to const local 'f'

--- a/test/cases/compile_errors/call_from_naked_func.zig
+++ b/test/cases/compile_errors/call_from_naked_func.zig
@@ -17,7 +17,7 @@ export fn comptimeBuiltinCall() callconv(.Naked) void {
 fn f() void {}
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:6: error: runtime call not allowed in naked function

--- a/test/cases/compile_errors/calling_function_with_naked_calling_convention.zig
+++ b/test/cases/compile_errors/calling_function_with_naked_calling_convention.zig
@@ -4,7 +4,7 @@ export fn entry() void {
 fn foo() callconv(.naked) void {}
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:5: error: unable to call function with calling convention 'naked'

--- a/test/cases/compile_errors/cast_negative_value_to_unsigned_integer.zig
+++ b/test/cases/compile_errors/cast_negative_value_to_unsigned_integer.zig
@@ -10,7 +10,7 @@ export fn entry1() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:36: error: type 'u32' cannot represent integer value '-1'

--- a/test/cases/compile_errors/compare_optional_to_non_optional_with_incomparable_type.zig
+++ b/test/cases/compile_errors/compare_optional_to_non_optional_with_incomparable_type.zig
@@ -5,7 +5,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :4:12: error: operator == not allowed for type '?[3]i32'

--- a/test/cases/compile_errors/compile_log.zig
+++ b/test/cases/compile_errors/compile_log.zig
@@ -13,7 +13,7 @@ export fn baz() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :6:5: error: found compile log statement

--- a/test/cases/compile_errors/compile_log_statement_warning_deduplication_in_generic_fn.zig
+++ b/test/cases/compile_errors/compile_log_statement_warning_deduplication_in_generic_fn.zig
@@ -10,7 +10,7 @@ fn inner(comptime n: usize) void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :8:9: error: found compile log statement

--- a/test/cases/compile_errors/compile_time_division_by_zero.zig
+++ b/test/cases/compile_errors/compile_time_division_by_zero.zig
@@ -8,7 +8,7 @@ export fn entry() usize {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:16: error: division by zero here causes undefined behavior

--- a/test/cases/compile_errors/compile_time_null_ptr_cast.zig
+++ b/test/cases/compile_errors/compile_time_null_ptr_cast.zig
@@ -5,7 +5,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:32: error: null pointer casted to type '*i32'

--- a/test/cases/compile_errors/compile_time_undef_ptr_cast.zig
+++ b/test/cases/compile_errors/compile_time_undef_ptr_cast.zig
@@ -6,7 +6,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:32: error: use of undefined value here causes undefined behavior

--- a/test/cases/compile_errors/discarded_array_bad_elem_type.zig
+++ b/test/cases/compile_errors/discarded_array_bad_elem_type.zig
@@ -6,7 +6,7 @@ export fn foo() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:9: error: expected type 'u16', found '*const [5:0]u8'

--- a/test/cases/compile_errors/duplicate_error_in_switch.zig
+++ b/test/cases/compile_errors/duplicate_error_in_switch.zig
@@ -15,7 +15,7 @@ fn foo(x: i32) !void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :5:9: error: duplicate switch value

--- a/test/cases/compile_errors/error_in_comptime_call_in_container_level_initializer.zig
+++ b/test/cases/compile_errors/error_in_comptime_call_in_container_level_initializer.zig
@@ -15,7 +15,7 @@ pub export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :9:48: error: caught unexpected error 'InvalidVersion'

--- a/test/cases/compile_errors/error_not_handled_in_switch.zig
+++ b/test/cases/compile_errors/error_not_handled_in_switch.zig
@@ -13,7 +13,7 @@ fn foo(x: i32) !void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:26: error: switch must handle all possibilities

--- a/test/cases/compile_errors/error_set_membership.zig
+++ b/test/cases/compile_errors/error_set_membership.zig
@@ -24,7 +24,7 @@ pub fn main() Error!void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :23:29: error: expected type 'error{InvalidCharacter}', found '@typeInfo(@typeInfo(@TypeOf(tmp.fooey)).@"fn".return_type.?).error_union.error_set'

--- a/test/cases/compile_errors/exact division failure.zig
+++ b/test/cases/compile_errors/exact division failure.zig
@@ -4,7 +4,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:15: error: exact division produced remainder

--- a/test/cases/compile_errors/exceeded_maximum_bit_width_of_integer.zig
+++ b/test/cases/compile_errors/exceeded_maximum_bit_width_of_integer.zig
@@ -8,7 +8,7 @@ export fn entry2() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:15: error: primitive integer type 'u65536' exceeds maximum bit width of 65535

--- a/test/cases/compile_errors/export_with_empty_name_string.zig
+++ b/test/cases/compile_errors/export_with_empty_name_string.zig
@@ -4,7 +4,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:25: error: exported symbol name cannot be empty

--- a/test/cases/compile_errors/fieldParentPtr-non_pointer.zig
+++ b/test/cases/compile_errors/fieldParentPtr-non_pointer.zig
@@ -4,7 +4,7 @@ export fn foo(a: *i32) Foo {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:12: error: expected pointer type, found 'i32'

--- a/test/cases/compile_errors/float exact division failure.zig
+++ b/test/cases/compile_errors/float exact division failure.zig
@@ -4,7 +4,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:15: error: exact division produced remainder

--- a/test/cases/compile_errors/function_call_assigned_to_incorrect_type.zig
+++ b/test/cases/compile_errors/function_call_assigned_to_incorrect_type.zig
@@ -7,7 +7,7 @@ fn concat() [16]f32 {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:17: error: expected type '[4]f32', found '[16]f32'

--- a/test/cases/compile_errors/function_prototype_with_no_body.zig
+++ b/test/cases/compile_errors/function_prototype_with_no_body.zig
@@ -4,7 +4,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :1:1: error: non-extern function has no body

--- a/test/cases/compile_errors/generic_instantiation_failure.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure.zig
@@ -19,7 +19,7 @@ pub export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :18:43: error: value of type 'type' ignored

--- a/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
@@ -36,7 +36,7 @@ pub fn is(comptime id: std.builtin.TypeId) TraitFn {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :8:48: error: expected type 'type', found 'bool'

--- a/test/cases/compile_errors/implicit_cast_from_array_to_mutable_slice.zig
+++ b/test/cases/compile_errors/implicit_cast_from_array_to_mutable_slice.zig
@@ -7,7 +7,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :6:9: error: array literal requires address-of operator (&) to coerce to slice type '[]i32'

--- a/test/cases/compile_errors/implicit_cast_from_f64_to_f32.zig
+++ b/test/cases/compile_errors/implicit_cast_from_f64_to_f32.zig
@@ -11,7 +11,7 @@ export fn entry2() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:14: error: expected type 'f32', found 'f64'

--- a/test/cases/compile_errors/int_to_err_non_global_invalid_number.zig
+++ b/test/cases/compile_errors/int_to_err_non_global_invalid_number.zig
@@ -13,7 +13,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :11:21: error: 'error.B' not a member of error set 'error{A,C}'

--- a/test/cases/compile_errors/invalid_peer_type_resolution.zig
+++ b/test/cases/compile_errors/invalid_peer_type_resolution.zig
@@ -24,7 +24,7 @@ export fn incompatiblePointers4() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :5:9: error: incompatible types: '?@Vector(10, i32)' and '@Vector(11, i32)'

--- a/test/cases/compile_errors/invalid_underscore_placement_in_int_literal-1.zig
+++ b/test/cases/compile_errors/invalid_underscore_placement_in_int_literal-1.zig
@@ -4,7 +4,7 @@ fn main() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:23: error: trailing digit separator

--- a/test/cases/compile_errors/leading_zero_in_integer.zig
+++ b/test/cases/compile_errors/leading_zero_in_integer.zig
@@ -16,7 +16,7 @@ export fn entry4() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:15: error: primitive integer type 'u000123' has leading zero

--- a/test/cases/compile_errors/load_vector_pointer_with_unknown_runtime_index.zig
+++ b/test/cases/compile_errors/load_vector_pointer_with_unknown_runtime_index.zig
@@ -11,7 +11,7 @@ fn loadv(ptr: anytype) i31 {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :10:15: error: unable to determine vector element index of type '*align(16:0:4:?) i31'

--- a/test/cases/compile_errors/method_call_with_first_arg_type_wrong_container.zig
+++ b/test/cases/compile_errors/method_call_with_first_arg_type_wrong_container.zig
@@ -24,7 +24,7 @@ export fn foo() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :23:6: error: no field or member function named 'init' in 'tmp.List'

--- a/test/cases/compile_errors/missing_const_in_slice_with_nested_array_type.zig
+++ b/test/cases/compile_errors/missing_const_in_slice_with_nested_array_type.zig
@@ -12,7 +12,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :4:26: error: array literal requires address-of operator (&) to coerce to slice type '[][2]f32'

--- a/test/cases/compile_errors/missing_main_fn_in_executable.zig
+++ b/test/cases/compile_errors/missing_main_fn_in_executable.zig
@@ -1,5 +1,5 @@
 // error
-// backend=llvm
+// backend=stage2
 // target=x86_64-linux
 // output_mode=Exe
 //

--- a/test/cases/compile_errors/nested_error_set_mismatch.zig
+++ b/test/cases/compile_errors/nested_error_set_mismatch.zig
@@ -11,7 +11,7 @@ fn foo() ?OtherError!i32 {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :5:34: error: expected type '?error{NextError}!i32', found '?error{OutOfMemory}!i32'

--- a/test/cases/compile_errors/nested_generic_function_param_type_mismatch.zig
+++ b/test/cases/compile_errors/nested_generic_function_param_type_mismatch.zig
@@ -16,7 +16,7 @@ pub export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :15:28: error: expected type '*const fn (type, u8, u8) u32', found '*const fn (void, u8, u8) u32'

--- a/test/cases/compile_errors/packed_struct_backing_int_wrong.zig
+++ b/test/cases/compile_errors/packed_struct_backing_int_wrong.zig
@@ -43,7 +43,7 @@ export fn entry7() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:31: error: backing integer type 'u32' has bit size 32 but the struct fields have a total bit size of 29

--- a/test/cases/compile_errors/packed_struct_with_fields_of_not_allowed_types.zig
+++ b/test/cases/compile_errors/packed_struct_with_fields_of_not_allowed_types.zig
@@ -78,7 +78,7 @@ export fn entry14() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :3:12: error: packed structs cannot contain fields of type 'anyerror'

--- a/test/cases/compile_errors/private_main_fn.zig
+++ b/test/cases/compile_errors/private_main_fn.zig
@@ -1,7 +1,7 @@
 fn main() void {}
 
 // error
-// backend=llvm
+// backend=stage2
 // target=x86_64-linux
 // output_mode=Exe
 //

--- a/test/cases/compile_errors/ptrcast_to_non-pointer.zig
+++ b/test/cases/compile_errors/ptrcast_to_non-pointer.zig
@@ -3,7 +3,7 @@ export fn entry(a: *i32) usize {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:12: error: expected pointer type, found 'usize'

--- a/test/cases/compile_errors/range_operator_in_switch_used_on_error_set.zig
+++ b/test/cases/compile_errors/range_operator_in_switch_used_on_error_set.zig
@@ -13,7 +13,7 @@ fn foo(x: i32) !void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:34: error: ranges not allowed when switching on type '@typeInfo(@typeInfo(@TypeOf(tmp.foo)).@"fn".return_type.?).error_union.error_set'

--- a/test/cases/compile_errors/reassign_to_array_parameter.zig
+++ b/test/cases/compile_errors/reassign_to_array_parameter.zig
@@ -6,7 +6,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:5: error: cannot assign to constant

--- a/test/cases/compile_errors/reassign_to_slice_parameter.zig
+++ b/test/cases/compile_errors/reassign_to_slice_parameter.zig
@@ -6,7 +6,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:5: error: cannot assign to constant

--- a/test/cases/compile_errors/return_from_naked_function.zig
+++ b/test/cases/compile_errors/return_from_naked_function.zig
@@ -7,7 +7,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:5: error: cannot return from naked function

--- a/test/cases/compile_errors/shlExact_shifts_out_1_bits.zig
+++ b/test/cases/compile_errors/shlExact_shifts_out_1_bits.zig
@@ -4,7 +4,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:15: error: operation caused overflow

--- a/test/cases/compile_errors/shrExact_shifts_out_1_bits.zig
+++ b/test/cases/compile_errors/shrExact_shifts_out_1_bits.zig
@@ -4,7 +4,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:15: error: exact shift shifted out 1 bits

--- a/test/cases/compile_errors/std.fmt_error_for_unused_arguments.zig
+++ b/test/cases/compile_errors/std.fmt_error_for_unused_arguments.zig
@@ -3,7 +3,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :?:?: error: 10 unused arguments in '{d} {d} {d} {d} {d}'

--- a/test/cases/compile_errors/store_vector_pointer_with_unknown_runtime_index.zig
+++ b/test/cases/compile_errors/store_vector_pointer_with_unknown_runtime_index.zig
@@ -11,7 +11,7 @@ fn storev(ptr: anytype, val: i31) void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :10:8: error: unable to determine vector element index of type '*align(16:0:4:?) i31'

--- a/test/cases/compile_errors/suspend_inside_suspend_block.zig
+++ b/test/cases/compile_errors/suspend_inside_suspend_block.zig
@@ -8,7 +8,7 @@ fn foo() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :6:9: error: cannot suspend inside suspend block

--- a/test/cases/compile_errors/switch_expression-unreachable_else_prong_enum.zig
+++ b/test/cases/compile_errors/switch_expression-unreachable_else_prong_enum.zig
@@ -20,7 +20,7 @@ export fn entry() usize {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :14:14: error: unreachable else prong; all cases already handled

--- a/test/cases/compile_errors/unable_to_evaluate_expr_inside_cimport.zig
+++ b/test/cases/compile_errors/unable_to_evaluate_expr_inside_cimport.zig
@@ -7,7 +7,7 @@ export fn entry() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:11: error: unable to evaluate comptime expression

--- a/test/cases/compile_errors/unreachable_else_prong_err_set.zig
+++ b/test/cases/compile_errors/unreachable_else_prong_err_set.zig
@@ -21,7 +21,7 @@ pub export fn simple() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :7:14: error: unreachable else prong; all cases already handled

--- a/test/cases/compile_errors/unreachable_in_naked_func.zig
+++ b/test/cases/compile_errors/unreachable_in_naked_func.zig
@@ -19,7 +19,7 @@ comptime {
 }
 
 // error
-// backend=llvm
+// backend=stage2
 // target=native
 //
 // :2:5: error: runtime safety check not allowed in naked function

--- a/test/cases/error_in_nested_declaration.zig
+++ b/test/cases/error_in_nested_declaration.zig
@@ -23,7 +23,7 @@ pub export fn entry2() void {
 }
 
 // error
-// backend=llvm
+// backend=stage2,llvm
 // target=native
 //
 // :6:20: error: cannot @bitCast to '[]i32'

--- a/test/cases/f32_passed_to_variadic_fn.zig
+++ b/test/cases/f32_passed_to_variadic_fn.zig
@@ -7,7 +7,7 @@ pub fn main() void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux-gnu
 // link_libc=true
 //

--- a/test/cases/fn_typeinfo_passed_to_comptime_fn.zig
+++ b/test/cases/fn_typeinfo_passed_to_comptime_fn.zig
@@ -14,5 +14,5 @@ fn foo(comptime info: std.builtin.Type) !void {
 
 // run
 // is_test=true
-// backend=llvm
+// backend=stage2,llvm
 //

--- a/test/cases/large_add_function.zig
+++ b/test/cases/large_add_function.zig
@@ -36,5 +36,5 @@ fn assert(ok: bool) void {
 // TODO: enable this for native backend
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=aarch64-linux,aarch64-macos

--- a/test/cases/llvm/address_space_pointer_access_chaining_pointer_to_optional_array.zig
+++ b/test/cases/llvm/address_space_pointer_access_chaining_pointer_to_optional_array.zig
@@ -7,6 +7,6 @@ pub fn main() void {
 
 // compile
 // output_mode=Exe
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //

--- a/test/cases/llvm/address_spaces_pointer_access_chaining_complex.zig
+++ b/test/cases/llvm/address_spaces_pointer_access_chaining_complex.zig
@@ -8,6 +8,6 @@ pub fn main() void {
 
 // compile
 // output_mode=Exe
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //

--- a/test/cases/llvm/for_loop.zig
+++ b/test/cases/llvm/for_loop.zig
@@ -11,6 +11,6 @@ pub fn main() void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //

--- a/test/cases/llvm/hello_world.zig
+++ b/test/cases/llvm/hello_world.zig
@@ -5,7 +5,7 @@ pub fn main() void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 // link_libc=true
 //

--- a/test/cases/llvm/large_slices.zig
+++ b/test/cases/llvm/large_slices.zig
@@ -4,6 +4,6 @@ pub fn main() void {
 }
 
 // compile
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //

--- a/test/cases/llvm/optionals.zig
+++ b/test/cases/llvm/optionals.zig
@@ -44,6 +44,6 @@ pub fn main() void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=x86_64-linux,x86_64-macos
 //

--- a/test/cases/maximum_sized_integer_literal.zig
+++ b/test/cases/maximum_sized_integer_literal.zig
@@ -18,5 +18,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/returning_undefined_sentinel_terminated_const_u8_slice.zig
+++ b/test/cases/returning_undefined_sentinel_terminated_const_u8_slice.zig
@@ -7,5 +7,5 @@ pub fn main() void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@alignCast misaligned.zig
+++ b/test/cases/safety/@alignCast misaligned.zig
@@ -21,5 +21,5 @@ fn foo(bytes: []u8) u32 {
     return int_slice[0];
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@enumFromInt - no matching tag value.zig
+++ b/test/cases/safety/@enumFromInt - no matching tag value.zig
@@ -22,5 +22,5 @@ fn bar(a: u2) Foo {
 fn baz(_: Foo) void {}
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@enumFromInt truncated bits - exhaustive.zig
+++ b/test/cases/safety/@enumFromInt truncated bits - exhaustive.zig
@@ -19,5 +19,5 @@ pub fn main() u8 {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@enumFromInt truncated bits - nonexhaustive.zig
+++ b/test/cases/safety/@enumFromInt truncated bits - nonexhaustive.zig
@@ -19,5 +19,5 @@ pub fn main() u8 {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@errorCast error not present in destination.zig
+++ b/test/cases/safety/@errorCast error not present in destination.zig
@@ -17,5 +17,5 @@ fn foo(set1: Set1) Set2 {
     return @errorCast(set1);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@errorCast error union casted to disjoint set.zig
+++ b/test/cases/safety/@errorCast error union casted to disjoint set.zig
@@ -16,5 +16,5 @@ fn foo() anyerror!i32 {
     return error.Bar;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@intCast to u0.zig
+++ b/test/cases/safety/@intCast to u0.zig
@@ -18,5 +18,5 @@ fn bar(one: u1, not_zero: i32) void {
     _ = x;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@intFromFloat cannot fit - negative out of range.zig
+++ b/test/cases/safety/@intFromFloat cannot fit - negative out of range.zig
@@ -16,5 +16,5 @@ fn bar(a: f32) i8 {
 }
 fn baz(_: i8) void {}
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@intFromFloat cannot fit - negative to unsigned.zig
+++ b/test/cases/safety/@intFromFloat cannot fit - negative to unsigned.zig
@@ -16,5 +16,5 @@ fn bar(a: f32) u8 {
 }
 fn baz(_: u8) void {}
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@intFromFloat cannot fit - positive out of range.zig
+++ b/test/cases/safety/@intFromFloat cannot fit - positive out of range.zig
@@ -16,5 +16,5 @@ fn bar(a: f32) u8 {
 }
 fn baz(_: u8) void {}
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@ptrFromInt address zero to non-optional byte-aligned pointer.zig
+++ b/test/cases/safety/@ptrFromInt address zero to non-optional byte-aligned pointer.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@ptrFromInt address zero to non-optional pointer.zig
+++ b/test/cases/safety/@ptrFromInt address zero to non-optional pointer.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@ptrFromInt with misaligned address.zig
+++ b/test/cases/safety/@ptrFromInt with misaligned address.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@tagName on corrupted enum value.zig
+++ b/test/cases/safety/@tagName on corrupted enum value.zig
@@ -22,5 +22,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/@tagName on corrupted union value.zig
+++ b/test/cases/safety/@tagName on corrupted union value.zig
@@ -23,5 +23,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/array slice sentinel mismatch vector.zig
+++ b/test/cases/safety/array slice sentinel mismatch vector.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/array slice sentinel mismatch.zig
+++ b/test/cases/safety/array slice sentinel mismatch.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/bad union field access.zig
+++ b/test/cases/safety/bad union field access.zig
@@ -23,5 +23,5 @@ fn bar(f: *Foo) void {
     f.float = 12.34;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/calling panic.zig
+++ b/test/cases/safety/calling panic.zig
@@ -12,5 +12,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/cast []u8 to bigger slice of wrong size.zig
+++ b/test/cases/safety/cast []u8 to bigger slice of wrong size.zig
@@ -17,5 +17,5 @@ fn widenSlice(slice: []align(1) const u8) []align(1) const i32 {
     return std.mem.bytesAsSlice(i32, slice);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/cast integer to global error and no code matches.zig
+++ b/test/cases/safety/cast integer to global error and no code matches.zig
@@ -15,5 +15,5 @@ fn bar(x: u16) anyerror {
     return @errorFromInt(x);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/empty slice with sentinel out of bounds.zig
+++ b/test/cases/safety/empty slice with sentinel out of bounds.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/exact division failure - vectors.zig
+++ b/test/cases/safety/exact division failure - vectors.zig
@@ -19,5 +19,5 @@ fn divExact(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
     return @divExact(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/exact division failure.zig
+++ b/test/cases/safety/exact division failure.zig
@@ -17,5 +17,5 @@ fn divExact(a: i32, b: i32) i32 {
     return @divExact(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/for_len_mismatch.zig
+++ b/test/cases/safety/for_len_mismatch.zig
@@ -21,5 +21,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/for_len_mismatch_three.zig
+++ b/test/cases/safety/for_len_mismatch_three.zig
@@ -20,5 +20,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/ignored expression integer overflow.zig
+++ b/test/cases/safety/ignored expression integer overflow.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/integer addition overflow.zig
+++ b/test/cases/safety/integer addition overflow.zig
@@ -19,5 +19,5 @@ fn add(a: u16, b: u16) u16 {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/integer division by zero - vectors.zig
+++ b/test/cases/safety/integer division by zero - vectors.zig
@@ -18,5 +18,5 @@ fn div0(a: @Vector(4, i32), b: @Vector(4, i32)) @Vector(4, i32) {
     return @divTrunc(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/integer division by zero.zig
+++ b/test/cases/safety/integer division by zero.zig
@@ -16,5 +16,5 @@ fn div0(a: i32, b: i32) i32 {
     return @divTrunc(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/integer multiplication overflow.zig
+++ b/test/cases/safety/integer multiplication overflow.zig
@@ -17,5 +17,5 @@ fn mul(a: u16, b: u16) u16 {
     return a * b;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/integer negation overflow.zig
+++ b/test/cases/safety/integer negation overflow.zig
@@ -17,5 +17,5 @@ fn neg(a: i16) i16 {
     return -a;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/integer subtraction overflow.zig
+++ b/test/cases/safety/integer subtraction overflow.zig
@@ -17,5 +17,5 @@ fn sub(a: u16, b: u16) u16 {
     return a - b;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/memcpy_alias.zig
+++ b/test/cases/safety/memcpy_alias.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     @memcpy(buffer[0..len], buffer[4 .. 4 + len]);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/memcpy_len_mismatch.zig
+++ b/test/cases/safety/memcpy_len_mismatch.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     @memcpy(buffer[0..len], buffer[len .. len + 4]);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/memset_array_undefined_bytes.zig
+++ b/test/cases/safety/memset_array_undefined_bytes.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     x += buffer[2];
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/memset_array_undefined_large.zig
+++ b/test/cases/safety/memset_array_undefined_large.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     x += buffer[2];
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/memset_slice_undefined_bytes.zig
+++ b/test/cases/safety/memset_slice_undefined_bytes.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
     x += buffer[2];
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/memset_slice_undefined_large.zig
+++ b/test/cases/safety/memset_slice_undefined_large.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
     x += buffer[2];
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/modrem by zero.zig
+++ b/test/cases/safety/modrem by zero.zig
@@ -16,5 +16,5 @@ fn div0(a: u32, b: u32) u32 {
     return a / b;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/modulus by zero.zig
+++ b/test/cases/safety/modulus by zero.zig
@@ -16,5 +16,5 @@ fn mod0(a: i32, b: i32) i32 {
     return @mod(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/noreturn returned.zig
+++ b/test/cases/safety/noreturn returned.zig
@@ -19,5 +19,5 @@ pub fn main() void {
     bar();
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/optional unwrap operator on C pointer.zig
+++ b/test/cases/safety/optional unwrap operator on C pointer.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/optional unwrap operator on null pointer.zig
+++ b/test/cases/safety/optional unwrap operator on null pointer.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/out of bounds array slice by length.zig
+++ b/test/cases/safety/out of bounds array slice by length.zig
@@ -16,5 +16,5 @@ fn foo(a: u32) u32 {
     return a;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/out of bounds slice access.zig
+++ b/test/cases/safety/out of bounds slice access.zig
@@ -17,5 +17,5 @@ fn bar(a: []const i32) i32 {
 }
 fn baz(_: i32) void {}
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/pointer casting null to non-optional pointer.zig
+++ b/test/cases/safety/pointer casting null to non-optional pointer.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/pointer casting to null function pointer.zig
+++ b/test/cases/safety/pointer casting to null function pointer.zig
@@ -19,5 +19,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/pointer slice sentinel mismatch.zig
+++ b/test/cases/safety/pointer slice sentinel mismatch.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/remainder division by zero.zig
+++ b/test/cases/safety/remainder division by zero.zig
@@ -16,5 +16,5 @@ fn rem0(a: i32, b: i32) i32 {
     return @rem(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/shift left by huge amount.zig
+++ b/test/cases/safety/shift left by huge amount.zig
@@ -18,5 +18,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/shift right by huge amount.zig
+++ b/test/cases/safety/shift right by huge amount.zig
@@ -18,5 +18,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed integer division overflow - vectors.zig
+++ b/test/cases/safety/signed integer division overflow - vectors.zig
@@ -19,5 +19,5 @@ fn div(a: @Vector(4, i16), b: @Vector(4, i16)) @Vector(4, i16) {
     return @divTrunc(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed integer division overflow.zig
+++ b/test/cases/safety/signed integer division overflow.zig
@@ -17,5 +17,5 @@ fn div(a: i16, b: i16) i16 {
     return @divTrunc(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed integer not fitting in cast to unsigned integer - widening.zig
+++ b/test/cases/safety/signed integer not fitting in cast to unsigned integer - widening.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed integer not fitting in cast to unsigned integer.zig
+++ b/test/cases/safety/signed integer not fitting in cast to unsigned integer.zig
@@ -16,5 +16,5 @@ fn unsigned_cast(x: i32) u32 {
     return @intCast(x);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed shift left overflow.zig
+++ b/test/cases/safety/signed shift left overflow.zig
@@ -17,5 +17,5 @@ fn shl(a: i16, b: u4) i16 {
     return @shlExact(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed shift right overflow.zig
+++ b/test/cases/safety/signed shift right overflow.zig
@@ -17,5 +17,5 @@ fn shr(a: i16, b: u4) i16 {
     return @shrExact(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/signed-unsigned vector cast.zig
+++ b/test/cases/safety/signed-unsigned vector cast.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice by length sentinel mismatch on lhs.zig
+++ b/test/cases/safety/slice by length sentinel mismatch on lhs.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice by length sentinel mismatch on rhs.zig
+++ b/test/cases/safety/slice by length sentinel mismatch on rhs.zig
@@ -14,5 +14,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice sentinel mismatch - floats.zig
+++ b/test/cases/safety/slice sentinel mismatch - floats.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice sentinel mismatch - optional pointers.zig
+++ b/test/cases/safety/slice sentinel mismatch - optional pointers.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice slice sentinel mismatch.zig
+++ b/test/cases/safety/slice slice sentinel mismatch.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice start index greater than end index.zig
+++ b/test/cases/safety/slice start index greater than end index.zig
@@ -20,5 +20,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice with sentinel out of bounds - runtime len.zig
+++ b/test/cases/safety/slice with sentinel out of bounds - runtime len.zig
@@ -19,5 +19,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slice with sentinel out of bounds.zig
+++ b/test/cases/safety/slice with sentinel out of bounds.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slicing null C pointer - runtime len.zig
+++ b/test/cases/safety/slicing null C pointer - runtime len.zig
@@ -17,5 +17,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/slicing null C pointer.zig
+++ b/test/cases/safety/slicing null C pointer.zig
@@ -16,5 +16,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/switch else on corrupt enum value - one prong.zig
+++ b/test/cases/safety/switch else on corrupt enum value - one prong.zig
@@ -20,5 +20,5 @@ pub fn main() !void {
     }
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/switch else on corrupt enum value - union.zig
+++ b/test/cases/safety/switch else on corrupt enum value - union.zig
@@ -25,5 +25,5 @@ pub fn main() !void {
     }
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/switch else on corrupt enum value.zig
+++ b/test/cases/safety/switch else on corrupt enum value.zig
@@ -19,5 +19,5 @@ pub fn main() !void {
     }
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/switch on corrupted enum value.zig
+++ b/test/cases/safety/switch on corrupted enum value.zig
@@ -23,5 +23,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/switch on corrupted union value.zig
+++ b/test/cases/safety/switch on corrupted union value.zig
@@ -23,5 +23,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/unreachable.zig
+++ b/test/cases/safety/unreachable.zig
@@ -11,5 +11,5 @@ pub fn main() !void {
     unreachable;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/unsigned integer not fitting in cast to signed integer - same bit count.zig
+++ b/test/cases/safety/unsigned integer not fitting in cast to signed integer - same bit count.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     return error.TestFailed;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/unsigned shift left overflow.zig
+++ b/test/cases/safety/unsigned shift left overflow.zig
@@ -17,5 +17,5 @@ fn shl(a: u16, b: u4) u16 {
     return @shlExact(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/unsigned shift right overflow.zig
+++ b/test/cases/safety/unsigned shift right overflow.zig
@@ -17,5 +17,5 @@ fn shr(a: u16, b: u4) u16 {
     return @shrExact(a, b);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/unwrap error switch.zig
+++ b/test/cases/safety/unwrap error switch.zig
@@ -17,5 +17,5 @@ fn bar() !void {
     return error.Whatever;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/unwrap error.zig
+++ b/test/cases/safety/unwrap error.zig
@@ -15,5 +15,5 @@ fn bar() !void {
     return error.Whatever;
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/value does not fit in shortening cast - u0.zig
+++ b/test/cases/safety/value does not fit in shortening cast - u0.zig
@@ -17,5 +17,5 @@ fn shorten_cast(x: u8) u0 {
     return @intCast(x);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/value does not fit in shortening cast.zig
+++ b/test/cases/safety/value does not fit in shortening cast.zig
@@ -17,5 +17,5 @@ fn shorten_cast(x: i32) i8 {
     return @intCast(x);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/safety/zero casted to error.zig
+++ b/test/cases/safety/zero casted to error.zig
@@ -15,5 +15,5 @@ fn bar(x: u16) anyerror {
     return @errorFromInt(x);
 }
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/taking_pointer_of_global_tagged_union.zig
+++ b/test/cases/taking_pointer_of_global_tagged_union.zig
@@ -22,5 +22,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 // target=native

--- a/test/cases/union_unresolved_layout.zig
+++ b/test/cases/union_unresolved_layout.zig
@@ -11,5 +11,5 @@ pub fn main() !void {
 }
 
 // run
-// backend=llvm
+// backend=stage2,llvm
 //

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -472,6 +472,10 @@ fn addFromDirInner(
                     // Rosetta has issues with ZLD
                     continue;
                 }
+                if (backend == .stage2 and target.ofmt == .coff) {
+                    // COFF linker has bitrotted
+                    continue;
+                }
 
                 const next = ctx.cases.items.len;
                 try ctx.cases.append(.{


### PR DESCRIPTION
This is all of the expected 0.14.0 progress on #21530, which can now be postponed once this commit is merged.

This required rewriting the (un)wrap operations since the original implementations were extremely buggy.

Also adds an easy way to retrigger Sema OPV bugs so that I don't have to keep updating #22419 all the time.