### PR TITLE
std: Abi.default: only require an os tag

### DIFF
--- a/lib/compiler/aro/aro/target.zig
+++ b/lib/compiler/aro/aro/target.zig
@@ -204,7 +204,7 @@ pub fn unnamedFieldAffectsAlignment(target: std.Target) bool {
         },
         .armeb => {
             if (std.Target.arm.featureSetHas(target.cpu.features, .has_v7)) {
-                if (std.Target.Abi.default(target.cpu.arch, target.os) == .eabi) return true;
+                if (std.Target.Abi.default(target.cpu.arch, target.os.tag) == .eabi) return true;
             }
         },
         .arm => return true,
@@ -716,7 +716,7 @@ test "alignment functions - smoke test" {
     const x86 = std.Target.Cpu.Arch.x86_64;
     target.os = std.Target.Os.Tag.defaultVersionRange(.linux, x86, .none);
     target.cpu = std.Target.Cpu.baseline(x86, target.os);
-    target.abi = std.Target.Abi.default(x86, target.os);
+    target.abi = std.Target.Abi.default(x86, target.os.tag);
 
     try std.testing.expect(isTlsSupported(target));
     try std.testing.expect(!ignoreNonZeroSizedBitfieldTypeAlignment(target));
@@ -729,7 +729,7 @@ test "alignment functions - smoke test" {
     const arm = std.Target.Cpu.Arch.arm;
     target.os = std.Target.Os.Tag.defaultVersionRange(.ios, arm, .none);
     target.cpu = std.Target.Cpu.baseline(arm, target.os);
-    target.abi = std.Target.Abi.default(arm, target.os);
+    target.abi = std.Target.Abi.default(arm, target.os.tag);
 
     try std.testing.expect(!isTlsSupported(target));
     try std.testing.expect(ignoreNonZeroSizedBitfieldTypeAlignment(target));

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -803,8 +803,8 @@ pub const Abi = enum {
     // - raygeneration
     // - vertex
 
-    pub fn default(arch: Cpu.Arch, os: Os) Abi {
-        return switch (os.tag) {
+    pub fn default(arch: Cpu.Arch, os_tag: Os.Tag) Abi {
+        return switch (os_tag) {
             .freestanding, .other => switch (arch) {
                 // Soft float is usually a sane default for freestanding.
                 .arm,

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -539,7 +539,7 @@ pub fn abiAndDynamicLinkerFromFile(
     var result: Target = .{
         .cpu = cpu,
         .os = os,
-        .abi = query.abi orelse Target.Abi.default(cpu.arch, os),
+        .abi = query.abi orelse Target.Abi.default(cpu.arch, os.tag),
         .ofmt = query.ofmt orelse Target.ObjectFormat.default(os.tag, cpu.arch),
         .dynamic_linker = query.dynamic_linker,
     };
@@ -1213,7 +1213,7 @@ fn detectAbiAndDynamicLinker(
 }
 
 fn defaultAbiAndDynamicLinker(cpu: Target.Cpu, os: Target.Os, query: Target.Query) Target {
-    const abi = query.abi orelse Target.Abi.default(cpu.arch, os);
+    const abi = query.abi orelse Target.Abi.default(cpu.arch, os.tag);
     return .{
         .cpu = cpu,
         .os = os,


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/23146