### PR TITLE
Sema: handle generated tag enums in union field order check

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36719,7 +36719,7 @@ fn unionFields(
             if (enum_index != field_i) {
                 const msg = msg: {
                     const enum_field_src: LazySrcLoc = .{
-                        .base_node_inst = tag_info.zir_index.unwrap().?,
+                        .base_node_inst = Type.fromInterned(tag_ty).typeDeclInstAllowGeneratedTag(zcu).?,
                         .offset = .{ .container_field_name = enum_index },
                     };
                     const msg = try sema.errMsg(name_src, "union field '{}' ordered differently than corresponding enum field", .{

--- a/test/cases/compile_errors/union_field_ordered_differently_than_enum.zig
+++ b/test/cases/compile_errors/union_field_ordered_differently_than_enum.zig
@@ -1,0 +1,27 @@
+const Tag = enum { a, b };
+
+const Union = union(Tag) {
+    b,
+    a,
+};
+
+const BaseUnion = union(enum) {
+    a,
+    b,
+};
+
+const GeneratedTagUnion = union(@typeInfo(BaseUnion).@"union".tag_type.?) {
+    b,
+    a,
+};
+
+export fn entry() usize {
+    return @sizeOf(Union) + @sizeOf(GeneratedTagUnion);
+}
+
+// error
+//
+// :4:5: error: union field 'b' ordered differently than corresponding enum field
+// :1:23: note: enum field here
+// :14:5: error: union field 'b' ordered differently than corresponding enum field
+// :10:5: note: enum field here


### PR DESCRIPTION
Fixes #23059

The "note: enum field here" now references the field in the base union type rather than crashing.