### PR TITLE
crypto.pcurves.common: generalize invert()

### DIFF
--- a/lib/std/crypto/pcurves/common.zig
+++ b/lib/std/crypto/pcurves/common.zig
@@ -197,7 +197,7 @@ pub fn Field(comptime params: FieldParams) type {
         /// Return the inverse of a field element, or 0 if a=0.
         // Field inversion from https://eprint.iacr.org/2021/549.pdf
         pub fn invert(a: Fe) Fe {
-            const iterations = (49 * field_bits + 57) / 17;
+            const iterations = (49 * field_bits + if (field_bits < 46) 80 else 57) / 17;
             const Limbs = @TypeOf(a.limbs);
             const Word = @TypeOf(a.limbs[0]);
             const XLimbs = [a.limbs.len + 1]Word;


### PR DESCRIPTION
The Bernstein-Yang inversion code was meant to be used only with the fields we currently use for the NIST curves.

But people copied that code and were confused that it didn't work as expected with other field sizes.

It doesn't cost anything to make it work with other field sizes, that may support in the future. So let's do it.
This also reduces the diff with the example zig code in fiat crypto.

Suggested by @Rexicon226 -- Thank you!