### PR TITLE
Sema: fix memcpy with C pointers

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3669,7 +3669,10 @@ fn indexablePtrLenOrNone(
     const zcu = pt.zcu;
     const operand_ty = sema.typeOf(operand);
     try checkMemOperand(sema, block, src, operand_ty);
-    if (operand_ty.ptrSize(zcu) == .many) return .none;
+    switch (operand_ty.ptrSize(zcu)) {
+        .many, .c => return .none,
+        .one, .slice => {},
+    }
     const field_name = try zcu.intern_pool.getOrPutString(sema.gpa, pt.tid, "len", .no_embedded_nulls);
     return sema.fieldVal(block, src, operand, field_name, src);
 }

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -69,6 +69,27 @@ fn testMemcpyDestManyPtr() !void {
     try expect(buf[4] == 'o');
 }
 
+test "@memcpy C pointer" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    try testMemcpyCPointer();
+    try comptime testMemcpyCPointer();
+}
+
+fn testMemcpyCPointer() !void {
+    const src = "hello";
+    var buf: [5]u8 = undefined;
+    @memcpy(@as([*c]u8, &buf), src);
+    try expect(buf[0] == 'h');
+    try expect(buf[1] == 'e');
+    try expect(buf[2] == 'l');
+    try expect(buf[3] == 'l');
+    try expect(buf[4] == 'o');
+}
+
 test "@memcpy slice" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;


### PR DESCRIPTION
before:
```
a.zig:5:13: error: type '[*c]u8' does not support field access
    @memcpy(@as([*c]u8, &buf), src);
            ^~~~~~~~~~~~~~~~~
```