### PR TITLE
Value: ensure that extern structs have their layout resolved in ptrField

### DIFF
--- a/src/Value.zig
+++ b/src/Value.zig
@@ -3779,6 +3779,7 @@ pub fn ptrField(parent_ptr: Value, field_idx: u32, pt: Zcu.PerThread) !Value {
                 .auto => break :field .{ field_ty, try aggregate_ty.fieldAlignmentSema(field_idx, pt) },
                 .@"extern" => {
                     // Well-defined layout, so just offset the pointer appropriately.
+                    try aggregate_ty.resolveLayout(pt);
                     const byte_off = aggregate_ty.structFieldOffset(field_idx, zcu);
                     const field_align = a: {
                         const parent_align = if (parent_ptr_info.flags.alignment == .none) pa: {

--- a/test/behavior/globals.zig
+++ b/test/behavior/globals.zig
@@ -167,3 +167,31 @@ test "global var can be indirectly self-referential" {
     try std.testing.expect(S.bar.other == &S.foo);
     try std.testing.expect(S.bar.other.other == &S.bar);
 }
+
+pub const Callbacks = extern struct {
+    key_callback: *const fn (key: i32) callconv(.c) i32,
+};
+
+var callbacks: Callbacks = undefined;
+var callbacks_loaded: bool = false;
+
+test "function pointer field call on global extern struct, conditional on global" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    if (callbacks_loaded) {
+        try std.testing.expectEqual(42, callbacks.key_callback(42));
+    }
+}
+
+test "function pointer field call on global extern struct" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn keyCallback(key: i32) callconv(.c) i32 {
+            return key;
+        }
+    };
+
+    callbacks = Callbacks{ .key_callback = S.keyCallback };
+    try std.testing.expectEqual(42, callbacks.key_callback(42));
+}


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/23161.

Before this fix, `"function pointer field call on global extern struct, conditional on global"` reproduces the above.

This resolution feels like it should be conditional on something - since it seems to only be required when the call itself is conditional on a global - let me know if this resolution should be done elsewhere.