### PR TITLE
Implement `@deprecated`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4740,6 +4740,43 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       {#see_also|@cVaArg|@cVaCopy|@cVaEnd#}
       {#header_close#}
+	
+      {#header_open|@deprecated#}
+      <pre>{#syntax#}@deprecated(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <pre>{#syntax#}@deprecated() void{#endsyntax#}</pre>
+      <p>
+	  Used to mark a given code path as deprecated. It evaluates to the same value
+	  passed in as argument, or the {#syntax#}void{#endsyntax#} value when given none.
+      </p>
+      <p>
+      As an example, in Zig 0.14.0 {#syntax#}std.time.sleep{#endsyntax#} was
+	  deprecated and the sleep function was moved to {#syntax#}std.Thread.sleep{#endsyntax#}.
+	  This is how this deprecation could have been expressed:
+	   
+      {#syntax_block|zig|lib/std/time.zig#}
+pub const sleep = @deprecated(std.Thread.sleep); // moved
+      {#end_syntax_block#}
+	  </p>
+      <p>
+      By default it is a <b>compile error</b> to depend on deprecated code in
+	  a module defined by the root package, while it is not in modules defined
+	  by dependencies. This behavior can be overridden for the entire dependency
+	  tree by passing {#syntax#}-fallow-deprecated{#endsyntax#} or
+	  {#syntax#}-fno-allow-deprecated{#endsyntax#} to {#syntax#}zig build{#endsyntax#}.
+      </p>
+      <p>
+	  Usage of this builtin is meant to help <i>direct</i> consumers discover (and remove)
+	  their dependance on deprecated code during the grace period before a deprecated
+	  functionality is turned into a {#syntax#}@compileError{#endsyntax#} or
+	  removed entirely.   
+      </p>
+
+	  <p>
+      {#syntax#}@deprecated{#endsyntax#} can also be used without argument: 	
+      {#code|test_deprecated_builtin.zig#}
+	  </p>
+	
+      {#header_close#}
 
       {#header_open|@divExact#}
       <pre>{#syntax#}@divExact(numerator: T, denominator: T) T{#endsyntax#}</pre>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2288,7 +2288,7 @@ or
       {#code|test_aligned_struct_fields.zig#}
 
       <p>
-      Equating packed structs results in a comparison of the backing integer, 
+      Equating packed structs results in a comparison of the backing integer,
       and only works for the `==` and `!=` operators.
       </p>
       {#code|test_packed_struct_equality.zig#}
@@ -4086,7 +4086,7 @@ fn performFn(start_value: i32) i32 {
       special-case syntax.
       </p>
       <p>
-			Here is an example of a generic {#syntax#}List{#endsyntax#} data structure.
+      Here is an example of a generic {#syntax#}List{#endsyntax#} data structure.
       </p>
       {#code|generic_data_structure.zig#}
 
@@ -4291,10 +4291,10 @@ pub fn print(self: *Writer, arg0: []const u8, arg1: i32) !void {
       <pre>{#syntax#}@addrSpaceCast(ptr: anytype) anytype{#endsyntax#}</pre>
       <p>
       Converts a pointer from one address space to another. The new address space is inferred
-			based on the result type. Depending on the current target and address spaces, this cast
-			may be a no-op, a complex operation, or illegal. If the cast is legal, then the resulting
-			pointer points to the same memory location as the pointer operand. It is always valid to
-			cast a pointer between the same address spaces.
+      based on the result type. Depending on the current target and address spaces, this cast
+      may be a no-op, a complex operation, or illegal. If the cast is legal, then the resulting
+      pointer points to the same memory location as the pointer operand. It is always valid to
+      cast a pointer between the same address spaces.
       </p>
       {#header_close#}
       {#header_open|@addWithOverflow#}
@@ -4307,7 +4307,7 @@ pub fn print(self: *Writer, arg0: []const u8, arg1: i32) !void {
       <pre>{#syntax#}@alignCast(ptr: anytype) anytype{#endsyntax#}</pre>
       <p>
       {#syntax#}ptr{#endsyntax#} can be {#syntax#}*T{#endsyntax#}, {#syntax#}?*T{#endsyntax#}, or {#syntax#}[]T{#endsyntax#}.
-			Changes the alignment of a pointer. The alignment to use is inferred based on the result type.
+      Changes the alignment of a pointer. The alignment to use is inferred based on the result type.
       </p>
       <p>A {#link|pointer alignment safety check|Incorrect Pointer Alignment#} is added
       to the generated code to make sure the pointer is aligned as promised.</p>
@@ -4384,7 +4384,7 @@ comptime {
       <pre>{#syntax#}@bitCast(value: anytype) anytype{#endsyntax#}</pre>
       <p>
       Converts a value of one type to another type. The return type is the
-			inferred result type.
+      inferred result type.
       </p>
       <p>
       Asserts that {#syntax#}@sizeOf(@TypeOf(value)) == @sizeOf(DestType){#endsyntax#}.
@@ -4740,41 +4740,41 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       {#see_also|@cVaArg|@cVaCopy|@cVaEnd#}
       {#header_close#}
-	
+
       {#header_open|@deprecated#}
       <pre>{#syntax#}@deprecated(value: anytype) @TypeOf(value){#endsyntax#}</pre>
       <pre>{#syntax#}@deprecated() void{#endsyntax#}</pre>
       <p>
-	  Used to mark a given code path as deprecated. It evaluates to the same value
-	  passed in as argument, or the void value when given none.
+      Used to mark a given code path as deprecated. It evaluates to the same value
+      passed in as argument, or the void value when given none.
       </p>
       <p>
       As an example, a library that wishes to move or rename a declaration, while
-	  deprecating usage of the old name can use {#syntax#}@deprecated{#endsyntax#} like so:
-	  </p>
+      deprecating usage of the old name can use {#syntax#}@deprecated{#endsyntax#} like so:
+      </p>
       {#syntax_block|zig|root.zig#}
 pub const fooToBar = @deprecated(bar.fromFoo); // moved
       {#end_syntax_block#}
 
       <p>
       By default it is a <b>compile error</b> to reference deprecated code in
-	  a module defined by the root package, while it is not in modules defined
-	  by dependencies. This behavior can be overridden for the entire dependency
-	  tree by passing {#syntax#}-fallow-deprecated{#endsyntax#} or
-	  {#syntax#}-fno-allow-deprecated{#endsyntax#} to {#syntax#}zig build{#endsyntax#}.
+      a module defined by the root package, while it is not in modules defined
+      by dependencies. This behavior can be overridden for the entire dependency
+      tree by passing {#syntax#}-fallow-deprecated{#endsyntax#} or
+      {#syntax#}-fno-allow-deprecated{#endsyntax#} to {#syntax#}zig build{#endsyntax#}.
       </p>
       <p>
-	  Usage of this builtin is meant to help <i>direct</i> consumers discover (and remove)
-	  their dependance on deprecated code during the grace period before a deprecated
-	  functionality is turned into a {#syntax#}@compileError{#endsyntax#} or
-	  removed entirely.   
+      Usage of this builtin is meant to help <i>direct</i> consumers discover (and remove)
+      their dependance on deprecated code during the grace period before a deprecated
+      functionality is turned into a {#syntax#}@compileError{#endsyntax#} or
+      removed entirely.
       </p>
 
-	  <p>
+      <p>
       Using {#syntax#}@deprecated{#endsyntax#} without an argument can be useful inside of blocks:
-	  </p>
+      </p>
       {#code|test_deprecated_builtin.zig#}
-	
+
       {#header_close#}
 
       {#header_open|@divExact#}
@@ -4891,8 +4891,8 @@ pub const fooToBar = @deprecated(bar.fromFoo); // moved
       <pre>{#syntax#}@errorCast(value: anytype) anytype{#endsyntax#}</pre>
       <p>
       Converts an error set or error union value from one error set to another error set. The return type is the
-			inferred result type. Attempting to convert an error which is not in the destination error
-			set results in safety-checked {#link|Illegal Behavior#}.
+      inferred result type. Attempting to convert an error which is not in the destination error
+      set results in safety-checked {#link|Illegal Behavior#}.
       </p>
       {#header_close#}
 
@@ -4971,7 +4971,7 @@ pub const fooToBar = @deprecated(bar.fromFoo); // moved
       <pre>{#syntax#}@floatFromInt(int: anytype) anytype{#endsyntax#}</pre>
       <p>
       Converts an integer to the closest floating point representation. The return type is the inferred result type.
-			To convert the other way, use {#link|@intFromFloat#}. This operation is legal
+      To convert the other way, use {#link|@intFromFloat#}. This operation is legal
       for all values of all integer types.
       </p>
       {#header_close#}
@@ -5063,7 +5063,7 @@ pub const fooToBar = @deprecated(bar.fromFoo); // moved
       <pre>{#syntax#}@intCast(int: anytype) anytype{#endsyntax#}</pre>
       <p>
       Converts an integer to another integer while keeping the same numerical value.
-			The return type is the inferred result type.
+      The return type is the inferred result type.
       Attempting to convert a number which is out of range of the destination type results in
       safety-checked {#link|Illegal Behavior#}.
       </p>
@@ -5316,7 +5316,7 @@ pub const fooToBar = @deprecated(bar.fromFoo); // moved
       <pre>{#syntax#}@ptrFromInt(address: usize) anytype{#endsyntax#}</pre>
       <p>
       Converts an integer to a {#link|pointer|Pointers#}. The return type is the inferred result type.
-			To convert the other way, use {#link|@intFromPtr#}. Casting an address of 0 to a destination type
+      To convert the other way, use {#link|@intFromPtr#}. Casting an address of 0 to a destination type
       which in not {#link|optional|Optional Pointers#} and does not have the {#syntax#}allowzero{#endsyntax#} attribute will result in a
       {#link|Pointer Cast Invalid Null#} panic when runtime safety checks are enabled.
       </p>

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4746,19 +4746,18 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       <pre>{#syntax#}@deprecated() void{#endsyntax#}</pre>
       <p>
 	  Used to mark a given code path as deprecated. It evaluates to the same value
-	  passed in as argument, or the {#syntax#}void{#endsyntax#} value when given none.
+	  passed in as argument, or the void value when given none.
       </p>
       <p>
-      As an example, in Zig 0.14.0 {#syntax#}std.time.sleep{#endsyntax#} was
-	  deprecated and the sleep function was moved to {#syntax#}std.Thread.sleep{#endsyntax#}.
-	  This is how this deprecation could have been expressed:
-	   
-      {#syntax_block|zig|lib/std/time.zig#}
-pub const sleep = @deprecated(std.Thread.sleep); // moved
-      {#end_syntax_block#}
+      As an example, a library that wishes to move or rename a declaration, while
+	  deprecating usage of the old name can use {#syntax#}@deprecated{#endsyntax#} like so:
 	  </p>
+      {#syntax_block|zig|root.zig#}
+pub const fooToBar = @deprecated(bar.fromFoo); // moved
+      {#end_syntax_block#}
+
       <p>
-      By default it is a <b>compile error</b> to depend on deprecated code in
+      By default it is a <b>compile error</b> to reference deprecated code in
 	  a module defined by the root package, while it is not in modules defined
 	  by dependencies. This behavior can be overridden for the entire dependency
 	  tree by passing {#syntax#}-fallow-deprecated{#endsyntax#} or
@@ -4772,9 +4771,9 @@ pub const sleep = @deprecated(std.Thread.sleep); // moved
       </p>
 
 	  <p>
-      {#syntax#}@deprecated{#endsyntax#} can also be used without argument: 	
-      {#code|test_deprecated_builtin.zig#}
+      Using {#syntax#}@deprecated{#endsyntax#} without an argument can be useful inside of blocks:
 	  </p>
+      {#code|test_deprecated_builtin.zig#}
 	
       {#header_close#}
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4745,36 +4745,36 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       <pre>{#syntax#}@deprecated(value: anytype) @TypeOf(value){#endsyntax#}</pre>
       <pre>{#syntax#}@deprecated() void{#endsyntax#}</pre>
       <p>
-      Used to mark a given code path as deprecated. It evaluates to the same value
-      passed in as argument, or the void value when given none.
+      Marks a given code path as scheduled for removal. Evaluates to the same
+      value passed in as argument, or the {#syntax#}void{#endsyntax#} value
+      when given none.
       </p>
       <p>
-      As an example, a library that wishes to move or rename a declaration, while
-      deprecating usage of the old name can use {#syntax#}@deprecated{#endsyntax#} like so:
+      When a public declaration has been moved to a new location, the old
+      location can be marked {#syntax#}@deprecated{#endsyntax#}:
       </p>
       {#syntax_block|zig|root.zig#}
 pub const fooToBar = @deprecated(bar.fromFoo); // moved
       {#end_syntax_block#}
-
       <p>
-      By default it is a <b>compile error</b> to reference deprecated code in
-      a module defined by the root package, while it is not in modules defined
-      by dependencies. This behavior can be overridden for the entire dependency
-      tree by passing {#syntax#}-fallow-deprecated{#endsyntax#} or
-      {#syntax#}-fno-allow-deprecated{#endsyntax#} to {#syntax#}zig build{#endsyntax#}.
+      By default deprecated code paths are disallowed in a module defined by
+      the root package but allowed in modules defined by the rest of the
+      dependency tree. This behavior can be overridden by passing
+      <code>-fallow-deprecated</code> or <code>-fno-allow-deprecated</code> to
+      <code>zig build</code>.
       </p>
       <p>
-      Usage of this builtin is meant to help <i>direct</i> consumers discover (and remove)
-      their dependance on deprecated code during the grace period before a deprecated
-      functionality is turned into a {#syntax#}@compileError{#endsyntax#} or
-      removed entirely.
+      The purpose of {#syntax#}@deprecated{#endsyntax#} is to provide at least
+      one version (a "grace period") of a package that supports both old and new APIs
+      simultaneously, while providing tooling for programmers to discover what needs
+      to be upgraded to migrate to the new API. Such a grace period has the key property
+      that it allows a project's dependency tree to be upgraded <em>one package at a time</em>.
       </p>
-
       <p>
-      Using {#syntax#}@deprecated{#endsyntax#} without an argument can be useful inside of blocks:
+      Using {#syntax#}@deprecated{#endsyntax#} without an argument can be
+      useful inside of conditionally compiled blocks:
       </p>
       {#code|test_deprecated_builtin.zig#}
-
       {#header_close#}
 
       {#header_open|@divExact#}

--- a/doc/langref/test_deprecated_builtin.zig
+++ b/doc/langref/test_deprecated_builtin.zig
@@ -1,0 +1,22 @@
+test "deprecated code path" {
+    compute(.greedy, false, 42);
+}
+
+const Strategy = enum { greedy, expensive, fast };
+fn compute(comptime strat: Strategy, comptime foo: bool, bar: usize) void {
+    switch (strat) {
+        .greedy => {
+            // This combination turned out to be ineffective.
+            if (!foo) @deprecated(); // use fast strategy when foo is false
+            runGreedy(foo, bar);
+        },
+        .expensive => runExpensive(foo, bar),
+        .fast => runFast(foo, bar),
+    }
+}
+
+extern fn runGreedy(foo: bool, bar: usize) void;
+extern fn runExpensive(foo: bool, bar: usize) void;
+extern fn runFast(foo: bool, bar: usize) void;
+
+// test_error=deprecated

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -260,6 +260,10 @@ pub fn main() !void {
                 graph.incremental = true;
             } else if (mem.eql(u8, arg, "-fno-incremental")) {
                 graph.incremental = false;
+            } else if (mem.eql(u8, arg, "-fallow-deprecated")) {
+                graph.allow_deprecated = true;
+            } else if (mem.eql(u8, arg, "-fno-allow-deprecated")) {
+                graph.allow_deprecated = false;
             } else if (mem.eql(u8, arg, "-fwine")) {
                 builder.enable_wine = true;
             } else if (mem.eql(u8, arg, "-fno-wine")) {
@@ -1283,6 +1287,8 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\    new                        Omit cached steps
         \\    failures                   (Default) Only print failed steps
         \\    none                       Do not print the build summary
+        \\  -fallow-deprecated           Allow usage of deprecated code for the entire build graph
+        \\  -fno-allow-deprecated        Disallow usage of deprecated code for the entire build graph
         \\  -j<N>                        Limit concurrent jobs (default is to use all CPU cores)
         \\  --maxrss <bytes>             Limit memory usage (default is to use available memory)
         \\  --skip-oom-steps             Instead of failing, skip steps that would exceed --maxrss

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -80,6 +80,7 @@ pub fn main() !void {
             .query = .{},
             .result = try std.zig.system.resolveTargetQuery(.{}),
         },
+        .root_builder = undefined, // populated below
     };
 
     graph.cache.addPrefix(.{ .path = null, .handle = std.fs.cwd() });
@@ -94,6 +95,7 @@ pub fn main() !void {
         local_cache_directory,
         dependencies.root_deps,
     );
+    graph.root_builder = builder;
 
     var targets = ArrayList([]const u8).init(arena);
     var debug_log_scopes = ArrayList([]const u8).init(arena);

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -94,6 +94,9 @@ available_deps: AvailableDeps,
 
 release_mode: ReleaseMode,
 
+// True only for the top-level builder.
+is_root: bool = false,
+
 pub const ReleaseMode = enum {
     off,
     any,
@@ -118,6 +121,7 @@ pub const Graph = struct {
     /// Information about the native target. Computed before build() is invoked.
     host: ResolvedTarget,
     incremental: ?bool = null,
+    allow_deprecated: ?bool = null,
     random_seed: u32 = 0,
     dependency_cache: InitializedDepMap = .empty,
     allow_so_scripts: ?bool = null,
@@ -304,6 +308,7 @@ pub fn create(
         .pkg_hash = "",
         .available_deps = available_deps,
         .release_mode = .off,
+        .is_root = true,
     };
     try b.top_level_steps.put(arena, b.install_tls.step.name, &b.install_tls);
     try b.top_level_steps.put(arena, b.uninstall_tls.step.name, &b.uninstall_tls);

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -94,9 +94,6 @@ available_deps: AvailableDeps,
 
 release_mode: ReleaseMode,
 
-/// `true` only for the root `Build`; `false` for any `Build` belonging to a dependency.
-is_root: bool = false,
-
 pub const ReleaseMode = enum {
     off,
     any,
@@ -121,10 +118,11 @@ pub const Graph = struct {
     /// Information about the native target. Computed before build() is invoked.
     host: ResolvedTarget,
     incremental: ?bool = null,
-    allow_deprecated: ?bool = null,
     random_seed: u32 = 0,
     dependency_cache: InitializedDepMap = .empty,
     allow_so_scripts: ?bool = null,
+    allow_deprecated: ?bool = null,
+    root_builder: *std.Build,
 };
 
 const AvailableDeps = []const struct { []const u8, []const u8 };
@@ -308,7 +306,6 @@ pub fn create(
         .pkg_hash = "",
         .available_deps = available_deps,
         .release_mode = .off,
-        .is_root = true,
     };
     try b.top_level_steps.put(arena, b.install_tls.step.name, &b.install_tls);
     try b.top_level_steps.put(arena, b.uninstall_tls.step.name, &b.uninstall_tls);

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -94,7 +94,7 @@ available_deps: AvailableDeps,
 
 release_mode: ReleaseMode,
 
-// True only for the top-level builder.
+/// `true` only for the root `Build`; `false` for any `Build` belonging to a dependency.
 is_root: bool = false,
 
 pub const ReleaseMode = enum {

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -25,7 +25,6 @@ stack_check: ?bool,
 sanitize_c: ?bool,
 sanitize_thread: ?bool,
 fuzz: ?bool,
-allow_deprecated: ?bool,
 code_model: std.builtin.CodeModel,
 valgrind: ?bool,
 pic: ?bool,
@@ -285,7 +284,6 @@ pub fn init(
                 .owner = owner,
                 .root_source_file = if (options.root_source_file) |lp| lp.dupe(owner) else null,
                 .import_table = .{},
-                .allow_deprecated = owner.graph.allow_deprecated orelse !owner.is_root,
                 .resolved_target = options.target,
                 .optimize = options.optimize,
                 .link_libc = options.link_libc,
@@ -560,7 +558,8 @@ pub fn appendZigProcessFlags(
     try addFlag(zig_args, m.red_zone, "-mred-zone", "-mno-red-zone");
 
     if (m.root_source_file != null) {
-        try addFlag(zig_args, m.allow_deprecated, "-fallow-deprecated", "-fno-allow-deprecated");
+        const allow_deprecated = m.owner.graph.allow_deprecated orelse !m.owner.is_root;
+        try addFlag(zig_args, allow_deprecated, "-fallow-deprecated", "-fno-allow-deprecated");
     }
 
     if (m.dwarf_format) |dwarf_format| {

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -557,10 +557,9 @@ pub fn appendZigProcessFlags(
     try addFlag(zig_args, m.pic, "-fPIC", "-fno-PIC");
     try addFlag(zig_args, m.red_zone, "-mred-zone", "-mno-red-zone");
 
-    if (m.root_source_file != null) {
-        const allow_deprecated = m.owner.graph.allow_deprecated orelse !m.owner.is_root;
-        try addFlag(zig_args, allow_deprecated, "-fallow-deprecated", "-fno-allow-deprecated");
-    }
+    // -fno-allow-deprecated is the CLI default, and not inherited, so only pass the flag if true.
+    const allow_deprecated = m.owner.graph.allow_deprecated orelse (m.owner.graph.root_builder != m.owner);
+    if (allow_deprecated == true) try zig_args.append("-fallow-deprecated");
 
     if (m.dwarf_format) |dwarf_format| {
         try zig_args.append(switch (dwarf_format) {

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -25,6 +25,7 @@ stack_check: ?bool,
 sanitize_c: ?bool,
 sanitize_thread: ?bool,
 fuzz: ?bool,
+allow_deprecated: ?bool,
 code_model: std.builtin.CodeModel,
 valgrind: ?bool,
 pic: ?bool,
@@ -284,6 +285,7 @@ pub fn init(
                 .owner = owner,
                 .root_source_file = if (options.root_source_file) |lp| lp.dupe(owner) else null,
                 .import_table = .{},
+                .allow_deprecated = owner.graph.allow_deprecated orelse !owner.is_root,
                 .resolved_target = options.target,
                 .optimize = options.optimize,
                 .link_libc = options.link_libc,
@@ -556,6 +558,10 @@ pub fn appendZigProcessFlags(
     try addFlag(zig_args, m.valgrind, "-fvalgrind", "-fno-valgrind");
     try addFlag(zig_args, m.pic, "-fPIC", "-fno-PIC");
     try addFlag(zig_args, m.red_zone, "-mred-zone", "-mno-red-zone");
+
+    if (m.root_source_file != null) {
+        try addFlag(zig_args, m.allow_deprecated, "-fallow-deprecated", "-fno-allow-deprecated");
+    }
 
     if (m.dwarf_format) |dwarf_format| {
         try zig_args.append(switch (dwarf_format) {

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -514,6 +514,7 @@ test Options {
             .result = try std.zig.system.resolveTargetQuery(.{}),
         },
         .zig_lib_directory = std.Build.Cache.Directory.cwd(),
+        .root_builder = undefined,
     };
 
     var builder = try std.Build.create(
@@ -522,6 +523,8 @@ test Options {
         .{ .path = "test", .handle = std.fs.cwd() },
         &.{},
     );
+
+    graph.root_builder = builder;
 
     const options = builder.addOptions();
 

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -9695,6 +9695,19 @@ fn builtinCall(
         .volatile_cast,
         => return ptrCast(gz, scope, ri, node),
 
+        .deprecated => {
+            _ = try gz.addExtendedNodeSmall(.deprecated, node, 0);
+            switch (params.len) {
+                0 => return .void_value,
+                1 => return expr(gz, scope, ri, params[0]),
+                else => return astgen.failNode(
+                    node,
+                    "expected 0 or 1 argument, found {}",
+                    .{params.len},
+                ),
+            }
+        },
+
         // zig fmt: off
         .has_decl  => return hasDeclOrField(gz, scope, ri, node, params[0], params[1], .has_decl),
         .has_field => return hasDeclOrField(gz, scope, ri, node, params[0], params[1], .has_field),

--- a/lib/std/zig/AstRlAnnotate.zig
+++ b/lib/std/zig/AstRlAnnotate.zig
@@ -817,8 +817,6 @@ fn blockExpr(astrl: *AstRlAnnotate, parent_block: ?*Block, ri: ResultInfo, node:
 }
 
 fn builtinCall(astrl: *AstRlAnnotate, block: ?*Block, ri: ResultInfo, node: Ast.Node.Index, args: []const Ast.Node.Index) !bool {
-    _ = ri; // Currently, no builtin consumes its result location.
-
     const tree = astrl.tree;
     const main_tokens = tree.nodes.items(.main_token);
     const builtin_token = main_tokens[node];
@@ -828,6 +826,11 @@ fn builtinCall(astrl: *AstRlAnnotate, block: ?*Block, ri: ResultInfo, node: Ast.
         if (expected != args.len) return false;
     }
     switch (info.tag) {
+        .deprecated => if (args.len >= 1) {
+            return astrl.expr(args[0], block, ri);
+        } else {
+            return false;
+        },
         .import => return false,
         .branch_hint => {
             _ = try astrl.expr(args[0], block, ResultInfo.type_only);

--- a/lib/std/zig/BuiltinFn.zig
+++ b/lib/std/zig/BuiltinFn.zig
@@ -121,6 +121,7 @@ pub const Tag = enum {
     work_item_id,
     work_group_size,
     work_group_id,
+    deprecated,
 };
 
 pub const EvalToError = enum {
@@ -1014,6 +1015,14 @@ pub const list = list: {
                 .tag = .work_group_id,
                 .param_count = 1,
                 .illegal_outside_function = true,
+            },
+        },
+        .{
+            "@deprecated",
+            .{
+                .tag = .deprecated,
+                .param_count = null,
+                .eval_to_error = .maybe,
             },
         },
     });

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -2112,6 +2112,9 @@ pub const Inst = struct {
         /// any code may have gone here, avoiding false-positive "unreachable code" errors.
         astgen_error,
 
+        /// `operand` is `src_node: i32`.
+        deprecated,
+
         pub const InstData = struct {
             opcode: Extended,
             small: u16,
@@ -4310,6 +4313,7 @@ fn findTrackableInner(
                 .value_placeholder => unreachable,
 
                 // Once again, we start with the boring tags.
+                .deprecated,
                 .this,
                 .ret_addr,
                 .builtin_src,

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -4313,7 +4313,6 @@ fn findTrackableInner(
                 .value_placeholder => unreachable,
 
                 // Once again, we start with the boring tags.
-                .deprecated,
                 .this,
                 .ret_addr,
                 .builtin_src,
@@ -4367,6 +4366,7 @@ fn findTrackableInner(
                 .tuple_decl,
                 .dbg_empty_stmt,
                 .astgen_error,
+                .deprecated,
                 => return,
 
                 // `@TypeOf` has a body.

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -869,6 +869,7 @@ pub const cache_helpers = struct {
         hh.add(mod.sanitize_c);
         hh.add(mod.sanitize_thread);
         hh.add(mod.fuzz);
+        hh.add(mod.allow_deprecated);
         hh.add(mod.unwind_tables);
         hh.add(mod.structured_cfg);
         hh.add(mod.no_builtin);

--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -238,7 +238,6 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
 
     const allow_deprecated = b: {
         if (options.inherited.allow_deprecated) |x| break :b x;
-        if (options.parent) |p| break :b p.allow_deprecated;
         break :b false;
     };
 

--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -27,6 +27,7 @@ red_zone: bool,
 sanitize_c: bool,
 sanitize_thread: bool,
 fuzz: bool,
+allow_deprecated: bool,
 unwind_tables: std.builtin.UnwindTables,
 cc_argv: []const []const u8,
 /// (SPIR-V) whether to generate a structured control flow graph or not
@@ -95,6 +96,7 @@ pub const CreateOptions = struct {
         sanitize_c: ?bool = null,
         sanitize_thread: ?bool = null,
         fuzz: ?bool = null,
+        allow_deprecated: ?bool = null,
         structured_cfg: ?bool = null,
         no_builtin: ?bool = null,
     };
@@ -231,6 +233,12 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
     const fuzz = b: {
         if (options.inherited.fuzz) |x| break :b x;
         if (options.parent) |p| break :b p.fuzz;
+        break :b false;
+    };
+
+    const allow_deprecated = b: {
+        if (options.inherited.allow_deprecated) |x| break :b x;
+        if (options.parent) |p| break :b p.allow_deprecated;
         break :b false;
     };
 
@@ -380,6 +388,7 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
         .sanitize_c = sanitize_c,
         .sanitize_thread = sanitize_thread,
         .fuzz = fuzz,
+        .allow_deprecated = allow_deprecated,
         .unwind_tables = unwind_tables,
         .cc_argv = options.cc_argv,
         .structured_cfg = structured_cfg,
@@ -474,6 +483,7 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
             .sanitize_c = sanitize_c,
             .sanitize_thread = sanitize_thread,
             .fuzz = fuzz,
+            .allow_deprecated = allow_deprecated,
             .unwind_tables = unwind_tables,
             .cc_argv = &.{},
             .structured_cfg = structured_cfg,
@@ -532,6 +542,7 @@ pub fn createLimited(gpa: Allocator, options: LimitedOptions) Allocator.Error!*P
         .sanitize_c = undefined,
         .sanitize_thread = undefined,
         .fuzz = undefined,
+        .allow_deprecated = undefined,
         .unwind_tables = undefined,
         .cc_argv = undefined,
         .structured_cfg = undefined,

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1342,15 +1342,6 @@ fn analyzeBodyInner(
             .extended => ext: {
                 const extended = datas[@intFromEnum(inst)].extended;
                 break :ext switch (extended.opcode) {
-                    .deprecated => {
-                        if (!mod.allow_deprecated) {
-                            const src_node: i32 = @bitCast(extended.operand);
-                            const src = block.nodeOffset(src_node);
-                            return sema.fail(block, src, "found deprecated code", .{});
-                        }
-
-                        break :ext .void_value;
-                    },
                     // zig fmt: off
                     .struct_decl        => try sema.zirStructDecl(        block, extended, inst),
                     .enum_decl          => try sema.zirEnumDecl(          block, extended, inst),
@@ -1413,6 +1404,15 @@ fn analyzeBodyInner(
                         }
                         i += 1;
                         continue;
+                    },
+                    .deprecated => {
+                        if (!mod.allow_deprecated) {
+                            const src_node: i32 = @bitCast(extended.operand);
+                            const src = block.nodeOffset(src_node);
+                            return sema.fail(block, src, "found deprecated code", .{});
+                        }
+
+                        break :ext .void_value;
                     },
                     .disable_instrumentation => {
                         try sema.zirDisableInstrumentation();

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1409,7 +1409,7 @@ fn analyzeBodyInner(
                         if (!mod.allow_deprecated) {
                             const src_node: i32 = @bitCast(extended.operand);
                             const src = block.nodeOffset(src_node);
-                            return sema.fail(block, src, "found deprecated code", .{});
+                            return sema.fail(block, src, "reached deprecated code", .{});
                         }
 
                         i += 1;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1412,7 +1412,8 @@ fn analyzeBodyInner(
                             return sema.fail(block, src, "found deprecated code", .{});
                         }
 
-                        break :ext .void_value;
+                        i += 1;
+                        continue;
                     },
                     .disable_instrumentation => {
                         try sema.zirDisableInstrumentation();

--- a/src/main.zig
+++ b/src/main.zig
@@ -520,6 +520,8 @@ const usage_build_generic =
     \\  -fno-sanitize-thread      Disable Thread Sanitizer
     \\  -ffuzz                    Enable fuzz testing instrumentation
     \\  -fno-fuzz                 Disable fuzz testing instrumentation
+    \\  -fallow-deprecated        Allow usage of deprecated code
+    \\  -fno-allow-deprecated     Disallow usage of deprecated code
     \\  -funwind-tables           Always produce unwind table entries for all functions
     \\  -fasync-unwind-tables     Always produce asynchronous unwind table entries for all functions
     \\  -fno-unwind-tables        Never produce unwind table entries
@@ -1454,6 +1456,10 @@ fn buildOutputType(
                         mod_opts.fuzz = true;
                     } else if (mem.eql(u8, arg, "-fno-fuzz")) {
                         mod_opts.fuzz = false;
+                    } else if (mem.eql(u8, arg, "-fallow-deprecated")) {
+                        mod_opts.allow_deprecated = true;
+                    } else if (mem.eql(u8, arg, "-fno-allow-deprecated")) {
+                        mod_opts.allow_deprecated = false;
                     } else if (mem.eql(u8, arg, "-fllvm")) {
                         create_module.opts.use_llvm = true;
                     } else if (mem.eql(u8, arg, "-fno-llvm")) {

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -535,6 +535,7 @@ const Writer = struct {
             .c_va_start,
             .in_comptime,
             .value_placeholder,
+            .deprecated,
             => try self.writeExtNode(stream, extended),
 
             .builtin_src => {

--- a/test/cases/compile_errors/deprecated.zig
+++ b/test/cases/compile_errors/deprecated.zig
@@ -6,4 +6,4 @@ pub export fn foo() usize {
 
 // error
 //
-// :1:13: error: found deprecated code
+// :1:13: error: reached deprecated code

--- a/test/cases/compile_errors/deprecated.zig
+++ b/test/cases/compile_errors/deprecated.zig
@@ -1,0 +1,9 @@
+const bad = @deprecated(42);
+
+pub export fn foo() usize {
+    return bad;
+}
+
+// error
+//
+// :1:13: error: found deprecated code

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -250,18 +250,4 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
             ":1:5: error: expected expression, found 'invalid token'",
         });
     }
-
-    {
-        const case = ctx.obj("usage of deprecated code", b.graph.host);
-
-        case.addError(
-            \\const bad = @deprecated(42);
-            \\
-            \\pub export fn foo() usize {
-            \\   return bad; 
-            \\}
-        , &[_][]const u8{
-            ":1:13: error: found deprecated code",
-        });
-    }
 }

--- a/test/compile_errors.zig
+++ b/test/compile_errors.zig
@@ -250,4 +250,18 @@ pub fn addCases(ctx: *Cases, b: *std.Build) !void {
             ":1:5: error: expected expression, found 'invalid token'",
         });
     }
+
+    {
+        const case = ctx.obj("usage of deprecated code", b.graph.host);
+
+        case.addError(
+            \\const bad = @deprecated(42);
+            \\
+            \\pub export fn foo() usize {
+            \\   return bad; 
+            \\}
+        , &[_][]const u8{
+            ":1:13: error: found deprecated code",
+        });
+    }
 }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1199,13 +1199,13 @@ pub fn addCliTests(b: *std.Build) *Step {
                 \\}
             ;
 
-            var src_dir = std.fs.cwd().makeOpenPath(b.pathJoin(&.{ tmp_path, "src" }), .{}) catch unreachable;
+            var src_dir = std.fs.cwd().makeOpenPath(b.pathJoin(&.{ tmp_path, "src" }), .{}) catch @panic("unable to create tmp path");
             defer src_dir.close();
 
-            var main = src_dir.createFile("main.zig", .{}) catch unreachable;
+            var main = src_dir.createFile("main.zig", .{}) catch @panic("unable to create main.zig");
             defer main.close();
 
-            main.writeAll(new_main_src) catch unreachable;
+            main.writeAll(new_main_src) catch @panic("unable to write to main.zig");
         }
 
         const init_exe = b.addSystemCommand(&.{ b.graph.zig_exe, "init" });

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1195,7 +1195,7 @@ pub fn addCliTests(b: *std.Build) *Step {
                 \\}
                 \\
                 \\test {
-                \\   if (bad != 42) return error.Bad;   
+                \\   if (bad != 42) return error.Bad;
                 \\}
             ;
 

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1176,6 +1176,100 @@ pub fn addCliTests(b: *std.Build) *Step {
         step.dependOn(&cleanup.step);
     }
 
+    {
+        // Test `zig build -fallow-deprecated`.
+
+        const deprecated_check: std.Build.Step.Run.StdIo.Check = .{
+            .expect_stderr_match = "found deprecated code",
+        };
+
+        const tmp_path = b.makeTempPath();
+
+        // create custom main.zig file containing a deprecated decl
+        {
+            const new_main_src =
+                \\const bad = @deprecated(42);
+                \\
+                \\pub fn main() u8 {
+                \\   return bad;
+                \\}
+                \\
+                \\test {
+                \\   if (bad != 42) return error.Bad;   
+                \\}
+            ;
+
+            var src_dir = std.fs.cwd().makeOpenPath(b.pathJoin(&.{ tmp_path, "src" }), .{}) catch unreachable;
+            defer src_dir.close();
+
+            var main = src_dir.createFile("main.zig", .{}) catch unreachable;
+            defer main.close();
+
+            main.writeAll(new_main_src) catch unreachable;
+        }
+
+        const init_exe = b.addSystemCommand(&.{ b.graph.zig_exe, "init" });
+        init_exe.setCwd(.{ .cwd_relative = tmp_path });
+        init_exe.setName("zig init");
+        init_exe.expectStdOutEqual("");
+        init_exe.expectStdErrEqual("info: created build.zig\n" ++
+            "info: created build.zig.zon\n" ++
+            "info: preserving already existing file: src" ++ s ++ "main.zig\n" ++
+            "info: created src" ++ s ++ "root.zig\n");
+
+        const run_test_bad = b.addSystemCommand(&.{ b.graph.zig_exe, "build", "test", "--color", "off" });
+        run_test_bad.setCwd(.{ .cwd_relative = tmp_path });
+        run_test_bad.setName("zig build test");
+        run_test_bad.expectExitCode(1);
+        run_test_bad.expectStdOutEqual("");
+        run_test_bad.addCheck(deprecated_check);
+        run_test_bad.step.dependOn(&init_exe.step);
+
+        const run_test = b.addSystemCommand(&.{
+            b.graph.zig_exe,
+            "build",
+            "test",
+            "--color",
+            "off",
+            "-fallow-deprecated",
+        });
+        run_test.setCwd(.{ .cwd_relative = tmp_path });
+        run_test.setName("zig build test");
+        run_test.expectExitCode(0);
+        run_test.expectStdOutEqual("");
+        run_test.expectStdErrEqual("");
+        run_test.step.dependOn(&init_exe.step);
+
+        const run_build_bad = b.addSystemCommand(&.{ b.graph.zig_exe, "build", "--color", "off" });
+        run_build_bad.setCwd(.{ .cwd_relative = tmp_path });
+        run_build_bad.setName("zig build test");
+        run_build_bad.expectExitCode(1);
+        run_build_bad.expectStdOutEqual("");
+        run_build_bad.addCheck(deprecated_check);
+        run_build_bad.step.dependOn(&init_exe.step);
+
+        const run_build = b.addSystemCommand(&.{
+            b.graph.zig_exe,
+            "build",
+            "--color",
+            "off",
+            "-fallow-deprecated",
+        });
+        run_build.setCwd(.{ .cwd_relative = tmp_path });
+        run_build.setName("zig build test");
+        run_build.expectExitCode(0);
+        run_build.expectStdOutEqual("");
+        run_build.expectStdErrEqual("");
+        run_build.step.dependOn(&init_exe.step);
+
+        const cleanup = b.addRemoveDirTree(.{ .cwd_relative = tmp_path });
+        cleanup.step.dependOn(&run_test.step);
+        cleanup.step.dependOn(&run_test_bad.step);
+        cleanup.step.dependOn(&run_build.step);
+        cleanup.step.dependOn(&run_build_bad.step);
+
+        step.dependOn(&cleanup.step);
+    }
     // Test Godbolt API
     if (builtin.os.tag == .linux and builtin.cpu.arch == .x86_64) {
         const tmp_path = b.makeTempPath();

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1180,7 +1180,7 @@ pub fn addCliTests(b: *std.Build) *Step {
         // Test `zig build -fallow-deprecated`.
 
         const deprecated_check: std.Build.Step.Run.StdIo.Check = .{
-            .expect_stderr_match = "found deprecated code",
+            .expect_stderr_match = "reached deprecated code",
         };
 
         const tmp_path = b.makeTempPath();


### PR DESCRIPTION
Implements #22822 

The part I'm most unsure about this implementation relates to how the build system represents `-fallow-deprecated` and `-fno-allow-deprecated` internally and how then this is reflected in the CLI invocation of `build-exe` and related subcommands.

