### PR TITLE
Move the compiler's LLVM bitcode builder to `std.zig.llvm`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,6 +500,11 @@ set(ZIG_STAGE2_SOURCES
     lib/std/zig/system/NativePaths.zig
     lib/std/zig/system/x86.zig
     lib/std/zig/tokenizer.zig
+    lib/std/zig/llvm.zig
+    lib/std/zig/llvm/BitcodeReader.zig
+    lib/std/zig/llvm/Builder.zig
+    lib/std/zig/llvm/bitcode_writer.zig
+    lib/std/zig/llvm/ir.zig
     src/Air.zig
     src/Builtin.zig
     src/Compilation.zig
@@ -567,11 +572,7 @@ set(ZIG_STAGE2_SOURCES
     src/codegen/c.zig
     src/codegen/c/Type.zig
     src/codegen/llvm.zig
-    src/codegen/llvm/BitcodeReader.zig
-    src/codegen/llvm/Builder.zig
     src/codegen/llvm/bindings.zig
-    src/codegen/llvm/bitcode_writer.zig
-    src/codegen/llvm/ir.zig
     src/codegen/spirv.zig
     src/codegen/spirv/Assembler.zig
     src/codegen/spirv/Module.zig

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -24,6 +24,7 @@ pub const LibCInstallation = @import("zig/LibCInstallation.zig");
 pub const WindowsSdk = @import("zig/WindowsSdk.zig");
 pub const LibCDirs = @import("zig/LibCDirs.zig");
 pub const target = @import("zig/target.zig");
+pub const llvm = @import("zig/llvm.zig");
 
 // Character literal parsing
 pub const ParsedCharLiteral = string_literal.ParsedCharLiteral;

--- a/lib/std/zig/llvm.zig
+++ b/lib/std/zig/llvm.zig
@@ -1,0 +1,3 @@
+pub const BitcodeReader = @import("llvm/BitcodeReader.zig");
+pub const bitcode_writer = @import("llvm/bitcode_writer.zig");
+pub const Builder = @import("llvm/Builder.zig");

--- a/lib/std/zig/llvm/BitcodeReader.zig
+++ b/lib/std/zig/llvm/BitcodeReader.zig
@@ -510,6 +510,6 @@ const Abbrev = struct {
 };
 
 const assert = std.debug.assert;
-const std = @import("std");
+const std = @import("../../std.zig");
 
 const BitcodeReader = @This();

--- a/lib/std/zig/llvm/bitcode_writer.zig
+++ b/lib/std/zig/llvm/bitcode_writer.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 
 pub const AbbrevOp = union(enum) {
     literal: u32, // 0

--- a/lib/std/zig/llvm/ir.zig
+++ b/lib/std/zig/llvm/ir.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../../std.zig");
 const Builder = @import("Builder.zig");
 const bitcode_writer = @import("bitcode_writer.zig");
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -542,7 +542,6 @@ pub const CObject = struct {
             }
 
             pub fn parse(gpa: Allocator, path: []const u8) !*Bundle {
-                const BitcodeReader = @import("codegen/llvm/BitcodeReader.zig");
                 const BlockId = enum(u32) {
                     Meta = 8,
                     Diag,
@@ -579,7 +578,7 @@ pub const CObject = struct {
                 defer file.close();
                 var br = std.io.bufferedReader(file.reader());
                 const reader = br.reader();
-                var bc = BitcodeReader.init(gpa, .{ .reader = reader.any() });
+                var bc = std.zig.llvm.BitcodeReader.init(gpa, .{ .reader = reader.any() });
                 defer bc.deinit();
 
                 var file_names: std.AutoArrayHashMapUnmanaged(u32, []const u8) = .empty;

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -6260,7 +6260,7 @@ pub const Alignment = enum(u6) {
         return n + 1;
     }
 
-    const LlvmBuilderAlignment = @import("codegen/llvm/Builder.zig").Alignment;
+    const LlvmBuilderAlignment = std.zig.llvm.Builder.Alignment;
 
     pub fn toLlvm(this: @This()) LlvmBuilderAlignment {
         return @enumFromInt(@intFromEnum(this));

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -6,7 +6,7 @@ const log = std.log.scoped(.codegen);
 const math = std.math;
 const DW = std.dwarf;
 
-const Builder = @import("llvm/Builder.zig");
+const Builder = std.zig.llvm.Builder;
 const llvm = if (build_options.have_llvm)
     @import("llvm/bindings.zig")
 else
@@ -1216,7 +1216,10 @@ pub const Object = struct {
                 }
             }
 
-            const bitcode = try o.builder.toBitcode(o.gpa);
+            const bitcode = try o.builder.toBitcode(o.gpa, .{
+                .name = "zig",
+                .version = build_options.semver,
+            });
             defer o.gpa.free(bitcode);
             o.builder.clearAndFree();
 


### PR DESCRIPTION
Mainly for the benefit of [projects like Roc](https://gist.github.com/rtfeldman/77fb430ee57b42f5f2ca973a3992532f).