### PR TITLE
posix: access/accessZ/faccessat/faccessatZ can return AccessDenied or PermissionDenied

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4914,6 +4914,7 @@ pub fn accessZ(path: [*:0]const u8, mode: u32) AccessError!void {
     switch (errno(system.access(path, mode))) {
         .SUCCESS => return,
         .ACCES => return error.PermissionDenied,
+        .PERM => return error.PermissionDenied,
         .ROFS => return error.ReadOnlyFileSystem,
         .LOOP => return error.SymLinkLoop,
         .TXTBSY => return error.FileBusy,
@@ -4999,6 +5000,7 @@ pub fn faccessatZ(dirfd: fd_t, path: [*:0]const u8, mode: u32, flags: u32) Acces
     switch (errno(system.faccessat(dirfd, path, mode, flags))) {
         .SUCCESS => return,
         .ACCES => return error.PermissionDenied,
+        .PERM => return error.PermissionDenied,
         .ROFS => return error.ReadOnlyFileSystem,
         .LOOP => return error.SymLinkLoop,
         .TXTBSY => return error.FileBusy,


### PR DESCRIPTION
`EACCES` is returned if the file mode bit (i.e., user/group/other rwx bits) disallow access (mapped to `error.AccessDenied`).  `EPERM` is returned if something else denies access (immutable bit, SELinux, capabilities, etc) and is mapped to `error.PermissionDenied`.  This somewhat subtle distinction in errors is part of POSIX, and can happen in practice on Linux or MacOS.

This PR is effectively an update/simplification of (abandoned) PR #19193.  See #16782 for deeper problems with the AccessDenied/PermissionDenied duopoly in Zig.

Tested locally with an immutable file.

Fixes #22733 and #19162.