### PR TITLE
docs: update old reference from builtin.Type.Struct to builtin.Type.@"struct"

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -261,7 +261,7 @@ test containerLayout {
     try testing.expect(containerLayout(U3) == .@"extern");
 }
 
-/// Instead of this function, prefer to use e.g. `@typeInfo(foo).Struct.decls`
+/// Instead of this function, prefer to use e.g. `@typeInfo(foo).@"struct".decls`
 /// directly when you know what kind of type it is.
 pub fn declarations(comptime T: type) []const Type.Declaration {
     return switch (@typeInfo(T)) {


### PR DESCRIPTION
A very simple change to reflect the new [std.builtin.Type](https://ziglang.org/documentation/master/std/#std.builtin.Type) format