### PR TITLE
incremental: invalidate namespace dependencies when a name changes visibility

### DIFF
--- a/test/incremental/make_decl_pub
+++ b/test/incremental/make_decl_pub
@@ -1,0 +1,25 @@
+#target=x86_64-linux-selfhosted
+#target=x86_64-linux-cbe
+#target=x86_64-windows-cbe
+#target=wasm32-wasi-selfhosted
+#update=initial version
+#file=main.zig
+const foo = @import("foo.zig");
+pub fn main() !void {
+    try foo.hello();
+}
+#file=foo.zig
+const std = @import("std");
+fn hello() !void {
+    try std.io.getStdOut().writeAll("Hello, World!\n");
+}
+#expect_error=main.zig:3:12: error: 'hello' is not marked 'pub'
+#expect_error=foo.zig:2:1: note: declared here
+
+#update=make hello pub
+#file=foo.zig
+const std = @import("std");
+pub fn hello() !void {
+    try std.io.getStdOut().writeAll("Hello, World!\n");
+}
+#expect_stdout="Hello, World!\n"


### PR DESCRIPTION
We could have more fine-grained dependencies here, but I think this is fine for now.