### PR TITLE
Zcu: rename `skip_analysis_errors` to `skip_analysis_this_update` and respect it

### DIFF
--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -181,7 +181,10 @@ analysis_roots: std.BoundedArray(*Package.Module, 4) = .{},
 /// Allocated into `gpa`.
 resolved_references: ?std.AutoHashMapUnmanaged(AnalUnit, ?ResolvedReference) = null,
 
-skip_analysis_errors: bool = false,
+/// If `true`, then semantic analysis must not occur on this update due to AstGen errors.
+/// Essentially the entire pipeline after AstGen, including Sema, codegen, and link, is skipped.
+/// Reset to `false` at the start of each update in `Compilation.update`.
+skip_analysis_this_update: bool = false,
 
 stage1_flags: packed struct {
     have_winmain: bool = false,


### PR DESCRIPTION
On updates with failed files, we should refrain from doing any semantic analysis, or even touching codegen/link. That way, incremental compilation state is untouched for when the user fixes the AstGen errors.

Resolves: #23205