### PR TITLE
crypto.Ed25519.KeyPair: return an error rather than assert

### DIFF
--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -298,7 +298,9 @@ pub const Ed25519 = struct {
             if (std.debug.runtime_safety) {
                 const pk_p = try Curve.fromBytes(secret_key.publicKeyBytes());
                 const recomputed_kp = try generateDeterministic(secret_key.seed());
-                debug.assert(mem.eql(u8, &recomputed_kp.public_key.toBytes(), &pk_p.toBytes()));
+                if (!mem.eql(u8, &recomputed_kp.public_key.toBytes(), &pk_p.toBytes())) {
+                    return error.NonCanonical;
+                }
             }
             return KeyPair{
                 .public_key = try PublicKey.fromBytes(secret_key.publicKeyBytes()),


### PR DESCRIPTION
When runtime safety is turned on, `Ed25519.fromSecretKey()` can currently hit an assertion if the format of the secret key is invalid.

Return an error instead, so that applications can recover.