### PR TITLE
std.c: fix sysconf names (std.c._SC) for android api

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -2269,7 +2269,10 @@ pub const SC = switch (native_os) {
     else => void,
 };
 
-pub const _SC = switch (native_os) {
+pub const _SC = if (builtin.abi.isAndroid()) enum(c_int) {
+    PAGESIZE = 39,
+    NPROCESSORS_ONLN = 97,
+} else switch (native_os) {
     .driverkit, .ios, .macos, .tvos, .visionos, .watchos => enum(c_int) {
         PAGESIZE = 29,
     },


### PR DESCRIPTION
c.f. https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/bits/sysconf.h

std.heap.DebugAllocator & std.heap.page_allocator breaks on android platform due to the mis-configured SC names.