### PR TITLE
std.enums.tagName: preserve sentinel in return value

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -55,7 +55,7 @@ pub fn values(comptime E: type) []const E {
 /// A safe alternative to @tagName() for non-exhaustive enums that doesn't
 /// panic when `e` has no tagged value.
 /// Returns the tag name for `e` or null if no tag exists.
-pub fn tagName(comptime E: type, e: E) ?[]const u8 {
+pub fn tagName(comptime E: type, e: E) ?[:0]const u8 {
     return inline for (@typeInfo(E).@"enum".fields) |f| {
         if (@intFromEnum(e) == f.value) break f.name;
     } else null;


### PR DESCRIPTION
The sentinel is guaranteed by `@tagName` or `std.builtin.Type.EnumField`, and its presence can be useful.

Bun has had a function identical to this PR's new version of `tagName`, and we rely on the sentinel in some places -- I tried replacing all our uses of it with the patched `std.enums.tagName` and it worked fine.