### PR TITLE
Default to printing floats with decimal instead of scientific notation

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -792,13 +792,13 @@ fn formatFloatValue(
 ) !void {
     var buf: [format_float.bufferSize(.decimal, f64)]u8 = undefined;
 
-    if (fmt.len == 0 or comptime std.mem.eql(u8, fmt, "e")) {
-        const s = formatFloat(&buf, value, .{ .mode = .scientific, .precision = options.precision }) catch |err| switch (err) {
+    if (fmt.len == 0 or comptime std.mem.eql(u8, fmt, "d")) {
+        const s = formatFloat(&buf, value, .{ .mode = .decimal, .precision = options.precision }) catch |err| switch (err) {
             error.BufferTooSmall => "(float)",
         };
         return formatBuf(s, options, writer);
-    } else if (comptime std.mem.eql(u8, fmt, "d")) {
-        const s = formatFloat(&buf, value, .{ .mode = .decimal, .precision = options.precision }) catch |err| switch (err) {
+    } else if (comptime std.mem.eql(u8, fmt, "e")) {
+        const s = formatFloat(&buf, value, .{ .mode = .scientific, .precision = options.precision }) catch |err| switch (err) {
             error.BufferTooSmall => "(float)",
         };
         return formatBuf(s, options, writer);
@@ -2180,7 +2180,7 @@ test "struct" {
     // Tuples
     try expectFmt("{ }", "{}", .{.{}});
     try expectFmt("{ -1 }", "{}", .{.{-1}});
-    try expectFmt("{ -1, 42, 2.5e4 }", "{}", .{.{ -1, 42, 0.25e5 }});
+    try expectFmt("{ -1, 42, 25000 }", "{}", .{.{ -1, 42, 0.25e5 }});
 }
 
 test "enum" {
@@ -2521,10 +2521,10 @@ test "formatFloatValue with comptime_float" {
     var buf: [20]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     try formatFloatValue(value, "", FormatOptions{}, fbs.writer());
-    try std.testing.expectEqualStrings(fbs.getWritten(), "1e0");
+    try std.testing.expectEqualStrings(fbs.getWritten(), "1");
 
-    try expectFmt("1e0", "{}", .{value});
-    try expectFmt("1e0", "{}", .{1.0});
+    try expectFmt("1", "{}", .{value});
+    try expectFmt("1", "{}", .{1.0});
 }
 
 test "formatType max_depth" {
@@ -2736,8 +2736,8 @@ test "runtime width specifier" {
 test "runtime precision specifier" {
     const number: f32 = 3.1415;
     const precision: usize = 2;
-    try expectFmt("3.14e0", "{:1.[1]}", .{ number, precision });
-    try expectFmt("3.14e0", "{:1.[precision]}", .{ .number = number, .precision = precision });
+    try expectFmt("3.14", "{:1.[1]}", .{ number, precision });
+    try expectFmt("3.14", "{:1.[precision]}", .{ .number = number, .precision = precision });
 }
 
 test "recursive format function" {

--- a/lib/std/json/dynamic_test.zig
+++ b/lib/std/json/dynamic_test.zig
@@ -254,7 +254,7 @@ test "Value.jsonStringify" {
         \\ true,
         \\ 42,
         \\ 43,
-        \\ 4.2e1,
+        \\ 42,
         \\ "weeee",
         \\ [
         \\  1,
@@ -266,7 +266,7 @@ test "Value.jsonStringify" {
         \\ }
         \\]
     ;
-    try testing.expectEqualSlices(u8, expected, fbs.getWritten());
+    try testing.expectEqualStrings(expected, fbs.getWritten());
 }
 
 test "parseFromValue(std.json.Value,...)" {

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -74,16 +74,16 @@ fn testBasicWriteStream(w: anytype, slice_stream: anytype) !void {
         \\{
         \\  "object": {
         \\    "one": 1,
-        \\    "two": 2e0
+        \\    "two": 2
         \\  },
         \\  "string": "This is a string",
         \\  "array": [
         \\    "Another string",
         \\    1,
-        \\    3.5e0
+        \\    3.5
         \\  ],
         \\  "int": 10,
-        \\  "float": 3.5e0
+        \\  "float": 3.5
         \\}
     ;
     try std.testing.expectEqualStrings(expected, result);
@@ -123,12 +123,12 @@ test "stringify basic types" {
     try testStringify("null", @as(?u8, null), .{});
     try testStringify("null", @as(?*u32, null), .{});
     try testStringify("42", 42, .{});
-    try testStringify("4.2e1", 42.0, .{});
+    try testStringify("42", 42.0, .{});
     try testStringify("42", @as(u8, 42), .{});
     try testStringify("42", @as(u128, 42), .{});
     try testStringify("9999999999999999", 9999999999999999, .{});
-    try testStringify("4.2e1", @as(f32, 42), .{});
-    try testStringify("4.2e1", @as(f64, 42), .{});
+    try testStringify("42", @as(f32, 42), .{});
+    try testStringify("42", @as(f64, 42), .{});
     try testStringify("\"ItBroke\"", @as(anyerror, error.ItBroke), .{});
     try testStringify("\"ItBroke\"", error.ItBroke, .{});
 }


### PR DESCRIPTION
Currently, `std.fmt` defaults to formatting floats with scientific notation. IIUC this was originally due to some limitations in the float formatting code that have since been resolved.

This results in some silly output, such as `@as(f32, 1)` being formatted as `1e0`. Outside of being a bit odd, it makes it easy to misinterpret output if you miss the `e` at the end of a number. You can just pass `d` to the formatter when formatting a single number, but this doesn't work if you're formatting e.g. a struct that contains fields with numbers. As such it's worth it to have a good default here.

This PR changes the default to decimal, and updates the corresponding tests.
