### PR TITLE
Remove numerous things deprecated during the 0.14 release cycle

### DIFF
--- a/doc/langref/build_c.zig
+++ b/doc/langref/build_c.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    const lib = b.addSharedLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .dynamic,
         .name = "mathtest",
         .root_source_file = b.path("mathtest.zig"),
         .version = .{ .major = 1, .minor = 0, .patch = 0 },

--- a/doc/langref/test_noreturn_from_exit.zig
+++ b/doc/langref/test_noreturn_from_exit.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const native_arch = builtin.cpu.arch;
 const expect = std.testing.expect;
 
-const WINAPI: std.builtin.CallingConvention = if (native_arch == .x86) .Stdcall else .C;
+const WINAPI: std.builtin.CallingConvention = if (native_arch == .x86) .{ .x86_stdcall = .{} } else .c;
 extern "kernel32" fn ExitProcess(exit_code: c_uint) callconv(WINAPI) noreturn;
 
 test "foo" {

--- a/lib/compiler/aro/aro/Parser.zig
+++ b/lib/compiler/aro/aro/Parser.zig
@@ -8259,7 +8259,7 @@ fn charLiteral(p: *Parser) Error!Result {
     const slice = char_kind.contentSlice(p.tokSlice(p.tok_i));
 
     var is_multichar = false;
-    if (slice.len == 1 and std.ascii.isASCII(slice[0])) {
+    if (slice.len == 1 and std.ascii.isAscii(slice[0])) {
         // fast path: single unescaped ASCII char
         val = slice[0];
     } else {

--- a/lib/compiler/aro_translate_c.zig
+++ b/lib/compiler/aro_translate_c.zig
@@ -1820,7 +1820,7 @@ pub fn main() !void {
     var tree = translate(gpa, &aro_comp, args) catch |err| switch (err) {
         error.ParsingFailed, error.FatalError => renderErrorsAndExit(&aro_comp),
         error.OutOfMemory => return error.OutOfMemory,
-        error.StreamTooLong => std.zig.fatal("An input file was larger than 4GiB", .{}),
+        error.StreamTooLong => std.process.fatal("An input file was larger than 4GiB", .{}),
     };
     defer tree.deinit(gpa);
 

--- a/lib/compiler/objcopy.zig
+++ b/lib/compiler/objcopy.zig
@@ -7,7 +7,7 @@ const Allocator = std.mem.Allocator;
 const File = std.fs.File;
 const assert = std.debug.assert;
 
-const fatal = std.zig.fatal;
+const fatal = std.process.fatal;
 const Server = std.zig.Server;
 
 pub fn main() !void {

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -692,6 +692,7 @@ pub fn addOptions(b: *Build) *Step.Options {
 
 pub const ExecutableOptions = struct {
     name: []const u8,
+    root_module: *Module,
     version: ?std.SemanticVersion = null,
     linkage: ?std.builtin.LinkMode = null,
     max_rss: usize = 0,
@@ -704,58 +705,12 @@ pub const ExecutableOptions = struct {
     /// Can be set regardless of target. The `.manifest` file will be ignored
     /// if the target object format does not support embedded manifests.
     win32_manifest: ?LazyPath = null,
-
-    /// Prefer populating this field (using e.g. `createModule`) instead of populating
-    /// the following fields (`root_source_file` etc). In a future release, those fields
-    /// will be removed, and this field will become non-optional.
-    root_module: ?*Module = null,
-
-    /// Deprecated; prefer populating `root_module`.
-    root_source_file: ?LazyPath = null,
-    /// Deprecated; prefer populating `root_module`.
-    target: ?ResolvedTarget = null,
-    /// Deprecated; prefer populating `root_module`.
-    optimize: std.builtin.OptimizeMode = .Debug,
-    /// Deprecated; prefer populating `root_module`.
-    code_model: std.builtin.CodeModel = .default,
-    /// Deprecated; prefer populating `root_module`.
-    link_libc: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    single_threaded: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    pic: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    strip: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    unwind_tables: ?std.builtin.UnwindTables = null,
-    /// Deprecated; prefer populating `root_module`.
-    omit_frame_pointer: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    sanitize_thread: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    error_tracing: ?bool = null,
 };
 
 pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
-    if (options.root_module != null and options.target != null) {
-        @panic("`root_module` and `target` cannot both be populated");
-    }
     return .create(b, .{
         .name = options.name,
-        .root_module = options.root_module orelse b.createModule(.{
-            .root_source_file = options.root_source_file,
-            .target = options.target orelse @panic("`root_module` and `target` cannot both be null"),
-            .optimize = options.optimize,
-            .link_libc = options.link_libc,
-            .single_threaded = options.single_threaded,
-            .pic = options.pic,
-            .strip = options.strip,
-            .unwind_tables = options.unwind_tables,
-            .omit_frame_pointer = options.omit_frame_pointer,
-            .sanitize_thread = options.sanitize_thread,
-            .error_tracing = options.error_tracing,
-            .code_model = options.code_model,
-        }),
+        .root_module = options.root_module,
         .version = options.version,
         .kind = .exe,
         .linkage = options.linkage,
@@ -769,210 +724,18 @@ pub fn addExecutable(b: *Build, options: ExecutableOptions) *Step.Compile {
 
 pub const ObjectOptions = struct {
     name: []const u8,
+    root_module: *Module,
     max_rss: usize = 0,
     use_llvm: ?bool = null,
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
-
-    /// Prefer populating this field (using e.g. `createModule`) instead of populating
-    /// the following fields (`root_source_file` etc). In a future release, those fields
-    /// will be removed, and this field will become non-optional.
-    root_module: ?*Module = null,
-
-    /// Deprecated; prefer populating `root_module`.
-    root_source_file: ?LazyPath = null,
-    /// Deprecated; prefer populating `root_module`.
-    target: ?ResolvedTarget = null,
-    /// Deprecated; prefer populating `root_module`.
-    optimize: std.builtin.OptimizeMode = .Debug,
-    /// Deprecated; prefer populating `root_module`.
-    code_model: std.builtin.CodeModel = .default,
-    /// Deprecated; prefer populating `root_module`.
-    link_libc: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    single_threaded: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    pic: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    strip: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    unwind_tables: ?std.builtin.UnwindTables = null,
-    /// Deprecated; prefer populating `root_module`.
-    omit_frame_pointer: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    sanitize_thread: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    error_tracing: ?bool = null,
 };
 
 pub fn addObject(b: *Build, options: ObjectOptions) *Step.Compile {
-    if (options.root_module != null and options.target != null) {
-        @panic("`root_module` and `target` cannot both be populated");
-    }
     return .create(b, .{
         .name = options.name,
-        .root_module = options.root_module orelse b.createModule(.{
-            .root_source_file = options.root_source_file,
-            .target = options.target orelse @panic("`root_module` and `target` cannot both be null"),
-            .optimize = options.optimize,
-            .link_libc = options.link_libc,
-            .single_threaded = options.single_threaded,
-            .pic = options.pic,
-            .strip = options.strip,
-            .unwind_tables = options.unwind_tables,
-            .omit_frame_pointer = options.omit_frame_pointer,
-            .sanitize_thread = options.sanitize_thread,
-            .error_tracing = options.error_tracing,
-            .code_model = options.code_model,
-        }),
+        .root_module = options.root_module,
         .kind = .obj,
-        .max_rss = options.max_rss,
-        .use_llvm = options.use_llvm,
-        .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir,
-    });
-}
-
-pub const SharedLibraryOptions = struct {
-    name: []const u8,
-    version: ?std.SemanticVersion = null,
-    max_rss: usize = 0,
-    use_llvm: ?bool = null,
-    use_lld: ?bool = null,
-    zig_lib_dir: ?LazyPath = null,
-    /// Embed a `.manifest` file in the compilation if the object format supports it.
-    /// https://learn.microsoft.com/en-us/windows/win32/sbscs/manifest-files-reference
-    /// Manifest files must have the extension `.manifest`.
-    /// Can be set regardless of target. The `.manifest` file will be ignored
-    /// if the target object format does not support embedded manifests.
-    win32_manifest: ?LazyPath = null,
-
-    /// Prefer populating this field (using e.g. `createModule`) instead of populating
-    /// the following fields (`root_source_file` etc). In a future release, those fields
-    /// will be removed, and this field will become non-optional.
-    root_module: ?*Module = null,
-
-    /// Deprecated; prefer populating `root_module`.
-    root_source_file: ?LazyPath = null,
-    /// Deprecated; prefer populating `root_module`.
-    target: ?ResolvedTarget = null,
-    /// Deprecated; prefer populating `root_module`.
-    optimize: std.builtin.OptimizeMode = .Debug,
-    /// Deprecated; prefer populating `root_module`.
-    code_model: std.builtin.CodeModel = .default,
-    /// Deprecated; prefer populating `root_module`.
-    link_libc: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    single_threaded: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    pic: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    strip: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    unwind_tables: ?std.builtin.UnwindTables = null,
-    /// Deprecated; prefer populating `root_module`.
-    omit_frame_pointer: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    sanitize_thread: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    error_tracing: ?bool = null,
-};
-
-/// Deprecated: use `b.addLibrary(.{ ..., .linkage = .dynamic })` instead.
-pub fn addSharedLibrary(b: *Build, options: SharedLibraryOptions) *Step.Compile {
-    if (options.root_module != null and options.target != null) {
-        @panic("`root_module` and `target` cannot both be populated");
-    }
-    return .create(b, .{
-        .name = options.name,
-        .root_module = options.root_module orelse b.createModule(.{
-            .target = options.target orelse @panic("`root_module` and `target` cannot both be null"),
-            .optimize = options.optimize,
-            .root_source_file = options.root_source_file,
-            .link_libc = options.link_libc,
-            .single_threaded = options.single_threaded,
-            .pic = options.pic,
-            .strip = options.strip,
-            .unwind_tables = options.unwind_tables,
-            .omit_frame_pointer = options.omit_frame_pointer,
-            .sanitize_thread = options.sanitize_thread,
-            .error_tracing = options.error_tracing,
-            .code_model = options.code_model,
-        }),
-        .kind = .lib,
-        .linkage = .dynamic,
-        .version = options.version,
-        .max_rss = options.max_rss,
-        .use_llvm = options.use_llvm,
-        .use_lld = options.use_lld,
-        .zig_lib_dir = options.zig_lib_dir,
-        .win32_manifest = options.win32_manifest,
-    });
-}
-
-pub const StaticLibraryOptions = struct {
-    name: []const u8,
-    version: ?std.SemanticVersion = null,
-    max_rss: usize = 0,
-    use_llvm: ?bool = null,
-    use_lld: ?bool = null,
-    zig_lib_dir: ?LazyPath = null,
-
-    /// Prefer populating this field (using e.g. `createModule`) instead of populating
-    /// the following fields (`root_source_file` etc). In a future release, those fields
-    /// will be removed, and this field will become non-optional.
-    root_module: ?*Module = null,
-
-    /// Deprecated; prefer populating `root_module`.
-    root_source_file: ?LazyPath = null,
-    /// Deprecated; prefer populating `root_module`.
-    target: ?ResolvedTarget = null,
-    /// Deprecated; prefer populating `root_module`.
-    optimize: std.builtin.OptimizeMode = .Debug,
-    /// Deprecated; prefer populating `root_module`.
-    code_model: std.builtin.CodeModel = .default,
-    /// Deprecated; prefer populating `root_module`.
-    link_libc: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    single_threaded: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    pic: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    strip: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    unwind_tables: ?std.builtin.UnwindTables = null,
-    /// Deprecated; prefer populating `root_module`.
-    omit_frame_pointer: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    sanitize_thread: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    error_tracing: ?bool = null,
-};
-
-/// Deprecated: use `b.addLibrary(.{ ..., .linkage = .static })` instead.
-pub fn addStaticLibrary(b: *Build, options: StaticLibraryOptions) *Step.Compile {
-    if (options.root_module != null and options.target != null) {
-        @panic("`root_module` and `target` cannot both be populated");
-    }
-    return .create(b, .{
-        .name = options.name,
-        .root_module = options.root_module orelse b.createModule(.{
-            .target = options.target orelse @panic("`root_module` and `target` cannot both be null"),
-            .optimize = options.optimize,
-            .root_source_file = options.root_source_file,
-            .link_libc = options.link_libc,
-            .single_threaded = options.single_threaded,
-            .pic = options.pic,
-            .strip = options.strip,
-            .unwind_tables = options.unwind_tables,
-            .omit_frame_pointer = options.omit_frame_pointer,
-            .sanitize_thread = options.sanitize_thread,
-            .error_tracing = options.error_tracing,
-            .code_model = options.code_model,
-        }),
-        .kind = .lib,
-        .linkage = .static,
-        .version = options.version,
         .max_rss = options.max_rss,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
@@ -1014,9 +777,8 @@ pub fn addLibrary(b: *Build, options: LibraryOptions) *Step.Compile {
 
 pub const TestOptions = struct {
     name: []const u8 = "test",
+    root_module: *Module,
     max_rss: usize = 0,
-    /// Deprecated; use `.filters = &.{filter}` instead of `.filter = filter`.
-    filter: ?[]const u8 = null,
     filters: []const []const u8 = &.{},
     test_runner: ?Step.Compile.TestRunner = null,
     use_llvm: ?bool = null,
@@ -1026,38 +788,6 @@ pub const TestOptions = struct {
     /// The object must be linked separately.
     /// Usually used in conjunction with a custom `test_runner`.
     emit_object: bool = false,
-
-    /// Prefer populating this field (using e.g. `createModule`) instead of populating
-    /// the following fields (`root_source_file` etc). In a future release, those fields
-    /// will be removed, and this field will become non-optional.
-    root_module: ?*Module = null,
-
-    /// Deprecated; prefer populating `root_module`.
-    root_source_file: ?LazyPath = null,
-    /// Deprecated; prefer populating `root_module`.
-    target: ?ResolvedTarget = null,
-    /// Deprecated; prefer populating `root_module`.
-    optimize: std.builtin.OptimizeMode = .Debug,
-    /// Deprecated; prefer populating `root_module`.
-    version: ?std.SemanticVersion = null,
-    /// Deprecated; prefer populating `root_module`.
-    link_libc: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    link_libcpp: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    single_threaded: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    pic: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    strip: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    unwind_tables: ?std.builtin.UnwindTables = null,
-    /// Deprecated; prefer populating `root_module`.
-    omit_frame_pointer: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    sanitize_thread: ?bool = null,
-    /// Deprecated; prefer populating `root_module`.
-    error_tracing: ?bool = null,
 };
 
 /// Creates an executable containing unit tests.
@@ -1069,33 +799,12 @@ pub const TestOptions = struct {
 /// two steps are separated because they are independently configured and
 /// cached.
 pub fn addTest(b: *Build, options: TestOptions) *Step.Compile {
-    if (options.root_module != null and options.root_source_file != null) {
-        @panic("`root_module` and `root_source_file` cannot both be populated");
-    }
     return .create(b, .{
         .name = options.name,
         .kind = if (options.emit_object) .test_obj else .@"test",
-        .root_module = options.root_module orelse b.createModule(.{
-            .root_source_file = options.root_source_file orelse @panic("`root_module` and `root_source_file` cannot both be null"),
-            .target = options.target orelse b.graph.host,
-            .optimize = options.optimize,
-            .link_libc = options.link_libc,
-            .link_libcpp = options.link_libcpp,
-            .single_threaded = options.single_threaded,
-            .pic = options.pic,
-            .strip = options.strip,
-            .unwind_tables = options.unwind_tables,
-            .omit_frame_pointer = options.omit_frame_pointer,
-            .sanitize_thread = options.sanitize_thread,
-            .error_tracing = options.error_tracing,
-        }),
+        .root_module = options.root_module,
         .max_rss = options.max_rss,
-        .filters = if (options.filter != null and options.filters.len > 0) filters: {
-            const filters = b.allocator.alloc([]const u8, 1 + options.filters.len) catch @panic("OOM");
-            filters[0] = b.dupe(options.filter.?);
-            for (filters[1..], options.filters) |*dest, source| dest.* = b.dupe(source);
-            break :filters filters;
-        } else b.dupeStrings(if (options.filter) |filter| &.{filter} else options.filters),
+        .filters = b.dupeStrings(options.filters),
         .test_runner = options.test_runner,
         .use_llvm = options.use_llvm,
         .use_lld = options.use_lld,
@@ -1113,22 +822,6 @@ pub const AssemblyOptions = struct {
     max_rss: usize = 0,
     zig_lib_dir: ?LazyPath = null,
 };
-
-/// Deprecated; prefer using `addObject` where the `root_module` has an empty
-/// `root_source_file` and contains an assembly file via `Module.addAssemblyFile`.
-pub fn addAssembly(b: *Build, options: AssemblyOptions) *Step.Compile {
-    const root_module = b.createModule(.{
-        .target = options.target,
-        .optimize = options.optimize,
-    });
-    root_module.addAssemblyFile(options.source_file);
-    return b.addObject(.{
-        .name = options.name,
-        .max_rss = options.max_rss,
-        .zig_lib_dir = options.zig_lib_dir,
-        .root_module = root_module,
-    });
-}
 
 /// This function creates a module and adds it to the package's module set, making
 /// it available to other packages which depend on this one.

--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -1326,7 +1326,7 @@ test "cache file and then recall it" {
     // Wait for file timestamps to tick
     const initial_time = try testGetCurrentFileTimestamp(tmp.dir);
     while ((try testGetCurrentFileTimestamp(tmp.dir)) == initial_time) {
-        std.time.sleep(1);
+        std.Thread.sleep(1);
     }
 
     var digest1: HexDigest = undefined;
@@ -1389,7 +1389,7 @@ test "check that changing a file makes cache fail" {
     // Wait for file timestamps to tick
     const initial_time = try testGetCurrentFileTimestamp(tmp.dir);
     while ((try testGetCurrentFileTimestamp(tmp.dir)) == initial_time) {
-        std.time.sleep(1);
+        std.Thread.sleep(1);
     }
 
     var digest1: HexDigest = undefined;
@@ -1501,7 +1501,7 @@ test "Manifest with files added after initial hash work" {
     // Wait for file timestamps to tick
     const initial_time = try testGetCurrentFileTimestamp(tmp.dir);
     while ((try testGetCurrentFileTimestamp(tmp.dir)) == initial_time) {
-        std.time.sleep(1);
+        std.Thread.sleep(1);
     }
 
     var digest1: HexDigest = undefined;
@@ -1551,7 +1551,7 @@ test "Manifest with files added after initial hash work" {
         // Wait for file timestamps to tick
         const initial_time2 = try testGetCurrentFileTimestamp(tmp.dir);
         while ((try testGetCurrentFileTimestamp(tmp.dir)) == initial_time2) {
-            std.time.sleep(1);
+            std.Thread.sleep(1);
         }
 
         {

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -8,9 +8,6 @@ pub const Style = union(enum) {
     /// A configure format supported by autotools that uses `#undef foo` to
     /// mark lines that can be substituted with different values.
     autoconf_undef: std.Build.LazyPath,
-    /// Deprecated. Renamed to `autoconf_undef`.
-    /// To be removed after 0.14.0 is tagged.
-    autoconf: std.Build.LazyPath,
     /// A configure format supported by autotools that uses `@FOO@` output variables.
     autoconf_at: std.Build.LazyPath,
     /// The configure format supported by CMake. It uses `@FOO@`, `${}` and
@@ -23,7 +20,7 @@ pub const Style = union(enum) {
 
     pub fn getPath(style: Style) ?std.Build.LazyPath {
         switch (style) {
-            .autoconf_undef, .autoconf, .autoconf_at, .cmake => |s| return s,
+            .autoconf_undef, .autoconf_at, .cmake => |s| return s,
             .blank, .nasm => return null,
         }
     }
@@ -205,7 +202,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     const asm_generated_line = "; " ++ header_text ++ "\n";
 
     switch (config_header.style) {
-        .autoconf_undef, .autoconf, .autoconf_at => |file_source| {
+        .autoconf_undef, .autoconf_at => |file_source| {
             try bw.writeAll(c_generated_line);
             const src_path = file_source.getPath2(b, step);
             const contents = std.fs.cwd().readFileAlloc(arena, src_path, config_header.max_bytes) catch |err| {
@@ -214,7 +211,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                 });
             };
             switch (config_header.style) {
-                .autoconf_undef, .autoconf => try render_autoconf_undef(step, contents, bw, config_header.values, src_path),
+                .autoconf_undef => try render_autoconf_undef(step, contents, bw, config_header.values, src_path),
                 .autoconf_at => try render_autoconf_at(step, contents, &aw, config_header.values, src_path),
                 else => unreachable,
             }

--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -63,19 +63,6 @@ pub fn getOutput(translate_c: *TranslateC) std.Build.LazyPath {
     return .{ .generated = .{ .file = &translate_c.output_file } };
 }
 
-/// Deprecated: use `createModule` or `addModule` with `std.Build.addExecutable` instead.
-/// Creates a step to build an executable from the translated source.
-pub fn addExecutable(translate_c: *TranslateC, options: AddExecutableOptions) *Step.Compile {
-    return translate_c.step.owner.addExecutable(.{
-        .root_source_file = translate_c.getOutput(),
-        .name = options.name orelse "translated_c",
-        .version = options.version,
-        .target = options.target orelse translate_c.target,
-        .optimize = options.optimize orelse translate_c.optimize,
-        .linkage = options.linkage,
-    });
-}
-
 /// Creates a module from the translated source and adds it to the package's
 /// module set making it available to other packages which depend on this one.
 /// `createModule` can be used instead to create a private module.

--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -4,7 +4,7 @@ const Watch = @This();
 const Step = std.Build.Step;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
-const fatal = std.zig.fatal;
+const fatal = std.process.fatal;
 
 dir_table: DirTable,
 os: Os,

--- a/lib/std/Thread/Condition.zig
+++ b/lib/std/Thread/Condition.zig
@@ -130,7 +130,7 @@ const SingleThreadedImpl = struct {
             unreachable; // deadlock detected
         };
 
-        std.time.sleep(timeout_ns);
+        std.Thread.sleep(timeout_ns);
         return error.Timeout;
     }
 
@@ -348,7 +348,7 @@ test "wait and signal" {
     }
 
     while (true) {
-        std.time.sleep(100 * std.time.ns_per_ms);
+        std.Thread.sleep(100 * std.time.ns_per_ms);
 
         multi_wait.mutex.lock();
         defer multi_wait.mutex.unlock();
@@ -405,7 +405,7 @@ test signal {
     }
 
     while (true) {
-        std.time.sleep(10 * std.time.ns_per_ms);
+        std.Thread.sleep(10 * std.time.ns_per_ms);
 
         signal_test.mutex.lock();
         defer signal_test.mutex.unlock();

--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -116,7 +116,7 @@ const SingleThreadedImpl = struct {
             unreachable; // deadlock detected
         };
 
-        std.time.sleep(delay);
+        std.Thread.sleep(delay);
         return error.Timeout;
     }
 

--- a/lib/std/Thread/ResetEvent.zig
+++ b/lib/std/Thread/ResetEvent.zig
@@ -74,7 +74,7 @@ const SingleThreadedImpl = struct {
             unreachable; // deadlock detected
         };
 
-        std.time.sleep(timeout_ns);
+        std.Thread.sleep(timeout_ns);
         return error.Timeout;
     }
 

--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -181,9 +181,6 @@ pub fn isAscii(c: u8) bool {
     return c < 128;
 }
 
-/// Deprecated: use `isAscii`
-pub const isASCII = isAscii;
-
 /// Uppercases the character and returns it as-is if already uppercase or not a letter.
 pub fn toUpper(c: u8) u8 {
     const mask = @as(u8, @intFromBool(isLower(c))) << 5;

--- a/lib/std/atomic.zig
+++ b/lib/std/atomic.zig
@@ -10,8 +10,6 @@ pub fn Value(comptime T: type) type {
             return .{ .raw = value };
         }
 
-        pub const fence = @compileError("@fence is deprecated, use other atomics to establish ordering");
-
         pub inline fn load(self: *const Self, comptime order: AtomicOrder) T {
             return @atomicLoad(T, &self.raw, order);
         }

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -154,9 +154,6 @@ pub const OptimizeMode = enum {
     ReleaseSmall,
 };
 
-/// Deprecated; use OptimizeMode.
-pub const Mode = OptimizeMode;
-
 /// The calling convention of a function defines how arguments and return values are passed, as well
 /// as any other requirements which callers and callees must respect, such as register preservation
 /// and stack alignment.
@@ -184,51 +181,6 @@ pub const CallingConvention = union(enum(u8)) {
         .spirv32, .spirv64 => .spirv_kernel,
         else => unreachable,
     };
-
-    /// Deprecated; use `.auto`.
-    pub const Unspecified: CallingConvention = .auto;
-    /// Deprecated; use `.c`.
-    pub const C: CallingConvention = .c;
-    /// Deprecated; use `.naked`.
-    pub const Naked: CallingConvention = .naked;
-    /// Deprecated; use `.@"inline"`.
-    pub const Inline: CallingConvention = .@"inline";
-    /// Deprecated; use `.x86_64_interrupt`, `.x86_interrupt`, or `.avr_interrupt`.
-    pub const Interrupt: CallingConvention = switch (builtin.target.cpu.arch) {
-        .x86_64 => .{ .x86_64_interrupt = .{} },
-        .x86 => .{ .x86_interrupt = .{} },
-        .avr => .avr_interrupt,
-        else => unreachable,
-    };
-    /// Deprecated; use `.avr_signal`.
-    pub const Signal: CallingConvention = .avr_signal;
-    /// Deprecated; use `.x86_stdcall`.
-    pub const Stdcall: CallingConvention = .{ .x86_stdcall = .{} };
-    /// Deprecated; use `.x86_fastcall`.
-    pub const Fastcall: CallingConvention = .{ .x86_fastcall = .{} };
-    /// Deprecated; use `.x86_64_vectorcall`, `.x86_vectorcall`, or `aarch64_vfabi`.
-    pub const Vectorcall: CallingConvention = switch (builtin.target.cpu.arch) {
-        .x86_64 => .{ .x86_64_vectorcall = .{} },
-        .x86 => .{ .x86_vectorcall = .{} },
-        .aarch64, .aarch64_be => .{ .aarch64_vfabi = .{} },
-        else => unreachable,
-    };
-    /// Deprecated; use `.x86_thiscall`.
-    pub const Thiscall: CallingConvention = .{ .x86_thiscall = .{} };
-    /// Deprecated; use `.arm_aapcs`.
-    pub const AAPCS: CallingConvention = .{ .arm_aapcs = .{} };
-    /// Deprecated; use `.arm_aapcs_vfp`.
-    pub const AAPCSVFP: CallingConvention = .{ .arm_aapcs_vfp = .{} };
-    /// Deprecated; use `.x86_64_sysv`.
-    pub const SysV: CallingConvention = .{ .x86_64_sysv = .{} };
-    /// Deprecated; use `.x86_64_win`.
-    pub const Win64: CallingConvention = .{ .x86_64_win = .{} };
-    /// Deprecated; use `.kernel`.
-    pub const Kernel: CallingConvention = .kernel;
-    /// Deprecated; use `.spirv_fragment`.
-    pub const Fragment: CallingConvention = .spirv_fragment;
-    /// Deprecated; use `.spirv_vertex`.
-    pub const Vertex: CallingConvention = .spirv_vertex;
 
     /// The default Zig calling convention when neither `export` nor `inline` is specified.
     /// This calling convention makes no guarantees about stack alignment, registers, etc.
@@ -1117,10 +1069,6 @@ pub const TestFn = struct {
     func: *const fn () anyerror!void,
 };
 
-/// Deprecated, use the `Panic` namespace instead.
-/// To be deleted after 0.14.0 is released.
-pub const PanicFn = fn ([]const u8, ?*StackTrace, ?usize) noreturn;
-
 /// This namespace is used by the Zig compiler to emit various kinds of safety
 /// panics. These can be overridden by making a public `panic` namespace in the
 /// root source file.
@@ -1135,9 +1083,6 @@ pub const panic: type = p: {
             }.panic);
         }
         break :p root.panic;
-    }
-    if (@hasDecl(root, "Panic")) {
-        break :p root.Panic; // Deprecated; use `panic` instead.
     }
     break :p switch (builtin.zig_backend) {
         .stage2_powerpc,

--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -101,7 +101,6 @@ pub const dh = struct {
 pub const kem = struct {
     pub const kyber_d00 = @import("crypto/ml_kem.zig").d00;
     pub const ml_kem = @import("crypto/ml_kem.zig").nist;
-    pub const ml_kem_01 = @compileError("deprecated: final version of the specification has been published, use ml_kem instead");
 };
 
 /// Elliptic-curve arithmetic.
@@ -400,20 +399,3 @@ test secureZero {
 
     try std.testing.expectEqualSlices(u8, &a, &b);
 }
-
-/// Deprecated in favor of `std.crypto`. To be removed after Zig 0.14.0 is released.
-///
-/// As a reminder, never use "utils" in a namespace (in any programming language).
-/// https://ziglang.org/documentation/0.13.0/#Avoid-Redundancy-in-Names
-pub const utils = struct {
-    /// Deprecated in favor of `std.crypto.secureZero`.
-    pub const secureZero = std.crypto.secureZero;
-    /// Deprecated in favor of `std.crypto.timing_safe.eql`.
-    pub const timingSafeEql = timing_safe.eql;
-    /// Deprecated in favor of `std.crypto.timing_safe.compare`.
-    pub const timingSafeCompare = timing_safe.compare;
-    /// Deprecated in favor of `std.crypto.timing_safe.add`.
-    pub const timingSafeAdd = timing_safe.add;
-    /// Deprecated in favor of `std.crypto.timing_safe.sub`.
-    pub const timingSafeSub = timing_safe.sub;
-};

--- a/lib/std/crypto/timing_safe.zig
+++ b/lib/std/crypto/timing_safe.zig
@@ -265,7 +265,7 @@ test classify {
 
     // Comparing secret data must be done in constant time. The result
     // is going to be considered as secret as well.
-    var res = std.crypto.utils.timingSafeEql([32]u8, out, secret);
+    var res = std.crypto.timing_safe.eql([32]u8, out, secret);
 
     // If we want to make a conditional jump based on a secret,
     // it has to be declassified.

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -227,10 +227,6 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
     nosuspend bw.print(fmt, args) catch return;
 }
 
-pub fn getStderrMutex() *std.Thread.Mutex {
-    @compileError("deprecated. call std.debug.lockStdErr() and std.debug.unlockStdErr() instead which will integrate properly with std.Progress");
-}
-
 /// TODO multithreaded awareness
 var self_debug_info: ?SelfInfo = null;
 

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -35,8 +35,6 @@ pub const realpathW = posix.realpathW;
 pub const getAppDataDir = @import("fs/get_app_data_dir.zig").getAppDataDir;
 pub const GetAppDataDirError = @import("fs/get_app_data_dir.zig").GetAppDataDirError;
 
-pub const MAX_PATH_BYTES = @compileError("deprecated; renamed to max_path_bytes");
-
 /// The maximum length of a file path that the operating system will accept.
 ///
 /// Paths, including those returned from file system operations, may be longer
@@ -90,9 +88,6 @@ pub const max_name_bytes = switch (native_os) {
         @compileError("NAME_MAX not implemented for " ++ @tagName(native_os)),
 };
 
-/// Deprecated: use `max_name_bytes`
-pub const MAX_NAME_BYTES = max_name_bytes;
-
 pub const base64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".*;
 
 /// Base64 encoder, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
@@ -100,11 +95,6 @@ pub const base64_encoder = base64.Base64Encoder.init(base64_alphabet, null);
 
 /// Base64 decoder, replacing the standard `+/` with `-_` so that it can be used in a file name on any filesystem.
 pub const base64_decoder = base64.Base64Decoder.init(base64_alphabet, null);
-
-/// Deprecated. Use `cwd().atomicSymLink()` instead.
-pub fn atomicSymLink(_: Allocator, existing_path: []const u8, new_path: []const u8) !void {
-    try cwd().atomicSymLink(existing_path, new_path, .{});
-}
 
 /// Same as `Dir.updateFile`, except asserts that both `source_path` and `dest_path`
 /// are absolute. See `Dir.updateFile` for a function that operates on both

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -1402,9 +1402,6 @@ pub fn setAsCwd(self: Dir) !void {
     try posix.fchdir(self.fd);
 }
 
-/// Deprecated: use `OpenOptions`
-pub const OpenDirOptions = OpenOptions;
-
 pub const OpenOptions = struct {
     /// `true` means the opened directory can be used as the `Dir` parameter
     /// for functions which operate based on an open directory handle. When `false`,
@@ -2458,8 +2455,6 @@ pub fn writeFile(self: Dir, options: WriteFileOptions) WriteFileError!void {
     defer file.close();
     try file.writeAll(options.data);
 }
-
-pub const writeFile2 = @compileError("deprecated; renamed to writeFile");
 
 pub const AccessError = posix.AccessError;
 

--- a/lib/std/hash.zig
+++ b/lib/std/hash.zig
@@ -81,9 +81,8 @@ fn uint16(input: u16) u16 {
     return x;
 }
 
-/// DEPRECATED: use std.hash.int()
 /// Source: https://github.com/skeeto/hash-prospector
-pub fn uint32(input: u32) u32 {
+fn uint32(input: u32) u32 {
     var x: u32 = input;
     x = (x ^ (x >> 17)) *% 0xed5ad4bb;
     x = (x ^ (x >> 11)) *% 0xac4c1b51;

--- a/lib/std/hash/crc/impl.zig
+++ b/lib/std/hash/crc/impl.zig
@@ -100,13 +100,3 @@ pub fn Crc(comptime W: type, comptime algorithm: Algorithm(W)) type {
         }
     };
 }
-
-pub const Polynomial = enum(u32) {
-    IEEE = @compileError("use Crc with algorithm .Crc32IsoHdlc"),
-    Castagnoli = @compileError("use Crc with algorithm .Crc32Iscsi"),
-    Koopman = @compileError("use Crc with algorithm .Crc32Koopman"),
-    _,
-};
-
-pub const Crc32WithPoly = @compileError("use Crc instead");
-pub const Crc32SmallWithPoly = @compileError("use Crc instead");

--- a/lib/std/leb128.zig
+++ b/lib/std/leb128.zig
@@ -33,9 +33,6 @@ pub fn readUleb128(comptime T: type, reader: anytype) !T {
     return @as(T, @truncate(value));
 }
 
-/// Deprecated: use `readUleb128`
-pub const readULEB128 = readUleb128;
-
 /// Write a single unsigned integer as unsigned LEB128 to the given writer.
 pub fn writeUleb128(writer: anytype, arg: anytype) !void {
     const Arg = @TypeOf(arg);
@@ -57,9 +54,6 @@ pub fn writeUleb128(writer: anytype, arg: anytype) !void {
         }
     }
 }
-
-/// Deprecated: use `writeUleb128`
-pub const writeULEB128 = writeUleb128;
 
 /// Read a single signed LEB128 value from the given reader as type T,
 /// or error.Overflow if the value cannot fit.
@@ -119,9 +113,6 @@ pub fn readIleb128(comptime T: type, reader: anytype) !T {
     return @as(T, @truncate(result));
 }
 
-/// Deprecated: use `readIleb128`
-pub const readILEB128 = readIleb128;
-
 /// Write a single signed integer as signed LEB128 to the given writer.
 pub fn writeIleb128(writer: anytype, arg: anytype) !void {
     const Arg = @TypeOf(arg);
@@ -175,9 +166,6 @@ pub fn writeUnsignedExtended(slice: []u8, arg: anytype) void {
     }
     slice[slice.len - 1] = @as(u7, @intCast(value));
 }
-
-/// Deprecated: use `writeIleb128`
-pub const writeILEB128 = writeIleb128;
 
 test writeUnsignedFixed {
     {

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -2222,9 +2222,6 @@ pub const Const = struct {
         TargetTooSmall,
     };
 
-    /// Deprecated; use `toInt`.
-    pub const to = toInt;
-
     /// Convert `self` to `Int`.
     ///
     /// Returns an error if self cannot be narrowed into the requested type without truncation.
@@ -2854,9 +2851,6 @@ pub const Managed = struct {
     }
 
     pub const ConvertError = Const.ConvertError;
-
-    /// Deprecated; use `toInt`.
-    pub const to = toInt;
 
     /// Convert `self` to `Int`.
     ///

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -688,7 +688,7 @@ test "string set base 36" {
     defer a.deinit();
 
     try a.setString(36, "fifvthrv1mzt79ez9");
-    try testing.expectEqual(123456789123456789123456789, try a.to(u128));
+    try testing.expectEqual(123456789123456789123456789, try a.toInt(u128));
 }
 
 test "string set bad char error" {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -2258,8 +2258,6 @@ test byteSwapAllFields {
     }, k);
 }
 
-pub const tokenize = @compileError("deprecated; use tokenizeAny, tokenizeSequence, or tokenizeScalar");
-
 /// Returns an iterator that iterates over the slices of `buffer` that are not
 /// any of the items in `delimiters`.
 ///
@@ -2457,8 +2455,6 @@ test "tokenize (reset)" {
         try testing.expect(it.next() == null);
     }
 }
-
-pub const split = @compileError("deprecated; use splitSequence, splitAny, or splitScalar");
 
 /// Returns an iterator that iterates over the slices of `buffer` that
 /// are separated by the byte sequence in `delimiter`.
@@ -2658,8 +2654,6 @@ test "split (reset)" {
         try testing.expect(it.next() == null);
     }
 }
-
-pub const splitBackwards = @compileError("deprecated; use splitBackwardsSequence, splitBackwardsAny, or splitBackwardsScalar");
 
 /// Returns an iterator that iterates backwards over the slices of `buffer` that
 /// are separated by the sequence in `delimiter`.

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -418,29 +418,6 @@ test fieldInfo {
     try testing.expect(comptime uf.type == u8);
 }
 
-/// Deprecated: use @FieldType
-pub fn FieldType(comptime T: type, comptime field: FieldEnum(T)) type {
-    return @FieldType(T, @tagName(field));
-}
-
-test FieldType {
-    const S = struct {
-        a: u8,
-        b: u16,
-    };
-
-    const U = union {
-        c: u32,
-        d: *const u8,
-    };
-
-    try testing.expect(FieldType(S, .a) == u8);
-    try testing.expect(FieldType(S, .b) == u16);
-
-    try testing.expect(FieldType(U, .c) == u32);
-    try testing.expect(FieldType(U, .d) == *const u8);
-}
-
 pub fn fieldNames(comptime T: type) *const [fields(T).len][:0]const u8 {
     return comptime blk: {
         const fieldInfos = fields(T);

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -214,8 +214,6 @@ pub const Address = extern union {
         /// Sets SO_REUSEADDR and SO_REUSEPORT on POSIX.
         /// Sets SO_REUSEADDR on Windows, which is roughly equivalent.
         reuse_address: bool = false,
-        /// Deprecated. Does the same thing as reuse_address.
-        reuse_port: bool = false,
         force_nonblocking: bool = false,
     };
 
@@ -232,7 +230,7 @@ pub const Address = extern union {
         };
         errdefer s.stream.close();
 
-        if (options.reuse_address or options.reuse_port) {
+        if (options.reuse_address) {
             try posix.setsockopt(
                 sockfd,
                 posix.SOL.SOCKET,

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -232,10 +232,10 @@ test "listen on an in use port" {
 
     const localhost = try net.Address.parseIp("127.0.0.1", 0);
 
-    var server1 = try localhost.listen(.{ .reuse_port = true });
+    var server1 = try localhost.listen(.{ .reuse_address = true });
     defer server1.deinit();
 
-    var server2 = try server1.listen_address.listen(.{ .reuse_port = true });
+    var server2 = try server1.listen_address.listen(.{ .reuse_address = true });
     defer server2.deinit();
 }
 
@@ -315,7 +315,7 @@ test "listen on a unix socket, send bytes, receive bytes" {
     try testing.expectEqualSlices(u8, "Hello world!", buf[0..n]);
 }
 
-test "listen on a unix socket with reuse_port option" {
+test "listen on a unix socket with reuse_address option" {
     if (!net.has_unix_sockets) return error.SkipZigTest;
     // Windows doesn't implement reuse port option.
     if (builtin.os.tag == .windows) return error.SkipZigTest;
@@ -326,7 +326,7 @@ test "listen on a unix socket with reuse_port option" {
     const socket_addr = try net.Address.initUnix(socket_path);
     defer std.fs.cwd().deleteFile(socket_path) catch {};
 
-    var server = try socket_addr.listen(.{ .reuse_port = true });
+    var server = try socket_addr.listen(.{ .reuse_address = true });
     server.deinit();
 }
 

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -146,7 +146,7 @@ pub fn OpenFile(sub_path_w: []const u16, options: OpenFileOptions) OpenError!HAN
                 // call has failed. There is not really a sane way to handle
                 // this other than retrying the creation after the OS finishes
                 // the deletion.
-                std.time.sleep(std.time.ns_per_ms);
+                std.Thread.sleep(std.time.ns_per_ms);
                 continue;
             },
             .VIRUS_INFECTED, .VIRUS_DELETED => return error.AntivirusInterference,
@@ -2847,9 +2847,6 @@ pub const STD_OUTPUT_HANDLE = maxInt(DWORD) - 11 + 1;
 
 /// The standard error device. Initially, this is the active console screen buffer, CONOUT$.
 pub const STD_ERROR_HANDLE = maxInt(DWORD) - 12 + 1;
-
-/// Deprecated; use `std.builtin.CallingConvention.winapi` instead.
-pub const WINAPI: std.builtin.CallingConvention = .winapi;
 
 pub const BOOL = c_int;
 pub const BOOLEAN = BYTE;

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1161,7 +1161,7 @@ test "POSIX file locking with fcntl" {
         posix.exit(0);
     } else {
         // parent waits for child to get shared lock:
-        std.time.sleep(1 * std.time.ns_per_ms);
+        std.Thread.sleep(1 * std.time.ns_per_ms);
         // parent expects deadlock when attempting to upgrade the shared lock to exclusive:
         struct_flock.start = 1;
         struct_flock.type = posix.F.WRLCK;

--- a/lib/std/time.zig
+++ b/lib/std/time.zig
@@ -8,9 +8,6 @@ const posix = std.posix;
 
 pub const epoch = @import("time/epoch.zig");
 
-/// Deprecated: moved to std.Thread.sleep
-pub const sleep = std.Thread.sleep;
-
 /// Get a calendar timestamp, in seconds, relative to UTC 1970-01-01.
 /// Precision of timing depends on the hardware and operating system.
 /// The return value is signed because it is possible to have a date that is

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -972,8 +972,6 @@ pub fn utf16LeToUtf8ArrayList(result: *std.ArrayList(u8), utf16le: []const u16) 
     return utf16LeToUtf8ArrayListImpl(result, utf16le, .cannot_encode_surrogate_half);
 }
 
-pub const utf16leToUtf8Alloc = @compileError("deprecated; renamed to utf16LeToUtf8Alloc");
-
 /// Caller must free returned memory.
 pub fn utf16LeToUtf8Alloc(allocator: mem.Allocator, utf16le: []const u16) Utf16LeToUtf8AllocError![]u8 {
     // optimistically guess that it will all be ascii.
@@ -983,8 +981,6 @@ pub fn utf16LeToUtf8Alloc(allocator: mem.Allocator, utf16le: []const u16) Utf16L
     try utf16LeToUtf8ArrayListImpl(&result, utf16le, .cannot_encode_surrogate_half);
     return result.toOwnedSlice();
 }
-
-pub const utf16leToUtf8AllocZ = @compileError("deprecated; renamed to utf16LeToUtf8AllocZ");
 
 /// Caller must free returned memory.
 pub fn utf16LeToUtf8AllocZ(allocator: mem.Allocator, utf16le: []const u16) Utf16LeToUtf8AllocError![:0]u8 {
@@ -1053,8 +1049,6 @@ fn utf16LeToUtf8Impl(utf8: []u8, utf16le: []const u16, comptime surrogates: Surr
     }
     return dest_index;
 }
-
-pub const utf16leToUtf8 = @compileError("deprecated; renamed to utf16LeToUtf8");
 
 pub fn utf16LeToUtf8(utf8: []u8, utf16le: []const u16) Utf16LeToUtf8Error!usize {
     return utf16LeToUtf8Impl(utf8, utf16le, .cannot_encode_surrogate_half);
@@ -1174,8 +1168,6 @@ pub fn utf8ToUtf16LeAlloc(allocator: mem.Allocator, utf8: []const u8) error{ Inv
     try utf8ToUtf16LeArrayListImpl(&result, utf8, .cannot_encode_surrogate_half);
     return result.toOwnedSlice();
 }
-
-pub const utf8ToUtf16LeWithNull = @compileError("deprecated; renamed to utf8ToUtf16LeAllocZ");
 
 pub fn utf8ToUtf16LeAllocZ(allocator: mem.Allocator, utf8: []const u8) error{ InvalidUtf8, OutOfMemory }![:0]u16 {
     // optimistically guess that it will not require surrogate pairs
@@ -1486,8 +1478,6 @@ fn formatUtf16Le(utf16le: []const u16, writer: *std.io.Writer) std.io.Writer.Err
     }
     try writer.writeAll(buf[0..u8len]);
 }
-
-pub const fmtUtf16le = @compileError("deprecated; renamed to fmtUtf16Le");
 
 /// Return a Formatter for a (potentially ill-formed) UTF-16 LE string,
 /// which will be converted to UTF-8 during formatting.

--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -200,18 +200,6 @@ pub fn nonSimdCall3(func: fn (usize, usize, usize, usize) usize, a1: usize, a2: 
     return doClientRequestExpr(0, .ClientCall3, @intFromPtr(func), a1, a2, a3, 0);
 }
 
-/// Deprecated: use `nonSimdCall0`
-pub const nonSIMDCall0 = nonSimdCall0;
-
-/// Deprecated: use `nonSimdCall1`
-pub const nonSIMDCall1 = nonSimdCall1;
-
-/// Deprecated: use `nonSimdCall2`
-pub const nonSIMDCall2 = nonSimdCall2;
-
-/// Deprecated: use `nonSimdCall3`
-pub const nonSIMDCall3 = nonSimdCall3;
-
 /// Counts the number of errors that have been recorded by a tool.  Nb:
 /// the tool must record the errors with VG_(maybe_record_error)() or
 /// VG_(unique_error)() for them to be counted.

--- a/lib/std/valgrind/callgrind.zig
+++ b/lib/std/valgrind/callgrind.zig
@@ -10,8 +10,6 @@ pub const ClientRequest = enum(usize) {
     StopInstrumentation,
 };
 
-pub const CallgrindClientRequest = @compileError("std.valgrind.callgrind.CallgrindClientRequest renamed to std.valgrind.callgrind.ClientRequest");
-
 fn doClientRequestExpr(default: usize, request: ClientRequest, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) usize {
     return valgrind.doClientRequest(default, @as(usize, @intCast(@intFromEnum(request))), a1, a2, a3, a4, a5);
 }

--- a/lib/std/valgrind/memcheck.zig
+++ b/lib/std/valgrind/memcheck.zig
@@ -20,8 +20,6 @@ pub const ClientRequest = enum(usize) {
     DisableAddrErrorReportingInRange,
 };
 
-pub const MemCheckClientRequest = @compileError("std.valgrind.memcheck.MemCheckClientRequest renamed to std.valgrind.memcheck.ClientRequest");
-
 fn doClientRequestExpr(default: usize, request: ClientRequest, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) usize {
     return valgrind.doClientRequest(default, @as(usize, @intCast(@intFromEnum(request))), a1, a2, a3, a4, a5);
 }

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -17,7 +17,6 @@ pub const Zir = @import("zig/Zir.zig");
 pub const Zoir = @import("zig/Zoir.zig");
 pub const ZonGen = @import("zig/ZonGen.zig");
 pub const system = @import("zig/system.zig");
-pub const CrossTarget = @compileError("deprecated; use std.Target.Query");
 pub const BuiltinFn = @import("zig/BuiltinFn.zig");
 pub const AstRlAnnotate = @import("zig/AstRlAnnotate.zig");
 pub const LibCInstallation = @import("zig/LibCInstallation.zig");
@@ -604,7 +603,7 @@ pub fn putAstErrorsIntoBundle(
 
 pub fn resolveTargetQueryOrFatal(target_query: std.Target.Query) std.Target {
     return std.zig.system.resolveTargetQuery(target_query) catch |err|
-        fatal("unable to resolve target: {s}", .{@errorName(err)});
+        std.process.fatal("unable to resolve target: {s}", .{@errorName(err)});
 }
 
 pub fn parseTargetQueryOrReportFatalError(
@@ -628,7 +627,7 @@ pub fn parseTargetQueryOrReportFatalError(
                     @tagName(diags.arch.?), help_text.items,
                 });
             }
-            fatal("unknown CPU: '{s}'", .{diags.cpu_name.?});
+            std.process.fatal("unknown CPU: '{s}'", .{diags.cpu_name.?});
         },
         error.UnknownCpuFeature => {
             help: {
@@ -641,7 +640,7 @@ pub fn parseTargetQueryOrReportFatalError(
                     @tagName(diags.arch.?), help_text.items,
                 });
             }
-            fatal("unknown CPU feature: '{s}'", .{diags.unknown_feature_name.?});
+            std.process.fatal("unknown CPU feature: '{s}'", .{diags.unknown_feature_name.?});
         },
         error.UnknownObjectFormat => {
             help: {
@@ -652,7 +651,7 @@ pub fn parseTargetQueryOrReportFatalError(
                 }
                 std.log.info("available object formats:\n{s}", .{help_text.items});
             }
-            fatal("unknown object format: '{s}'", .{opts.object_format.?});
+            std.process.fatal("unknown object format: '{s}'", .{opts.object_format.?});
         },
         error.UnknownArchitecture => {
             help: {
@@ -663,16 +662,13 @@ pub fn parseTargetQueryOrReportFatalError(
                 }
                 std.log.info("available architectures:\n{s} native\n", .{help_text.items});
             }
-            fatal("unknown architecture: '{s}'", .{diags.unknown_architecture_name.?});
+            std.process.fatal("unknown architecture: '{s}'", .{diags.unknown_architecture_name.?});
         },
-        else => |e| fatal("unable to parse target query '{s}': {s}", .{
+        else => |e| std.process.fatal("unable to parse target query '{s}': {s}", .{
             opts.arch_os_abi, @errorName(e),
         }),
     };
 }
-
-/// Deprecated; see `std.process.fatal`.
-pub const fatal = std.process.fatal;
 
 /// Collects all the environment variables that Zig could possibly inspect, so
 /// that we can do reflection on this and print them with `zig env`.

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -254,9 +254,6 @@ test "sizeof" {
 
 pub const CIntLiteralBase = enum { decimal, octal, hex };
 
-/// Deprecated: use `CIntLiteralBase`
-pub const CIntLiteralRadix = CIntLiteralBase;
-
 fn PromoteIntLiteralReturnType(comptime SuffixType: type, comptime number: comptime_int, comptime base: CIntLiteralBase) type {
     const signed_decimal = [_]type{ c_int, c_long, c_longlong, c_ulonglong };
     const signed_oct_hex = [_]type{ c_int, c_uint, c_long, c_ulong, c_longlong, c_ulonglong };

--- a/lib/std/zig/llvm/Builder.zig
+++ b/lib/std/zig/llvm/Builder.zig
@@ -10638,7 +10638,7 @@ fn fnTypeAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = std.hash.Wyhash.init(comptime std.hash.uint32(@intFromEnum(tag)));
+            var hasher = std.hash.Wyhash.init(comptime std.hash.int(@intFromEnum(tag)));
             hasher.update(std.mem.asBytes(&key.ret));
             hasher.update(std.mem.sliceAsBytes(key.params));
             return @truncate(hasher.final());
@@ -10698,7 +10698,7 @@ fn vectorTypeAssumeCapacity(
         builder: *const Builder,
         pub fn hash(_: @This(), key: Type.Vector) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(tag)),
+                comptime std.hash.int(@intFromEnum(tag)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -10727,7 +10727,7 @@ fn arrayTypeAssumeCapacity(self: *Builder, len: u64, child: Type) Type {
             builder: *const Builder,
             pub fn hash(_: @This(), key: Type.Vector) u32 {
                 return @truncate(std.hash.Wyhash.hash(
-                    comptime std.hash.uint32(@intFromEnum(Type.Tag.small_array)),
+                    comptime std.hash.int(@intFromEnum(Type.Tag.small_array)),
                     std.mem.asBytes(&key),
                 ));
             }
@@ -10753,7 +10753,7 @@ fn arrayTypeAssumeCapacity(self: *Builder, len: u64, child: Type) Type {
             builder: *const Builder,
             pub fn hash(_: @This(), key: Type.Array) u32 {
                 return @truncate(std.hash.Wyhash.hash(
-                    comptime std.hash.uint32(@intFromEnum(Type.Tag.array)),
+                    comptime std.hash.int(@intFromEnum(Type.Tag.array)),
                     std.mem.asBytes(&key),
                 ));
             }
@@ -10794,7 +10794,7 @@ fn structTypeAssumeCapacity(
         builder: *const Builder,
         pub fn hash(_: @This(), key: []const Type) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(tag)),
+                comptime std.hash.int(@intFromEnum(tag)),
                 std.mem.sliceAsBytes(key),
             ));
         }
@@ -10826,7 +10826,7 @@ fn opaqueTypeAssumeCapacity(self: *Builder, name: String) Type {
         builder: *const Builder,
         pub fn hash(_: @This(), key: String) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Type.Tag.named_structure)),
+                comptime std.hash.int(@intFromEnum(Type.Tag.named_structure)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -10887,7 +10887,7 @@ fn getOrPutTypeNoExtraAssumeCapacity(self: *Builder, item: Type.Item) struct { n
         builder: *const Builder,
         pub fn hash(_: @This(), key: Type.Item) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Type.Tag.simple)),
+                comptime std.hash.int(@intFromEnum(Type.Tag.simple)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -11021,7 +11021,7 @@ fn bigIntConstAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(key.tag)));
+            var hasher = std.hash.Wyhash.init(std.hash.int(@intFromEnum(key.tag)));
             hasher.update(std.mem.asBytes(&key.type));
             hasher.update(std.mem.sliceAsBytes(key.limbs));
             return @truncate(hasher.final());
@@ -11084,7 +11084,7 @@ fn doubleConstAssumeCapacity(self: *Builder, val: f64) Constant {
         builder: *const Builder,
         pub fn hash(_: @This(), key: f64) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Constant.Tag.double)),
+                comptime std.hash.int(@intFromEnum(Constant.Tag.double)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -11115,7 +11115,7 @@ fn fp128ConstAssumeCapacity(self: *Builder, val: f128) Constant {
         builder: *const Builder,
         pub fn hash(_: @This(), key: f128) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Constant.Tag.fp128)),
+                comptime std.hash.int(@intFromEnum(Constant.Tag.fp128)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -11149,7 +11149,7 @@ fn x86_fp80ConstAssumeCapacity(self: *Builder, val: f80) Constant {
         builder: *const Builder,
         pub fn hash(_: @This(), key: f80) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Constant.Tag.x86_fp80)),
+                comptime std.hash.int(@intFromEnum(Constant.Tag.x86_fp80)),
                 std.mem.asBytes(&key)[0..10],
             ));
         }
@@ -11182,7 +11182,7 @@ fn ppc_fp128ConstAssumeCapacity(self: *Builder, val: [2]f64) Constant {
         builder: *const Builder,
         pub fn hash(_: @This(), key: [2]f64) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Constant.Tag.ppc_fp128)),
+                comptime std.hash.int(@intFromEnum(Constant.Tag.ppc_fp128)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -11317,7 +11317,7 @@ fn splatConstAssumeCapacity(self: *Builder, ty: Type, val: Constant) Constant {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Constant.Splat) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Constant.Tag.splat)),
+                comptime std.hash.int(@intFromEnum(Constant.Tag.splat)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -11420,7 +11420,7 @@ fn blockAddrConstAssumeCapacity(
         builder: *const Builder,
         pub fn hash(_: @This(), key: Constant.BlockAddress) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                comptime std.hash.uint32(@intFromEnum(Constant.Tag.blockaddress)),
+                comptime std.hash.int(@intFromEnum(Constant.Tag.blockaddress)),
                 std.mem.asBytes(&key),
             ));
         }
@@ -11546,7 +11546,7 @@ fn castConstAssumeCapacity(self: *Builder, tag: Constant.Tag, val: Constant, ty:
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                std.hash.uint32(@intFromEnum(key.tag)),
+                std.hash.int(@intFromEnum(key.tag)),
                 std.mem.asBytes(&key.cast),
             ));
         }
@@ -11621,7 +11621,7 @@ fn gepConstAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = std.hash.Wyhash.init(comptime std.hash.uint32(@intFromEnum(tag)));
+            var hasher = std.hash.Wyhash.init(comptime std.hash.int(@intFromEnum(tag)));
             hasher.update(std.mem.asBytes(&key.type));
             hasher.update(std.mem.asBytes(&key.base));
             hasher.update(std.mem.asBytes(&key.inrange));
@@ -11685,7 +11685,7 @@ fn binConstAssumeCapacity(
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                std.hash.uint32(@intFromEnum(key.tag)),
+                std.hash.int(@intFromEnum(key.tag)),
                 std.mem.asBytes(&key.extra),
             ));
         }
@@ -11723,7 +11723,7 @@ fn asmConstAssumeCapacity(
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                std.hash.uint32(@intFromEnum(key.tag)),
+                std.hash.int(@intFromEnum(key.tag)),
                 std.mem.asBytes(&key.extra),
             ));
         }
@@ -11773,7 +11773,7 @@ fn getOrPutConstantNoExtraAssumeCapacity(
         builder: *const Builder,
         pub fn hash(_: @This(), key: Constant.Item) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                std.hash.uint32(@intFromEnum(key.tag)),
+                std.hash.int(@intFromEnum(key.tag)),
                 std.mem.asBytes(&key.data),
             ));
         }
@@ -11804,7 +11804,7 @@ fn getOrPutConstantAggregateAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(key.tag)));
+            var hasher = std.hash.Wyhash.init(std.hash.int(@intFromEnum(key.tag)));
             hasher.update(std.mem.asBytes(&key.type));
             hasher.update(std.mem.sliceAsBytes(key.vals));
             return @truncate(hasher.final());
@@ -12421,7 +12421,7 @@ fn metadataSimpleAssumeCapacity(self: *Builder, tag: Metadata.Tag, value: anytyp
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(key.tag)));
+            var hasher = std.hash.Wyhash.init(std.hash.int(@intFromEnum(key.tag)));
             inline for (std.meta.fields(@TypeOf(value))) |field| {
                 hasher.update(std.mem.asBytes(&@field(key.value, field.name)));
             }
@@ -12457,7 +12457,7 @@ fn metadataDistinctAssumeCapacity(self: *Builder, tag: Metadata.Tag, value: anyt
     const Adapter = struct {
         pub fn hash(_: @This(), key: Key) u32 {
             return @truncate(std.hash.Wyhash.hash(
-                std.hash.uint32(@intFromEnum(key.tag)),
+                std.hash.int(@intFromEnum(key.tag)),
                 std.mem.asBytes(&key.index),
             ));
         }
@@ -12853,7 +12853,7 @@ fn debugEnumeratorAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(key.tag)));
+            var hasher = std.hash.Wyhash.init(std.hash.int(@intFromEnum(key.tag)));
             hasher.update(std.mem.asBytes(&key.name));
             hasher.update(std.mem.asBytes(&key.bit_width));
             hasher.update(std.mem.sliceAsBytes(key.value.limbs));
@@ -12935,7 +12935,7 @@ fn debugExpressionAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = comptime std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(Metadata.Tag.expression)));
+            var hasher = comptime std.hash.Wyhash.init(std.hash.int(@intFromEnum(Metadata.Tag.expression)));
             hasher.update(std.mem.sliceAsBytes(key.elements));
             return @truncate(hasher.final());
         }
@@ -12981,7 +12981,7 @@ fn metadataTupleAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = comptime std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(Metadata.Tag.tuple)));
+            var hasher = comptime std.hash.Wyhash.init(std.hash.int(@intFromEnum(Metadata.Tag.tuple)));
             hasher.update(std.mem.sliceAsBytes(key.elements));
             return @truncate(hasher.final());
         }
@@ -13029,7 +13029,7 @@ fn strTupleAssumeCapacity(
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Key) u32 {
-            var hasher = comptime std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(Metadata.Tag.tuple)));
+            var hasher = comptime std.hash.Wyhash.init(std.hash.int(@intFromEnum(Metadata.Tag.tuple)));
             hasher.update(std.mem.sliceAsBytes(key.elements));
             return @truncate(hasher.final());
         }
@@ -13159,7 +13159,7 @@ fn metadataConstantAssumeCapacity(self: *Builder, constant: Constant) Metadata {
     const Adapter = struct {
         builder: *const Builder,
         pub fn hash(_: @This(), key: Constant) u32 {
-            var hasher = comptime std.hash.Wyhash.init(std.hash.uint32(@intFromEnum(Metadata.Tag.constant)));
+            var hasher = comptime std.hash.Wyhash.init(std.hash.int(@intFromEnum(Metadata.Tag.constant)));
             hasher.update(std.mem.asBytes(&key));
             return @truncate(hasher.final());
         }

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -1861,7 +1861,7 @@ pub const NullTerminatedString = enum(u32) {
 
         pub fn hash(ctx: @This(), a: NullTerminatedString) u32 {
             _ = ctx;
-            return std.hash.uint32(@intFromEnum(a));
+            return std.hash.int(@intFromEnum(a));
         }
     };
 
@@ -4740,7 +4740,7 @@ pub const Index = enum(u32) {
 
         pub fn hash(ctx: @This(), a: Index) u32 {
             _ = ctx;
-            return std.hash.uint32(@intFromEnum(a));
+            return std.hash.int(@intFromEnum(a));
         }
     };
 
@@ -12725,7 +12725,7 @@ const GlobalErrorSet = struct {
         name: NullTerminatedString,
     ) Allocator.Error!GlobalErrorSet.Index {
         if (name == .empty) return .none;
-        const hash = std.hash.uint32(@intFromEnum(name));
+        const hash = std.hash.int(@intFromEnum(name));
         var map = ges.shared.map.acquire();
         const Map = @TypeOf(map);
         var map_mask = map.header().mask();
@@ -12818,7 +12818,7 @@ const GlobalErrorSet = struct {
         name: NullTerminatedString,
     ) ?GlobalErrorSet.Index {
         if (name == .empty) return .none;
-        const hash = std.hash.uint32(@intFromEnum(name));
+        const hash = std.hash.int(@intFromEnum(name));
         const map = ges.shared.map.acquire();
         const map_mask = map.header().mask();
         const names_items = ges.shared.names.acquire().view().items(.@"0");

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -808,7 +808,7 @@ pub const Namespace = struct {
 
         pub fn hash(ctx: NavNameContext, nav: InternPool.Nav.Index) u32 {
             const name = ctx.zcu.intern_pool.getNav(nav).name;
-            return std.hash.uint32(@intFromEnum(name));
+            return std.hash.int(@intFromEnum(name));
         }
 
         pub fn eql(ctx: NavNameContext, a_nav: InternPool.Nav.Index, b_nav: InternPool.Nav.Index, b_index: usize) bool {
@@ -824,7 +824,7 @@ pub const Namespace = struct {
 
         pub fn hash(ctx: NameAdapter, s: InternPool.NullTerminatedString) u32 {
             _ = ctx;
-            return std.hash.uint32(@intFromEnum(s));
+            return std.hash.int(@intFromEnum(s));
         }
 
         pub fn eql(ctx: NameAdapter, a: InternPool.NullTerminatedString, b_nav: InternPool.Nav.Index, b_index: usize) bool {

--- a/src/arch/wasm/CodeGen.zig
+++ b/src/arch/wasm/CodeGen.zig
@@ -3974,7 +3974,7 @@ fn airSwitchBr(cg: *CodeGen, inst: Air.Inst.Index, is_dispatch_loop: bool) Inner
         var width_bigint: std.math.big.int.Mutable = .{ .limbs = limbs, .positive = undefined, .len = undefined };
         width_bigint.sub(max_bigint, min_bigint);
         width_bigint.addScalar(width_bigint.toConst(), 1);
-        break :width width_bigint.toConst().to(u32) catch null;
+        break :width width_bigint.toConst().toInt(u32) catch null;
     };
 
     try cg.startBlock(.block, .empty); // whole switch block start
@@ -4015,7 +4015,7 @@ fn airSwitchBr(cg: *CodeGen, inst: Air.Inst.Index, is_dispatch_loop: bool) Inner
                 const val_bigint = val.toBigInt(&val_space, zcu);
                 var index_bigint: std.math.big.int.Mutable = .{ .limbs = limbs, .positive = undefined, .len = undefined };
                 index_bigint.sub(val_bigint, min_bigint);
-                branch_list[index_bigint.toConst().to(u32) catch unreachable] = case.idx;
+                branch_list[index_bigint.toConst().toInt(u32) catch unreachable] = case.idx;
             }
             for (case.ranges) |range| {
                 var low_space: Value.BigIntSpace = undefined;
@@ -4024,9 +4024,9 @@ fn airSwitchBr(cg: *CodeGen, inst: Air.Inst.Index, is_dispatch_loop: bool) Inner
                 const high_bigint = Value.fromInterned(range[1].toInterned().?).toBigInt(&high_space, zcu);
                 var index_bigint: std.math.big.int.Mutable = .{ .limbs = limbs, .positive = undefined, .len = undefined };
                 index_bigint.sub(low_bigint, min_bigint);
-                const start = index_bigint.toConst().to(u32) catch unreachable;
+                const start = index_bigint.toConst().toInt(u32) catch unreachable;
                 index_bigint.sub(high_bigint, min_bigint);
-                const end = (index_bigint.toConst().to(u32) catch unreachable) + 1;
+                const end = (index_bigint.toConst().toInt(u32) catch unreachable) + 1;
                 @memset(branch_list[start..end], case.idx);
             }
         }

--- a/src/arch/wasm/Emit.zig
+++ b/src/arch/wasm/Emit.zig
@@ -263,7 +263,7 @@ pub fn lowerToCode(emit: *Emit) Error!void {
                 code.appendNTimesAssumeCapacity(0, 5);
             } else {
                 const sp_global: Wasm.GlobalIndex = .stack_pointer;
-                std.leb.writeULEB128(code.fixedWriter(), @intFromEnum(sp_global)) catch unreachable;
+                std.leb.writeUleb128(code.fixedWriter(), @intFromEnum(sp_global)) catch unreachable;
             }
 
             inst += 1;

--- a/src/arch/wasm/Mir.zig
+++ b/src/arch/wasm/Mir.zig
@@ -687,7 +687,7 @@ pub fn lower(mir: *const Mir, wasm: *Wasm, code: *std.ArrayListUnmanaged(u8)) st
         const sp_global: Wasm.GlobalIndex = .stack_pointer;
         // load stack pointer
         code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.global_get));
-        std.leb.writeULEB128(code.fixedWriter(), @intFromEnum(sp_global)) catch unreachable;
+        std.leb.writeUleb128(code.fixedWriter(), @intFromEnum(sp_global)) catch unreachable;
         // store stack pointer so we can restore it when we return from the function
         code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.local_tee));
         leb.writeUleb128(code.fixedWriter(), mir.prologue.sp_local) catch unreachable;
@@ -710,7 +710,7 @@ pub fn lower(mir: *const Mir, wasm: *Wasm, code: *std.ArrayListUnmanaged(u8)) st
         // Store the current stack pointer value into the global stack pointer so other function calls will
         // start from this value instead and not overwrite the current stack.
         code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.global_set));
-        std.leb.writeULEB128(code.fixedWriter(), @intFromEnum(sp_global)) catch unreachable;
+        std.leb.writeUleb128(code.fixedWriter(), @intFromEnum(sp_global)) catch unreachable;
     }
 
     var emit: Emit = .{

--- a/src/link/MachO/dyld_info/Trie.zig
+++ b/src/link/MachO/dyld_info/Trie.zig
@@ -189,9 +189,9 @@ fn finalizeNode(self: *Trie, node_index: Node.Index, offset_in_trie: u32) !Final
     if (slice.items(.is_terminal)[node_index]) {
         const export_flags = slice.items(.export_flags)[node_index];
         const vmaddr_offset = slice.items(.vmaddr_offset)[node_index];
-        try leb.writeULEB128(writer, export_flags);
-        try leb.writeULEB128(writer, vmaddr_offset);
-        try leb.writeULEB128(writer, stream.bytes_written);
+        try leb.writeUleb128(writer, export_flags);
+        try leb.writeUleb128(writer, vmaddr_offset);
+        try leb.writeUleb128(writer, stream.bytes_written);
     } else {
         node_size += 1; // 0x0 for non-terminal nodes
     }
@@ -201,7 +201,7 @@ fn finalizeNode(self: *Trie, node_index: Node.Index, offset_in_trie: u32) !Final
         const edge = &self.edges.items[edge_index];
         const next_node_offset = slice.items(.trie_offset)[edge.node];
         node_size += @intCast(edge.label.len + 1);
-        try leb.writeULEB128(writer, next_node_offset);
+        try leb.writeUleb128(writer, next_node_offset);
     }
 
     const trie_offset = slice.items(.trie_offset)[node_index];
@@ -251,13 +251,13 @@ fn writeNode(self: *Trie, node_index: Node.Index, writer: anytype) !void {
         // TODO Implement for special flags.
         assert(export_flags & macho.EXPORT_SYMBOL_FLAGS_REEXPORT == 0 and
             export_flags & macho.EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER == 0);
-        try leb.writeULEB128(info_stream.writer(), export_flags);
-        try leb.writeULEB128(info_stream.writer(), vmaddr_offset);
+        try leb.writeUleb128(info_stream.writer(), export_flags);
+        try leb.writeUleb128(info_stream.writer(), vmaddr_offset);
 
         // Encode the size of the terminal node info.
         var size_buf: [@sizeOf(u64)]u8 = undefined;
         var size_stream = std.io.fixedBufferStream(&size_buf);
-        try leb.writeULEB128(size_stream.writer(), info_stream.pos);
+        try leb.writeUleb128(size_stream.writer(), info_stream.pos);
 
         // Now, write them to the output stream.
         try writer.writeAll(size_buf[0..size_stream.pos]);
@@ -274,7 +274,7 @@ fn writeNode(self: *Trie, node_index: Node.Index, writer: anytype) !void {
         // Write edge label and offset to next node in trie.
         try writer.writeAll(edge.label);
         try writer.writeByte(0);
-        try leb.writeULEB128(writer, slice.items(.trie_offset)[edge.node]);
+        try leb.writeUleb128(writer, slice.items(.trie_offset)[edge.node]);
     }
 }
 

--- a/src/link/Wasm/Flush.zig
+++ b/src/link/Wasm/Flush.zig
@@ -146,7 +146,7 @@ pub fn finish(f: *Flush, wasm: *Wasm) !void {
                     const int_tag_ty = Zcu.Type.fromInterned(data.ip_index).intTagType(zcu);
                     gop.value_ptr.* = .{ .tag_name = .{
                         .symbol_name = try wasm.internStringFmt("__zig_tag_name_{d}", .{@intFromEnum(data.ip_index)}),
-                        .type_index = try wasm.internFunctionType(.Unspecified, &.{int_tag_ty.ip_index}, .slice_const_u8_sentinel_0, target),
+                        .type_index = try wasm.internFunctionType(.auto, &.{int_tag_ty.ip_index}, .slice_const_u8_sentinel_0, target),
                         .table_index = @intCast(wasm.tag_name_offs.items.len),
                     } };
                     try wasm.functions.put(gpa, .fromZcuFunc(wasm, @enumFromInt(gop.index)), {});

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -153,9 +153,9 @@ test "extern struct with stdcallcc fn pointer" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     const S = extern struct {
-        ptr: *const fn () callconv(if (builtin.target.cpu.arch == .x86) .Stdcall else .c) i32,
+        ptr: *const fn () callconv(if (builtin.target.cpu.arch == .x86) .{ .x86_stdcall = .{} } else .c) i32,
 
-        fn foo() callconv(if (builtin.target.cpu.arch == .x86) .Stdcall else .c) i32 {
+        fn foo() callconv(if (builtin.target.cpu.arch == .x86) .{ .x86_stdcall = .{} } else .c) i32 {
             return 1234;
         }
     };
@@ -170,8 +170,8 @@ fn fComplexCallconvRet(x: u32) callconv(blk: {
     const s: struct { n: u32 } = .{ .n = nComplexCallconv };
     break :blk switch (s.n) {
         0 => .c,
-        1 => .Inline,
-        else => .Unspecified,
+        1 => .@"inline",
+        else => .auto,
     };
 }) struct { x: u32 } {
     return .{ .x = x * x };

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -670,7 +670,7 @@ test "reified function type params initialized with field pointer" {
         };
         const Bar = @Type(.{
             .@"fn" = .{
-                .calling_convention = .Unspecified,
+                .calling_convention = .auto,
                 .is_generic = false,
                 .is_var_args = false,
                 .return_type = void,

--- a/test/c_abi/main.zig
+++ b/test/c_abi/main.zig
@@ -5763,7 +5763,7 @@ test "f128 f128 struct" {
 }
 
 // The stdcall attribute on C functions is ignored when compiled on non-x86
-const stdcall_callconv: std.builtin.CallingConvention = if (builtin.cpu.arch == .x86) .Stdcall else .C;
+const stdcall_callconv: std.builtin.CallingConvention = if (builtin.cpu.arch == .x86) .{ .x86_stdcall = .{} } else .c;
 
 extern fn stdcall_scalars(i8, i16, i32, f32, f64) callconv(stdcall_callconv) void;
 test "Stdcall ABI scalars" {

--- a/test/cases/compile_errors/callconv_from_global_variable.zig
+++ b/test/cases/compile_errors/callconv_from_global_variable.zig
@@ -1,4 +1,4 @@
-var cc: @import("std").builtin.CallingConvention = .C;
+var cc: @import("std").builtin.CallingConvention = .c;
 export fn foo() callconv(cc) void {}
 
 // error

--- a/test/cases/compile_errors/implicit_cast_of_error_set_not_a_subset.zig
+++ b/test/cases/compile_errors/implicit_cast_of_error_set_not_a_subset.zig
@@ -12,5 +12,5 @@ fn foo(set1: Set1) void {
 // backend=stage2
 // target=native
 //
-// :7:21: error: expected type 'error{C,A}', found 'error{A,B}'
+// :7:21: error: expected type 'error{A,C}', found 'error{A,B}'
 // :7:21: note: 'error.B' not a member of destination error set

--- a/test/cases/compile_errors/reify_type.Fn_with_is_generic_true.zig
+++ b/test/cases/compile_errors/reify_type.Fn_with_is_generic_true.zig
@@ -1,6 +1,6 @@
 const Foo = @Type(.{
     .@"fn" = .{
-        .calling_convention = .Unspecified,
+        .calling_convention = .auto,
         .is_generic = true,
         .is_var_args = false,
         .return_type = u0,

--- a/test/cases/compile_errors/reify_type.Fn_with_is_var_args_true_and_non-C_callconv.zig
+++ b/test/cases/compile_errors/reify_type.Fn_with_is_var_args_true_and_non-C_callconv.zig
@@ -1,6 +1,6 @@
 const Foo = @Type(.{
     .@"fn" = .{
-        .calling_convention = .Unspecified,
+        .calling_convention = .auto,
         .is_generic = false,
         .is_var_args = true,
         .return_type = u0,

--- a/test/cases/compile_errors/reify_type.Fn_with_return_type_null.zig
+++ b/test/cases/compile_errors/reify_type.Fn_with_return_type_null.zig
@@ -1,6 +1,6 @@
 const Foo = @Type(.{
     .@"fn" = .{
-        .calling_convention = .Unspecified,
+        .calling_convention = .auto,
         .is_generic = false,
         .is_var_args = false,
         .return_type = null,

--- a/test/src/LlvmIr.zig
+++ b/test/src/LlvmIr.zig
@@ -90,19 +90,21 @@ pub fn addCase(self: *LlvmIr, case: TestCase) void {
 
     const obj = self.b.addObject(.{
         .name = "test",
-        .root_source_file = self.b.addWriteFiles().add("test.zig", case.source),
-        .use_llvm = true,
+        .root_module = self.b.createModule(.{
+            .root_source_file = self.b.addWriteFiles().add("test.zig", case.source),
 
-        .code_model = case.params.code_model,
-        .error_tracing = case.params.error_tracing,
-        .omit_frame_pointer = case.params.omit_frame_pointer,
-        .optimize = case.params.optimize,
-        .pic = case.params.pic,
-        .sanitize_thread = case.params.sanitize_thread,
-        .single_threaded = case.params.single_threaded,
-        .strip = case.params.strip,
-        .target = target,
-        .unwind_tables = case.params.unwind_tables,
+            .code_model = case.params.code_model,
+            .error_tracing = case.params.error_tracing,
+            .omit_frame_pointer = case.params.omit_frame_pointer,
+            .optimize = case.params.optimize,
+            .pic = case.params.pic,
+            .sanitize_thread = case.params.sanitize_thread,
+            .single_threaded = case.params.single_threaded,
+            .strip = case.params.strip,
+            .target = target,
+            .unwind_tables = case.params.unwind_tables,
+        }),
+        .use_llvm = true,
     });
 
     obj.dll_export_fns = case.params.dll_export_fns;

--- a/test/standalone/c_embed_path/build.zig
+++ b/test/standalone/c_embed_path/build.zig
@@ -8,8 +8,10 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "test",
-        .target = b.graph.host,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = b.graph.host,
+            .optimize = optimize,
+        }),
     });
     exe.addCSourceFile(.{
         .file = b.path("test.c"),

--- a/test/standalone/config_header/build.zig
+++ b/test/standalone/config_header/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const config_header = b.addConfigHeader(
-        .{ .style = .{ .autoconf = b.path("config.h.in") } },
+        .{ .style = .{ .autoconf_undef = b.path("config.h.in") } },
         .{
             .SOME_NO = null,
             .SOME_TRUE = true,

--- a/tools/docgen.zig
+++ b/tools/docgen.zig
@@ -10,7 +10,7 @@ const mem = std.mem;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const getExternalExecutor = std.zig.system.getExternalExecutor;
-const fatal = std.zig.fatal;
+const fatal = std.process.fatal;
 
 const max_doc_file_size = 10 * 1024 * 1024;
 

--- a/tools/doctest.zig
+++ b/tools/doctest.zig
@@ -1,6 +1,6 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const fatal = std.zig.fatal;
+const fatal = std.process.fatal;
 const mem = std.mem;
 const fs = std.fs;
 const process = std.process;

--- a/tools/migrate_langref.zig
+++ b/tools/migrate_langref.zig
@@ -7,7 +7,7 @@ const mem = std.mem;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const max_doc_file_size = 10 * 1024 * 1024;
-const fatal = std.zig.fatal;
+const fatal = std.process.fatal;
 
 pub fn main() !void {
     var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);


### PR DESCRIPTION
Basically everything that has a direct replacement or no uses left.

Notable omissions:

- std.ArrayHashMap: Too much fallout, needs a separate cleanup.
- std.debug.runtime_safety: Too much fallout.
- std.heap.GeneralPurposeAllocator: Lots of references to it remain, not a simple find and replace as "debug allocator" is not equivalent to "general purpose allocator".
- std.io.Reader: Is being reworked at the moment.
- std.unicode.utf8Decode(): No replacement, needs a new API first.
- Manifest backwards compat options: Removal would break test data used by TestFetchBuilder.
- panic handler needs to be a namespace: Many tests still rely on it being a function, needs a separate cleanup.