### PR TITLE
adds labeled switch to the grammar.y documentation

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7886,7 +7886,7 @@ Statement
      / KEYWORD_errdefer Payload? BlockExprStatement
      / IfStatement
      / LabeledStatement
-     / SwitchExpr
+     / BlockLabel? SwitchExpr
      / VarDeclExprStatement
 
 ComptimeStatement

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7954,7 +7954,7 @@ PrimaryExpr
      / KEYWORD_continue BreakLabel?
      / KEYWORD_resume Expr
      / KEYWORD_return Expr?
-     / BlockLabel? LoopExpr
+     / BlockLabel? (LoopExpr / SwitchExpr)
      / Block
      / CurlySuffixExpr
 

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7954,7 +7954,8 @@ PrimaryExpr
      / KEYWORD_continue BreakLabel?
      / KEYWORD_resume Expr
      / KEYWORD_return Expr?
-     / BlockLabel? (LoopExpr / SwitchExpr)
+     / BlockLabel? LoopExpr
+     / BlockLabel SwitchExpr
      / Block
      / CurlySuffixExpr
 


### PR DESCRIPTION
BlockLabels now also support Switch Expressions for Duff's Device like control flow.