### PR TITLE
Fix build failure in sbrk allocator, caused by #20511

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -989,6 +989,7 @@ test {
     _ = GeneralPurposeAllocator;
     _ = FixedBufferAllocator;
     _ = ThreadSafeAllocator;
+    _ = SbrkAllocator;
     if (builtin.target.isWasm()) {
         _ = WasmAllocator;
     }

--- a/lib/std/heap/sbrk_allocator.zig
+++ b/lib/std/heap/sbrk_allocator.zig
@@ -11,6 +11,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
         pub const vtable: Allocator.VTable = .{
             .alloc = alloc,
             .resize = resize,
+            .remap = remap,
             .free = free,
         };
 
@@ -39,13 +40,13 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
 
         // TODO don't do the naive locking strategy
         var lock: std.Thread.Mutex = .{};
-        fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, return_address: usize) ?[*]u8 {
+        fn alloc(ctx: *anyopaque, len: usize, log2_align: mem.Alignment, return_address: usize) ?[*]u8 {
             _ = ctx;
             _ = return_address;
             lock.lock();
             defer lock.unlock();
             // Make room for the freelist next pointer.
-            const alignment = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_align));
+            const alignment = log2_align.toByteUnits();
             const actual_len = @max(len +| @sizeOf(usize), alignment);
             const slot_size = math.ceilPowerOfTwo(usize, actual_len) catch return null;
             const class = math.log2(slot_size) - min_class;
@@ -82,7 +83,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
         fn resize(
             ctx: *anyopaque,
             buf: []u8,
-            log2_buf_align: u8,
+            log2_buf_align: mem.Alignment,
             new_len: usize,
             return_address: usize,
         ) bool {
@@ -92,7 +93,7 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
             defer lock.unlock();
             // We don't want to move anything from one size class to another, but we
             // can recover bytes in between powers of two.
-            const buf_align = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_buf_align));
+            const buf_align = log2_buf_align.toByteUnits();
             const old_actual_len = @max(buf.len + @sizeOf(usize), buf_align);
             const new_actual_len = @max(new_len +| @sizeOf(usize), buf_align);
             const old_small_slot_size = math.ceilPowerOfTwoAssert(usize, old_actual_len);
@@ -109,17 +110,27 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
             }
         }
 
+        fn remap(
+            context: *anyopaque,
+            memory: []u8,
+            alignment: mem.Alignment,
+            new_len: usize,
+            return_address: usize,
+        ) ?[*]u8 {
+            return if (resize(context, memory, alignment, new_len, return_address)) memory.ptr else null;
+        }
+
         fn free(
             ctx: *anyopaque,
             buf: []u8,
-            log2_buf_align: u8,
+            log2_buf_align: mem.Alignment,
             return_address: usize,
         ) void {
             _ = ctx;
             _ = return_address;
             lock.lock();
             defer lock.unlock();
-            const buf_align = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_buf_align));
+            const buf_align = log2_buf_align.toByteUnits();
             const actual_len = @max(buf.len + @sizeOf(usize), buf_align);
             const slot_size = math.ceilPowerOfTwoAssert(usize, actual_len);
             const class = math.log2(slot_size) - min_class;
@@ -157,4 +168,12 @@ pub fn SbrkAllocator(comptime sbrk: *const fn (n: usize) usize) type {
             return sbrk(pow2_pages * pages_per_bigpage * heap.pageSize());
         }
     };
+}
+
+test SbrkAllocator {
+    _ = SbrkAllocator(struct {
+        fn sbrk(_: usize) usize {
+            return 0;
+        }
+    }.sbrk);
 }


### PR DESCRIPTION
This fixes the sbrk allocator build failures tracked by #22806, and adds a test to `std` that ensures the allocator continues to compile in the future.

There were two failures I needed to fix to get this working:
1. The `Allocator.VTable` was missing `remap`. I declared the function using the same implementation as the arena allocator.
2. Function signatures switched from `u8` to `mem.Alignment`. I switched over, and started calling `toByteUnits()` to perform the same conversion as before.

## Testing
I validated this change by running std tests with `zig test lib/std/std.zig --zig-lib-dir lib`.
I confirmed that they fail with the newly added test, and then pass after the code change.