### PR TITLE
lib/std/Build/Cache.zig: remove .wasi SkipZigTest checks

### DIFF
--- a/lib/std/Build/Cache.zig
+++ b/lib/std/Build/Cache.zig
@@ -1254,11 +1254,6 @@ fn testGetCurrentFileTimestamp(dir: fs.Dir) !i128 {
 }
 
 test "cache file and then recall it" {
-    if (builtin.os.tag == .wasi) {
-        // https://github.com/ziglang/zig/issues/5437
-        return error.SkipZigTest;
-    }
-
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1320,11 +1315,6 @@ test "cache file and then recall it" {
 }
 
 test "check that changing a file makes cache fail" {
-    if (builtin.os.tag == .wasi) {
-        // https://github.com/ziglang/zig/issues/5437
-        return error.SkipZigTest;
-    }
-
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1394,11 +1384,6 @@ test "check that changing a file makes cache fail" {
 }
 
 test "no file inputs" {
-    if (builtin.os.tag == .wasi) {
-        // https://github.com/ziglang/zig/issues/5437
-        return error.SkipZigTest;
-    }
-
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1442,11 +1427,6 @@ test "no file inputs" {
 }
 
 test "Manifest with files added after initial hash work" {
-    if (builtin.os.tag == .wasi) {
-        // https://github.com/ziglang/zig/issues/5437
-        return error.SkipZigTest;
-    }
-
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 


### PR DESCRIPTION
The build Cache test pass on Wasi now.

Fixes #5437