### PR TITLE
compiler: Don't consider powerpc to have red zone support yet.

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -306,12 +306,8 @@ pub fn hasRedZone(target: std.Target) bool {
     return switch (target.cpu.arch) {
         .aarch64,
         .aarch64_be,
-        .powerpc,
-        .powerpcle,
-        .powerpc64,
-        .powerpc64le,
-        .x86_64,
         .x86,
+        .x86_64,
         => true,
 
         else => false,


### PR DESCRIPTION
The command line flag is only supported in Clang 20: https://github.com/ziglang/zig/issues/23056

This gets rid of some warnings when using zig cc.