### PR TITLE
Revert "skip regressed LLVM 17 std lib test on powerpc"

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -4637,11 +4637,6 @@ test "read/write(Var)PackedInt" {
         else => {},
     }
 
-    if (builtin.cpu.arch == .powerpc) {
-        // https://github.com/ziglang/zig/issues/16951
-        return error.SkipZigTest;
-    }
-
     const foreign_endian: Endian = if (native_endian == .big) .little else .big;
     const expect = std.testing.expect;
     var prng = std.Random.DefaultPrng.init(1234);


### PR DESCRIPTION
This reverts commit 5b8af7a2a9140fd0533961b62addc61f57b33343.

Closes #16951.