### PR TITLE
PerThread: add missing `.opaque_type` entry in `ensureTypeUpToDate`

### DIFF
--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -3712,7 +3712,7 @@ pub fn ensureTypeUpToDate(pt: Zcu.PerThread, ty: InternPool.Index) Zcu.SemaError
     }
 
     const ty_key = switch (ip.indexToKey(ty)) {
-        .struct_type, .union_type, .enum_type => |key| key,
+        .struct_type, .union_type, .enum_type, .opaque_type => |key| key,
         else => unreachable,
     };
     const declared_ty_key = switch (ty_key) {


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/23167.
Fixes https://github.com/ziglang/zig/issues/22869.