### PR TITLE
`link.MachO`: Don't force GOT indirection on aarch64.

### DIFF
--- a/src/link/MachO/Atom.zig
+++ b/src/link/MachO/Atom.zig
@@ -482,8 +482,7 @@ pub fn scanRelocs(self: Atom, macho_file: *MachO) !void {
                 const symbol = rel.getTargetSymbol(self, macho_file);
                 if (symbol.flags.import or
                     (symbol.flags.@"export" and symbol.flags.weak) or
-                    symbol.flags.interposable or
-                    macho_file.getTarget().cpu.arch == .aarch64) // TODO relax on arm64
+                    symbol.flags.interposable)
                 {
                     symbol.setSectionFlags(.{ .needs_got = true });
                     if (symbol.flags.weak) {


### PR DESCRIPTION
Just curious if this hack is still necessary so I want to see what the macOS CI machines think about it.