### PR TITLE
Sema: convert slice sentinel to single pointer correctly

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -26342,12 +26342,14 @@ fn zirMemcpy(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!void
             var info = dest_ty.ptrInfo(zcu);
             info.flags.size = .one;
             info.child = array_ty.toIntern();
+            info.sentinel = .none;
             break :info info;
         });
         const src_array_ptr_ty = try pt.ptrType(info: {
             var info = src_ty.ptrInfo(zcu);
             info.flags.size = .one;
             info.child = array_ty.toIntern();
+            info.sentinel = .none;
             break :info info;
         });
 

--- a/test/behavior/memcpy.zig
+++ b/test/behavior/memcpy.zig
@@ -133,3 +133,34 @@ test "@memcpy zero-bit type with aliasing" {
     S.doTheTest();
     comptime S.doTheTest();
 }
+
+test "@memcpy with sentinel" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn doTheTest() void {
+            const field = @typeInfo(struct { a: u32 }).@"struct".fields[0];
+            var buffer: [field.name.len]u8 = undefined;
+            @memcpy(&buffer, field.name);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+test "@memcpy no sentinel source into sentinel destination" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn doTheTest() void {
+            const src: []const u8 = &.{ 1, 2, 3 };
+            comptime var dest_buf: [3:0]u8 = @splat(0);
+            const dest: [:0]u8 = &dest_buf;
+            @memcpy(dest, src);
+        }
+    };
+
+    S.doTheTest();
+    comptime S.doTheTest();
+}


### PR DESCRIPTION
If the `src_ty` is a `[:0]const u8`, the single pointer would try to inherit the sentinel, which is invalid. I've fixed it to move the sentinel to the child type, if there is one, and then clear the sentinel from the pointer info we're inheriting.