### PR TITLE
Allocator: limit alignment to page_size_min

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -635,27 +635,24 @@ pub fn testAllocatorLargeAlignment(base_allocator: mem.Allocator) !void {
     var validationAllocator = mem.validationWrap(base_allocator);
     const allocator = validationAllocator.allocator();
 
-    const large_align: usize = page_size_min / 2;
+    const max_align: mem.Alignment = .max_alignment;
 
-    var align_mask: usize = undefined;
-    align_mask = @shlWithOverflow(~@as(usize, 0), @as(Allocator.Log2Align, @ctz(large_align)))[0];
-
-    var slice = try allocator.alignedAlloc(u8, large_align, 500);
-    try testing.expect(@intFromPtr(slice.ptr) & align_mask == @intFromPtr(slice.ptr));
+    var slice = try allocator.alignedAlloc(u8, max_align.toByteUnits(), 500);
+    try testing.expect(max_align.check(@intFromPtr(slice.ptr)));
 
     if (allocator.resize(slice, 100)) {
         slice = slice[0..100];
     }
 
     slice = try allocator.realloc(slice, 5000);
-    try testing.expect(@intFromPtr(slice.ptr) & align_mask == @intFromPtr(slice.ptr));
+    try testing.expect(max_align.check(@intFromPtr(slice.ptr)));
 
     if (allocator.resize(slice, 10)) {
         slice = slice[0..10];
     }
 
     slice = try allocator.realloc(slice, 20000);
-    try testing.expect(@intFromPtr(slice.ptr) & align_mask == @intFromPtr(slice.ptr));
+    try testing.expect(max_align.check(@intFromPtr(slice.ptr)));
 
     allocator.free(slice);
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -29,6 +29,8 @@ pub const Alignment = enum(math.Log2Int(usize)) {
     @"64" = 6,
     _,
 
+    pub const max_alignment: Alignment = .fromByteUnits(std.heap.page_size_min);
+
     pub fn toByteUnits(a: Alignment) usize {
         return @as(usize, 1) << @intFromEnum(a);
     }

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -23,7 +23,7 @@ pub const VTable = struct {
     /// Return a pointer to `len` bytes with specified `alignment`, or return
     /// `null` indicating the allocation failed.
     ///
-    /// The `alignment` parameter may not be greater that `Alignment.max_alignment`.
+    /// The `alignment` parameter may not be greater than `Alignment.max_alignment`.
     ///
     /// `ret_addr` is optionally provided as the first return address of the
     /// allocation call stack. If the value is `0` it means no return address

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -23,6 +23,8 @@ pub const VTable = struct {
     /// Return a pointer to `len` bytes with specified `alignment`, or return
     /// `null` indicating the allocation failed.
     ///
+    /// The `alignment` parameter may not be greater that `Alignment.max_alignment`.
+    ///
     /// `ret_addr` is optionally provided as the first return address of the
     /// allocation call stack. If the value is `0` it means no return address
     /// has been provided.
@@ -261,6 +263,8 @@ fn allocWithSizeAndAlignment(self: Allocator, comptime size: usize, comptime ali
 }
 
 fn allocBytesWithAlignment(self: Allocator, comptime alignment: u29, byte_count: usize, return_address: usize) Error![*]align(alignment) u8 {
+    comptime assert(Alignment.compare(.fromByteUnits(alignment), .lte, .max_alignment));
+
     if (byte_count == 0) {
         const ptr = comptime std.mem.alignBackward(usize, math.maxInt(usize), alignment);
         return @as([*]align(alignment) u8, @ptrFromInt(ptr));


### PR DESCRIPTION
The check for alignment is specifically only done in `allocBytesWithAligment` so that it can be done at compile time.

Closes #7952