### PR TITLE
remove unneeded native_os check

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -923,7 +923,6 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) Get
         const port_c = try std.fmt.allocPrintZ(allocator, "{}", .{port});
         defer allocator.free(port_c);
 
-        const sys = if (native_os == .windows) windows.ws2_32 else posix.system;
         const hints: posix.addrinfo = .{
             .flags = .{ .NUMERICSERV = true },
             .family = posix.AF.UNSPEC,
@@ -935,8 +934,8 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) Get
             .next = null,
         };
         var res: ?*posix.addrinfo = null;
-        switch (sys.getaddrinfo(name_c.ptr, port_c.ptr, &hints, &res)) {
-            @as(sys.EAI, @enumFromInt(0)) => {},
+        switch (posix.system.getaddrinfo(name_c.ptr, port_c.ptr, &hints, &res)) {
+            @as(posix.system.EAI, @enumFromInt(0)) => {},
             .ADDRFAMILY => return error.HostLacksNetworkAddresses,
             .AGAIN => return error.TemporaryNameServerFailure,
             .BADFLAGS => unreachable, // Invalid hints
@@ -952,7 +951,7 @@ pub fn getAddressList(allocator: mem.Allocator, name: []const u8, port: u16) Get
             },
             else => unreachable,
         }
-        defer if (res) |some| sys.freeaddrinfo(some);
+        defer if (res) |some| posix.system.freeaddrinfo(some);
 
         const addr_count = blk: {
             var count: usize = 0;


### PR DESCRIPTION
The check is not needed, since we are already checking for the os at line 847 and returning at 916 when the check succeeds. Therefore, at 926, we know the os is not windows.

Closes #22882 