### PR TITLE
build: Don't check parent directories for git tag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -259,6 +259,8 @@ pub fn build(b: *std.Build) !void {
             "git",
             "-C",
             b.build_root.path orelse ".",
+            "--git-dir",
+            ".git",
             "describe",
             "--match",
             "*.*.*",


### PR DESCRIPTION
Sometimes Zig is built not from a git repository (e.g. from tarball), but inside another git repository (e.g. distro package repository). Make sure that the version check tries to parse a tag of Zig, and not of a parent directory.
