### PR TITLE
`llvm`: Fix C ABI integer promotion for loongarch64.

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -12525,7 +12525,7 @@ fn ccAbiPromoteInt(
             else => null,
         },
         else => switch (target.cpu.arch) {
-            .riscv64 => switch (int_info.bits) {
+            .loongarch64, .riscv64 => switch (int_info.bits) {
                 0...16 => int_info.signedness,
                 32 => .signed, // LLVM always signextends 32 bit ints, unsure if bug.
                 17...31, 33...63 => int_info.signedness,


### PR DESCRIPTION
It appears to just be a 1:1 copy of riscv64, including the super weird sign extension quirk for `u32`.

Contributes to #21671.