### PR TITLE
std.DynLib: fix proper type of chain_ptr on GnuHashSection32

### DIFF
--- a/lib/std/dynamic_library.zig
+++ b/lib/std/dynamic_library.zig
@@ -397,7 +397,7 @@ pub const ElfDynLib = struct {
 
             const bloom_ptr: [*]u32 = @ptrFromInt(bloom_offset);
             const buckets_ptr: [*]u32 = @ptrFromInt(buckets_offset);
-            const chain_ptr: [*]u32 = @ptrFromInt(chain_offset);
+            const chain_ptr: [*]elf.gnu_hash.ChainEntry = @ptrFromInt(chain_offset);
 
             return .{
                 .symoffset = header.symoffset,


### PR DESCRIPTION
After commit 6ef2384 usage of DynLib on 32-bit archs is broken, as type for temporary _chain_ptr_ on GnuHashSection32.fromPtr should be [\*]elf.gnu_hash.ChainEntry to match the _chain_ field on the structure when returning. GnuHashSection64 is fine.

On GnuHashSection32:
https://github.com/ziglang/zig/blob/6ef2384c07ef6817f134ffc61e34bcea6e87df92/lib/std/dynamic_library.zig#L400
On GnuHashSection64:
https://github.com/ziglang/zig/blob/6ef2384c07ef6817f134ffc61e34bcea6e87df92/lib/std/dynamic_library.zig#L427

Repro:

```zig
const std = @import("std");

const _my_func = *const fn () callconv(.C) c_int;

pub fn main() !void {
    var libx = try std.DynLib.open("/usr/lib/libx.so.1");
    defer libx.close();

    const my_func = libx.lookup(_my_func, "my_func").?;
    _ = my_func();
}
```
Fails on {arm,mips,x86}-linux but compiles on {x86_64,aarch64}-linux

```
zig build-exe -freference-trace=9 -target mips-linux main.zig

/home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/dynamic_library.zig:408:26: error: expected type '[*]elf.gnu_hash.ChainEntry', found '[*]u32'
                .chain = chain_ptr,
                         ^~~~~~~~~
/home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/dynamic_library.zig:408:26: note: pointer type child 'u32' cannot cast into pointer type child 'elf.gnu_hash.ChainEntry'
/home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/elf.zig:2410:35: note: struct declared here
    pub const ChainEntry = packed struct(u32) {
                           ~~~~~~~^~~~~~
referenced by:
    lookupAddress: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/dynamic_library.zig:470:66
    lookup__anon_2922: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/dynamic_library.zig:378:31
    lookup__anon_1926: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/dynamic_library.zig:46:33
    main: main.zig:9:32
    posixCallMainAndExit: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/start.zig:656:37
    _start: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/start.zig:464:40
    comptime: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/start.zig:91:63
    start: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/std.zig:97:27
    comptime: /home/user/.asdf/installs/zig/0.14.0-dev.3357+c44f4501e/lib/std/std.zig:168:9
```

With the patch it compiles fine on both 32/64-bits archs.