### PR TITLE
`llvm`: Use inline variants of `memcpy`/`memset` intrinsics when using `-fno-builtin`

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -5771,6 +5771,7 @@ pub const FuncGen = struct {
                     try o.builder.intValue(.i8, 0xaa),
                     len,
                     if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal,
+                    self.ng.ownerModule().no_builtin,
                 );
                 const owner_mod = self.ng.ownerModule();
                 if (owner_mod.valgrind) {
@@ -5821,6 +5822,7 @@ pub const FuncGen = struct {
                 try o.builder.intValue(.i8, 0xaa),
                 len,
                 .normal,
+                self.ng.ownerModule().no_builtin,
             );
             const owner_mod = self.ng.ownerModule();
             if (owner_mod.valgrind) {
@@ -9734,6 +9736,7 @@ pub const FuncGen = struct {
                 if (safety) try o.builder.intValue(.i8, 0xaa) else try o.builder.undefValue(.i8),
                 len,
                 if (ptr_ty.isVolatilePtr(zcu)) .@"volatile" else .normal,
+                self.ng.ownerModule().no_builtin,
             );
             if (safety and owner_mod.valgrind) {
                 try self.valgrindMarkUndef(dest_ptr, len);
@@ -10041,9 +10044,22 @@ pub const FuncGen = struct {
                     try o.builder.undefValue(.i8);
                 const len = try self.sliceOrArrayLenInBytes(dest_slice, ptr_ty);
                 if (intrinsic_len0_traps) {
-                    try self.safeWasmMemset(dest_ptr, fill_byte, len, dest_ptr_align, access_kind);
+                    try self.safeWasmMemset(
+                        dest_ptr,
+                        fill_byte,
+                        len,
+                        dest_ptr_align,
+                        access_kind,
+                    );
                 } else {
-                    _ = try self.wip.callMemSet(dest_ptr, dest_ptr_align, fill_byte, len, access_kind);
+                    _ = try self.wip.callMemSet(
+                        dest_ptr,
+                        dest_ptr_align,
+                        fill_byte,
+                        len,
+                        access_kind,
+                        self.ng.ownerModule().no_builtin,
+                    );
                 }
                 const owner_mod = self.ng.ownerModule();
                 if (safety and owner_mod.valgrind) {
@@ -10060,9 +10076,22 @@ pub const FuncGen = struct {
                 const fill_byte = try o.builder.intValue(.i8, byte_val);
                 const len = try self.sliceOrArrayLenInBytes(dest_slice, ptr_ty);
                 if (intrinsic_len0_traps) {
-                    try self.safeWasmMemset(dest_ptr, fill_byte, len, dest_ptr_align, access_kind);
+                    try self.safeWasmMemset(
+                        dest_ptr,
+                        fill_byte,
+                        len,
+                        dest_ptr_align,
+                        access_kind,
+                    );
                 } else {
-                    _ = try self.wip.callMemSet(dest_ptr, dest_ptr_align, fill_byte, len, access_kind);
+                    _ = try self.wip.callMemSet(
+                        dest_ptr,
+                        dest_ptr_align,
+                        fill_byte,
+                        len,
+                        access_kind,
+                        self.ng.ownerModule().no_builtin,
+                    );
                 }
                 return .none;
             }
@@ -10077,9 +10106,22 @@ pub const FuncGen = struct {
             const len = try self.sliceOrArrayLenInBytes(dest_slice, ptr_ty);
 
             if (intrinsic_len0_traps) {
-                try self.safeWasmMemset(dest_ptr, fill_byte, len, dest_ptr_align, access_kind);
+                try self.safeWasmMemset(
+                    dest_ptr,
+                    fill_byte,
+                    len,
+                    dest_ptr_align,
+                    access_kind,
+                );
             } else {
-                _ = try self.wip.callMemSet(dest_ptr, dest_ptr_align, fill_byte, len, access_kind);
+                _ = try self.wip.callMemSet(
+                    dest_ptr,
+                    dest_ptr_align,
+                    fill_byte,
+                    len,
+                    access_kind,
+                    self.ng.ownerModule().no_builtin,
+                );
             }
             return .none;
         }
@@ -10131,6 +10173,7 @@ pub const FuncGen = struct {
                 elem_abi_align.toLlvm(),
                 try o.builder.intValue(llvm_usize_ty, elem_abi_size),
                 access_kind,
+                self.ng.ownerModule().no_builtin,
             );
         } else _ = try self.wip.store(access_kind, value, it_ptr.toValue(), it_ptr_align);
         const next_ptr = try self.wip.gep(.inbounds, elem_llvm_ty, it_ptr.toValue(), &.{
@@ -10158,7 +10201,14 @@ pub const FuncGen = struct {
         const end_block = try self.wip.block(2, "MemsetTrapEnd");
         _ = try self.wip.brCond(cond, memset_block, end_block, .none);
         self.wip.cursor = .{ .block = memset_block };
-        _ = try self.wip.callMemSet(dest_ptr, dest_ptr_align, fill_byte, len, access_kind);
+        _ = try self.wip.callMemSet(
+            dest_ptr,
+            dest_ptr_align,
+            fill_byte,
+            len,
+            access_kind,
+            self.ng.ownerModule().no_builtin,
+        );
         _ = try self.wip.br(end_block);
         self.wip.cursor = .{ .block = end_block };
     }
@@ -10200,6 +10250,7 @@ pub const FuncGen = struct {
                 src_ptr_ty.ptrAlignment(zcu).toLlvm(),
                 len,
                 access_kind,
+                self.ng.ownerModule().no_builtin,
             );
             _ = try self.wip.br(end_block);
             self.wip.cursor = .{ .block = end_block };
@@ -10213,6 +10264,7 @@ pub const FuncGen = struct {
             src_ptr_ty.ptrAlignment(zcu).toLlvm(),
             len,
             access_kind,
+            self.ng.ownerModule().no_builtin,
         );
         return .none;
     }
@@ -11346,6 +11398,7 @@ pub const FuncGen = struct {
             ptr_alignment,
             try o.builder.intValue(try o.lowerType(Type.usize), size_bytes),
             access_kind,
+            fg.ng.ownerModule().no_builtin,
         );
         return result_ptr;
     }
@@ -11513,6 +11566,7 @@ pub const FuncGen = struct {
             elem_ty.abiAlignment(zcu).toLlvm(),
             try o.builder.intValue(try o.lowerType(Type.usize), elem_ty.abiSize(zcu)),
             access_kind,
+            self.ng.ownerModule().no_builtin,
         );
     }
 

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -5902,7 +5902,7 @@ pub const FuncGen = struct {
         const result_alignment = va_list_ty.abiAlignment(pt.zcu).toLlvm();
         const dest_list = try self.buildAllocaWorkaround(va_list_ty, result_alignment);
 
-        _ = try self.wip.callIntrinsic(.normal, .none, .va_copy, &.{}, &.{ dest_list, src_list }, "");
+        _ = try self.wip.callIntrinsic(.normal, .none, .va_copy, &.{dest_list.typeOfWip(&self.wip)}, &.{ dest_list, src_list }, "");
         return if (isByRef(va_list_ty, zcu))
             dest_list
         else
@@ -5913,7 +5913,7 @@ pub const FuncGen = struct {
         const un_op = self.air.instructions.items(.data)[@intFromEnum(inst)].un_op;
         const src_list = try self.resolveInst(un_op);
 
-        _ = try self.wip.callIntrinsic(.normal, .none, .va_end, &.{}, &.{src_list}, "");
+        _ = try self.wip.callIntrinsic(.normal, .none, .va_end, &.{src_list.typeOfWip(&self.wip)}, &.{src_list}, "");
         return .none;
     }
 
@@ -5927,7 +5927,7 @@ pub const FuncGen = struct {
         const result_alignment = va_list_ty.abiAlignment(pt.zcu).toLlvm();
         const dest_list = try self.buildAllocaWorkaround(va_list_ty, result_alignment);
 
-        _ = try self.wip.callIntrinsic(.normal, .none, .va_start, &.{}, &.{dest_list}, "");
+        _ = try self.wip.callIntrinsic(.normal, .none, .va_start, &.{dest_list.typeOfWip(&self.wip)}, &.{dest_list}, "");
         return if (isByRef(va_list_ty, zcu))
             dest_list
         else

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -2634,6 +2634,7 @@ pub const Intrinsic = enum {
     cos,
     pow,
     exp,
+    exp10,
     exp2,
     ldexp,
     frexp,
@@ -2801,22 +2802,22 @@ pub const Intrinsic = enum {
         .va_start = .{
             .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .overloaded },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn },
         },
         .va_end = .{
             .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .overloaded },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn },
         },
         .va_copy = .{
             .ret_len = 0,
             .params = &.{
-                .{ .kind = .{ .type = .ptr } },
-                .{ .kind = .{ .type = .ptr } },
+                .{ .kind = .overloaded },
+                .{ .kind = .{ .matches = 0 } },
             },
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .willreturn },
         },
@@ -2929,7 +2930,7 @@ pub const Intrinsic = enum {
             .params = &.{
                 .{ .kind = .overloaded, .attrs = &.{ .@"noalias", .nocapture, .writeonly } },
                 .{ .kind = .overloaded, .attrs = &.{ .@"noalias", .nocapture, .readonly } },
-                .{ .kind = .overloaded, .attrs = &.{.immarg} },
+                .{ .kind = .overloaded },
                 .{ .kind = .{ .type = .i1 }, .attrs = &.{.immarg} },
             },
             .attrs = &.{ .nocallback, .nofree, .nounwind, .willreturn, .{ .memory = .{ .argmem = .readwrite } } },
@@ -2959,7 +2960,7 @@ pub const Intrinsic = enum {
             .params = &.{
                 .{ .kind = .overloaded, .attrs = &.{ .nocapture, .writeonly } },
                 .{ .kind = .{ .type = .i8 } },
-                .{ .kind = .overloaded, .attrs = &.{.immarg} },
+                .{ .kind = .overloaded },
                 .{ .kind = .{ .type = .i1 }, .attrs = &.{.immarg} },
             },
             .attrs = &.{ .nocallback, .nofree, .nounwind, .willreturn, .{ .memory = .{ .argmem = .write } } },
@@ -3015,6 +3016,14 @@ pub const Intrinsic = enum {
             .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
         },
         .exp2 = .{
+            .ret_len = 1,
+            .params = &.{
+                .{ .kind = .overloaded },
+                .{ .kind = .{ .matches = 0 } },
+            },
+            .attrs = &.{ .nocallback, .nofree, .nosync, .nounwind, .speculatable, .willreturn, .{ .memory = Attribute.Memory.all(.none) } },
+        },
+        .exp10 = .{
             .ret_len = 1,
             .params = &.{
                 .{ .kind = .overloaded },

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -6102,6 +6102,7 @@ pub const WipFunction = struct {
         src_align: Alignment,
         len: Value,
         kind: MemoryAccessKind,
+        @"inline": bool,
     ) Allocator.Error!Instruction.Index {
         var dst_attrs = [_]Attribute.Index{try self.builder.attr(.{ .@"align" = dst_align })};
         var src_attrs = [_]Attribute.Index{try self.builder.attr(.{ .@"align" = src_align })};
@@ -6113,7 +6114,7 @@ pub const WipFunction = struct {
                 try self.builder.attrs(&dst_attrs),
                 try self.builder.attrs(&src_attrs),
             }),
-            .memcpy,
+            if (@"inline") .@"memcpy.inline" else .memcpy,
             &.{ dst.typeOfWip(self), src.typeOfWip(self), len.typeOfWip(self) },
             &.{ dst, src, len, switch (kind) {
                 .normal => Value.false,
@@ -6131,12 +6132,13 @@ pub const WipFunction = struct {
         val: Value,
         len: Value,
         kind: MemoryAccessKind,
+        @"inline": bool,
     ) Allocator.Error!Instruction.Index {
         var dst_attrs = [_]Attribute.Index{try self.builder.attr(.{ .@"align" = dst_align })};
         const value = try self.callIntrinsic(
             .normal,
             try self.builder.fnAttrs(&.{ .none, .none, try self.builder.attrs(&dst_attrs) }),
-            .memset,
+            if (@"inline") .@"memset.inline" else .memset,
             &.{ dst.typeOfWip(self), len.typeOfWip(self) },
             &.{ dst, val, len, switch (kind) {
                 .normal => Value.false,


### PR DESCRIPTION
This is a correctness issue: When `-fno-builtin` is used, we must assume that we could be compiling the `memcpy`/`memset` implementations, so generating calls to them is problematic.

```
Benchmark 1 (3 runs): ./release/bin/zig build -Doptimize=ReleaseFast -Dno-lib -Denable-llvm=false -Duse-llvm=false
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.5s  ± 69.2ms    12.4s  … 12.5s           0 ( 0%)        0%
  peak_rss           1.13GB ± 5.96MB    1.13GB … 1.14GB          0 ( 0%)        0%
  cpu_cycles         98.3G  ±  105M     98.2G  … 98.4G           0 ( 0%)        0%
  instructions        270G  ±  147M      270G  …  270G           0 ( 0%)        0%
  cache_references    227M  ±  204K      227M  …  227M           0 ( 0%)        0%
  cache_misses       82.6M  ± 1.01M     81.5M  … 83.5M           0 ( 0%)        0%
  branch_misses       344M  ± 61.8K      344M  …  344M           0 ( 0%)        0%
Benchmark 2 (3 runs): ./release-pr/bin/zig build -Doptimize=ReleaseFast -Dno-lib -Denable-llvm=false -Duse-llvm=false
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          12.4s  ± 53.3ms    12.4s  … 12.5s           0 ( 0%)          -  0.2% ±  1.1%
  peak_rss           1.13GB ± 3.31MB    1.12GB … 1.13GB          0 ( 0%)          -  0.6% ±  1.0%
  cpu_cycles         98.3G  ±  165M     98.2G  … 98.5G           0 ( 0%)          +  0.0% ±  0.3%
  instructions        270G  ± 42.7M      270G  …  270G           0 ( 0%)          +  0.1% ±  0.1%
  cache_references    225M  ±  329K      225M  …  225M           0 ( 0%)          -  0.9% ±  0.3%
  cache_misses       82.4M  ±  187K     82.1M  … 82.5M           0 ( 0%)          -  0.4% ±  2.0%
  branch_misses       344M  ± 6.84M      339M  …  351M           0 ( 0%)          -  0.2% ±  3.2%
```