### PR TITLE
Skip empty/invalid records/certs in MacOS keychain files

### DIFF
--- a/lib/std/crypto/Certificate/Bundle/macos.zig
+++ b/lib/std/crypto/Certificate/Bundle/macos.zig
@@ -61,9 +61,15 @@ pub fn rescanMac(cb: *Bundle, gpa: Allocator) RescanMacError!void {
             }
 
             for (record_list) |record_offset| {
+                // An offset of zero means that the record is not present.
+                // An offset that is not 4-byte-aligned is invalid.
+                if (record_offset == 0 or record_offset % 4 != 0) continue;
+
                 try stream.seekTo(db_header.schema_offset + table_offset + record_offset);
 
                 const cert_header = try reader.readStructEndian(X509CertHeader, .big);
+
+                if (cert_header.cert_size == 0) continue;
 
                 try cb.bytes.ensureUnusedCapacity(gpa, cert_header.cert_size);
 


### PR DESCRIPTION
In the original PR that implemented `rescanMac` (https://github.com/ziglang/zig/pull/14325), it included a list of references for the keychain format. Multiple of those references include the checks that are added in this commit, and empirically this fixes the loading of a real keychain file that was previously failing (it had both a record with offset 0 and a record with cert_size 0).

To give more detail: when not skipping a record with offset zero, it would attempt to read the base of the table as a `X509CertHeader`, but the base of the table is actually a `TableHeader`. It would then take this misinterpreted `X509CertHeader` and read N bytes that follow it (where N is equal to the misinterpreted `cert_size`), and then try to parse those bytes as a DER cert. These bytes are just some arbitrary bytes in the keychain file, though, not the actual start of a cert, so it would fail at some arbitrary point in `Certificate.parse`.

What this means is that https://github.com/ziglang/zig/pull/22701 didn't directly cause a regression, but instead exposed a latent bug, and that these zero-record-offset/zero-cert-size records are seemingly much more common in `/Library/Keychains/System.keychain`.

Fixes #22870

---

Specifically, this has fixed the regression for @nurpax detailed in https://ziggit.dev/t/zig-fetch-failing-with-discover-remote-git-server-capabilities-certificatebundleloadfailure/8608

However, this fix does not explain/account for the 'swap the ordering' workaround from https://github.com/ziglang/zig/issues/22870#issuecomment-2653836145, so this may not be a full solution. Would appreciate @jedisct1 checking to see that this fixes the regression for them.