### PR TITLE
improve invalid tuple errors

### DIFF
--- a/test/cases/compile_errors/tuple_declarations.zig
+++ b/test/cases/compile_errors/tuple_declarations.zig
@@ -15,6 +15,13 @@ const T = struct {
     const a = 1;
 };
 
+const T2 = struct {
+    const a = 1;
+
+    b: u32,
+    []const u8,
+};
+
 // error
 // backend=stage2
 // target=native
@@ -22,5 +29,8 @@ const T = struct {
 // :2:5: error: enum field missing name
 // :5:5: error: union field missing name
 // :8:5: error: tuple field has a name
+// :9:5: note: tuple field here
 // :15:5: error: tuple declarations cannot contain declarations
 // :12:5: note: tuple field here
+// :19:5: error: tuple declarations cannot contain declarations
+// :22:5: note: tuple field here


### PR DESCRIPTION
this does 2 things
1. add a note when a tuple field has a name, fixes #23045 
before:
```
a.zig:1:20: error: tuple field has a name
const S = struct { a: usize = 1, b = 2, c: isize = 3, d: []const u8 };
                   ^
```
after:
```
a.zig:1:20: error: tuple field has a name
const S = struct { a: usize = 1, b = 2, c: isize = 3, d: []const u8 };
                   ^
a.zig:1:34: note: tuple field here
const S = struct { a: usize = 1, b = 2, c: isize = 3, d: []const u8 };
                                 ^~~~~
```

2. fix the note when a decl is encountered in a tuple but the first field also has a name
```zig
const S2 = struct {
    const a = 0;
    b: u8 = 0,
    u8,
};
```
before:
```
a.zig:2:5: error: tuple declarations cannot contain declarations
    const a = 0;
    ^~~~~~~~~~~
a.zig:3:5: note: tuple field here
    b: u8 = 0,
    ^~~~~~~~~
```
after:
```
a.zig:2:5: error: tuple declarations cannot contain declarations
    const a = 0;
    ^~~~~~~~~~~
a.zig:4:5: note: tuple field here
    u8,
    ^~
```