### PR TITLE
Autodoc: Improve documentation for common types declared as type functions

### DIFF
--- a/lib/docs/wasm/main.zig
+++ b/lib/docs/wasm/main.zig
@@ -380,16 +380,48 @@ export fn decl_params(decl_index: Decl.Index) Slice(Ast.Node.Index) {
 }
 
 fn decl_fields_fallible(decl_index: Decl.Index) ![]Ast.Node.Index {
+    const decl = decl_index.get();
+    const ast = decl.file.get_ast();
+
+    switch (decl.categorize()) {
+        .type_function => {
+            const node_tags = ast.nodes.items(.tag);
+
+            // Find the return statement
+            if (decl.get_type_fn_return_expr()) |return_expr| {
+                switch (node_tags[return_expr]) {
+                    .call, .call_comma, .call_one, .call_one_comma => {
+                        const node_data = ast.nodes.items(.data);
+                        const function = node_data[return_expr].lhs;
+                        const token = ast.nodes.items(.main_token)[function];
+                        const name = ast.tokenSlice(token);
+                        if (decl.lookup(name)) |function_decl| {
+                            return decl_fields_fallible(function_decl);
+                        }
+                    },
+                    .container_decl, .container_decl_trailing, .container_decl_two, .container_decl_two_trailing, .container_decl_arg, .container_decl_arg_trailing => {
+                        return ast_decl_fields_fallible(ast, return_expr);
+                    },
+                    else => {},
+                }
+            }
+            return &.{};
+        },
+        else => {
+            const value_node = decl.value_node() orelse return &.{};
+            return ast_decl_fields_fallible(ast, value_node);
+        },
+    }
+}
+
+fn ast_decl_fields_fallible(ast: *Ast, ast_index: Ast.Node.Index) ![]Ast.Node.Index {
     const g = struct {
         var result: std.ArrayListUnmanaged(Ast.Node.Index) = .empty;
     };
     g.result.clearRetainingCapacity();
-    const decl = decl_index.get();
-    const ast = decl.file.get_ast();
     const node_tags = ast.nodes.items(.tag);
-    const value_node = decl.value_node() orelse return &.{};
     var buf: [2]Ast.Node.Index = undefined;
-    const container_decl = ast.fullContainerDecl(&buf, value_node) orelse return &.{};
+    const container_decl = ast.fullContainerDecl(&buf, ast_index) orelse return &.{};
     for (container_decl.ast.members) |member_node| switch (node_tags[member_node]) {
         .container_field_init,
         .container_field_align,
@@ -883,6 +915,13 @@ export fn categorize_decl(decl_index: Decl.Index, resolve_alias_count: usize) Wa
 }
 
 export fn type_fn_members(parent: Decl.Index, include_private: bool) Slice(Decl.Index) {
+    const decl = parent.get();
+
+    // If the type function returns another type function, get the members of that function
+    if (decl.get_type_fn_return_type_fn()) |function_decl| {
+        return namespace_members(function_decl, include_private);
+    }
+
     return namespace_members(parent, include_private);
 }
 


### PR DESCRIPTION
This change adds additional information to Autodoc for types such as ArrayList, StaticStringMap, BoundedArray, and more, by inspecting the contents of the function and surfacing information from the type returned by the function, if possible.

## Before
The [current documentation](https://ziglang.org/documentation/master/std/#std.array_list.ArrayList) for `ArrayList` displays a doc comment, as well as function parameters and source code.
![Screenshot_20250217_221359](https://github.com/user-attachments/assets/f2e5446c-1d9d-49cc-ba3d-a69b078c9d17)

Important information is missing from the docs, such as the presence of the `items` field, and functions for adding/removing/etc. People have to read the source code to know that `ArrayList` is really an alias for `ArrayListAligned`, and go to the documentation there to see the available functions. The `items` field doesn't show up on the [documentation](https://ziglang.org/documentation/master/std/#std.array_list.ArrayListAligned) for `ArrayListAligned` either.

## After
This change updates the ArrayList documentation to show the following:
![Screenshot_20250217_221523](https://github.com/user-attachments/assets/dd42f623-7c6c-4d67-ab9b-a341241fe588)

## How does it work?
This adds code to Autodoc looking for two specific kinds of code inside of a type function:

1. Returning another type function
When looking at a type function like the `ArrayList` function, Autodoc will look at the body of the function, see it returns another type (`ArrayListAligned`), and include any fields and members found in `ArrayListAligned` in the documentation.
```zig
pub fn ArrayList(comptime T: type) type {
    return ArrayListAligned(T, null);
}
```

2. Returning a `struct`
```zig
pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
    if (alignment) |a| {
        if (a == @alignOf(T)) {
            return ArrayListAligned(T, null);
        }
    }
    return struct {
        items: Slice,
        capacity: usize,
        allocator: Allocator,

        // ... functions
    };
}
```
In type functions such as `ArrayListAligned`, Autodoc will find the `struct` that's returned (or any container for that matter), and consider the fields of that container fields of the type function for documentation purposes.

## Testing
- I ran `zig std` and clicked through a variety of types in `std`, comparing the documentation before and after. Many types appear to benefit from this, and have more expansive documentation.
- I verified that links continue to work on documentation pages, taking me to the correct documentation pages for newly referenced functions and types.