### PR TITLE
Allow \u escape in string literal to encode surrogate code point #20270

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -732,12 +732,12 @@
         </tr>
         <tr>
             <th scope="row"><code>\u{NNNNNN}</code></th>
-          <td>hexadecimal Unicode scalar value UTF-8 encoded (1 or more digits)</td>
+          <td>hexadecimal Unicode code point (1 or more digits)</td>
         </tr>
         </tbody>
       </table>
       </div>
-      <p>Note that the maximum valid Unicode scalar value is {#syntax#}0x10ffff{#endsyntax#}.</p>
+      <p>Note that the highest Unicode code point is {#syntax#}0x10ffff{#endsyntax#}. Character literals are integers ('A' = 65 and '\u{10000}' = 0x10000 = 65,536), but \u escapes in string literals are encoded as UTF-8 ("A" = "\u{41}" = "\x41" and "\u{10000}" = "\xF0\x90\x80\x80"). \u escapes can be used for surrogate code points, which are not Unicode scalar values or technically allowed in UTF-8 as defined by the Unicode standard, but can be useful in practice.</p>
       {#header_close#}
       {#header_open|Multiline String Literals#}
       <p>

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -43,6 +43,10 @@ pub fn utf8Encode(c: u21, out: []u8) error{ Utf8CannotEncodeSurrogateHalf, Codep
     return utf8EncodeImpl(c, out, .cannot_encode_surrogate_half);
 }
 
+pub fn utf8EncodeAllowSurrogates(c: u21, out: []u8) error{ CodepointTooLarge }!u3 {
+    return utf8EncodeImpl(c, out, .can_encode_surrogate_half);
+}
+
 const Surrogates = enum {
     cannot_encode_surrogate_half,
     can_encode_surrogate_half,

--- a/src/Package/Manifest.zig
+++ b/src/Package/Manifest.zig
@@ -545,7 +545,7 @@ const Parse = struct {
                 try p.appendErrorOff(
                     token,
                     offset + @as(u32, @intCast(bad_index)),
-                    "unicode escape does not correspond to a valid unicode scalar value",
+                    "unicode escape does not correspond to a Unicode code point",
                     .{},
                 );
             },


### PR DESCRIPTION
Patch to enable the use of \u escapes in string literals to encode surrogate code points as per issue #20270.  Please review and let me know of any changes needed.

(The last comment suggests outlawing raw C1 controls U+80..U+9F from literals.  I can work on that separately if that change is also considered accepted.)