### PR TITLE
preserve error traces across @errorCast

### DIFF
--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -854,7 +854,7 @@ pub const WasiExecModel = enum {
 
 /// This data structure is used by the Zig language code generation and
 /// therefore must be kept in sync with the compiler implementation.
-pub const CallModifier = enum {
+pub const CallModifier = enum(u3) {
     /// Equivalent to function call syntax.
     auto,
 

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -9683,7 +9683,7 @@ fn builtinCall(
 
             const result = try gz.addExtendedPayload(.error_cast, Zir.Inst.BinNode{
                 .lhs = try ri.rl.resultTypeForCast(gz, node, builtin_name),
-                .rhs = try expr(gz, scope, .{ .rl = .none }, params[0]),
+                .rhs = try expr(gz, scope, .{ .rl = .none, .ctx = .error_handling_expr }, params[0]),
                 .node = gz.nodeIndexToRelative(node),
             });
             return rvalue(gz, ri, result, node);

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -10331,7 +10331,7 @@ fn callExpr(
                 .callee = callee_obj,
                 .flags = .{
                     .pop_error_return_trace = !propagate_error_trace,
-                    .packed_modifier = @intCast(@intFromEnum(modifier)),
+                    .packed_modifier = modifier,
                     .args_len = @intCast(call.ast.params.len),
                 },
             });
@@ -10352,7 +10352,7 @@ fn callExpr(
                 .field_name_start = callee_field.field_name_start,
                 .flags = .{
                     .pop_error_return_trace = !propagate_error_trace,
-                    .packed_modifier = @intCast(@intFromEnum(modifier)),
+                    .packed_modifier = modifier,
                     .args_len = @intCast(call.ast.params.len),
                 },
             });

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -2997,22 +2997,13 @@ pub const Inst = struct {
         flags: Flags,
         callee: Ref,
 
-        pub const Flags = packed struct {
-            /// std.builtin.CallModifier in packed form
-            pub const PackedModifier = u3;
+        pub const Flags = packed struct(u32) {
             pub const PackedArgsLen = u27;
 
-            packed_modifier: PackedModifier,
+            packed_modifier: std.builtin.CallModifier,
             ensure_result_used: bool = false,
             pop_error_return_trace: bool,
             args_len: PackedArgsLen,
-
-            comptime {
-                if (@sizeOf(Flags) != 4 or @bitSizeOf(Flags) != 32)
-                    @compileError("Layout of Call.Flags needs to be updated!");
-                if (@bitSizeOf(std.builtin.CallModifier) != @bitSizeOf(PackedModifier))
-                    @compileError("Call.Flags.PackedModifier needs to be updated!");
-            }
         };
     };
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -7184,7 +7184,7 @@ fn zirCall(
     const extra = sema.code.extraData(ExtraType, inst_data.payload_index);
     const args_len = extra.data.flags.args_len;
 
-    const modifier: std.builtin.CallModifier = @enumFromInt(extra.data.flags.packed_modifier);
+    const modifier = extra.data.flags.packed_modifier;
     const ensure_result_used = extra.data.flags.ensure_result_used;
     const pop_error_return_trace = extra.data.flags.pop_error_return_trace;
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -1311,6 +1311,9 @@ const Writer = struct {
         if (extra.data.flags.ensure_result_used) {
             try stream.writeAll("nodiscard ");
         }
+        if (extra.data.flags.pop_error_return_trace) {
+            try stream.writeAll("poperrtrace ");
+        }
         try stream.print(".{s}, ", .{@tagName(extra.data.flags.packed_modifier)});
         switch (kind) {
             .direct => try self.writeInstRef(stream, extra.data.callee),

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -1311,7 +1311,7 @@ const Writer = struct {
         if (extra.data.flags.ensure_result_used) {
             try stream.writeAll("nodiscard ");
         }
-        try stream.print(".{s}, ", .{@tagName(@as(std.builtin.CallModifier, @enumFromInt(extra.data.flags.packed_modifier)))});
+        try stream.print(".{s}, ", .{@tagName(extra.data.flags.packed_modifier)});
         switch (kind) {
             .direct => try self.writeInstRef(stream, extra.data.callee),
             .field => {

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1082,6 +1082,22 @@ test "@errorCast from error union to error union" {
     try expectError(error.A, comptime S.doTheTest(error.A));
 }
 
+fn foo4() error{OutOfMemory}!void {
+    return @errorCast(bar4());
+}
+
+fn bar4() anyerror!void {
+    return error.OutOfMemory;
+}
+
+test "@errorCast error return trace" {
+    if (!builtin.have_error_return_tracing) return;
+    const err = foo4();
+    const index = @errorReturnTrace().?.index;
+    _ = err catch {};
+    try expectEqual(2, index);
+}
+
 test "result location initialization of error union with OPV payload" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1082,11 +1082,11 @@ test "@errorCast from error union to error union" {
     try expectError(error.A, comptime S.doTheTest(error.A));
 }
 
-fn foo4() error{OutOfMemory}!void {
+noinline fn foo4() error{OutOfMemory}!void {
     return @errorCast(bar4());
 }
 
-fn bar4() anyerror!void {
+noinline fn bar4() anyerror!void {
     return error.OutOfMemory;
 }
 


### PR DESCRIPTION
Fixes #20177

This is my first time really going deeper into the compiler, so please
spare me if I made some fatal mistake. I decided to tackle this one
since I can across it while debugging a project of mine, and thought it
would be a good place to get a foot in the water of the compiler
internals.

The actual patch to the bug is one line, which leads to
`AstGen.callExpr` having the proper value for `propagate_error_trace`.

Additionally, I made `print_zir.writeCall` print the
`pop_error_return_trace` value of function calls to help future
debugging.

As an extra goodie, I also refactored the type of
`Zir.Flags.packed_modifier` to directly use `std.builtin.CallModifier`,
removing all the messy casting. I did this since I saw the mess while
tracing down this bug.