### PR TITLE
std/lib: {fs,io,posix} test clean up

### DIFF
--- a/lib/std/io/test.zig
+++ b/lib/std/io/test.zig
@@ -108,10 +108,7 @@ test "File seek ops" {
 
     const tmp_file_name = "temp_test_file.txt";
     var file = try tmp.dir.createFile(tmp_file_name, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(tmp_file_name) catch {};
-    }
+    defer file.close();
 
     try file.writeAll(&([_]u8{0x55} ** 8192));
 
@@ -135,10 +132,7 @@ test "setEndPos" {
 
     const tmp_file_name = "temp_test_file.txt";
     var file = try tmp.dir.createFile(tmp_file_name, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(tmp_file_name) catch {};
-    }
+    defer file.close();
 
     // Verify that the file size changes and the file offset is not moved
     try std.testing.expect((try file.getEndPos()) == 0);
@@ -161,10 +155,8 @@ test "updateTimes" {
 
     const tmp_file_name = "just_a_temporary_file.txt";
     var file = try tmp.dir.createFile(tmp_file_name, .{ .read = true });
-    defer {
-        file.close();
-        tmp.dir.deleteFile(tmp_file_name) catch {};
-    }
+    defer file.close();
+
     const stat_old = try file.stat();
     // Set atime and mtime to 5s before
     try file.updateTimes(

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -8,7 +8,6 @@ const io = std.io;
 const fs = std.fs;
 const mem = std.mem;
 const elf = std.elf;
-const File = std.fs.File;
 const Thread = std.Thread;
 const linux = std.os.linux;
 
@@ -19,8 +18,6 @@ const AtomicRmwOp = std.builtin.AtomicRmwOp;
 const AtomicOrder = std.builtin.AtomicOrder;
 const native_os = builtin.target.os.tag;
 const tmpDir = std.testing.tmpDir;
-const Dir = std.fs.Dir;
-const ArenaAllocator = std.heap.ArenaAllocator;
 
 // https://github.com/ziglang/zig/issues/20288
 test "WTF-8 to WTF-16 conversion buffer overflows" {
@@ -115,50 +112,62 @@ test "open smoke test" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    // Get base abs path
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+    const base_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(base_path);
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    var file_path: []u8 = undefined;
-    var fd: posix.fd_t = undefined;
     const mode: posix.mode_t = if (native_os == .windows) 0 else 0o666;
 
-    // Create some file using `open`.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode);
-    posix.close(fd);
+    {
+        // Create some file using `open`.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode);
+        posix.close(fd);
+    }
 
-    // Try this again with the same flags. This op should fail with error.PathAlreadyExists.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    try expectError(error.PathAlreadyExists, posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode));
+    {
+        // Try this again with the same flags. This op should fail with error.PathAlreadyExists.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        try expectError(error.PathAlreadyExists, posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode));
+    }
 
-    // Try opening without `EXCL` flag.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true }, mode);
-    posix.close(fd);
+    {
+        // Try opening without `EXCL` flag.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true }, mode);
+        posix.close(fd);
+    }
 
-    // Try opening as a directory which should fail.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    try expectError(error.NotDir, posix.open(file_path, .{ .ACCMODE = .RDWR, .DIRECTORY = true }, mode));
+    {
+        // Try opening as a directory which should fail.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        try expectError(error.NotDir, posix.open(file_path, .{ .ACCMODE = .RDWR, .DIRECTORY = true }, mode));
+    }
 
-    // Create some directory
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    try posix.mkdir(file_path, mode);
+    {
+        // Create some directory
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+        try posix.mkdir(file_path, mode);
+    }
 
-    // Open dir using `open`
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDONLY, .DIRECTORY = true }, mode);
-    posix.close(fd);
+    {
+        // Open dir using `open`
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDONLY, .DIRECTORY = true }, mode);
+        posix.close(fd);
+    }
 
-    // Try opening as file which should fail.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    try expectError(error.IsDir, posix.open(file_path, .{ .ACCMODE = .RDWR }, mode));
+    {
+        // Try opening as file which should fail.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+        try expectError(error.IsDir, posix.open(file_path, .{ .ACCMODE = .RDWR }, mode));
+    }
 }
 
 test "openat smoke test" {
@@ -705,8 +714,6 @@ test "mmap" {
             try testing.expectEqual(i, try stream.readInt(u32, .little));
         }
     }
-
-    try tmp.dir.deleteFile(test_out_file);
 }
 
 test "getenv" {
@@ -732,10 +739,7 @@ test "fcntl" {
     const test_out_file = "os_tmp_test";
 
     const file = try tmp.dir.createFile(test_out_file, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(test_out_file) catch {};
-    }
+    defer file.close();
 
     // Note: The test assumes createFile opens the file with CLOEXEC
     {
@@ -771,10 +775,7 @@ test "sync" {
 
     const test_out_file = "os_tmp_test";
     const file = try tmp.dir.createFile(test_out_file, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(test_out_file) catch {};
-    }
+    defer file.close();
 
     posix.sync();
     try posix.syncfs(file.handle);
@@ -791,10 +792,7 @@ test "fsync" {
 
     const test_out_file = "os_tmp_test";
     const file = try tmp.dir.createFile(test_out_file, .{});
-    defer {
-        file.close();
-        tmp.dir.deleteFile(test_out_file) catch {};
-    }
+    defer file.close();
 
     try posix.fsync(file.handle);
     try posix.fdatasync(file.handle);
@@ -1041,54 +1039,65 @@ test "rename smoke test" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    // Get base abs path
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+    const base_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(base_path);
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    var file_path: []u8 = undefined;
-    var fd: posix.fd_t = undefined;
     const mode: posix.mode_t = if (native_os == .windows) 0 else 0o666;
 
-    // Create some file using `open`.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode);
-    posix.close(fd);
+    {
+        // Create some file using `open`.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode);
+        posix.close(fd);
 
-    // Rename the file
-    var new_file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_file" });
-    try posix.rename(file_path, new_file_path);
+        // Rename the file
+        const new_file_path = try fs.path.join(a, &.{ base_path, "some_other_file" });
+        defer a.free(new_file_path);
+        try posix.rename(file_path, new_file_path);
+    }
 
-    // Try opening renamed file
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_file" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDWR }, mode);
-    posix.close(fd);
+    {
+        // Try opening renamed file
+        const file_path = try fs.path.join(a, &.{ base_path, "some_other_file" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDWR }, mode);
+        posix.close(fd);
+    }
 
-    // Try opening original file - should fail with error.FileNotFound
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    try expectError(error.FileNotFound, posix.open(file_path, .{ .ACCMODE = .RDWR }, mode));
+    {
+        // Try opening original file - should fail with error.FileNotFound
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        try expectError(error.FileNotFound, posix.open(file_path, .{ .ACCMODE = .RDWR }, mode));
+    }
 
-    // Create some directory
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    try posix.mkdir(file_path, mode);
+    {
+        // Create some directory
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+        try posix.mkdir(file_path, mode);
 
-    // Rename the directory
-    new_file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_dir" });
-    try posix.rename(file_path, new_file_path);
+        // Rename the directory
+        const new_file_path = try fs.path.join(a, &.{ base_path, "some_other_dir" });
+        defer a.free(new_file_path);
+        try posix.rename(file_path, new_file_path);
+    }
 
-    // Try opening renamed directory
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_dir" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDONLY, .DIRECTORY = true }, mode);
-    posix.close(fd);
+    {
+        // Try opening renamed directory
+        const file_path = try fs.path.join(a, &.{ base_path, "some_other_dir" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDONLY, .DIRECTORY = true }, mode);
+        posix.close(fd);
+    }
 
-    // Try opening original directory - should fail with error.FileNotFound
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    try expectError(error.FileNotFound, posix.open(file_path, .{ .ACCMODE = .RDONLY, .DIRECTORY = true }, mode));
+    {
+        // Try opening original directory - should fail with error.FileNotFound
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+        try expectError(error.FileNotFound, posix.open(file_path, .{ .ACCMODE = .RDONLY, .DIRECTORY = true }, mode));
+    }
 }
 
 test "access smoke test" {
@@ -1098,44 +1107,50 @@ test "access smoke test" {
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    // Get base abs path
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+    const base_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(base_path);
 
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    var file_path: []u8 = undefined;
-    var fd: posix.fd_t = undefined;
     const mode: posix.mode_t = if (native_os == .windows) 0 else 0o666;
-
-    // Create some file using `open`.
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode);
-    posix.close(fd);
-
-    // Try to access() the file
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    if (native_os == .windows) {
-        try posix.access(file_path, posix.F_OK);
-    } else {
-        try posix.access(file_path, posix.F_OK | posix.W_OK | posix.R_OK);
+    {
+        // Create some file using `open`.
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        const fd = try posix.open(file_path, .{ .ACCMODE = .RDWR, .CREAT = true, .EXCL = true }, mode);
+        posix.close(fd);
     }
 
-    // Try to access() a non-existent file - should fail with error.FileNotFound
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_other_file" });
-    try expectError(error.FileNotFound, posix.access(file_path, posix.F_OK));
+    {
+        // Try to access() the file
+        const file_path = try fs.path.join(a, &.{ base_path, "some_file" });
+        defer a.free(file_path);
+        if (native_os == .windows) {
+            try posix.access(file_path, posix.F_OK);
+        } else {
+            try posix.access(file_path, posix.F_OK | posix.W_OK | posix.R_OK);
+        }
+    }
 
-    // Create some directory
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    try posix.mkdir(file_path, mode);
+    {
+        // Try to access() a non-existent file - should fail with error.FileNotFound
+        const file_path = try fs.path.join(a, &.{ base_path, "some_other_file" });
+        defer a.free(file_path);
+        try expectError(error.FileNotFound, posix.access(file_path, posix.F_OK));
+    }
 
-    // Try to access() the directory
-    file_path = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_dir" });
-    try posix.access(file_path, posix.F_OK);
+    {
+        // Create some directory
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+        try posix.mkdir(file_path, mode);
+    }
+
+    {
+        // Try to access() the directory
+        const file_path = try fs.path.join(a, &.{ base_path, "some_dir" });
+        defer a.free(file_path);
+
+        try posix.access(file_path, posix.F_OK);
+    }
 }
 
 test "timerfd" {
@@ -1167,103 +1182,59 @@ test "isatty" {
 }
 
 test "read with empty buffer" {
-    if (native_os == .wasi) return error.SkipZigTest;
-
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    // Get base abs path
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    const file_path: []u8 = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    var file = try fs.cwd().createFile(file_path, .{ .read = true });
+    var file = try tmp.dir.createFile("read_empty", .{ .read = true });
     defer file.close();
 
-    const bytes = try allocator.alloc(u8, 0);
+    const bytes = try a.alloc(u8, 0);
+    defer a.free(bytes);
 
-    _ = try posix.read(file.handle, bytes);
+    const rc = try posix.read(file.handle, bytes);
+    try expectEqual(rc, 0);
 }
 
 test "pread with empty buffer" {
-    if (native_os == .wasi) return error.SkipZigTest;
-
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    // Get base abs path
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    const file_path: []u8 = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    var file = try fs.cwd().createFile(file_path, .{ .read = true });
+    var file = try tmp.dir.createFile("pread_empty", .{ .read = true });
     defer file.close();
 
-    const bytes = try allocator.alloc(u8, 0);
+    const bytes = try a.alloc(u8, 0);
+    defer a.free(bytes);
 
-    _ = try posix.pread(file.handle, bytes, 0);
+    const rc = try posix.pread(file.handle, bytes, 0);
+    try expectEqual(rc, 0);
 }
 
 test "write with empty buffer" {
-    if (native_os == .wasi) return error.SkipZigTest;
-
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    // Get base abs path
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    const file_path: []u8 = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    var file = try fs.cwd().createFile(file_path, .{});
+    var file = try tmp.dir.createFile("write_empty", .{});
     defer file.close();
 
-    const bytes = try allocator.alloc(u8, 0);
+    const bytes = try a.alloc(u8, 0);
+    defer a.free(bytes);
 
-    _ = try posix.write(file.handle, bytes);
+    const rc = try posix.write(file.handle, bytes);
+    try expectEqual(rc, 0);
 }
 
 test "pwrite with empty buffer" {
-    if (native_os == .wasi) return error.SkipZigTest;
-
     var tmp = tmpDir(.{});
     defer tmp.cleanup();
 
-    var arena = ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    // Get base abs path
-    const base_path = blk: {
-        const relative_path = try fs.path.join(allocator, &[_][]const u8{ ".zig-cache", "tmp", tmp.sub_path[0..] });
-        break :blk try fs.realpathAlloc(allocator, relative_path);
-    };
-
-    const file_path: []u8 = try fs.path.join(allocator, &[_][]const u8{ base_path, "some_file" });
-    var file = try fs.cwd().createFile(file_path, .{});
+    var file = try tmp.dir.createFile("pwrite_empty", .{});
     defer file.close();
 
-    const bytes = try allocator.alloc(u8, 0);
+    const bytes = try a.alloc(u8, 0);
+    defer a.free(bytes);
 
-    _ = try posix.pwrite(file.handle, bytes, 0);
+    const rc = try posix.pwrite(file.handle, bytes, 0);
+    try expectEqual(rc, 0);
 }
 
 fn expectMode(dir: posix.fd_t, file: []const u8, mode: posix.mode_t) !void {


### PR DESCRIPTION
* use `tmp.dir.realpathAlloc()` to get full path into tmpDir instances
* use `testing.allocator` to remove Arena allocator setups
* Trust `TmpDir.cleanup()` to clean up contained files and sub-trees
* Remove some unnecessary absolute paths (enabling WASI to run the tests)
* Drop some no-longer necessary `[_][]const u8` casts
* Add scopes to reduce `var` usage in favor of `const`
* Move platform-specific (e.g., WASI+libc) logic into the core of a test (instead of skipping the whole test) to improve coverage