### PR TITLE
io_uring: Update to kernel changes in 6.11 and 6.12

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -6138,26 +6138,28 @@ pub const IO_URING_OP_SUPPORTED = 1 << 0;
 
 pub const io_uring_probe_op = extern struct {
     op: IORING_OP,
-
     resv: u8,
-
-    /// IO_URING_OP_* flags
-    flags: u16,
-
+    flags: u16, // IO_URING_OP_* flags
     resv2: u32,
+
+    pub fn is_supported(self: @This()) bool {
+        return self.flags & IO_URING_OP_SUPPORTED != 0;
+    }
 };
 
 pub const io_uring_probe = extern struct {
-    /// last opcode supported
-    last_op: IORING_OP,
-
-    /// Number of io_uring_probe_op following
-    ops_len: u8,
-
+    last_op: IORING_OP, // last opcode supported
+    ops_len: u8, // length of ops[] array below
     resv: u16,
     resv2: [3]u32,
+    ops: [256]io_uring_probe_op,
 
-    // Followed by up to `ops_len` io_uring_probe_op structures
+    pub fn is_supported(self: @This(), op: IORING_OP) bool {
+        const i = @intFromEnum(op);
+        if (i > @intFromEnum(self.last_op) or i >= self.ops_len)
+            return false;
+        return self.ops[i].is_supported();
+    }
 };
 
 pub const io_uring_restriction = extern struct {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5806,6 +5806,9 @@ pub const IORING_OP = enum(u8) {
     FUTEX_WAITV,
     FIXED_FD_INSTALL,
     FTRUNCATE,
+    BIND,
+    LISTEN,
+    RECV_ZC,
 
     _,
 };
@@ -6188,6 +6191,13 @@ pub const IORING_RESTRICTION = enum(u16) {
     SQE_FLAGS_REQUIRED = 3,
 
     _,
+};
+
+pub const IO_URING_SOCKET_OP = enum(u16) {
+    SIOCIN = 0,
+    SIOCOUTQ = 1,
+    GETSOCKOPT = 2,
+    SETSOCKOPT = 3,
 };
 
 pub const io_uring_buf = extern struct {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -6154,6 +6154,7 @@ pub const io_uring_probe = extern struct {
     resv2: [3]u32,
     ops: [256]io_uring_probe_op,
 
+    /// Is the operation supported on the running kernel.
     pub fn is_supported(self: @This(), op: IORING_OP) bool {
         const i = @intFromEnum(op);
         if (i > @intFromEnum(self.last_op) or i >= self.ops_len)

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -5933,6 +5933,8 @@ pub const IORING_CQE_F_MORE = 1 << 1;
 pub const IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
 /// Set for notification CQEs. Can be used to distinct them from sends.
 pub const IORING_CQE_F_NOTIF = 1 << 3;
+/// If set, the buffer ID set in the completion will get more completions.
+pub const IORING_CQE_F_BUF_MORE = 1 << 4;
 
 pub const IORING_CQE_BUFFER_SHIFT = 16;
 
@@ -6222,8 +6224,13 @@ pub const io_uring_buf_reg = extern struct {
     ring_addr: u64,
     ring_entries: u32,
     bgid: u16,
-    pad: u16,
+    flags: u16,
     resv: [3]u64,
+
+    pub const FLAG = struct {
+        // Incremental buffer consummation.
+        pub const INC: u16 = 2;
+    };
 };
 
 pub const io_uring_getevents_arg = extern struct {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -6141,7 +6141,8 @@ pub const IO_URING_OP_SUPPORTED = 1 << 0;
 pub const io_uring_probe_op = extern struct {
     op: IORING_OP,
     resv: u8,
-    flags: u16, // IO_URING_OP_* flags
+    /// IO_URING_OP_* flags
+    flags: u16,
     resv2: u32,
 
     pub fn is_supported(self: @This()) bool {
@@ -6150,8 +6151,10 @@ pub const io_uring_probe_op = extern struct {
 };
 
 pub const io_uring_probe = extern struct {
-    last_op: IORING_OP, // last opcode supported
-    ops_len: u8, // length of ops[] array below
+    /// Last opcode supported
+    last_op: IORING_OP,
+    /// Length of ops[] array below
+    ops_len: u8,
     resv: u16,
     resv2: [3]u32,
     ops: [256]io_uring_probe_op,
@@ -6224,12 +6227,14 @@ pub const io_uring_buf_reg = extern struct {
     ring_addr: u64,
     ring_entries: u32,
     bgid: u16,
-    flags: u16,
+    flags: Flags,
     resv: [3]u64,
 
-    pub const FLAG = struct {
-        // Incremental buffer consummation.
-        pub const INC: u16 = 2;
+    pub const Flags = packed struct {
+        _0: u1 = 0,
+        /// Incremental buffer consumption.
+        inc: bool,
+        _: u14 = 0,
     };
 };
 

--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -3103,7 +3103,7 @@ test "provide_buffers: read" {
         const cqe = try ring.copy_cqe();
         switch (cqe.err()) {
             // Happens when the kernel is < 5.7
-            .INVAL => return error.SkipZigTest,
+            .INVAL, .BADF => return error.SkipZigTest,
             .SUCCESS => {},
             else => |errno| std.debug.panic("unhandled errno: {}", .{errno}),
         }
@@ -3230,7 +3230,7 @@ test "remove_buffers" {
 
         const cqe = try ring.copy_cqe();
         switch (cqe.err()) {
-            .INVAL => return error.SkipZigTest,
+            .INVAL, .BADF => return error.SkipZigTest,
             .SUCCESS => {},
             else => |errno| std.debug.panic("unhandled errno: {}", .{errno}),
         }

--- a/lib/std/os/linux/io_uring_sqe.zig
+++ b/lib/std/os/linux/io_uring_sqe.zig
@@ -666,4 +666,14 @@ pub const io_uring_sqe = extern struct {
         // addr3 is overloaded, https://github.com/axboe/liburing/blob/e1003e496e66f9b0ae06674869795edf772d5500/src/include/liburing/io_uring.h#L102
         sqe.addr3 = optval;
     }
+
+    pub fn set_flags(sqe: *linux.io_uring_sqe, flags: u8) void {
+        sqe.flags |= flags;
+    }
+
+    /// This SQE forms a link with the next SQE in the submission ring. Next SQE
+    /// will not be started before this one completes. Forms a chain of SQEs.
+    pub fn link_next(sqe: *linux.io_uring_sqe) void {
+        sqe.flags |= linux.IOSQE_IO_LINK;
+    }
 };


### PR DESCRIPTION
io_uring is in active development and each new kernel brings some new features. This is an update to the most important changes from kernels 6.11 and 6.12.

**[Bind/listen](https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.11-and-6.12#add-support-for-bindlisten) support**
 IoUring.bind and IoUring.listen functions are added. For listening sockets is it common to set some socket options, so I added generic IoUring.cmd_sock but also posix like IoUring.setsokopt and IoUring.getsockopt.


**Probing capabilities**
When app has to run on different kernels it is handy to check if some [operation](https://github.com/ianic/zig/blob/fdb63447f5eecbb79c12d018edd21a72fdcb642c/lib/std/os/linux.zig#L5752) is supported on the running kernel. 
Example:
```
const probe = try ring.get_probe();
if (!probe.is_supported(.LISTEN)) return error.SkipZigTest;
``` 


**[Incremental provided buffer consumption](https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.11-and-6.12#incremental-provided-buffer-consumption)** 
IoUring.BufferGroup will now use incremental consumption whenever kernel supports it.

Before, provided buffers were wholly consumed when picked. Now, each cqe points to a different buffer. With this, cqe points to the part of the buffer. Multiple cqes can reuse the same buffer. Appropriate buffer sizing becomes less important.

There are slight changes in BufferGroup interface (it now needs to track the current receive point for each buffer). Init requires an allocator instead of buffers slice, it will allocate buffers slice and head pointers slice. Get and put now requires cqe because there we have information will the buffer be reused.
