### PR TITLE
build: add private frameworks directory to Darwin's native paths

### DIFF
--- a/lib/std/zig/system/NativePaths.zig
+++ b/lib/std/zig/system/NativePaths.zig
@@ -86,6 +86,7 @@ pub fn detect(arena: Allocator, native_target: std.Target) !NativePaths {
         if (std.zig.system.darwin.isSdkInstalled(arena)) sdk: {
             const sdk = std.zig.system.darwin.getSdk(arena, native_target) orelse break :sdk;
             try self.addLibDir(try std.fs.path.join(arena, &.{ sdk, "usr/lib" }));
+            try self.addFrameworkDir(try std.fs.path.join(arena, &.{ sdk, "System/Library/PrivateFrameworks" }));
             try self.addFrameworkDir(try std.fs.path.join(arena, &.{ sdk, "System/Library/Frameworks" }));
             try self.addIncludeDir(try std.fs.path.join(arena, &.{ sdk, "usr/include" }));
         }


### PR DESCRIPTION
Closes #17017 

To avoid confusion as to what the correct private framework search path is, add it by default. This ordering keeps the original Frameworks path as the first one to be searched.