### PR TITLE
std.time.epoch: delete YearLeapKind 

### DIFF
--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -607,11 +607,11 @@ const Date = struct {
         }
 
         {
-            const is_leap = std.time.epoch.isLeapYear(date.year);
+            const is_leap_year = std.time.epoch.isLeapYear(date.year);
             var month: u4 = 1;
             while (month < date.month) : (month += 1) {
                 const days: u64 = std.time.epoch.getDaysInMonth(
-                    @as(std.time.epoch.YearLeapKind, @enumFromInt(@intFromBool(is_leap))),
+                    is_leap_year,
                     @as(std.time.epoch.Month, @enumFromInt(month)),
                 );
                 sec += days * std.time.epoch.secs_per_day;

--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -141,11 +141,11 @@ pub const Time = extern struct {
     pub const unspecified_timezone: i16 = 0x7ff;
 
     fn daysInYear(year: u16, max_month: u4) u9 {
-        const leap_year: std.time.epoch.YearLeapKind = if (std.time.epoch.isLeapYear(year)) .leap else .not_leap;
+        const is_leap_year = std.time.epoch.isLeapYear(year);
         var days: u9 = 0;
         var month: u4 = 0;
         while (month < max_month) : (month += 1) {
-            days += std.time.epoch.getDaysInMonth(leap_year, @enumFromInt(month + 1));
+            days += std.time.epoch.getDaysInMonth(is_leap_year, @enumFromInt(month + 1));
         }
         return days;
     }

--- a/lib/std/time/epoch.zig
+++ b/lib/std/time/epoch.zig
@@ -117,9 +117,9 @@ pub const YearAndDay = struct {
             if (days_left < days_in_month)
                 break;
             days_left -= days_in_month;
-            month = @as(Month, @enumFromInt(@intFromEnum(month) + 1));
+            month = @enumFromInt(@intFromEnum(month) + 1);
         }
-        return .{ .month = month, .day_index = @as(u5, @intCast(days_left)) };
+        return .{ .month = month, .day_index = @intCast(days_left) };
     }
 };
 
@@ -141,7 +141,7 @@ pub const EpochDay = struct {
             year_day -= year_size;
             year += 1;
         }
-        return .{ .year = year, .day = @as(u9, @intCast(year_day)) };
+        return .{ .year = year, .day = @intCast(year_day) };
     }
 };
 
@@ -151,11 +151,11 @@ pub const DaySeconds = struct {
 
     /// the number of hours past the start of the day (0 to 23)
     pub fn getHoursIntoDay(self: DaySeconds) u5 {
-        return @as(u5, @intCast(@divTrunc(self.secs, 3600)));
+        return @intCast(@divTrunc(self.secs, 3600));
     }
     /// the number of minutes past the hour (0 to 59)
     pub fn getMinutesIntoHour(self: DaySeconds) u6 {
-        return @as(u6, @intCast(@divTrunc(@mod(self.secs, 3600), 60)));
+        return @intCast(@divTrunc(@mod(self.secs, 3600), 60));
     }
     /// the number of seconds past the start of the minute (0 to 59)
     pub fn getSecondsIntoMinute(self: DaySeconds) u6 {
@@ -170,7 +170,7 @@ pub const EpochSeconds = struct {
     /// Returns the number of days since the epoch as an EpochDay.
     /// Use EpochDay to get information about the day of this time.
     pub fn getEpochDay(self: EpochSeconds) EpochDay {
-        return EpochDay{ .day = @as(u47, @intCast(@divTrunc(self.secs, secs_per_day))) };
+        return EpochDay{ .day = @intCast(@divTrunc(self.secs, secs_per_day)) };
     }
 
     /// Returns the number of seconds into the day as DaySeconds.

--- a/lib/std/time/epoch.zig
+++ b/lib/std/time/epoch.zig
@@ -64,8 +64,6 @@ pub fn getDaysInYear(year: Year) u9 {
     return if (isLeapYear(year)) 366 else 365;
 }
 
-pub const YearLeapKind = enum(u1) { not_leap, leap };
-
 pub const Month = enum(u4) {
     jan = 1,
     feb,
@@ -88,13 +86,10 @@ pub const Month = enum(u4) {
 };
 
 /// Get the number of days in the given month
-pub fn getDaysInMonth(leap_year: YearLeapKind, month: Month) u5 {
+pub fn getDaysInMonth(is_leap_year: bool, month: Month) u5 {
     return switch (month) {
         .jan => 31,
-        .feb => @as(u5, switch (leap_year) {
-            .leap => 29,
-            .not_leap => 28,
-        }),
+        .feb => if (is_leap_year) 29 else 28,
         .mar => 31,
         .apr => 30,
         .may => 31,
@@ -116,9 +111,9 @@ pub const YearAndDay = struct {
     pub fn calculateMonthDay(self: YearAndDay) MonthAndDay {
         var month: Month = .jan;
         var days_left = self.day;
-        const leap_kind: YearLeapKind = if (isLeapYear(self.year)) .leap else .not_leap;
+        const is_leap_year = isLeapYear(self.year);
         while (true) {
-            const days_in_month = getDaysInMonth(leap_kind, month);
+            const days_in_month = getDaysInMonth(is_leap_year, month);
             if (days_left < days_in_month)
                 break;
             days_left -= days_in_month;


### PR DESCRIPTION
There doesn't really seem to be a point in having this type.
Code seems to be improved without it.

Skimming through code that references the type I could find like 2-3 actual uses of it so it probably doesn't need a deprecation period.