### PR TITLE
`test`: Disable packet timeout for debugger tests.

### DIFF
--- a/test/src/Debugger.zig
+++ b/test/src/Debugger.zig
@@ -2391,6 +2391,7 @@ fn addGdbTest(
             "--batch",
             "--command",
         },
+        "set remotetimeout 0",
         commands,
         &.{
             "--args",
@@ -2416,6 +2417,7 @@ fn addLldbTest(
             "--batch",
             "--source",
         },
+        "settings set plugin.process.gdb-remote.packet-timeout 0",
         commands,
         &.{
             "--",
@@ -2435,6 +2437,7 @@ fn addTest(
     target: Target,
     files: []const File,
     db_argv1: []const []const u8,
+    db_commands: []const u8,
     commands: []const u8,
     db_argv2: []const []const u8,
     expected_output: []const []const u8,
@@ -2476,7 +2479,10 @@ fn addTest(
     const commands_wf = db.b.addWriteFiles();
     const run = std.Build.Step.Run.create(db.b, db.b.fmt("run {s} {s}", .{ name, target.test_name_suffix }));
     run.addArgs(db_argv1);
-    run.addFileArg(commands_wf.add(db.b.fmt("{s}.cmd", .{name}), db.b.fmt("{s}\n\nquit {d}\n", .{ commands, success })));
+    run.addFileArg(commands_wf.add(
+        db.b.fmt("{s}.cmd", .{name}),
+        db.b.fmt("{s}\n\n{s}\n\nquit {d}\n", .{ db_commands, commands, success }),
+    ));
     run.addArgs(db_argv2);
     run.addArtifactArg(exe);
     for (expected_output) |expected| run.addCheck(.{ .expect_stdout_match = db.b.fmt("{s}\n", .{expected}) });


### PR DESCRIPTION
On my machine, the defaults are 5 seconds (LLDB) and 2 seconds (GDB). These are too low on the CI machines during high load, and the CI system itself already enforces a timeout on jobs anyway, so just disable the timeout altogether.