### PR TITLE
Autodoc: improve error reporting

### DIFF
--- a/lib/docs/index.html
+++ b/lib/docs/index.html
@@ -6,6 +6,9 @@
     <title>Zig Documentation</title>
     <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNTMgMTQwIj48ZyBmaWxsPSIjRjdBNDFEIj48Zz48cG9seWdvbiBwb2ludHM9IjQ2LDIyIDI4LDQ0IDE5LDMwIi8+PHBvbHlnb24gcG9pbnRzPSI0NiwyMiAzMywzMyAyOCw0NCAyMiw0NCAyMiw5NSAzMSw5NSAyMCwxMDAgMTIsMTE3IDAsMTE3IDAsMjIiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMzEsOTUgMTIsMTE3IDQsMTA2Ii8+PC9nPjxnPjxwb2x5Z29uIHBvaW50cz0iNTYsMjIgNjIsMzYgMzcsNDQiLz48cG9seWdvbiBwb2ludHM9IjU2LDIyIDExMSwyMiAxMTEsNDQgMzcsNDQgNTYsMzIiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMTE2LDk1IDk3LDExNyA5MCwxMDQiLz48cG9seWdvbiBwb2ludHM9IjExNiw5NSAxMDAsMTA0IDk3LDExNyA0MiwxMTcgNDIsOTUiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMTUwLDAgNTIsMTE3IDMsMTQwIDEwMSwyMiIvPjwvZz48Zz48cG9seWdvbiBwb2ludHM9IjE0MSwyMiAxNDAsNDAgMTIyLDQ1Ii8+PHBvbHlnb24gcG9pbnRzPSIxNTMsMjIgMTUzLDExNyAxMDYsMTE3IDEyMCwxMDUgMTI1LDk1IDEzMSw5NSAxMzEsNDUgMTIyLDQ1IDEzMiwzNiAxNDEsMjIiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMTI1LDk1IDEzMCwxMTAgMTA2LDExNyIvPjwvZz48L2c+PC9zdmc+">
     <style type="text/css">
+      *, *::before, *::after {
+        box-sizing: border-box;
+      }
       body {
         font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
         color: #000000;
@@ -157,6 +160,23 @@
         cursor: default;
       }
 
+      #errors {
+        background-color: #faa;
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        max-height: min(20em, 50vh);
+        padding: 0.5em;
+        overflow: auto;
+      }
+      #errors h1 {
+        font-size: 1.5em;
+      }
+      #errors pre {
+        background-color: #fcc;
+      }
+
       #listSearchResults li.selected {
         background-color: #93e196;
       }
@@ -250,6 +270,14 @@
           background-color: #000;
         }
         #listSearchResults li.selected a {
+          color: #fff;
+        }
+        #errors {
+          background-color: #800;
+          color: #fff;
+        }
+        #errors pre {
+          background-color: #a00;
           color: #fff;
         }
         dl > div {
@@ -413,6 +441,10 @@
       <dl><dt><kbd>↑</kbd></dt><dd>Move up in search results</dd></dl>
       <dl><dt><kbd>↓</kbd></dt><dd>Move down in search results</dd></dl>
       <dl><dt><kbd>⏎</kbd></dt><dd>Go to active search result</dd></dl>
+    </div>
+    <div id="errors" class="hidden">
+      <h1>Errors</h1>
+      <pre id="errorsText"></pre>
     </div>
     <script src="main.js"></script>
   </body>

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -11,6 +11,11 @@
     const CAT_type_type = 9;
     const CAT_type_function = 10;
 
+    const LOG_err = 0;
+    const LOG_warn = 1;
+    const LOG_info = 2;
+    const LOG_debug = 3;
+
     const domDocTestsCode = document.getElementById("docTestsCode");
     const domFnErrorsAnyError = document.getElementById("fnErrorsAnyError");
     const domFnProto = document.getElementById("fnProto");
@@ -84,13 +89,22 @@
 
     WebAssembly.instantiateStreaming(wasm_promise, {
       js: {
-        log: function(ptr, len) {
+        log: function(level, ptr, len) {
           const msg = decodeString(ptr, len);
-          console.log(msg);
-        },
-        panic: function (ptr, len) {
-            const msg = decodeString(ptr, len);
-            throw new Error("panic: " + msg);
+          switch (level) {
+            case LOG_err:
+              console.error(msg);
+              break;
+            case LOG_warn:
+              console.warn(msg);
+              break;
+            case LOG_info:
+              console.info(msg);
+              break;
+            case LOG_debug:
+              console.debug(msg);
+              break;
+          }
         },
       },
     }).then(function(obj) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -53,6 +53,8 @@
     const domStatus = document.getElementById("status");
     const domTableFnErrors = document.getElementById("tableFnErrors");
     const domTldDocs = document.getElementById("tldDocs");
+    const domErrors = document.getElementById("errors");
+    const domErrorsText = document.getElementById("errorsText");
 
     var searchTimer = null;
 
@@ -94,6 +96,8 @@
           switch (level) {
             case LOG_err:
               console.error(msg);
+              domErrorsText.textContent += msg + "\n";
+              domErrors.classList.remove("hidden");
               break;
             case LOG_warn:
               console.warn(msg);


### PR DESCRIPTION
This PR aims to improve error handling and reporting in Autodoc, to help address potentially confusing scenarios such as the one described here: https://ziggit.dev/t/file-has-unexpected-syntax-error-when-building-documentation/8387

There are several changes included:

- Any parse errors in source files are reported to the user, and the AST is replaced with that of an empty file to avoid the rest of Autodoc bugging out when trying to handle an incomplete/invalid AST.
- The "file must contain trailing newline" check is converted from an assertion to a reported and handled error.
- The JS log function is enhanced to accept the log level so it can use `console.error`, `console.warn`, etc. instead of `console.log` (this brings several benefits, including colors in the browser console and stack traces for error logs).
- The panic handling is unified and implemented in the Zig Wasm code, using the error logging.
- Any errors (including panics) are reported to the user in the UI, checking off one item of #19249.
  - **Edit:** actually, I just noticed this PR checks two items off that issue:
    - "make the panic handler reflect the failure in the user interface"
    - "instead of logging "can't index foo because it has syntax errors" put it in the UI"

Screenshots of Autodoc with the following simple project:

<details>
<summary>s.zig</summary>

```zig
fdsafdsaf fdsafd dfdafa
```

</details>

<details>
<summary>g.zig</summary>

```zig
//! Implementation of playing card ranks

/// This is a rank
pub const Rank = enum {
    Nine,
};
```
(no newline at end of file)

</details>

![light mode view](https://github.com/user-attachments/assets/0116f2fe-09f8-4494-8248-ecfbdd8afc6e)

![dark mode view](https://github.com/user-attachments/assets/b4052fd4-2efb-4d27-8250-39b855a00a72)

