### PR TITLE
std: containers should not hint on what allocator to use.

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -1065,9 +1065,9 @@ pub fn ArrayListAlignedUnmanaged(comptime T: type, comptime alignment: ?u29) typ
         /// Modify the array so that it can hold at least `new_capacity` items.
         /// Implements super-linear growth to achieve amortized O(1) append operations.
         /// Invalidates element pointers if additional memory is needed.
-        pub fn ensureTotalCapacity(self: *Self, gpa: Allocator, new_capacity: usize) Allocator.Error!void {
+        pub fn ensureTotalCapacity(self: *Self, allocator: Allocator, new_capacity: usize) Allocator.Error!void {
             if (self.capacity >= new_capacity) return;
-            return self.ensureTotalCapacityPrecise(gpa, growCapacity(self.capacity, new_capacity));
+            return self.ensureTotalCapacityPrecise(allocator, growCapacity(self.capacity, new_capacity));
         }
 
         /// If the current capacity is less than `new_capacity`, this function will


### PR DESCRIPTION
This PR is a proposal to rename the `gpa` parameters to `allocator` in all containers type.

The reasoning is that containers should not hint on what allocator to use, especially since Zig tends to embrace unmanaged containers, meaning that the parent is responsible of the memory lifecycle. Hinting to provide a GPA makes it contradictory. E.g. There are use-cases where using an Arena instead of a GPA makes sense while storing data into a list or a map.

I know this has been recently changed for some of these types (e.g. the std.ArrayHashMap in https://github.com/ziglang/zig/pull/22087/commits/e374483d67592907522141546450e89e4d2f5d1e), but we can also notice that it is inconsistent today in the ArrayList (where `gpa` is used only for `ensureTotalCapacity` while all other functions use `allocator`).

While this can make sense to use a parameter named `gpa` in _application_ code (as mentioned in  https://zig.news/kristoff/on-allocator-names-3o4g), it's not ideal in Zig std _unmanaged_ containers.