### PR TITLE
rescanMac: Avoid overallocating/overreading by millions of bytes

### DIFF
--- a/lib/std/crypto/Certificate/Bundle/macos.zig
+++ b/lib/std/crypto/Certificate/Bundle/macos.zig
@@ -71,11 +71,9 @@ pub fn rescanMac(cb: *Bundle, gpa: Allocator) RescanMacError!void {
 
                 if (cert_header.cert_size == 0) continue;
 
-                try cb.bytes.ensureUnusedCapacity(gpa, cert_header.cert_size);
-
                 const cert_start = @as(u32, @intCast(cb.bytes.items.len));
-                const dest_buf = cb.bytes.allocatedSlice()[cert_start..];
-                cb.bytes.items.len += try reader.readAtLeast(dest_buf, cert_header.cert_size);
+                const dest_buf = try cb.bytes.addManyAsSlice(gpa, cert_header.cert_size);
+                try reader.readNoEof(dest_buf);
 
                 try cb.parseCert(gpa, cert_start, now_sec);
             }


### PR DESCRIPTION
Something random I noticed while investigating https://github.com/ziglang/zig/issues/22870

---

readAtLeast is greedy and will read the entire length of the buffer if it can. However, reading past the end of the cert in this case is useless, so reading the full length of the buffer just puts an increasingly large (due to the growth algorithm of ArrayList) collection of wasted bytes after each cert in cb.bytes.

In practical terms, this ends up saving potentially millions of bytes of wasted reads/allocations. In my testing, after reading the keychain files on my machine, cb.bytes ends up with these capacities:

- Before this PR: cb.bytes.capacity = 32720747
- After this PR: cb.bytes.capacity = 251937

That's a decrease of 99.2%

Additionally, swaps to readNoEof since it should be an error to hit EOF without reading the full cert size.