### PR TITLE
Minor fix for `Allocator.remap` and `mem.bytesAsSlice` for zero-sized types

### DIFF
--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -927,24 +927,17 @@ test "parse at comptime" {
 }
 
 test "parse with zero-bit field" {
-	const str =
-		\\{
-		\\    "a": ["a", "a"],
-		\\    "b": "a"
-		\\}
-	;
-	const ZeroSizedEnum = enum { a };
-	try testing.expectEqual(0, @sizeOf(ZeroSizedEnum));
+    const str =
+        \\{
+        \\    "a": ["a", "a"],
+        \\    "b": "a"
+        \\}
+    ;
+    const ZeroSizedEnum = enum { a };
+    try testing.expectEqual(0, @sizeOf(ZeroSizedEnum));
 
-	const Inner = struct {
-		a: []const ZeroSizedEnum,
-		b: ZeroSizedEnum
-	};
-	const expected: Inner = .{
-		.a = &.{ .a, .a },
-		.b = .a
-	};
+    const Inner = struct { a: []const ZeroSizedEnum, b: ZeroSizedEnum };
+    const expected: Inner = .{ .a = &.{ .a, .a }, .b = .a };
 
-	try testAllParseFunctions(Inner, expected, str);
-
+    try testAllParseFunctions(Inner, expected, str);
 }

--- a/lib/std/json/static_test.zig
+++ b/lib/std/json/static_test.zig
@@ -925,3 +925,26 @@ test "parse at comptime" {
     };
     comptime testing.expectEqual(@as(u64, 9999), config.uptime) catch unreachable;
 }
+
+test "parse with zero-bit field" {
+	const str =
+		\\{
+		\\    "a": ["a", "a"],
+		\\    "b": "a"
+		\\}
+	;
+	const ZeroSizedEnum = enum { a };
+	try testing.expectEqual(0, @sizeOf(ZeroSizedEnum));
+
+	const Inner = struct {
+		a: []const ZeroSizedEnum,
+		b: ZeroSizedEnum
+	};
+	const expected: Inner = .{
+		.a = &.{ .a, .a },
+		.b = .a
+	};
+
+	try testAllParseFunctions(Inner, expected, str);
+
+}

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -229,16 +229,15 @@ test "Allocator.resize" {
 }
 
 test "Allocator alloc and remap with zero-bit type" {
-	var values = try testing.allocator.alloc(void, 10);
-	defer testing.allocator.free(values);
+    var values = try testing.allocator.alloc(void, 10);
+    defer testing.allocator.free(values);
 
-	try testing.expectEqual(10, values.len);
-	const remaped = testing.allocator.remap(values, 200);
-	try testing.expect(remaped != null);
+    try testing.expectEqual(10, values.len);
+    const remaped = testing.allocator.remap(values, 200);
+    try testing.expect(remaped != null);
 
-	values = remaped.?;
-	try testing.expectEqual(200, values.len);
-
+    values = remaped.?;
+    try testing.expectEqual(200, values.len);
 }
 
 /// Copy all of source into dest at position 0.
@@ -4303,16 +4302,16 @@ test "bytesAsSlice preserves pointer attributes" {
 }
 
 test "bytesAsSlice with zero-bit element type" {
-	{
-		const bytes = [_]u8{};
-		const slice = bytesAsSlice(void, &bytes);
-		try testing.expectEqual(0, slice.len);
-	}
-	{
-		const bytes = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
-		const slice = bytesAsSlice(u0, &bytes);
-		try testing.expectEqual(0, slice.len);
-	}
+    {
+        const bytes = [_]u8{};
+        const slice = bytesAsSlice(void, &bytes);
+        try testing.expectEqual(0, slice.len);
+    }
+    {
+        const bytes = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+        const slice = bytesAsSlice(u0, &bytes);
+        try testing.expectEqual(0, slice.len);
+    }
 }
 
 fn SliceAsBytesReturnType(comptime Slice: type) type {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -228,6 +228,19 @@ test "Allocator.resize" {
     }
 }
 
+test "Allocator alloc and remap with zero-bit type" {
+	var values = try testing.allocator.alloc(void, 10);
+	defer testing.allocator.free(values);
+
+	try testing.expectEqual(10, values.len);
+	const remaped = testing.allocator.remap(values, 200);
+	try testing.expect(remaped != null);
+
+	values = remaped.?;
+	try testing.expectEqual(200, values.len);
+
+}
+
 /// Copy all of source into dest at position 0.
 /// dest.len must be >= source.len.
 /// If the slices overlap, dest.ptr must be <= src.ptr.

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -4220,10 +4220,11 @@ fn BytesAsSliceReturnType(comptime T: type, comptime bytesType: type) type {
 
 /// Given a slice of bytes, returns a slice of the specified type
 /// backed by those bytes, preserving pointer attributes.
+/// If `T` is zero-bytes sized, the returned slice has a len of zero.
 pub fn bytesAsSlice(comptime T: type, bytes: anytype) BytesAsSliceReturnType(T, @TypeOf(bytes)) {
     // let's not give an undefined pointer to @ptrCast
     // it may be equal to zero and fail a null check
-    if (bytes.len == 0) {
+    if (bytes.len == 0 or @sizeOf(T) == 0) {
         return &[0]T{};
     }
 
@@ -4299,6 +4300,19 @@ test "bytesAsSlice preserves pointer attributes" {
     try testing.expectEqual(in.is_volatile, out.is_volatile);
     try testing.expectEqual(in.is_allowzero, out.is_allowzero);
     try testing.expectEqual(in.alignment, out.alignment);
+}
+
+test "bytesAsSlice with zero-bit element type" {
+	{
+		const bytes = [_]u8{};
+		const slice = bytesAsSlice(void, &bytes);
+		try testing.expectEqual(0, slice.len);
+	}
+	{
+		const bytes = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+		const slice = bytesAsSlice(u0, &bytes);
+		try testing.expectEqual(0, slice.len);
+	}
 }
 
 fn SliceAsBytesReturnType(comptime Slice: type) type {

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -311,12 +311,15 @@ pub fn resize(self: Allocator, allocation: anytype, new_len: usize) bool {
 /// `allocation` may be an empty slice, in which case a new allocation is made.
 ///
 /// `new_len` may be zero, in which case the allocation is freed.
+///
+/// If the allocation's elements' type is zero bytes sized, `allocation.len` is set to `new_len`.
 pub fn remap(self: Allocator, allocation: anytype, new_len: usize) t: {
     const Slice = @typeInfo(@TypeOf(allocation)).pointer;
     break :t ?[]align(Slice.alignment) Slice.child;
 } {
     const Slice = @typeInfo(@TypeOf(allocation)).pointer;
     const T = Slice.child;
+
     const alignment = Slice.alignment;
     if (new_len == 0) {
         self.free(allocation);
@@ -325,6 +328,11 @@ pub fn remap(self: Allocator, allocation: anytype, new_len: usize) t: {
     if (allocation.len == 0) {
         return null;
     }
+	if (@sizeOf(T) == 0) {
+		var new_memory = allocation;
+		new_memory.len = new_len;
+		return new_memory;
+	}
     const old_memory = mem.sliceAsBytes(allocation);
     // I would like to use saturating multiplication here, but LLVM cannot lower it
     // on WebAssembly: https://github.com/ziglang/zig/issues/9660

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -328,11 +328,11 @@ pub fn remap(self: Allocator, allocation: anytype, new_len: usize) t: {
     if (allocation.len == 0) {
         return null;
     }
-	if (@sizeOf(T) == 0) {
-		var new_memory = allocation;
-		new_memory.len = new_len;
-		return new_memory;
-	}
+    if (@sizeOf(T) == 0) {
+        var new_memory = allocation;
+        new_memory.len = new_len;
+        return new_memory;
+    }
     const old_memory = mem.sliceAsBytes(allocation);
     // I would like to use saturating multiplication here, but LLVM cannot lower it
     // on WebAssembly: https://github.com/ziglang/zig/issues/9660


### PR DESCRIPTION
This PR does 3 things:
- for `Allocator.remap`, if the type is zero-sized, then it only changes the slice's length
- for `mem.bytesAsSlice`, if the type is zero-sized, it returns a slice with a length of zero (instead of crashing because of a division by zero)
- added a test for the 2 first points and one for json parsing with zero-sized types

Fixes #23168 