### PR TITLE
stdlib: handle EEXIST in mmap with FIXED_NOREPLACE. Fixes #21475

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -1420,6 +1420,7 @@ const LinuxThreadImpl = struct {
             error.PermissionDenied => unreachable,
             error.ProcessFdQuotaExceeded => unreachable,
             error.SystemFdQuotaExceeded => unreachable,
+            error.MappingAlreadyExists => unreachable,
             else => |e| return e,
         };
         assert(mapped.len >= map_bytes);

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4753,6 +4753,9 @@ pub const MMapError = error{
     ProcessFdQuotaExceeded,
     SystemFdQuotaExceeded,
     OutOfMemory,
+
+    /// Using FIXED_NOREPLACE flag and the process has already mapped memory at the given address
+    MappingAlreadyExists,
 } || UnexpectedError;
 
 /// Map files or devices into memory.
@@ -4791,6 +4794,7 @@ pub fn mmap(
         .MFILE => return error.ProcessFdQuotaExceeded,
         .NFILE => return error.SystemFdQuotaExceeded,
         .NOMEM => return error.OutOfMemory,
+        .EXIST => return error.MappingAlreadyExists,
         else => return unexpectedErrno(err),
     }
 }


### PR DESCRIPTION
# Fix mmap handling for EEXIST with MAP_FIXED_NOREPLACE  
## **Fixes #21475**  

This patch adds `MappingAlreadyExists` to the `MMapError` error set and ensures that `mmap` correctly handles `EEXIST`, which can only be returned when using the `MAP_FIXED_NOREPLACE` flag.

## **Changes Made**  
1. **Updated `MMapError` in `std.posix`**  
   - Added `MappingAlreadyExists` to the error set.  
   - Matched `E.EXIST` to this new error in the `mmap` function.  

2. **Updated `loadPath` in `std.debug.Dwarf.zig`**  
   - Replaced `try` with `catch` on the `mmap` call site to explicitly mark `MappingAlreadyExists` as `unreachable` while still propagating all other errors up the call stack.  

3. **Updated `spawn` in `std.Thread.zig`**  
   - Marked `MappingAlreadyExists` as `unreachable` in the `catch` block, along with other `mmap` errors that are also unreachable.  

## **Rationale**  
- The two places in the standard library that call `mmap` (`loadPath` in `Dwarf.zig` and `spawn` in `Thread.zig`) **do not** use `MAP_FIXED_NOREPLACE`.  
- According to the `mmap(2)` man pages, `EEXIST` is **only** returned if `MAP_FIXED_NOREPLACE` is used.  
- This means that these parts of the standard library **cannot** actually encounter this error.  
- Changing `try` to `catch` in `loadPath` ensures that the error is properly marked unreachable while preserving correct error propagation.  
- The `spawn` function already marks similar unreachable errors, so `MappingAlreadyExists` was handled the same way.  
