### PR TITLE
Replace deprecated std.io.Reader and std.io.Writer

### DIFF
--- a/lib/compiler/resinator/compile.zig
+++ b/lib/compiler/resinator/compile.zig
@@ -2983,7 +2983,7 @@ pub fn LimitedWriter(comptime WriterType: type) type {
         bytes_left: u64,
 
         pub const Error = error{NoSpaceLeft} || WriterType.Error;
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         const Self = @This();
 

--- a/lib/compiler/resinator/compile.zig
+++ b/lib/compiler/resinator/compile.zig
@@ -2949,7 +2949,7 @@ pub fn HeaderSlurpingReader(comptime size: usize, comptime ReaderType: anytype) 
         slurped_header: [size]u8 = [_]u8{0x00} ** size,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = std.io.Reader(*@This(), Error, read);
+        pub const Reader = std.io.GenericReader(*@This(), Error, read);
 
         pub fn read(self: *@This(), buf: []u8) Error!usize {
             const amt = try self.child_reader.read(buf);

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -342,7 +342,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
             @compileError("The Writer interface is only defined for ArrayList(u8) " ++
                 "but the given type is ArrayList(" ++ @typeName(T) ++ ")")
         else
-            std.io.Writer(*Self, Allocator.Error, appendWrite);
+            std.io.GenericWriter(*Self, Allocator.Error, appendWrite);
 
         /// Initializes a Writer which will append to the list.
         pub fn writer(self: *Self) Writer {
@@ -350,14 +350,14 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
         }
 
         /// Same as `append` except it returns the number of bytes written, which is always the same
-        /// as `m.len`. The purpose of this function existing is to match `std.io.Writer` API.
+        /// as `m.len`. The purpose of this function existing is to match `std.io.GenericWriter` API.
         /// Invalidates element pointers if additional memory is needed.
         fn appendWrite(self: *Self, m: []const u8) Allocator.Error!usize {
             try self.appendSlice(m);
             return m.len;
         }
 
-        pub const FixedWriter = std.io.Writer(*Self, Allocator.Error, appendWriteFixed);
+        pub const FixedWriter = std.io.GenericWriter(*Self, Allocator.Error, appendWriteFixed);
 
         /// Initializes a Writer which will append to the list but will return
         /// `error.OutOfMemory` rather than increasing capacity.
@@ -365,7 +365,7 @@ pub fn ArrayListAligned(comptime T: type, comptime alignment: ?u29) type {
             return .{ .context = self };
         }
 
-        /// The purpose of this function existing is to match `std.io.Writer` API.
+        /// The purpose of this function existing is to match `std.io.GenericWriter` API.
         fn appendWriteFixed(self: *Self, m: []const u8) error{OutOfMemory}!usize {
             const available_capacity = self.capacity - self.items.len;
             if (m.len > available_capacity)
@@ -944,7 +944,7 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
             @compileError("The Writer interface is only defined for ArrayList(u8) " ++
                 "but the given type is ArrayList(" ++ @typeName(T) ++ ")")
         else
-            std.io.Writer(WriterContext, Allocator.Error, appendWrite);
+            std.io.GenericWriter(WriterContext, Allocator.Error, appendWrite);
 
         /// Initializes a Writer which will append to the list.
         pub fn writer(self: *Self, allocator: Allocator) Writer {
@@ -953,14 +953,14 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
 
         /// Same as `append` except it returns the number of bytes written,
         /// which is always the same as `m.len`. The purpose of this function
-        /// existing is to match `std.io.Writer` API.
+        /// existing is to match `std.io.GenericWriter` API.
         /// Invalidates element pointers if additional memory is needed.
         fn appendWrite(context: WriterContext, m: []const u8) Allocator.Error!usize {
             try context.self.appendSlice(context.allocator, m);
             return m.len;
         }
 
-        pub const FixedWriter = std.io.Writer(*Self, Allocator.Error, appendWriteFixed);
+        pub const FixedWriter = std.io.GenericWriter(*Self, Allocator.Error, appendWriteFixed);
 
         /// Initializes a Writer which will append to the list but will return
         /// `error.OutOfMemory` rather than increasing capacity.
@@ -968,7 +968,7 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
             return .{ .context = self };
         }
 
-        /// The purpose of this function existing is to match `std.io.Writer` API.
+        /// The purpose of this function existing is to match `std.io.GenericWriter` API.
         fn appendWriteFixed(self: *Self, m: []const u8) error{OutOfMemory}!usize {
             const available_capacity = self.capacity - self.items.len;
             if (m.len > available_capacity)

--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -110,7 +110,7 @@ pub const Base64Encoder = struct {
     }
 
     // destWriter must be compatible with std.io.Writer's writeAll interface
-    // sourceReader must be compatible with std.io.Reader's read interface
+    // sourceReader must be compatible with std.io.GenericReader's read interface
     pub fn encodeFromReaderToWriter(encoder: *const Base64Encoder, destWriter: anytype, sourceReader: anytype) !void {
         while (true) {
             var tempSource: [3]u8 = undefined;

--- a/lib/std/base64.zig
+++ b/lib/std/base64.zig
@@ -99,7 +99,7 @@ pub const Base64Encoder = struct {
         }
     }
 
-    // dest must be compatible with std.io.Writer's writeAll interface
+    // dest must be compatible with std.io.GenericWriter's writeAll interface
     pub fn encodeWriter(encoder: *const Base64Encoder, dest: anytype, source: []const u8) !void {
         var chunker = window(u8, source, 3, 3);
         while (chunker.next()) |chunk| {
@@ -109,7 +109,7 @@ pub const Base64Encoder = struct {
         }
     }
 
-    // destWriter must be compatible with std.io.Writer's writeAll interface
+    // destWriter must be compatible with std.io.GenericWriter's writeAll interface
     // sourceReader must be compatible with std.io.GenericReader's read interface
     pub fn encodeFromReaderToWriter(encoder: *const Base64Encoder, destWriter: anytype, sourceReader: anytype) !void {
         while (true) {

--- a/lib/std/bounded_array.zig
+++ b/lib/std/bounded_array.zig
@@ -276,7 +276,7 @@ pub fn BoundedArrayAligned(
             @compileError("The Writer interface is only defined for BoundedArray(u8, ...) " ++
                 "but the given type is BoundedArray(" ++ @typeName(T) ++ ", ...)")
         else
-            std.io.Writer(*Self, error{Overflow}, appendWrite);
+            std.io.GenericWriter(*Self, error{Overflow}, appendWrite);
 
         /// Initializes a writer which will write into the array.
         pub fn writer(self: *Self) Writer {
@@ -284,7 +284,7 @@ pub fn BoundedArrayAligned(
         }
 
         /// Same as `appendSlice` except it returns the number of bytes written, which is always the same
-        /// as `m.len`. The purpose of this function existing is to match `std.io.Writer` API.
+        /// as `m.len`. The purpose of this function existing is to match `std.io.GenericWriter` API.
         fn appendWrite(self: *Self, m: []const u8) error{Overflow}!usize {
             try self.appendSlice(m);
             return m.len;

--- a/lib/std/compress.zig
+++ b/lib/std/compress.zig
@@ -16,7 +16,7 @@ pub fn HashedReader(ReaderType: type, HasherType: type) type {
         hasher: HasherType,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = std.io.Reader(*@This(), Error, read);
+        pub const Reader = std.io.GenericReader(*@This(), Error, read);
 
         pub fn read(self: *@This(), buf: []u8) Error!usize {
             const amt = try self.child_reader.read(buf);

--- a/lib/std/compress.zig
+++ b/lib/std/compress.zig
@@ -43,7 +43,7 @@ pub fn HashedWriter(WriterType: type, HasherType: type) type {
         hasher: HasherType,
 
         pub const Error = WriterType.Error;
-        pub const Writer = std.io.Writer(*@This(), Error, write);
+        pub const Writer = std.io.GenericWriter(*@This(), Error, write);
 
         pub fn write(self: *@This(), buf: []const u8) Error!usize {
             const amt = try self.child_writer.write(buf);

--- a/lib/std/compress/flate/deflate.zig
+++ b/lib/std/compress/flate/deflate.zig
@@ -355,7 +355,7 @@ fn Deflate(comptime container: Container, comptime WriterType: type, comptime Bl
 
         // Writer interface
 
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
         pub const Error = BlockWriterType.Error;
 
         /// Write `input` of uncompressed data.
@@ -512,7 +512,7 @@ fn SimpleCompressor(
 
         // Writer interface
 
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
         pub const Error = BlockWriterType.Error;
 
         // Write `input` of uncompressed data.

--- a/lib/std/compress/flate/inflate.zig
+++ b/lib/std/compress/flate/inflate.zig
@@ -341,7 +341,7 @@ pub fn Inflate(comptime container: Container, comptime LookaheadType: type, comp
 
         // Reader interface
 
-        pub const Reader = std.io.Reader(*Self, Error, read);
+        pub const Reader = std.io.GenericReader(*Self, Error, read);
 
         /// Returns the number of bytes read. It may be less than buffer.len.
         /// If the number of bytes read is 0, it means end of stream.

--- a/lib/std/compress/lzma.zig
+++ b/lib/std/compress/lzma.zig
@@ -30,7 +30,7 @@ pub fn Decompress(comptime ReaderType: type) type {
             Allocator.Error ||
             error{ CorruptInput, EndOfStream, Overflow };
 
-        pub const Reader = std.io.Reader(*Self, Error, read);
+        pub const Reader = std.io.GenericReader(*Self, Error, read);
 
         allocator: Allocator,
         in_reader: ReaderType,

--- a/lib/std/compress/xz.zig
+++ b/lib/std/compress/xz.zig
@@ -34,7 +34,7 @@ pub fn Decompress(comptime ReaderType: type) type {
         const Self = @This();
 
         pub const Error = ReaderType.Error || block.Decoder(ReaderType).Error;
-        pub const Reader = std.io.Reader(*Self, Error, read);
+        pub const Reader = std.io.GenericReader(*Self, Error, read);
 
         allocator: Allocator,
         block_decoder: block.Decoder(ReaderType),

--- a/lib/std/compress/xz/block.zig
+++ b/lib/std/compress/xz/block.zig
@@ -27,7 +27,7 @@ pub fn Decoder(comptime ReaderType: type) type {
             ReaderType.Error ||
             DecodeError ||
             Allocator.Error;
-        pub const Reader = std.io.Reader(*Self, Error, read);
+        pub const Reader = std.io.GenericReader(*Self, Error, read);
 
         allocator: Allocator,
         inner_reader: ReaderType,

--- a/lib/std/compress/zstandard.zig
+++ b/lib/std/compress/zstandard.zig
@@ -50,7 +50,7 @@ pub fn Decompressor(comptime ReaderType: type) type {
             OutOfMemory,
         };
 
-        pub const Reader = std.io.Reader(*Self, Error, read);
+        pub const Reader = std.io.GenericReader(*Self, Error, read);
 
         pub fn init(source: ReaderType, options: DecompressorOptions) Self {
             return .{

--- a/lib/std/compress/zstandard/readers.zig
+++ b/lib/std/compress/zstandard/readers.zig
@@ -4,7 +4,7 @@ pub const ReversedByteReader = struct {
     remaining_bytes: usize,
     bytes: []const u8,
 
-    const Reader = std.io.Reader(*ReversedByteReader, error{}, readFn);
+    const Reader = std.io.GenericReader(*ReversedByteReader, error{}, readFn);
 
     pub fn init(bytes: []const u8) ReversedByteReader {
         return .{

--- a/lib/std/crypto/aegis.zig
+++ b/lib/std/crypto/aegis.zig
@@ -803,7 +803,7 @@ fn AegisMac(comptime T: type) type {
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Mac, Error, write);
+        pub const Writer = std.io.GenericWriter(*Mac, Error, write);
 
         fn write(self: *Mac, bytes: []const u8) Error!usize {
             self.update(bytes);

--- a/lib/std/crypto/blake2.zig
+++ b/lib/std/crypto/blake2.zig
@@ -187,7 +187,7 @@ pub fn Blake2s(comptime out_bits: usize) type {
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);

--- a/lib/std/crypto/blake3.zig
+++ b/lib/std/crypto/blake3.zig
@@ -476,7 +476,7 @@ pub const Blake3 = struct {
     }
 
     pub const Error = error{};
-    pub const Writer = std.io.Writer(*Blake3, Error, write);
+    pub const Writer = std.io.GenericWriter(*Blake3, Error, write);
 
     fn write(self: *Blake3, bytes: []const u8) Error!usize {
         self.update(bytes);

--- a/lib/std/crypto/sha1.zig
+++ b/lib/std/crypto/sha1.zig
@@ -269,7 +269,7 @@ pub const Sha1 = struct {
     }
 
     pub const Error = error{};
-    pub const Writer = std.io.Writer(*Self, Error, write);
+    pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
     fn write(self: *Self, bytes: []const u8) Error!usize {
         self.update(bytes);

--- a/lib/std/crypto/sha2.zig
+++ b/lib/std/crypto/sha2.zig
@@ -376,7 +376,7 @@ fn Sha2x32(comptime iv: Iv32, digest_bits: comptime_int) type {
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);

--- a/lib/std/crypto/sha3.zig
+++ b/lib/std/crypto/sha3.zig
@@ -82,7 +82,7 @@ pub fn Keccak(comptime f: u11, comptime output_bits: u11, comptime default_delim
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);
@@ -193,7 +193,7 @@ fn ShakeLike(comptime security_level: u11, comptime default_delim: u8, comptime 
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);
@@ -286,7 +286,7 @@ fn CShakeLike(comptime security_level: u11, comptime default_delim: u8, comptime
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);
@@ -392,7 +392,7 @@ fn KMacLike(comptime security_level: u11, comptime default_delim: u8, comptime r
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);
@@ -484,7 +484,7 @@ fn TupleHashLike(comptime security_level: u11, comptime default_delim: u8, compt
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);

--- a/lib/std/crypto/siphash.zig
+++ b/lib/std/crypto/siphash.zig
@@ -240,7 +240,7 @@ fn SipHash(comptime T: type, comptime c_rounds: usize, comptime d_rounds: usize)
         }
 
         pub const Error = error{};
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
 
         fn write(self: *Self, bytes: []const u8) Error!usize {
             self.update(bytes);

--- a/lib/std/debug/Pdb.zig
+++ b/lib/std/debug/Pdb.zig
@@ -562,7 +562,7 @@ const MsfStream = struct {
         return block * self.block_size + offset;
     }
 
-    pub fn reader(self: *MsfStream) std.io.Reader(*MsfStream, Error, read) {
+    pub fn reader(self: *MsfStream) std.io.GenericReader(*MsfStream, Error, read) {
         return .{ .context = self };
     }
 };

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -39,7 +39,7 @@ pub fn LinearFifo(
 
         const Self = @This();
         pub const Reader = std.io.GenericReader(*Self, error{}, readFn);
-        pub const Writer = std.io.Writer(*Self, error{OutOfMemory}, appendWrite);
+        pub const Writer = std.io.GenericWriter(*Self, error{OutOfMemory}, appendWrite);
 
         // Type of Self argument for slice operations.
         // If buffer is inline (Static) then we need to ensure we haven't
@@ -320,7 +320,7 @@ pub fn LinearFifo(
         }
 
         /// Same as `write` except it returns the number of bytes written, which is always the same
-        /// as `bytes.len`. The purpose of this function existing is to match `std.io.Writer` API.
+        /// as `bytes.len`. The purpose of this function existing is to match `std.io.GenericWriter` API.
         fn appendWrite(self: *Self, bytes: []const u8) error{OutOfMemory}!usize {
             try self.write(bytes);
             return bytes.len;

--- a/lib/std/fifo.zig
+++ b/lib/std/fifo.zig
@@ -38,7 +38,7 @@ pub fn LinearFifo(
         count: usize,
 
         const Self = @This();
-        pub const Reader = std.io.Reader(*Self, error{}, readFn);
+        pub const Reader = std.io.GenericReader(*Self, error{}, readFn);
         pub const Writer = std.io.Writer(*Self, error{OutOfMemory}, appendWrite);
 
         // Type of Self argument for slice operations.
@@ -231,7 +231,7 @@ pub fn LinearFifo(
         }
 
         /// Same as `read` except it returns an error union
-        /// The purpose of this function existing is to match `std.io.Reader` API.
+        /// The purpose of this function existing is to match `std.io.GenericReader` API.
         fn readFn(self: *Self, dest: []u8) error{}!usize {
             return self.read(dest);
         }

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1586,7 +1586,7 @@ pub fn reader(file: File) Reader {
     return .{ .context = file };
 }
 
-pub const Writer = io.Writer(File, WriteError, write);
+pub const Writer = io.GenericWriter(File, WriteError, write);
 
 pub fn writer(file: File) Writer {
     return .{ .context = file };

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1580,7 +1580,7 @@ fn writeFileAllSendfile(self: File, in_file: File, args: WriteFileOptions) posix
     }
 }
 
-pub const Reader = io.Reader(File, ReadError, read);
+pub const Reader = io.GenericReader(File, ReadError, read);
 
 pub fn reader(file: File) Reader {
     return .{ .context = file };

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -312,7 +312,7 @@ pub const Connection = struct {
         EndOfStream,
     };
 
-    pub const Reader = std.io.Reader(*Connection, ReadError, read);
+    pub const Reader = std.io.GenericReader(*Connection, ReadError, read);
 
     pub fn reader(conn: *Connection) Reader {
         return Reader{ .context = conn };
@@ -938,7 +938,7 @@ pub const Request = struct {
 
     const TransferReadError = Connection.ReadError || proto.HeadersParser.ReadError;
 
-    const TransferReader = std.io.Reader(*Request, TransferReadError, transferRead);
+    const TransferReader = std.io.GenericReader(*Request, TransferReadError, transferRead);
 
     fn transferReader(req: *Request) TransferReader {
         return .{ .context = req };
@@ -1098,7 +1098,7 @@ pub const Request = struct {
     pub const ReadError = TransferReadError || proto.HeadersParser.CheckCompleteHeadError ||
         error{ DecompressionFailure, InvalidTrailers };
 
-    pub const Reader = std.io.Reader(*Request, ReadError, read);
+    pub const Reader = std.io.GenericReader(*Request, ReadError, read);
 
     pub fn reader(req: *Request) Reader {
         return .{ .context = req };

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -375,7 +375,7 @@ pub const Connection = struct {
         UnexpectedWriteFailure,
     };
 
-    pub const Writer = std.io.Writer(*Connection, WriteError, write);
+    pub const Writer = std.io.GenericWriter(*Connection, WriteError, write);
 
     pub fn writer(conn: *Connection) Writer {
         return Writer{ .context = conn };
@@ -1138,7 +1138,7 @@ pub const Request = struct {
 
     pub const WriteError = Connection.WriteError || error{ NotWriteable, MessageTooLong };
 
-    pub const Writer = std.io.Writer(*Request, WriteError, write);
+    pub const Writer = std.io.GenericWriter(*Request, WriteError, write);
 
     pub fn writer(req: *Request) Writer {
         return .{ .context = req };

--- a/lib/std/http/protocol.zig
+++ b/lib/std/http/protocol.zig
@@ -359,7 +359,7 @@ const MockBufferedConnection = struct {
     }
 
     pub const WriteError = std.io.FixedBufferStream([]const u8).WriteError;
-    pub const Writer = std.io.Writer(*MockBufferedConnection, WriteError, write);
+    pub const Writer = std.io.GenericWriter(*MockBufferedConnection, WriteError, write);
 
     pub fn writer(conn: *MockBufferedConnection) Writer {
         return Writer{ .context = conn };

--- a/lib/std/http/protocol.zig
+++ b/lib/std/http/protocol.zig
@@ -344,7 +344,7 @@ const MockBufferedConnection = struct {
     }
 
     pub const ReadError = std.io.FixedBufferStream([]const u8).ReadError || error{EndOfStream};
-    pub const Reader = std.io.Reader(*MockBufferedConnection, ReadError, read);
+    pub const Reader = std.io.GenericReader(*MockBufferedConnection, ReadError, read);
 
     pub fn reader(conn: *MockBufferedConnection) Reader {
         return Reader{ .context = conn };

--- a/lib/std/io/buffered_atomic_file.zig
+++ b/lib/std/io/buffered_atomic_file.zig
@@ -11,7 +11,7 @@ pub const BufferedAtomicFile = struct {
 
     pub const buffer_size = 4096;
     pub const BufferedWriter = std.io.BufferedWriter(buffer_size, File.Writer);
-    pub const Writer = std.io.Writer(*BufferedWriter, BufferedWriter.Error, BufferedWriter.write);
+    pub const Writer = std.io.GenericWriter(*BufferedWriter, BufferedWriter.Error, BufferedWriter.write);
 
     /// TODO when https://github.com/ziglang/zig/issues/2761 is solved
     /// this API will not need an allocator

--- a/lib/std/io/buffered_reader.zig
+++ b/lib/std/io/buffered_reader.zig
@@ -12,7 +12,7 @@ pub fn BufferedReader(comptime buffer_size: usize, comptime ReaderType: type) ty
         end: usize = 0,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.GenericReader(*Self, Error, read);
 
         const Self = @This();
 
@@ -61,7 +61,7 @@ test "OneByte" {
 
         const Error = error{NoError};
         const Self = @This();
-        const Reader = io.Reader(*Self, Error, read);
+        const Reader = io.GenericReader(*Self, Error, read);
 
         fn init(str: []const u8) Self {
             return Self{
@@ -105,7 +105,7 @@ test "Block" {
 
         const Error = error{NoError};
         const Self = @This();
-        const Reader = io.Reader(*Self, Error, read);
+        const Reader = io.GenericReader(*Self, Error, read);
 
         fn init(block: []const u8, reads_allowed: usize) Self {
             return Self{

--- a/lib/std/io/buffered_writer.zig
+++ b/lib/std/io/buffered_writer.zig
@@ -10,7 +10,7 @@ pub fn BufferedWriter(comptime buffer_size: usize, comptime WriterType: type) ty
         end: usize = 0,
 
         pub const Error = WriterType.Error;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
 
         const Self = @This();
 

--- a/lib/std/io/c_writer.zig
+++ b/lib/std/io/c_writer.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const io = std.io;
 const testing = std.testing;
 
-pub const CWriter = io.Writer(*std.c.FILE, std.fs.File.WriteError, cWriterWrite);
+pub const CWriter = io.GenericWriter(*std.c.FILE, std.fs.File.WriteError, cWriterWrite);
 
 pub fn cWriter(c_file: *std.c.FILE) CWriter {
     return .{ .context = c_file };

--- a/lib/std/io/change_detection_stream.zig
+++ b/lib/std/io/change_detection_stream.zig
@@ -8,7 +8,7 @@ pub fn ChangeDetectionStream(comptime WriterType: type) type {
     return struct {
         const Self = @This();
         pub const Error = WriterType.Error;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
 
         anything_changed: bool,
         underlying_writer: WriterType,

--- a/lib/std/io/counting_reader.zig
+++ b/lib/std/io/counting_reader.zig
@@ -9,7 +9,7 @@ pub fn CountingReader(comptime ReaderType: anytype) type {
         bytes_read: u64 = 0,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*@This(), Error, read);
+        pub const Reader = io.GenericReader(*@This(), Error, read);
 
         pub fn read(self: *@This(), buf: []u8) Error!usize {
             const amt = try self.child_reader.read(buf);

--- a/lib/std/io/counting_writer.zig
+++ b/lib/std/io/counting_writer.zig
@@ -9,7 +9,7 @@ pub fn CountingWriter(comptime WriterType: type) type {
         child_stream: WriterType,
 
         pub const Error = WriterType.Error;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
 
         const Self = @This();
 

--- a/lib/std/io/find_byte_writer.zig
+++ b/lib/std/io/find_byte_writer.zig
@@ -8,7 +8,7 @@ pub fn FindByteWriter(comptime UnderlyingWriter: type) type {
     return struct {
         const Self = @This();
         pub const Error = UnderlyingWriter.Error;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
 
         underlying_writer: UnderlyingWriter,
         byte_found: bool,

--- a/lib/std/io/fixed_buffer_stream.zig
+++ b/lib/std/io/fixed_buffer_stream.zig
@@ -4,8 +4,8 @@ const testing = std.testing;
 const mem = std.mem;
 const assert = std.debug.assert;
 
-/// This turns a byte buffer into an `io.Writer`, `io.GenericReader`, or `io.SeekableStream`.
-/// If the supplied byte buffer is const, then `io.Writer` is not available.
+/// This turns a byte buffer into an `io.GenericWriter`, `io.GenericReader`, or `io.SeekableStream`.
+/// If the supplied byte buffer is const, then `io.GenericWriter` is not available.
 pub fn FixedBufferStream(comptime Buffer: type) type {
     return struct {
         /// `Buffer` is either a `[]u8` or `[]const u8`.
@@ -18,7 +18,7 @@ pub fn FixedBufferStream(comptime Buffer: type) type {
         pub const GetSeekPosError = error{};
 
         pub const Reader = io.GenericReader(*Self, ReadError, read);
-        pub const Writer = io.Writer(*Self, WriteError, write);
+        pub const Writer = io.GenericWriter(*Self, WriteError, write);
 
         pub const SeekableStream = io.SeekableStream(
             *Self,

--- a/lib/std/io/fixed_buffer_stream.zig
+++ b/lib/std/io/fixed_buffer_stream.zig
@@ -4,7 +4,7 @@ const testing = std.testing;
 const mem = std.mem;
 const assert = std.debug.assert;
 
-/// This turns a byte buffer into an `io.Writer`, `io.Reader`, or `io.SeekableStream`.
+/// This turns a byte buffer into an `io.Writer`, `io.GenericReader`, or `io.SeekableStream`.
 /// If the supplied byte buffer is const, then `io.Writer` is not available.
 pub fn FixedBufferStream(comptime Buffer: type) type {
     return struct {
@@ -17,7 +17,7 @@ pub fn FixedBufferStream(comptime Buffer: type) type {
         pub const SeekError = error{};
         pub const GetSeekPosError = error{};
 
-        pub const Reader = io.Reader(*Self, ReadError, read);
+        pub const Reader = io.GenericReader(*Self, ReadError, read);
         pub const Writer = io.Writer(*Self, WriteError, write);
 
         pub const SeekableStream = io.SeekableStream(

--- a/lib/std/io/limited_reader.zig
+++ b/lib/std/io/limited_reader.zig
@@ -9,7 +9,7 @@ pub fn LimitedReader(comptime ReaderType: type) type {
         bytes_left: u64,
 
         pub const Error = ReaderType.Error;
-        pub const Reader = io.Reader(*Self, Error, read);
+        pub const Reader = io.GenericReader(*Self, Error, read);
 
         const Self = @This();
 

--- a/lib/std/io/multi_writer.zig
+++ b/lib/std/io/multi_writer.zig
@@ -15,7 +15,7 @@ pub fn MultiWriter(comptime Writers: type) type {
         streams: Writers,
 
         pub const Error = ErrSet;
-        pub const Writer = io.Writer(*Self, Error, write);
+        pub const Writer = io.GenericWriter(*Self, Error, write);
 
         pub fn writer(self: *Self) Writer {
             return .{ .context = self };

--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -2,9 +2,9 @@ const std = @import("../std.zig");
 const builtin = @import("builtin");
 const io = std.io;
 
-/// Provides `io.GenericReader`, `io.Writer`, and `io.SeekableStream` for in-memory buffers as
+/// Provides `io.GenericReader`, `io.GenericWriter`, and `io.SeekableStream` for in-memory buffers as
 /// well as files.
-/// For memory sources, if the supplied byte buffer is const, then `io.Writer` is not available.
+/// For memory sources, if the supplied byte buffer is const, then `io.GenericWriter` is not available.
 /// The error set of the stream functions is the error set of the corresponding file functions.
 pub const StreamSource = union(enum) {
     // TODO: expose UEFI files to std.os in a way that allows this to be true
@@ -27,7 +27,7 @@ pub const StreamSource = union(enum) {
     pub const GetSeekPosError = io.FixedBufferStream([]u8).GetSeekPosError || (if (has_file) std.fs.File.GetSeekPosError else error{});
 
     pub const Reader = io.GenericReader(*StreamSource, ReadError, read);
-    pub const Writer = io.Writer(*StreamSource, WriteError, write);
+    pub const Writer = io.GenericWriter(*StreamSource, WriteError, write);
     pub const SeekableStream = io.SeekableStream(
         *StreamSource,
         SeekError,

--- a/lib/std/io/stream_source.zig
+++ b/lib/std/io/stream_source.zig
@@ -2,7 +2,7 @@ const std = @import("../std.zig");
 const builtin = @import("builtin");
 const io = std.io;
 
-/// Provides `io.Reader`, `io.Writer`, and `io.SeekableStream` for in-memory buffers as
+/// Provides `io.GenericReader`, `io.Writer`, and `io.SeekableStream` for in-memory buffers as
 /// well as files.
 /// For memory sources, if the supplied byte buffer is const, then `io.Writer` is not available.
 /// The error set of the stream functions is the error set of the corresponding file functions.
@@ -26,7 +26,7 @@ pub const StreamSource = union(enum) {
     pub const SeekError = io.FixedBufferStream([]u8).SeekError || (if (has_file) std.fs.File.SeekError else error{});
     pub const GetSeekPosError = io.FixedBufferStream([]u8).GetSeekPosError || (if (has_file) std.fs.File.GetSeekPosError else error{});
 
-    pub const Reader = io.Reader(*StreamSource, ReadError, read);
+    pub const Reader = io.GenericReader(*StreamSource, ReadError, read);
     pub const Writer = io.Writer(*StreamSource, WriteError, write);
     pub const SeekableStream = io.SeekableStream(
         *StreamSource,

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -6,7 +6,7 @@
 //! The high-level `parseFromSlice` and `parseFromTokenSource` deserialize a JSON document into a Zig type.
 //! Parse into a dynamically-typed `Value` to load any JSON value for runtime inspection.
 //!
-//! The low-level `writeStream` emits syntax-conformant JSON tokens to a `std.io.Writer`.
+//! The low-level `writeStream` emits syntax-conformant JSON tokens to a `std.io.GenericWriter`.
 //! The high-level `stringify` serializes a Zig or `Value` type into JSON.
 
 const builtin = @import("builtin");

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -1,7 +1,7 @@
 //! JSON parsing and stringification conforming to RFC 8259. https://datatracker.ietf.org/doc/html/rfc8259
 //!
 //! The low-level `Scanner` API produces `Token`s from an input slice or successive slices of inputs,
-//! The `Reader` API connects a `std.io.Reader` to a `Scanner`.
+//! The `Reader` API connects a `std.io.GenericReader` to a `Scanner`.
 //!
 //! The high-level `parseFromSlice` and `parseFromTokenSource` deserialize a JSON document into a Zig type.
 //! Parse into a dynamically-typed `Value` to load any JSON value for runtime inspection.

--- a/lib/std/json/scanner.zig
+++ b/lib/std/json/scanner.zig
@@ -219,7 +219,7 @@ pub const AllocWhen = enum { alloc_if_needed, alloc_always };
 /// This limit can be specified by calling `nextAllocMax()` instead of `nextAlloc()`.
 pub const default_max_value_len = 4 * 1024 * 1024;
 
-/// Connects a `std.io.Reader` to a `std.json.Scanner`.
+/// Connects a `std.io.GenericReader` to a `std.json.Scanner`.
 /// All `next*()` methods here handle `error.BufferUnderrun` from `std.json.Scanner`, and then read from the reader.
 pub fn Reader(comptime buffer_size: usize, comptime ReaderType: type) type {
     return struct {

--- a/lib/std/json/stringify.zig
+++ b/lib/std/json/stringify.zig
@@ -38,7 +38,7 @@ pub const StringifyOptions = struct {
     emit_nonportable_numbers_as_strings: bool = false,
 };
 
-/// Writes the given value to the `std.io.Writer` stream.
+/// Writes the given value to the `std.io.GenericWriter` stream.
 /// See `WriteStream` for how the given value is serialized into JSON.
 /// The maximum nesting depth of the output JSON document is 256.
 /// See also `stringifyMaxDepth` and `stringifyArbitraryDepth`.
@@ -81,7 +81,7 @@ pub fn stringifyArbitraryDepth(
 }
 
 /// Calls `stringifyArbitraryDepth` and stores the result in dynamically allocated memory
-/// instead of taking a `std.io.Writer`.
+/// instead of taking a `std.io.GenericWriter`.
 ///
 /// Caller owns returned memory.
 pub fn stringifyAlloc(

--- a/lib/std/json/stringify_test.zig
+++ b/lib/std/json/stringify_test.zig
@@ -307,7 +307,7 @@ test "stringify tuple" {
 fn testStringify(expected: []const u8, value: anytype, options: StringifyOptions) !void {
     const ValidationWriter = struct {
         const Self = @This();
-        pub const Writer = std.io.Writer(*Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*Self, Error, write);
         pub const Error = error{
             TooMuchData,
             DifferentData,

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1800,7 +1800,7 @@ pub const Stream = struct {
     pub const WriteError = posix.WriteError;
 
     pub const Reader = io.GenericReader(Stream, ReadError, read);
-    pub const Writer = io.Writer(Stream, WriteError, write);
+    pub const Writer = io.GenericWriter(Stream, WriteError, write);
 
     pub fn reader(self: Stream) Reader {
         return .{ .context = self };

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1799,7 +1799,7 @@ pub const Stream = struct {
     pub const ReadError = posix.ReadError;
     pub const WriteError = posix.WriteError;
 
-    pub const Reader = io.Reader(Stream, ReadError, read);
+    pub const Reader = io.GenericReader(Stream, ReadError, read);
     pub const Writer = io.Writer(Stream, WriteError, write);
 
     pub fn reader(self: Stream) Reader {

--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -25,7 +25,7 @@ pub const File = extern struct {
     pub const WriteError = error{WriteError};
 
     pub const SeekableStream = io.SeekableStream(*const File, SeekError, GetSeekPosError, seekTo, seekBy, getPos, getEndPos);
-    pub const Reader = io.Reader(*const File, ReadError, readFn);
+    pub const Reader = io.GenericReader(*const File, ReadError, readFn);
     pub const Writer = io.Writer(*const File, WriteError, writeFn);
 
     pub fn seekableStream(self: *File) SeekableStream {

--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -26,7 +26,7 @@ pub const File = extern struct {
 
     pub const SeekableStream = io.SeekableStream(*const File, SeekError, GetSeekPosError, seekTo, seekBy, getPos, getEndPos);
     pub const Reader = io.GenericReader(*const File, ReadError, readFn);
-    pub const Writer = io.Writer(*const File, WriteError, writeFn);
+    pub const Writer = io.GenericWriter(*const File, WriteError, writeFn);
 
     pub fn seekableStream(self: *File) SeekableStream {
         return .{ .context = self };

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -341,7 +341,7 @@ pub fn Iterator(comptime ReaderType: type) type {
             unread_bytes: *u64,
             parent_reader: ReaderType,
 
-            pub const Reader = std.io.Reader(File, ReaderType.Error, File.read);
+            pub const Reader = std.io.GenericReader(File, ReaderType.Error, File.read);
 
             pub fn reader(self: File) Reader {
                 return .{ .context = self };

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -3319,7 +3319,7 @@ fn AutoIndentingStream(comptime UnderlyingWriter: type) type {
     return struct {
         const Self = @This();
         pub const WriteError = UnderlyingWriter.Error;
-        pub const Writer = std.io.Writer(*Self, WriteError, write);
+        pub const Writer = std.io.GenericWriter(*Self, WriteError, write);
 
         underlying_writer: UnderlyingWriter,
 

--- a/lib/std/zig/string_literal.zig
+++ b/lib/std/zig/string_literal.zig
@@ -322,7 +322,7 @@ test parseCharLiteral {
     );
 }
 
-/// Parses `bytes` as a Zig string literal and writes the result to the std.io.Writer type.
+/// Parses `bytes` as a Zig string literal and writes the result to the std.io.GenericWriter type.
 /// Asserts `bytes` has '"' at beginning and end.
 pub fn parseWrite(writer: anytype, bytes: []const u8) error{OutOfMemory}!Result {
     assert(bytes.len >= 2 and bytes[0] == '"' and bytes[bytes.len - 1] == '"');

--- a/lib/std/zip.zig
+++ b/lib/std/zip.zig
@@ -106,7 +106,7 @@ pub const EndRecord = extern struct {
 /// Find and return the end record for the given seekable zip stream.
 /// Note that `seekable_stream` must be an instance of `std.io.SeekableStream` and
 /// its context must also have a `.reader()` method that returns an instance of
-/// `std.io.Reader`.
+/// `std.io.GenericReader`.
 pub fn findEndRecord(seekable_stream: anytype, stream_len: u64) !EndRecord {
     var buf: [@sizeOf(EndRecord) + std.math.maxInt(u16)]u8 = undefined;
     const record_len_max = @min(stream_len, buf.len);
@@ -617,7 +617,7 @@ pub const ExtractOptions = struct {
 /// Extract the zipped files inside `seekable_stream` to the given `dest` directory.
 /// Note that `seekable_stream` must be an instance of `std.io.SeekableStream` and
 /// its context must also have a `.reader()` method that returns an instance of
-/// `std.io.Reader`.
+/// `std.io.GenericReader`.
 pub fn extract(dest: std.fs.Dir, seekable_stream: anytype, options: ExtractOptions) !void {
     const SeekableStream = @TypeOf(seekable_stream);
     var iter = try Iterator(SeekableStream).init(seekable_stream);

--- a/src/Package/Fetch/git.zig
+++ b/src/Package/Fetch/git.zig
@@ -1019,7 +1019,7 @@ pub const Session = struct {
             ProtocolError,
             UnexpectedPacket,
         };
-        pub const Reader = std.io.Reader(*FetchStream, ReadError, read);
+        pub const Reader = std.io.GenericReader(*FetchStream, ReadError, read);
 
         const StreamCode = enum(u8) {
             pack_data = 1,

--- a/src/codegen/llvm/Builder.zig
+++ b/src/codegen/llvm/Builder.zig
@@ -9478,7 +9478,7 @@ fn WriterWithErrors(comptime BackingWriter: type, comptime ExtraErrors: type) ty
         backing_writer: BackingWriter,
 
         pub const Error = BackingWriter.Error || ExtraErrors;
-        pub const Writer = std.io.Writer(*const Self, Error, write);
+        pub const Writer = std.io.GenericWriter(*const Self, Error, write);
 
         const Self = @This();
 

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1040,7 +1040,7 @@ test "generic type constructed from inferred error set of unresolved function" {
             _ = bytes;
             return 0;
         }
-        const T = std.io.Writer(void, @typeInfo(@typeInfo(@TypeOf(write)).@"fn".return_type.?).error_union.error_set, write);
+        const T = std.io.GenericWriter(void, @typeInfo(@typeInfo(@TypeOf(write)).@"fn".return_type.?).error_union.error_set, write);
         fn writer() T {
             return .{ .context = {} };
         }


### PR DESCRIPTION
This PR replaces the deprecated `std.io.Reader` and `std.io.Writer` with `GenericReader` and `GenericWriter`.

Zig's `std.io.Reader` and `std.io.Writer` have been deprecated in favor of `GenericReader` and `GenericWriter`. However, multiple parts of the standard library still use the old API, such as:
```zig
pub const Reader = io.Reader(File, ReadError, read);
pub const Writer = io.Writer(File, WriteError, write);
```

To align with the latest API changes and avoid using deprecated symbols, this PR updates all occurrences of std.io.Reader and std.io.Writer in the standard library.