### PR TITLE
Adds non allocating alternatives to ZON parse functions

### DIFF
--- a/lib/std/zon/parse.zig
+++ b/lib/std/zon/parse.zig
@@ -294,8 +294,7 @@ pub fn fromSlice(
 /// Like `fromSlice`, but asserts at compile time that the result type doesn't contain pointers. As
 /// such, the result doesn't need to be freed.
 ///
-/// An allocator is still required for temporary allocations made during parsing, and status must
-/// still be freed if it is non-null.
+/// An allocator is still required for temporary allocations made during parsing.
 pub fn fromSliceFlat(
     T: type,
     gpa: Allocator,

--- a/lib/std/zon/parse.zig
+++ b/lib/std/zon/parse.zig
@@ -1352,7 +1352,7 @@ test "std.zon ast errors" {
     defer diag.deinit(gpa);
     try std.testing.expectError(
         error.ParseZon,
-        fromSliceAlloc(struct {}, gpa, ".{.x = 1 .y = 2}", &diag, .{}),
+        fromSlice(struct {}, gpa, ".{.x = 1 .y = 2}", &diag, .{}),
     );
     try std.testing.expectFmt("1:13: error: expected ',' after initializer\n", "{f}", .{diag});
 }
@@ -1360,7 +1360,7 @@ test "std.zon ast errors" {
 test "std.zon comments" {
     const gpa = std.testing.allocator;
 
-    try std.testing.expectEqual(@as(u8, 10), fromSliceAlloc(u8, gpa,
+    try std.testing.expectEqual(@as(u8, 10), fromSlice(u8, gpa,
         \\// comment
         \\10 // comment
         \\// comment
@@ -1369,7 +1369,7 @@ test "std.zon comments" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa,
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa,
             \\//! comment
             \\10 // comment
             \\// comment
@@ -1403,7 +1403,7 @@ test "std.zon failure/oom formatting" {
 test "std.zon fromSliceAlloc syntax error" {
     try std.testing.expectError(
         error.ParseZon,
-        fromSliceAlloc(u8, std.testing.allocator, ".{", null, .{}),
+        fromSlice(u8, std.testing.allocator, ".{", null, .{}),
     );
 }
 
@@ -1412,9 +1412,9 @@ test "std.zon optional" {
 
     // Basic usage
     {
-        const none = try fromSliceAlloc(?u32, gpa, "null", null, .{});
+        const none = try fromSlice(?u32, gpa, "null", null, .{});
         try std.testing.expect(none == null);
-        const some = try fromSliceAlloc(?u32, gpa, "1", null, .{});
+        const some = try fromSlice(?u32, gpa, "1", null, .{});
         try std.testing.expect(some.? == 1);
     }
 
@@ -1436,18 +1436,18 @@ test "std.zon unions" {
         const Tagged = union(enum) { x: f32, @"y y": bool, z, @"z z" };
         const Untagged = union { x: f32, @"y y": bool, z: void, @"z z": void };
 
-        const tagged_x = try fromSliceAlloc(Tagged, gpa, ".{.x = 1.5}", null, .{});
+        const tagged_x = try fromSlice(Tagged, gpa, ".{.x = 1.5}", null, .{});
         try std.testing.expectEqual(Tagged{ .x = 1.5 }, tagged_x);
-        const tagged_y = try fromSliceAlloc(Tagged, gpa, ".{.@\"y y\" = true}", null, .{});
+        const tagged_y = try fromSlice(Tagged, gpa, ".{.@\"y y\" = true}", null, .{});
         try std.testing.expectEqual(Tagged{ .@"y y" = true }, tagged_y);
-        const tagged_z_shorthand = try fromSliceAlloc(Tagged, gpa, ".z", null, .{});
+        const tagged_z_shorthand = try fromSlice(Tagged, gpa, ".z", null, .{});
         try std.testing.expectEqual(@as(Tagged, .z), tagged_z_shorthand);
-        const tagged_zz_shorthand = try fromSliceAlloc(Tagged, gpa, ".@\"z z\"", null, .{});
+        const tagged_zz_shorthand = try fromSlice(Tagged, gpa, ".@\"z z\"", null, .{});
         try std.testing.expectEqual(@as(Tagged, .@"z z"), tagged_zz_shorthand);
 
-        const untagged_x = try fromSliceAlloc(Untagged, gpa, ".{.x = 1.5}", null, .{});
+        const untagged_x = try fromSlice(Untagged, gpa, ".{.x = 1.5}", null, .{});
         try std.testing.expect(untagged_x.x == 1.5);
-        const untagged_y = try fromSliceAlloc(Untagged, gpa, ".{.@\"y y\" = true}", null, .{});
+        const untagged_y = try fromSlice(Untagged, gpa, ".{.@\"y y\" = true}", null, .{});
         try std.testing.expect(untagged_y.@"y y");
     }
 
@@ -1563,16 +1563,16 @@ test "std.zon structs" {
         const Vec2 = struct { x: f32, y: f32 };
         const Vec3 = struct { x: f32, y: f32, z: f32 };
 
-        const zero = try fromSliceAlloc(Vec0, gpa, ".{}", null, .{});
+        const zero = try fromSlice(Vec0, gpa, ".{}", null, .{});
         try std.testing.expectEqual(Vec0{}, zero);
 
-        const one = try fromSliceAlloc(Vec1, gpa, ".{.x = 1.2}", null, .{});
+        const one = try fromSlice(Vec1, gpa, ".{.x = 1.2}", null, .{});
         try std.testing.expectEqual(Vec1{ .x = 1.2 }, one);
 
-        const two = try fromSliceAlloc(Vec2, gpa, ".{.x = 1.2, .y = 3.4}", null, .{});
+        const two = try fromSlice(Vec2, gpa, ".{.x = 1.2, .y = 3.4}", null, .{});
         try std.testing.expectEqual(Vec2{ .x = 1.2, .y = 3.4 }, two);
 
-        const three = try fromSliceAlloc(Vec3, gpa, ".{.x = 1.2, .y = 3.4, .z = 5.6}", null, .{});
+        const three = try fromSlice(Vec3, gpa, ".{.x = 1.2, .y = 3.4, .z = 5.6}", null, .{});
         try std.testing.expectEqual(Vec3{ .x = 1.2, .y = 3.4, .z = 5.6 }, three);
     }
 
@@ -1598,7 +1598,7 @@ test "std.zon structs" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Vec2, gpa, ".{.x=1.5, .z=2.5}", &diag, .{}),
+            fromSlice(Vec2, gpa, ".{.x=1.5, .z=2.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             \\1:12: error: unexpected field 'z'
@@ -1617,7 +1617,7 @@ test "std.zon structs" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Vec2, gpa, ".{.x=1.5, .x=2.5, .x=3.5}", &diag, .{}),
+            fromSlice(Vec2, gpa, ".{.x=1.5, .x=2.5, .x=3.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             \\1:4: error: duplicate struct field name
@@ -1629,7 +1629,7 @@ test "std.zon structs" {
     // Ignore unknown fields
     {
         const Vec2 = struct { x: f32, y: f32 = 2.0 };
-        const parsed = try fromSliceAlloc(Vec2, gpa, ".{ .x = 1.0, .z = 3.0 }", null, .{
+        const parsed = try fromSlice(Vec2, gpa, ".{ .x = 1.0, .z = 3.0 }", null, .{
             .ignore_unknown_fields = true,
         });
         try std.testing.expectEqual(Vec2{ .x = 1.0, .y = 2.0 }, parsed);
@@ -1642,7 +1642,7 @@ test "std.zon structs" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Vec2, gpa, ".{.x=1.5, .z=2.5}", &diag, .{}),
+            fromSlice(Vec2, gpa, ".{.x=1.5, .z=2.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             \\1:4: error: unexpected field 'x'
@@ -1658,7 +1658,7 @@ test "std.zon structs" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Vec2, gpa, ".{.x=1.5}", &diag, .{}),
+            fromSlice(Vec2, gpa, ".{.x=1.5}", &diag, .{}),
         );
         try std.testing.expectFmt("1:2: error: missing required field y\n", "{f}", .{diag});
     }
@@ -1666,14 +1666,14 @@ test "std.zon structs" {
     // Default field
     {
         const Vec2 = struct { x: f32, y: f32 = 1.5 };
-        const parsed = try fromSliceAlloc(Vec2, gpa, ".{.x = 1.2}", null, .{});
+        const parsed = try fromSlice(Vec2, gpa, ".{.x = 1.2}", null, .{});
         try std.testing.expectEqual(Vec2{ .x = 1.2, .y = 1.5 }, parsed);
     }
 
     // Comptime field
     {
         const Vec2 = struct { x: f32, comptime y: f32 = 1.5 };
-        const parsed = try fromSliceAlloc(Vec2, gpa, ".{.x = 1.2}", null, .{});
+        const parsed = try fromSlice(Vec2, gpa, ".{.x = 1.2}", null, .{});
         try std.testing.expectEqual(Vec2{ .x = 1.2, .y = 1.5 }, parsed);
     }
 
@@ -1682,7 +1682,7 @@ test "std.zon structs" {
         const Vec2 = struct { x: f32, comptime y: f32 = 1.5 };
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        const parsed = fromSliceAlloc(Vec2, gpa, ".{.x = 1.2, .y = 1.5}", &diag, .{});
+        const parsed = fromSlice(Vec2, gpa, ".{.x = 1.2, .y = 1.5}", &diag, .{});
         try std.testing.expectError(error.ParseZon, parsed);
         try std.testing.expectFmt(
             \\1:18: error: cannot initialize comptime field
@@ -1694,14 +1694,14 @@ test "std.zon structs" {
     // incorrect way that broke for enum values)
     {
         const Vec0 = struct { x: enum { x } };
-        const parsed = try fromSliceAlloc(Vec0, gpa, ".{ .x = .x }", null, .{});
+        const parsed = try fromSlice(Vec0, gpa, ".{ .x = .x }", null, .{});
         try std.testing.expectEqual(Vec0{ .x = .x }, parsed);
     }
 
     // Enum field and struct field with @
     {
         const Vec0 = struct { @"x x": enum { @"x x" } };
-        const parsed = try fromSliceAlloc(Vec0, gpa, ".{ .@\"x x\" = .@\"x x\" }", null, .{});
+        const parsed = try fromSlice(Vec0, gpa, ".{ .@\"x x\" = .@\"x x\" }", null, .{});
         try std.testing.expectEqual(Vec0{ .@"x x" = .@"x x" }, parsed);
     }
 
@@ -1711,7 +1711,7 @@ test "std.zon structs" {
         {
             var diag: Diagnostics = .{};
             defer diag.deinit(gpa);
-            const parsed = fromSliceAlloc(struct {}, gpa, "Empty{}", &diag, .{});
+            const parsed = fromSlice(struct {}, gpa, "Empty{}", &diag, .{});
             try std.testing.expectError(error.ParseZon, parsed);
             try std.testing.expectFmt(
                 \\1:1: error: types are not available in ZON
@@ -1724,7 +1724,7 @@ test "std.zon structs" {
         {
             var diag: Diagnostics = .{};
             defer diag.deinit(gpa);
-            const parsed = fromSliceAlloc([3]u8, gpa, "[3]u8{1, 2, 3}", &diag, .{});
+            const parsed = fromSlice([3]u8, gpa, "[3]u8{1, 2, 3}", &diag, .{});
             try std.testing.expectError(error.ParseZon, parsed);
             try std.testing.expectFmt(
                 \\1:1: error: types are not available in ZON
@@ -1750,7 +1750,7 @@ test "std.zon structs" {
         {
             var diag: Diagnostics = .{};
             defer diag.deinit(gpa);
-            const parsed = fromSliceAlloc(
+            const parsed = fromSlice(
                 struct { u8, u8, u8 },
                 gpa,
                 "Tuple{1, 2, 3}",
@@ -1769,7 +1769,7 @@ test "std.zon structs" {
         {
             var diag: Diagnostics = .{};
             defer diag.deinit(gpa);
-            const parsed = fromSliceAlloc(struct {}, gpa, ".{ .x = Tuple{1, 2, 3} }", &diag, .{});
+            const parsed = fromSlice(struct {}, gpa, ".{ .x = Tuple{1, 2, 3} }", &diag, .{});
             try std.testing.expectError(error.ParseZon, parsed);
             try std.testing.expectFmt(
                 \\1:9: error: types are not available in ZON
@@ -1790,16 +1790,16 @@ test "std.zon tuples" {
         const Tuple2 = struct { f32, bool };
         const Tuple3 = struct { f32, bool, u8 };
 
-        const zero = try fromSliceAlloc(Tuple0, gpa, ".{}", null, .{});
+        const zero = try fromSlice(Tuple0, gpa, ".{}", null, .{});
         try std.testing.expectEqual(Tuple0{}, zero);
 
-        const one = try fromSliceAlloc(Tuple1, gpa, ".{1.2}", null, .{});
+        const one = try fromSlice(Tuple1, gpa, ".{1.2}", null, .{});
         try std.testing.expectEqual(Tuple1{1.2}, one);
 
-        const two = try fromSliceAlloc(Tuple2, gpa, ".{1.2, true}", null, .{});
+        const two = try fromSlice(Tuple2, gpa, ".{1.2, true}", null, .{});
         try std.testing.expectEqual(Tuple2{ 1.2, true }, two);
 
-        const three = try fromSliceAlloc(Tuple3, gpa, ".{1.2, false, 3}", null, .{});
+        const three = try fromSlice(Tuple3, gpa, ".{1.2, false, 3}", null, .{});
         try std.testing.expectEqual(Tuple3{ 1.2, false, 3 }, three);
     }
 
@@ -1818,7 +1818,7 @@ test "std.zon tuples" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Tuple, gpa, ".{0.5, true, 123}", &diag, .{}),
+            fromSlice(Tuple, gpa, ".{0.5, true, 123}", &diag, .{}),
         );
         try std.testing.expectFmt("1:14: error: index 2 outside of tuple length 2\n", "{f}", .{diag});
     }
@@ -1830,7 +1830,7 @@ test "std.zon tuples" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Tuple, gpa, ".{0.5}", &diag, .{}),
+            fromSlice(Tuple, gpa, ".{0.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:2: error: missing tuple field with index 1\n",
@@ -1846,7 +1846,7 @@ test "std.zon tuples" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Tuple, gpa, ".{.foo = 10.0}", &diag, .{}),
+            fromSlice(Tuple, gpa, ".{.foo = 10.0}", &diag, .{}),
         );
         try std.testing.expectFmt("1:2: error: expected tuple\n", "{f}", .{diag});
     }
@@ -1858,7 +1858,7 @@ test "std.zon tuples" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Struct, gpa, ".{10.0}", &diag, .{}),
+            fromSlice(Struct, gpa, ".{10.0}", &diag, .{}),
         );
         try std.testing.expectFmt("1:2: error: expected struct\n", "{f}", .{diag});
     }
@@ -1866,7 +1866,7 @@ test "std.zon tuples" {
     // Comptime field
     {
         const Vec2 = struct { f32, comptime f32 = 1.5 };
-        const parsed = try fromSliceAlloc(Vec2, gpa, ".{ 1.2 }", null, .{});
+        const parsed = try fromSlice(Vec2, gpa, ".{ 1.2 }", null, .{});
         try std.testing.expectEqual(Vec2{ 1.2, 1.5 }, parsed);
     }
 
@@ -1875,7 +1875,7 @@ test "std.zon tuples" {
         const Vec2 = struct { f32, comptime f32 = 1.5 };
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        const parsed = fromSliceAlloc(Vec2, gpa, ".{ 1.2, 1.5}", &diag, .{});
+        const parsed = fromSlice(Vec2, gpa, ".{ 1.2, 1.5}", &diag, .{});
         try std.testing.expectError(error.ParseZon, parsed);
         try std.testing.expectFmt(
             \\1:9: error: cannot initialize comptime field
@@ -1894,22 +1894,22 @@ test "std.zon arrays and slices" {
     {
         // Arrays
         {
-            const zero = try fromSliceAlloc([0]u8, gpa, ".{}", null, .{});
+            const zero = try fromSlice([0]u8, gpa, ".{}", null, .{});
             try std.testing.expectEqualSlices(u8, &@as([0]u8, .{}), &zero);
 
-            const one = try fromSliceAlloc([1]u8, gpa, ".{'a'}", null, .{});
+            const one = try fromSlice([1]u8, gpa, ".{'a'}", null, .{});
             try std.testing.expectEqualSlices(u8, &@as([1]u8, .{'a'}), &one);
 
-            const two = try fromSliceAlloc([2]u8, gpa, ".{'a', 'b'}", null, .{});
+            const two = try fromSlice([2]u8, gpa, ".{'a', 'b'}", null, .{});
             try std.testing.expectEqualSlices(u8, &@as([2]u8, .{ 'a', 'b' }), &two);
 
-            const two_comma = try fromSliceAlloc([2]u8, gpa, ".{'a', 'b',}", null, .{});
+            const two_comma = try fromSlice([2]u8, gpa, ".{'a', 'b',}", null, .{});
             try std.testing.expectEqualSlices(u8, &@as([2]u8, .{ 'a', 'b' }), &two_comma);
 
-            const three = try fromSliceAlloc([3]u8, gpa, ".{'a', 'b', 'c'}", null, .{});
+            const three = try fromSlice([3]u8, gpa, ".{'a', 'b', 'c'}", null, .{});
             try std.testing.expectEqualSlices(u8, &.{ 'a', 'b', 'c' }, &three);
 
-            const sentinel = try fromSliceAlloc([3:'z']u8, gpa, ".{'a', 'b', 'c'}", null, .{});
+            const sentinel = try fromSlice([3:'z']u8, gpa, ".{'a', 'b', 'c'}", null, .{});
             const expected_sentinel: [3:'z']u8 = .{ 'a', 'b', 'c' };
             try std.testing.expectEqualSlices(u8, &expected_sentinel, &sentinel);
         }
@@ -1966,7 +1966,7 @@ test "std.zon arrays and slices" {
     {
         // Arrays
         {
-            const sentinel = try fromSliceAlloc([1:2]u8, gpa, ".{1}", null, .{});
+            const sentinel = try fromSlice([1:2]u8, gpa, ".{1}", null, .{});
             try std.testing.expectEqual(@as(usize, 1), sentinel.len);
             try std.testing.expectEqual(@as(u8, 1), sentinel[0]);
             try std.testing.expectEqual(@as(u8, 2), sentinel[1]);
@@ -1988,7 +1988,7 @@ test "std.zon arrays and slices" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc([0]u8, gpa, ".{'a', 'b', 'c'}", &diag, .{}),
+            fromSlice([0]u8, gpa, ".{'a', 'b', 'c'}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:3: error: index 0 outside of array of length 0\n",
@@ -2003,7 +2003,7 @@ test "std.zon arrays and slices" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc([1]u8, gpa, ".{'a', 'b'}", &diag, .{}),
+            fromSlice([1]u8, gpa, ".{'a', 'b'}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:8: error: index 1 outside of array of length 1\n",
@@ -2018,7 +2018,7 @@ test "std.zon arrays and slices" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc([2]u8, gpa, ".{'a'}", &diag, .{}),
+            fromSlice([2]u8, gpa, ".{'a'}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:2: error: expected 2 array elements; found 1\n",
@@ -2033,7 +2033,7 @@ test "std.zon arrays and slices" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc([3]u8, gpa, ".{}", &diag, .{}),
+            fromSlice([3]u8, gpa, ".{}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:2: error: expected 3 array elements; found 0\n",
@@ -2050,7 +2050,7 @@ test "std.zon arrays and slices" {
             defer diag.deinit(gpa);
             try std.testing.expectError(
                 error.ParseZon,
-                fromSliceAlloc([3]bool, gpa, ".{'a', 'b', 'c'}", &diag, .{}),
+                fromSlice([3]bool, gpa, ".{'a', 'b', 'c'}", &diag, .{}),
             );
             try std.testing.expectFmt("1:3: error: expected type 'bool'\n", "{f}", .{diag});
         }
@@ -2075,7 +2075,7 @@ test "std.zon arrays and slices" {
             defer diag.deinit(gpa);
             try std.testing.expectError(
                 error.ParseZon,
-                fromSliceAlloc([3]u8, gpa, "'a'", &diag, .{}),
+                fromSlice([3]u8, gpa, "'a'", &diag, .{}),
             );
             try std.testing.expectFmt("1:1: error: expected array\n", "{f}", .{diag});
         }
@@ -2166,7 +2166,7 @@ test "std.zon string literal" {
             defer diag.deinit(gpa);
             try std.testing.expectError(
                 error.ParseZon,
-                fromSliceAlloc([4:0]u8, gpa, "\"abcd\"", &diag, .{}),
+                fromSlice([4:0]u8, gpa, "\"abcd\"", &diag, .{}),
             );
             try std.testing.expectFmt("1:1: error: expected array\n", "{f}", .{diag});
         }
@@ -2176,7 +2176,7 @@ test "std.zon string literal" {
             defer diag.deinit(gpa);
             try std.testing.expectError(
                 error.ParseZon,
-                fromSliceAlloc([4:0]u8, gpa, "\\\\abcd", &diag, .{}),
+                fromSlice([4:0]u8, gpa, "\\\\abcd", &diag, .{}),
             );
             try std.testing.expectFmt("1:1: error: expected array\n", "{f}", .{diag});
         }
@@ -2362,12 +2362,12 @@ test "std.zon enum literals" {
     };
 
     // Tags that exist
-    try std.testing.expectEqual(Enum.foo, try fromSliceAlloc(Enum, gpa, ".foo", null, .{}));
-    try std.testing.expectEqual(Enum.bar, try fromSliceAlloc(Enum, gpa, ".bar", null, .{}));
-    try std.testing.expectEqual(Enum.baz, try fromSliceAlloc(Enum, gpa, ".baz", null, .{}));
+    try std.testing.expectEqual(Enum.foo, try fromSlice(Enum, gpa, ".foo", null, .{}));
+    try std.testing.expectEqual(Enum.bar, try fromSlice(Enum, gpa, ".bar", null, .{}));
+    try std.testing.expectEqual(Enum.baz, try fromSlice(Enum, gpa, ".baz", null, .{}));
     try std.testing.expectEqual(
         Enum.@"ab\nc",
-        try fromSliceAlloc(Enum, gpa, ".@\"ab\\nc\"", null, .{}),
+        try fromSlice(Enum, gpa, ".@\"ab\\nc\"", null, .{}),
     );
 
     // Bad tag
@@ -2376,7 +2376,7 @@ test "std.zon enum literals" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Enum, gpa, ".qux", &diag, .{}),
+            fromSlice(Enum, gpa, ".qux", &diag, .{}),
         );
         try std.testing.expectFmt(
             \\1:2: error: unexpected enum literal 'qux'
@@ -2394,7 +2394,7 @@ test "std.zon enum literals" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Enum, gpa, ".@\"foobarbaz\"", &diag, .{}),
+            fromSlice(Enum, gpa, ".@\"foobarbaz\"", &diag, .{}),
         );
         try std.testing.expectFmt(
             \\1:2: error: unexpected enum literal 'foobarbaz'
@@ -2412,7 +2412,7 @@ test "std.zon enum literals" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Enum, gpa, "true", &diag, .{}),
+            fromSlice(Enum, gpa, "true", &diag, .{}),
         );
         try std.testing.expectFmt("1:1: error: expected enum literal\n", "{f}", .{diag});
     }
@@ -2423,7 +2423,7 @@ test "std.zon enum literals" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(Enum, gpa, ".@\"\\x00\"", &diag, .{}),
+            fromSlice(Enum, gpa, ".@\"\\x00\"", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:2: error: identifier cannot contain null bytes\n",
@@ -2446,7 +2446,7 @@ test "std.zon parse bool" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(bool, gpa, " foo", &diag, .{}),
+            fromSlice(bool, gpa, " foo", &diag, .{}),
         );
         try std.testing.expectFmt(
             \\1:2: error: invalid expression
@@ -2458,7 +2458,7 @@ test "std.zon parse bool" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(bool, gpa, "123", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(bool, gpa, "123", &diag, .{}));
         try std.testing.expectFmt("1:1: error: expected type 'bool'\n", "{f}", .{diag});
     }
 }
@@ -2488,42 +2488,42 @@ test "std.zon parse int" {
     const gpa = std.testing.allocator;
 
     // Test various numbers and types
-    try std.testing.expectEqual(@as(u8, 10), try fromSliceAlloc(u8, gpa, "10", null, .{}));
-    try std.testing.expectEqual(@as(i16, 24), try fromSliceAlloc(i16, gpa, "24", null, .{}));
-    try std.testing.expectEqual(@as(i14, -4), try fromSliceAlloc(i14, gpa, "-4", null, .{}));
-    try std.testing.expectEqual(@as(i32, -123), try fromSliceAlloc(i32, gpa, "-123", null, .{}));
+    try std.testing.expectEqual(@as(u8, 10), try fromSlice(u8, gpa, "10", null, .{}));
+    try std.testing.expectEqual(@as(i16, 24), try fromSlice(i16, gpa, "24", null, .{}));
+    try std.testing.expectEqual(@as(i14, -4), try fromSlice(i14, gpa, "-4", null, .{}));
+    try std.testing.expectEqual(@as(i32, -123), try fromSlice(i32, gpa, "-123", null, .{}));
 
     // Test limits
-    try std.testing.expectEqual(@as(i8, 127), try fromSliceAlloc(i8, gpa, "127", null, .{}));
-    try std.testing.expectEqual(@as(i8, -128), try fromSliceAlloc(i8, gpa, "-128", null, .{}));
+    try std.testing.expectEqual(@as(i8, 127), try fromSlice(i8, gpa, "127", null, .{}));
+    try std.testing.expectEqual(@as(i8, -128), try fromSlice(i8, gpa, "-128", null, .{}));
 
     // Test characters
-    try std.testing.expectEqual(@as(u8, 'a'), try fromSliceAlloc(u8, gpa, "'a'", null, .{}));
-    try std.testing.expectEqual(@as(u8, 'z'), try fromSliceAlloc(u8, gpa, "'z'", null, .{}));
+    try std.testing.expectEqual(@as(u8, 'a'), try fromSlice(u8, gpa, "'a'", null, .{}));
+    try std.testing.expectEqual(@as(u8, 'z'), try fromSlice(u8, gpa, "'z'", null, .{}));
 
     // Test big integers
     try std.testing.expectEqual(
         @as(u65, 36893488147419103231),
-        try fromSliceAlloc(u65, gpa, "36893488147419103231", null, .{}),
+        try fromSlice(u65, gpa, "36893488147419103231", null, .{}),
     );
     try std.testing.expectEqual(
         @as(u65, 36893488147419103231),
-        try fromSliceAlloc(u65, gpa, "368934_881_474191032_31", null, .{}),
+        try fromSlice(u65, gpa, "368934_881_474191032_31", null, .{}),
     );
 
     // Test big integer limits
     try std.testing.expectEqual(
         @as(i66, 36893488147419103231),
-        try fromSliceAlloc(i66, gpa, "36893488147419103231", null, .{}),
+        try fromSlice(i66, gpa, "36893488147419103231", null, .{}),
     );
     try std.testing.expectEqual(
         @as(i66, -36893488147419103232),
-        try fromSliceAlloc(i66, gpa, "-36893488147419103232", null, .{}),
+        try fromSlice(i66, gpa, "-36893488147419103232", null, .{}),
     );
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(
+        try std.testing.expectError(error.ParseZon, fromSlice(
             i66,
             gpa,
             "36893488147419103232",
@@ -2539,7 +2539,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(
+        try std.testing.expectError(error.ParseZon, fromSlice(
             i66,
             gpa,
             "-36893488147419103233",
@@ -2554,75 +2554,75 @@ test "std.zon parse int" {
     }
 
     // Test parsing whole number floats as integers
-    try std.testing.expectEqual(@as(i8, -1), try fromSliceAlloc(i8, gpa, "-1.0", null, .{}));
-    try std.testing.expectEqual(@as(i8, 123), try fromSliceAlloc(i8, gpa, "123.0", null, .{}));
+    try std.testing.expectEqual(@as(i8, -1), try fromSlice(i8, gpa, "-1.0", null, .{}));
+    try std.testing.expectEqual(@as(i8, 123), try fromSlice(i8, gpa, "123.0", null, .{}));
 
     // Test non-decimal integers
-    try std.testing.expectEqual(@as(i16, 0xff), try fromSliceAlloc(i16, gpa, "0xff", null, .{}));
-    try std.testing.expectEqual(@as(i16, -0xff), try fromSliceAlloc(i16, gpa, "-0xff", null, .{}));
-    try std.testing.expectEqual(@as(i16, 0o77), try fromSliceAlloc(i16, gpa, "0o77", null, .{}));
-    try std.testing.expectEqual(@as(i16, -0o77), try fromSliceAlloc(i16, gpa, "-0o77", null, .{}));
-    try std.testing.expectEqual(@as(i16, 0b11), try fromSliceAlloc(i16, gpa, "0b11", null, .{}));
-    try std.testing.expectEqual(@as(i16, -0b11), try fromSliceAlloc(i16, gpa, "-0b11", null, .{}));
+    try std.testing.expectEqual(@as(i16, 0xff), try fromSlice(i16, gpa, "0xff", null, .{}));
+    try std.testing.expectEqual(@as(i16, -0xff), try fromSlice(i16, gpa, "-0xff", null, .{}));
+    try std.testing.expectEqual(@as(i16, 0o77), try fromSlice(i16, gpa, "0o77", null, .{}));
+    try std.testing.expectEqual(@as(i16, -0o77), try fromSlice(i16, gpa, "-0o77", null, .{}));
+    try std.testing.expectEqual(@as(i16, 0b11), try fromSlice(i16, gpa, "0b11", null, .{}));
+    try std.testing.expectEqual(@as(i16, -0b11), try fromSlice(i16, gpa, "-0b11", null, .{}));
 
     // Test non-decimal big integers
-    try std.testing.expectEqual(@as(u65, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(u65, 0x1ffffffffffffffff), try fromSlice(
         u65,
         gpa,
         "0x1ffffffffffffffff",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(i66, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(i66, 0x1ffffffffffffffff), try fromSlice(
         i66,
         gpa,
         "0x1ffffffffffffffff",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(i66, -0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(i66, -0x1ffffffffffffffff), try fromSlice(
         i66,
         gpa,
         "-0x1ffffffffffffffff",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(u65, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(u65, 0x1ffffffffffffffff), try fromSlice(
         u65,
         gpa,
         "0o3777777777777777777777",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(i66, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(i66, 0x1ffffffffffffffff), try fromSlice(
         i66,
         gpa,
         "0o3777777777777777777777",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(i66, -0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(i66, -0x1ffffffffffffffff), try fromSlice(
         i66,
         gpa,
         "-0o3777777777777777777777",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(u65, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(u65, 0x1ffffffffffffffff), try fromSlice(
         u65,
         gpa,
         "0b11111111111111111111111111111111111111111111111111111111111111111",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(i66, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(i66, 0x1ffffffffffffffff), try fromSlice(
         i66,
         gpa,
         "0b11111111111111111111111111111111111111111111111111111111111111111",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(i66, -0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(i66, -0x1ffffffffffffffff), try fromSlice(
         i66,
         gpa,
         "-0b11111111111111111111111111111111111111111111111111111111111111111",
@@ -2634,7 +2634,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "32a32", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "32a32", &diag, .{}));
         try std.testing.expectFmt(
             "1:3: error: invalid digit 'a' for decimal base\n",
             "{f}",
@@ -2646,7 +2646,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "true", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "true", &diag, .{}));
         try std.testing.expectFmt("1:1: error: expected type 'u8'\n", "{f}", .{diag});
     }
 
@@ -2654,7 +2654,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "256", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "256", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: type 'u8' cannot represent value\n",
             "{f}",
@@ -2666,7 +2666,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "-129", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "-129", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: type 'i8' cannot represent value\n",
             "{f}",
@@ -2678,7 +2678,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "-1", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "-1", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: type 'u8' cannot represent value\n",
             "{f}",
@@ -2690,7 +2690,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "1.5", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "1.5", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: type 'u8' cannot represent value\n",
             "{f}",
@@ -2702,7 +2702,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "-1.0", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "-1.0", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: type 'u8' cannot represent value\n",
             "{f}",
@@ -2714,7 +2714,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "-0", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "-0", &diag, .{}));
         try std.testing.expectFmt(
             \\1:2: error: integer literal '-0' is ambiguous
             \\1:2: note: use '0' for an integer zero
@@ -2727,7 +2727,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(f32, gpa, "-0", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(f32, gpa, "-0", &diag, .{}));
         try std.testing.expectFmt(
             \\1:2: error: integer literal '-0' is ambiguous
             \\1:2: note: use '0' for an integer zero
@@ -2738,15 +2738,15 @@ test "std.zon parse int" {
 
     // Negative float 0 is allowed
     try std.testing.expect(
-        std.math.isNegativeZero(try fromSliceAlloc(f32, gpa, "-0.0", null, .{})),
+        std.math.isNegativeZero(try fromSlice(f32, gpa, "-0.0", null, .{})),
     );
-    try std.testing.expect(std.math.isPositiveZero(try fromSliceAlloc(f32, gpa, "0.0", null, .{})));
+    try std.testing.expect(std.math.isPositiveZero(try fromSlice(f32, gpa, "0.0", null, .{})));
 
     // Double negation is not allowed
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "--2", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "--2", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: expected number or 'inf' after '-'\n",
             "{f}",
@@ -2759,7 +2759,7 @@ test "std.zon parse int" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(f32, gpa, "--2.0", &diag, .{}),
+            fromSlice(f32, gpa, "--2.0", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:1: error: expected number or 'inf' after '-'\n",
@@ -2772,7 +2772,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "0xg", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "0xg", &diag, .{}));
         try std.testing.expectFmt("1:3: error: invalid digit 'g' for hex base\n", "{f}", .{diag});
     }
 
@@ -2780,7 +2780,7 @@ test "std.zon parse int" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(u8, gpa, "0123", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(u8, gpa, "0123", &diag, .{}));
         try std.testing.expectFmt(
             \\1:1: error: number '0123' has leading zero
             \\1:1: note: use '0o' prefix for octal literals
@@ -2795,7 +2795,7 @@ test "std.zon negative char" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(f32, gpa, "-'a'", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(f32, gpa, "-'a'", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: expected number or 'inf' after '-'\n",
             "{f}",
@@ -2805,7 +2805,7 @@ test "std.zon negative char" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i16, gpa, "-'a'", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i16, gpa, "-'a'", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: expected number or 'inf' after '-'\n",
             "{f}",
@@ -2820,44 +2820,44 @@ test "std.zon parse float" {
     const gpa = std.testing.allocator;
 
     // Test decimals
-    try std.testing.expectEqual(@as(f16, 0.5), try fromSliceAlloc(f16, gpa, "0.5", null, .{}));
+    try std.testing.expectEqual(@as(f16, 0.5), try fromSlice(f16, gpa, "0.5", null, .{}));
     try std.testing.expectEqual(
         @as(f32, 123.456),
-        try fromSliceAlloc(f32, gpa, "123.456", null, .{}),
+        try fromSlice(f32, gpa, "123.456", null, .{}),
     );
     try std.testing.expectEqual(
         @as(f64, -123.456),
-        try fromSliceAlloc(f64, gpa, "-123.456", null, .{}),
+        try fromSlice(f64, gpa, "-123.456", null, .{}),
     );
-    try std.testing.expectEqual(@as(f128, 42.5), try fromSliceAlloc(f128, gpa, "42.5", null, .{}));
+    try std.testing.expectEqual(@as(f128, 42.5), try fromSlice(f128, gpa, "42.5", null, .{}));
 
     // Test whole numbers with and without decimals
-    try std.testing.expectEqual(@as(f16, 5.0), try fromSliceAlloc(f16, gpa, "5.0", null, .{}));
-    try std.testing.expectEqual(@as(f16, 5.0), try fromSliceAlloc(f16, gpa, "5", null, .{}));
-    try std.testing.expectEqual(@as(f32, -102), try fromSliceAlloc(f32, gpa, "-102.0", null, .{}));
-    try std.testing.expectEqual(@as(f32, -102), try fromSliceAlloc(f32, gpa, "-102", null, .{}));
+    try std.testing.expectEqual(@as(f16, 5.0), try fromSlice(f16, gpa, "5.0", null, .{}));
+    try std.testing.expectEqual(@as(f16, 5.0), try fromSlice(f16, gpa, "5", null, .{}));
+    try std.testing.expectEqual(@as(f32, -102), try fromSlice(f32, gpa, "-102.0", null, .{}));
+    try std.testing.expectEqual(@as(f32, -102), try fromSlice(f32, gpa, "-102", null, .{}));
 
     // Test characters and negated characters
-    try std.testing.expectEqual(@as(f32, 'a'), try fromSliceAlloc(f32, gpa, "'a'", null, .{}));
-    try std.testing.expectEqual(@as(f32, 'z'), try fromSliceAlloc(f32, gpa, "'z'", null, .{}));
+    try std.testing.expectEqual(@as(f32, 'a'), try fromSlice(f32, gpa, "'a'", null, .{}));
+    try std.testing.expectEqual(@as(f32, 'z'), try fromSlice(f32, gpa, "'z'", null, .{}));
 
     // Test big integers
     try std.testing.expectEqual(
         @as(f32, 36893488147419103231.0),
-        try fromSliceAlloc(f32, gpa, "36893488147419103231", null, .{}),
+        try fromSlice(f32, gpa, "36893488147419103231", null, .{}),
     );
     try std.testing.expectEqual(
         @as(f32, -36893488147419103231.0),
-        try fromSliceAlloc(f32, gpa, "-36893488147419103231", null, .{}),
+        try fromSlice(f32, gpa, "-36893488147419103231", null, .{}),
     );
-    try std.testing.expectEqual(@as(f128, 0x1ffffffffffffffff), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(f128, 0x1ffffffffffffffff), try fromSlice(
         f128,
         gpa,
         "0x1ffffffffffffffff",
         null,
         .{},
     ));
-    try std.testing.expectEqual(@as(f32, @floatFromInt(0x1ffffffffffffffff)), try fromSliceAlloc(
+    try std.testing.expectEqual(@as(f32, @floatFromInt(0x1ffffffffffffffff)), try fromSlice(
         f32,
         gpa,
         "0x1ffffffffffffffff",
@@ -2868,33 +2868,33 @@ test "std.zon parse float" {
     // Exponents, underscores
     try std.testing.expectEqual(
         @as(f32, 123.0E+77),
-        try fromSliceAlloc(f32, gpa, "12_3.0E+77", null, .{}),
+        try fromSlice(f32, gpa, "12_3.0E+77", null, .{}),
     );
 
     // Hexadecimal
     try std.testing.expectEqual(
         @as(f32, 0x103.70p-5),
-        try fromSliceAlloc(f32, gpa, "0x103.70p-5", null, .{}),
+        try fromSlice(f32, gpa, "0x103.70p-5", null, .{}),
     );
     try std.testing.expectEqual(
         @as(f32, -0x103.70),
-        try fromSliceAlloc(f32, gpa, "-0x103.70", null, .{}),
+        try fromSlice(f32, gpa, "-0x103.70", null, .{}),
     );
     try std.testing.expectEqual(
         @as(f32, 0x1234_5678.9ABC_CDEFp-10),
-        try fromSliceAlloc(f32, gpa, "0x1234_5678.9ABC_CDEFp-10", null, .{}),
+        try fromSlice(f32, gpa, "0x1234_5678.9ABC_CDEFp-10", null, .{}),
     );
 
     // inf, nan
-    try std.testing.expect(std.math.isPositiveInf(try fromSliceAlloc(f32, gpa, "inf", null, .{})));
-    try std.testing.expect(std.math.isNegativeInf(try fromSliceAlloc(f32, gpa, "-inf", null, .{})));
-    try std.testing.expect(std.math.isNan(try fromSliceAlloc(f32, gpa, "nan", null, .{})));
+    try std.testing.expect(std.math.isPositiveInf(try fromSlice(f32, gpa, "inf", null, .{})));
+    try std.testing.expect(std.math.isNegativeInf(try fromSlice(f32, gpa, "-inf", null, .{})));
+    try std.testing.expect(std.math.isNan(try fromSlice(f32, gpa, "nan", null, .{})));
 
     // Negative nan not allowed
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(f32, gpa, "-nan", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(f32, gpa, "-nan", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: expected number or 'inf' after '-'\n",
             "{f}",
@@ -2906,7 +2906,7 @@ test "std.zon parse float" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "nan", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "nan", &diag, .{}));
         try std.testing.expectFmt("1:1: error: expected type 'i8'\n", "{f}", .{diag});
     }
 
@@ -2914,7 +2914,7 @@ test "std.zon parse float" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "nan", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "nan", &diag, .{}));
         try std.testing.expectFmt("1:1: error: expected type 'i8'\n", "{f}", .{diag});
     }
 
@@ -2922,7 +2922,7 @@ test "std.zon parse float" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "inf", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "inf", &diag, .{}));
         try std.testing.expectFmt("1:1: error: expected type 'i8'\n", "{f}", .{diag});
     }
 
@@ -2930,7 +2930,7 @@ test "std.zon parse float" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(i8, gpa, "-inf", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(i8, gpa, "-inf", &diag, .{}));
         try std.testing.expectFmt("1:1: error: expected type 'i8'\n", "{f}", .{diag});
     }
 
@@ -2938,7 +2938,7 @@ test "std.zon parse float" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(f32, gpa, "foo", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(f32, gpa, "foo", &diag, .{}));
         try std.testing.expectFmt(
             \\1:1: error: invalid expression
             \\1:1: note: ZON allows identifiers 'true', 'false', 'null', 'inf', and 'nan'
@@ -2950,7 +2950,7 @@ test "std.zon parse float" {
     {
         var diag: Diagnostics = .{};
         defer diag.deinit(gpa);
-        try std.testing.expectError(error.ParseZon, fromSliceAlloc(f32, gpa, "-foo", &diag, .{}));
+        try std.testing.expectError(error.ParseZon, fromSlice(f32, gpa, "-foo", &diag, .{}));
         try std.testing.expectFmt(
             "1:1: error: expected number or 'inf' after '-'\n",
             "{f}",
@@ -2964,7 +2964,7 @@ test "std.zon parse float" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(f32, gpa, "\"foo\"", &diag, .{}),
+            fromSlice(f32, gpa, "\"foo\"", &diag, .{}),
         );
         try std.testing.expectFmt("1:1: error: expected type 'f32'\n", "{f}", .{diag});
     }
@@ -3052,7 +3052,7 @@ test "std.zon free on error" {
     // unions.
     try std.testing.expectEqual(
         @as(f32, 1.5),
-        (try fromSliceAlloc(union { x: f32 }, std.testing.allocator, ".{ .x = 1.5 }", null, .{})).x,
+        (try fromSlice(union { x: f32 }, std.testing.allocator, ".{ .x = 1.5 }", null, .{})).x,
     );
 
     // We can also parse types that can't be freed if it's impossible for an error to occur after
@@ -3155,29 +3155,29 @@ test "std.zon vector" {
     // Passing cases
     try std.testing.expectEqual(
         @Vector(0, bool){},
-        try fromSliceAlloc(@Vector(0, bool), gpa, ".{}", null, .{}),
+        try fromSlice(@Vector(0, bool), gpa, ".{}", null, .{}),
     );
     try std.testing.expectEqual(
         @Vector(3, bool){ true, false, true },
-        try fromSliceAlloc(@Vector(3, bool), gpa, ".{true, false, true}", null, .{}),
+        try fromSlice(@Vector(3, bool), gpa, ".{true, false, true}", null, .{}),
     );
 
     try std.testing.expectEqual(
         @Vector(0, f32){},
-        try fromSliceAlloc(@Vector(0, f32), gpa, ".{}", null, .{}),
+        try fromSlice(@Vector(0, f32), gpa, ".{}", null, .{}),
     );
     try std.testing.expectEqual(
         @Vector(3, f32){ 1.5, 2.5, 3.5 },
-        try fromSliceAlloc(@Vector(3, f32), gpa, ".{1.5, 2.5, 3.5}", null, .{}),
+        try fromSlice(@Vector(3, f32), gpa, ".{1.5, 2.5, 3.5}", null, .{}),
     );
 
     try std.testing.expectEqual(
         @Vector(0, u8){},
-        try fromSliceAlloc(@Vector(0, u8), gpa, ".{}", null, .{}),
+        try fromSlice(@Vector(0, u8), gpa, ".{}", null, .{}),
     );
     try std.testing.expectEqual(
         @Vector(3, u8){ 2, 4, 6 },
-        try fromSliceAlloc(@Vector(3, u8), gpa, ".{2, 4, 6}", null, .{}),
+        try fromSlice(@Vector(3, u8), gpa, ".{2, 4, 6}", null, .{}),
     );
 
     {
@@ -3206,7 +3206,7 @@ test "std.zon vector" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(@Vector(2, f32), gpa, ".{0.5}", &diag, .{}),
+            fromSlice(@Vector(2, f32), gpa, ".{0.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:2: error: expected 2 vector elements; found 1\n",
@@ -3221,7 +3221,7 @@ test "std.zon vector" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(@Vector(2, f32), gpa, ".{0.5, 1.5, 2.5}", &diag, .{}),
+            fromSlice(@Vector(2, f32), gpa, ".{0.5, 1.5, 2.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:2: error: expected 2 vector elements; found 3\n",
@@ -3236,7 +3236,7 @@ test "std.zon vector" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(@Vector(3, f32), gpa, ".{0.5, true, 2.5}", &diag, .{}),
+            fromSlice(@Vector(3, f32), gpa, ".{0.5, true, 2.5}", &diag, .{}),
         );
         try std.testing.expectFmt(
             "1:8: error: expected type 'f32'\n",
@@ -3251,7 +3251,7 @@ test "std.zon vector" {
         defer diag.deinit(gpa);
         try std.testing.expectError(
             error.ParseZon,
-            fromSliceAlloc(@Vector(3, u8), gpa, "true", &diag, .{}),
+            fromSlice(@Vector(3, u8), gpa, "true", &diag, .{}),
         );
         try std.testing.expectFmt("1:1: error: expected type '@Vector(3, u8)'\n", "{f}", .{diag});
     }


### PR DESCRIPTION
Adds the following functions to `std.zon.parse`:
* `fromSliceFlat`
* `fromZoirFlat`
* `fromZoirNodeFlat`

These are identical to the existing functions with "flat" stripped from the name, but they assert at compile time that the result type doesn't contain a pointer and therefore doesn't need to be freed. As such, the latter two functions do not require an allocator as an argument. (`fromSlice` still does as it needs to allocate the `Ast` and `Zoir`.)

I'm open to alternative suggestions for the names. I think "flat" as in "flat in memory" is pretty reasonable, though it could be misinterpreted as to do with nesting. I would have simply named them `noAlloc`, but this is confusing since `fromSliceFlat` does in fact create (temporary) allocations.

Replaces #22835, CC @NicoElbers (thanks for the reminder that I wanted to do this!)