### PR TITLE
disable fuzzer on 32 bit linux

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -431,6 +431,14 @@ pub fn main() !void {
                 .windows => fatal("--fuzz not yet implemented for {s}", .{@tagName(builtin.os.tag)}),
                 else => {},
             }
+            switch (@bitSizeOf(usize)) {
+                // Current implementation depends usize being 64bits,
+                // More specifically, posix.mmap()'s second parameter, `length: usize`,
+                // must be the same bit-size as std.fs.getEndPos()'s return value, which is `u64`.
+                // Affects or affected by issues #5185, #22523, and #22464.
+                64 => {},
+                else => fatal("--fuzz is only implemented for 64-bit architectures", .{}),
+            }
             const listen_address = std.net.Address.parseIp("127.0.0.1", listen_port) catch unreachable;
             try Fuzz.start(
                 gpa,

--- a/lib/std/Build/Fuzz/WebServer.zig
+++ b/lib/std/Build/Fuzz/WebServer.zig
@@ -628,9 +628,17 @@ fn prepareTables(
         return error.AlreadyReported;
     };
 
+    // Account for bit-size mismatch between fs.getEndPos() and posix.mmap() ideas about file length
+    if (file_size >= std.math.maxInt(usize)) {
+        // maxInt(usize) may be too large a ceiling for some libc's
+        log.err("coverage file '{}' is too large to mmap", .{coverage_file_path});
+        return error.OutOfMemory;
+    }
+    const file_usize: usize = @truncate(file_size);
+
     const mapped_memory = std.posix.mmap(
         null,
-        file_size,
+        file_usize,
         std.posix.PROT.READ,
         .{ .TYPE = .SHARED },
         coverage_file.handle,


### PR DESCRIPTION
Addresses #22523 by:

1. only allowing fuzz testing on 64-bit platforms
2. add a test and @truncate, NOP on 64-bit platforms, which still allows building on 32-bit platforms