### PR TITLE
lib/compiler/build_runner: only build Fuzz on 64-bit platforms

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -431,6 +431,13 @@ pub fn main() !void {
                 .windows => fatal("--fuzz not yet implemented for {s}", .{@tagName(builtin.os.tag)}),
                 else => {},
             }
+            if (@bitSizeOf(usize) != 64) {
+                // Current implementation depends on posix.mmap()'s second parameter, `length: usize`,
+                // being compatible with `std.fs.getEndPos() u64`'s return value. This is not the case
+                // on 32-bit platforms.
+                // Affects or affected by issues #5185, #22523, and #22464.
+                fatal("--fuzz not yet implemented on {d}-bit platforms", .{@bitSizeOf(usize)});
+            }
             const listen_address = std.net.Address.parseIp("127.0.0.1", listen_port) catch unreachable;
             try Fuzz.start(
                 gpa,


### PR DESCRIPTION
@andrewrk here is a cleaner PR.

Addresses #22523 by dead-coding Fuzz.Start() on non-64-bit platforms.

**Replaces**: [PR 23008](https://github.com/ziglang/zig/pull/23008)
**Reason**: omitting the unnecessary changes I'd proposed to Fuzz/WebServer.zig.