### PR TITLE
glibc: don't redirect fts to fts64 before glibc 2.23

### DIFF
--- a/lib/libc/include/generic-glibc/fts.h
+++ b/lib/libc/include/generic-glibc/fts.h
@@ -147,6 +147,8 @@ typedef struct _ftsent {
 } FTSENT;
 
 #ifdef __USE_LARGEFILE64
+// zig patch: 64bits variants appeared starting from glibc 2.23
+# if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 23) || __GLIBC__ > 2
 typedef struct _ftsent64 {
 	struct _ftsent64 *fts_cycle;	/* cycle node */
 	struct _ftsent64 *fts_parent;	/* parent directory */
@@ -175,9 +177,15 @@ typedef struct _ftsent64 {
 	struct stat64 *fts_statp;	/* stat(2) information */
 	char fts_name[1];		/* file name */
 } FTSENT64;
+# endif
 #endif
 
 __BEGIN_DECLS
+
+// zig patch: 64bits variants appeared starting from glibc 2.23
+// before that version, we can't declare nor redirect to them
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 23) || __GLIBC__ > 2
+
 #ifndef __USE_FILE_OFFSET64
 FTSENT	*fts_children (FTS *, int);
 int	 fts_close (FTS *);
@@ -216,6 +224,19 @@ int	 __REDIRECT_NTH (fts_set, (FTS *, FTSENT *, int),
 #  endif
 # endif
 #endif
+#else /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 23) || __GLIBC__ > 2 */
+FTSENT	*fts_children (FTS *, int);
+int	 fts_close (FTS *);
+FTS	*fts_open (char * const *, int,
+		   int (*)(const FTSENT **, const FTSENT **));
+FTSENT	*fts_read (FTS *);
+int	 fts_set (FTS *, FTSENT *, int) __THROW;
+#endif
+
+// zig patch: 64bits time variants appeared starting from glibc 2.34
+// before that version, there is nothing to declare
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 34) || __GLIBC__ > 2
+
 #ifdef __USE_LARGEFILE64
 # ifndef __USE_TIME64_REDIRECTS
 FTSENT64 *fts64_children (FTS64 *, int);
@@ -243,6 +264,8 @@ int	 __REDIRECT_NTH (fts64_set, (FTS64 *, FTSENT64 *, int),
 #  endif
 # endif
 #endif
+
+#endif /* (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 34) || __GLIBC__ > 2 */
 __END_DECLS
 
 #endif /* fts.h */


### PR DESCRIPTION
This PR prevents the 64bits variants of the `fts_*` API from being declared before glibc 2.23.
It also prevents the 64bits time variants from being declared when targeting glibc versions <2.34