### PR TITLE
Enable compiler-rt tests for wasm32-wasi

### DIFF
--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1430,14 +1430,6 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             test_target.use_llvm == false and mem.eql(u8, options.name, "compiler-rt"))
             continue;
 
-        // TODO get compiler-rt tests passing for wasm32-wasi
-        // currently causes "LLVM ERROR: Unable to expand fixed point multiplication."
-        if (target.cpu.arch == .wasm32 and target.os.tag == .wasi and
-            mem.eql(u8, options.name, "compiler-rt"))
-        {
-            continue;
-        }
-
         // TODO get universal-libc tests passing for other self-hosted backends.
         if (target.cpu.arch != .x86_64 and
             test_target.use_llvm == false and mem.eql(u8, options.name, "universal-libc"))


### PR DESCRIPTION
I think the underlying issue was the same as https://github.com/ziglang/zig/issues/13258 and that has been worked-around in LLVM 19 (see https://github.com/llvm/llvm-project/issues/58557).

Fixes #15325