### PR TITLE
AstGen: improve 'file cannot be a tuple' source location

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -5097,18 +5097,16 @@ fn structDeclInner(
     const gpa = astgen.gpa;
     const tree = astgen.tree;
 
-    {
-        const is_tuple = for (container_decl.ast.members) |member_node| {
+    is_tuple: {
+        const tuple_field_node = for (container_decl.ast.members) |member_node| {
             const container_field = tree.fullContainerField(member_node) orelse continue;
-            if (container_field.ast.tuple_like) break true;
-        } else false;
+            if (container_field.ast.tuple_like) break member_node;
+        } else break :is_tuple;
 
-        if (is_tuple) {
-            if (node == 0) {
-                return astgen.failTok(0, "file cannot be a tuple", .{});
-            } else {
-                return tupleDecl(gz, scope, node, container_decl, layout, backing_int_node);
-            }
+        if (node == 0) {
+            return astgen.failNode(tuple_field_node, "file cannot be a tuple", .{});
+        } else {
+            return tupleDecl(gz, scope, node, container_decl, layout, backing_int_node);
         }
     }
 

--- a/test/cases/compile_errors/file_level_tuple_with_decls.zig
+++ b/test/cases/compile_errors/file_level_tuple_with_decls.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+u8,
+
+// error
+//
+// :3:1: error: file cannot be a tuple


### PR DESCRIPTION
Instead of just reporting this on token 0, report it on the first tuple-like field.