### PR TITLE
langref: update splat section

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -5498,8 +5498,9 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#header_open|@splat#}
       <pre>{#syntax#}@splat(scalar: anytype) anytype{#endsyntax#}</pre>
       <p>
-      Produces a vector where each element is the value {#syntax#}scalar{#endsyntax#}.
-      The return type and thus the length of the vector is inferred.
+      Produces an array or vector where each element is the value
+      {#syntax#}scalar{#endsyntax#}. The return type and thus the length of the
+      vector is inferred.
       </p>
       {#code|test_splat_builtin.zig#}
 

--- a/doc/langref/test_splat_builtin.zig
+++ b/doc/langref/test_splat_builtin.zig
@@ -7,4 +7,10 @@ test "vector @splat" {
     try expect(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
 }
 
+test "array @splat" {
+    const scalar: u32 = 5;
+    const result: [4]u32 = @splat(scalar);
+    try expect(std.mem.eql(u32, &@as([4]u32, result), &[_]u32{ 5, 5, 5, 5 }));
+}
+
 // test


### PR DESCRIPTION
Updates the `@splat()` docs to specify that it can now be used on arrays.

Test case is also updated.