### PR TITLE
Fix uninitialized memory in __pthread_cond_s for glibc versions less than 2.41

### DIFF
--- a/lib/libc/glibc/sysdeps/nptl/bits/thread-shared-types.h
+++ b/lib/libc/glibc/sysdeps/nptl/bits/thread-shared-types.h
@@ -99,6 +99,8 @@ struct __pthread_cond_s
   unsigned int __g1_orig_size;
   unsigned int __wrefs;
   unsigned int __g_signals[2];
+  unsigned int __unused_initialized_1;
+  unsigned int __unused_initialized_2;
 };
 
 typedef unsigned int __tss_t;

--- a/lib/libc/glibc/sysdeps/nptl/pthread.h
+++ b/lib/libc/glibc/sysdeps/nptl/pthread.h
@@ -152,7 +152,7 @@ enum
 
 
 /* Conditional variable handling.  */
-#define PTHREAD_COND_INITIALIZER { { {0}, {0}, {0, 0}, 0, 0, {0, 0} } }
+#define PTHREAD_COND_INITIALIZER { { {0}, {0}, {0, 0}, 0, 0, {0, 0}, 0, 0 } }
 
 
 /* Cleanup buffers */

--- a/lib/libc/include/generic-glibc/bits/thread-shared-types.h
+++ b/lib/libc/include/generic-glibc/bits/thread-shared-types.h
@@ -99,6 +99,8 @@ struct __pthread_cond_s
   unsigned int __g1_orig_size;
   unsigned int __wrefs;
   unsigned int __g_signals[2];
+  unsigned int __unused_initialized_1;
+  unsigned int __unused_initialized_2;
 };
 
 typedef unsigned int __tss_t;

--- a/lib/libc/include/generic-glibc/pthread.h
+++ b/lib/libc/include/generic-glibc/pthread.h
@@ -152,7 +152,7 @@ enum
 
 
 /* Conditional variable handling.  */
-#define PTHREAD_COND_INITIALIZER { { {0}, {0}, {0, 0}, 0, 0, {0, 0} } }
+#define PTHREAD_COND_INITIALIZER { { {0}, {0}, {0, 0}, 0, 0, {0, 0}, 0, 0 } }
 
 
 /* Cleanup buffers */


### PR DESCRIPTION
@alexrp Opened a detailed description over on [glibc's bugzilla](https://sourceware.org/bugzilla/show_bug.cgi?id=32786).  I'll just copy that in as I believe it summarizes this fix as well:

> glibc 2.41 changed the definition of `__pthread_cond_s` to remove the `__g_refs` field. This is fine for programs that are compiled against <=2.40, but for programs compiled against 2.41 and run against <=2.40, rather than an upfront symbol version error, you can get some rather nasty concurrency bugs because of uninitialized memory in `__pthread_cond_s`.
> 
> This happens because `PTHREAD_COND_INITIALIZER` in the 2.41 headers no longer zeroes the removed `__g_refs` field. So when the program is run against a <=2.40 libc that expects a larger `__pthread_cond_s`, it ends up accessing uninitialized memory at the end of the structure, i.e. `__g_signals`.
> 
> So 2.41 probably should have come with a version bump for all `pthread_cond_*` symbols. But since the ship has sailed on this, I would suggest at least doing said bump in 2.42 so that 2.41 is the only version that doesn't give an upfront error.

In zig's case, we added some glib defines and now things work again!  Also just want to say I LOVE how zig maintains the libc's with the version defines.  Super creative and makes cross compiling super easy!

Shoutout to:

@alexrp @darksylinc @Rexicon226 @190n 

And thanks again to the awesome zig team!  This tool is phenomenal! :)