### PR TITLE
fuzzer: don't remove or modify byte of empty input

### DIFF
--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -287,7 +287,8 @@ const Fuzzer = struct {
         while (true) {
             const chosen_index = rng.uintLessThanBiased(usize, f.corpus.items.len);
             const modification = rng.enumValue(Mutation);
-            f.mutateAndRunOne(chosen_index, modification);
+            if (f.corpus.items[chosen_index].bytes.len > 0 or modification == .add_byte)
+                f.mutateAndRunOne(chosen_index, modification);
         }
     }
 


### PR DESCRIPTION
The actual patch is rather trivial, but the debugging process reveals more hidden problems.  In today's episode of _Who Fuzzes the Fuzzer?_, I got a segfault with the following:
```zig
const std = @import("std");

fn findSecret(context: []const u8, input: []const u8) !void {
    if (std.mem.eql(u8, context, input))
        return error.FoundSecretString;
}

test "fuzz example" {
    try std.testing.fuzz(@as([]const u8, "canyoufindme"), findSecret, .{
        .corpus = &.{ "c" }
    });
}
```

Relevant log:
```console
Segmentation fault at address 0x0
.../lib/fuzzer.zig:589:35: 0x11a2880 in start (fuzzer)
        @memcpy(l.items[old_len..][0..items.len], items);
                                  ^
.../lib/fuzzer.zig:460:17: 0x11a4e9f in fuzzer_start (fuzzer)
    fuzzer.start() catch |err| oom(err);
```

Yes, part of the trace is missing, but I managed to pinpoint the bug to be from below when `old_input.len == 0`, leading to `omitted_index == std.math.maxInt(usize)`:
https://github.com/ziglang/zig/blob/8e0a4ca4b34a0222d9261d51c34fba8ce2a1d0bc/lib/fuzzer.zig#L314-L318

Mysteriously, assertions are evaded, unreachables are reached, bound checks are ignored and panics don't pan above the segfaulting statement.  I took a look at `lib/fuzzer/web/main.zig`'s `panic` function does indeed call `@trap`:
https://github.com/ziglang/zig/blob/8e0a4ca4b34a0222d9261d51c34fba8ce2a1d0bc/lib/fuzzer/web/main.zig#L33-L38