### PR TITLE
Fetch: enhance Mach-O executable detection for modern Macs

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1850,7 +1850,11 @@ const FileHeader = struct {
         return magic_number == std.macho.MH_MAGIC or
             magic_number == std.macho.MH_MAGIC_64 or
             magic_number == std.macho.FAT_MAGIC or
-            magic_number == std.macho.FAT_MAGIC_64;
+            magic_number == std.macho.FAT_MAGIC_64 or
+            magic_number == std.macho.MH_CIGAM or
+            magic_number == std.macho.MH_CIGAM_64 or
+            magic_number == std.macho.FAT_CIGAM or
+            magic_number == std.macho.FAT_CIGAM_64;
     }
 
     pub fn isExecutable(self: *FileHeader) bool {
@@ -1874,6 +1878,11 @@ test FileHeader {
     const macho64_magic_bytes = [_]u8{ 0xCF, 0xFA, 0xED, 0xFE };
     h.bytes_read = 0;
     h.update(&macho64_magic_bytes);
+    try std.testing.expect(h.isExecutable());
+
+    const macho64_cigam_bytes = [_]u8{ 0xFE, 0xED, 0xFA, 0xCF };
+    h.bytes_read = 0;
+    h.update(&macho64_cigam_bytes);
     try std.testing.expect(h.isExecutable());
 }
 


### PR DESCRIPTION
This is a follow-up to #21555, which makes the detection work for M1 (and later) Macs.

Also see my investigation here: https://github.com/ziglang/zig/issues/21044#issuecomment-2711510643