### PR TITLE
std.atomic: make cache_line const a comptime_int

### DIFF
--- a/lib/std/atomic.zig
+++ b/lib/std/atomic.zig
@@ -482,7 +482,7 @@ pub fn cacheLineForCpu(cpu: std.Target.Cpu) u16 {
 ///
 /// https://en.wikipedia.org/wiki/False_sharing
 /// https://github.com/golang/go/search?q=CacheLinePadSize
-pub const cache_line = cacheLineForCpu(builtin.cpu);
+pub const cache_line: comptime_int = cacheLineForCpu(builtin.cpu);
 
 test "current CPU has a cache line size" {
     _ = cache_line;


### PR DESCRIPTION
This fixes potential issues and unintended coercions in other areas, such as std.ArrayList.

Previously:

```
const std = @import("std");
const Foo = struct { buf: [68536]u8 = undefined };

pub fn main() void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    var v = std.ArrayList(Foo).init(gpa.allocator());
    v.append(undefined) catch unreachable;
}
```

would yield

```
/home/kiedtl/zig14/lib/std/array_list.zig:1220:81: error: type 'u16' cannot represent integer value '68536'
        const init_capacity = @as(comptime_int, @max(1, std.atomic.cache_line / @sizeOf(T)));
                                                                                ^~~~~~~~~~
referenced by:
    growCapacity: /home/kiedtl/zig14/lib/std/array_list.zig:1227:35
    ensureTotalCapacity: /home/kiedtl/zig14/lib/std/array_list.zig:449:89
    8 reference(s) hidden; use '-freference-trace=10' to see all references
```

This change fixes this.