### PR TITLE
Mitigation of #15108 in `std.heap.page_size_min`

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -42,8 +42,8 @@ pub var next_mmap_addr_hint: ?[*]align(page_size_min) u8 = null;
 ///
 /// On many systems, the actual page size can only be determined at runtime
 /// with `pageSize`.
-pub const page_size_min: usize = std.options.page_size_min orelse page_size_min_default orelse
-    @compileError(@tagName(builtin.cpu.arch) ++ "-" ++ @tagName(builtin.os.tag) ++ " has unknown page_size_min; populate std.options.page_size_min");
+pub const page_size_min: usize = std.options.page_size_min orelse (page_size_min_default orelse
+    @compileError(@tagName(builtin.cpu.arch) ++ "-" ++ @tagName(builtin.os.tag) ++ " has unknown page_size_min; populate std.options.page_size_min"));
 
 /// comptime-known maximum page size of the target.
 ///


### PR DESCRIPTION
If `root.std_options.page_size_min` is not `null` accessing `std.heap.page_size_min` results in the error described in #15108.


```zig
const std = @import("std");

pub const std_options: std.Options = .{
    .page_size_min = 4096,
};

comptime {
    @compileLog(std.heap.page_size_min);
}
```

```
$ zig build-obj test.zig
/home/user/zig/0.14.0-dev.3445+6c3cbb0c8/files/lib/std/heap.zig:45:89: error: expected optional type, found 'usize'
pub const page_size_min: usize = std.options.page_size_min orelse page_size_min_default orelse
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```


This was introduced in #22488.

See also: [Discord `zig-help` link](https://discord.com/channels/605571803288698900/1345765450323070986)