### PR TITLE
lib/std/os/uefi/protocol/file.zig: change io adapter fns to const ptr

### DIFF
--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -28,15 +28,15 @@ pub const File = extern struct {
     pub const Reader = io.Reader(*const File, ReadError, readFn);
     pub const Writer = io.Writer(*const File, WriteError, writeFn);
 
-    pub fn seekableStream(self: *File) SeekableStream {
+    pub fn seekableStream(self: *const File) SeekableStream {
         return .{ .context = self };
     }
 
-    pub fn reader(self: *File) Reader {
+    pub fn reader(self: *const File) Reader {
         return .{ .context = self };
     }
 
-    pub fn writer(self: *File) Writer {
+    pub fn writer(self: *const File) Writer {
         return .{ .context = self };
     }
 


### PR DESCRIPTION
The rest of the methods in this type expect a `*const File`, and the type definitions even specify `*const File`. It's also only possible to construct a `*const File` ie
```zig
const uefi = @import("std").uefi;
const fs = try boot_services.openProtocolSt(uefi.protocol.SimpleFileSystem, uefi.handle);
var vol: *const uefi.protocol.File = undefined;
try fs.openVolume(&vol).err();
```

where `fs.openVolume` expects a `**const File`. As such, calling `vol.reader()` results in a type error, since a `*const File` can't be downcasted to `*File`