### PR TITLE
posix/write: catch MSGSIZE error

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1198,6 +1198,10 @@ pub const WriteError = error{
     /// This error occurs when a device gets disconnected before or mid-flush
     /// while it's being written to - errno(6): No such device or address.
     NoDevice,
+
+    /// The socket type requires that message be sent atomically, and the size of the message
+    /// to be sent made this impossible. The message is not transmitted.
+    MessageTooBig,
 } || UnexpectedError;
 
 /// Write to a file descriptor.
@@ -1279,6 +1283,7 @@ pub fn write(fd: fd_t, bytes: []const u8) WriteError!usize {
             .CONNRESET => return error.ConnectionResetByPeer,
             .BUSY => return error.DeviceBusy,
             .NXIO => return error.NoDevice,
+            .MSGSIZE => return error.MessageTooBig,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -202,6 +202,7 @@ const FmtError = error{
     DestinationAddressRequired,
     DiskQuota,
     FileTooBig,
+    MessageTooBig,
     InputOutput,
     NoSpaceLeft,
     AccessDenied,


### PR DESCRIPTION
I was having an unknown error code when trying to use `std.posix.write` on a unix datagram socket on macOS, while the same code was perfectly working on Linux: investigating, I found that the default max buffer size writeable on macOS is way smaller than on Linux.

This PR catches the `MSGSIZE` write error on `std.posix.write` to get a more instructive stacktrace. (I reused the name and comment from the `std.posix.send`  implementation)

This change could be debatable if you think that `std.posix.send` should've been used instead of `std.posix.write` here, which I agree with, and `MSGSIZE` would've been properly caught in the `std.posix.send` implementation.

I'd argue that since `write` can technically write on an unixgram sockets, I don't see a good reason to ignore this error code while at least one OS returns it on a `write` call.

## Reproduce

Here is how to reproduce the bug:
```zig
const std = @import("std");

pub fn fake_server() !i32 {
    const sockfd: i32 = try std.posix.socket(
        std.posix.AF.UNIX,
        std.posix.SOCK.DGRAM | std.posix.SOCK.CLOEXEC | std.posix.SOCK.NONBLOCK,
        0,
    );
    var addr: std.net.Address = try std.net.Address.initUnix("mysock.sock");
    try std.posix.bind(sockfd, &addr.any, @sizeOf(std.posix.sockaddr.in));
    return sockfd;
}

pub fn main() !void {
    const server_sockfd = try fake_server();
    defer {
        std.posix.close(server_sockfd);
        std.fs.cwd().deleteFile("mysock.sock") catch {};
    }

    const sockfd = try std.posix.socket(
        std.posix.AF.UNIX,
        std.posix.SOCK.DGRAM,
        0,
    );
    var addr = try std.net.Address.initUnix("mysock.sock");
    try std.posix.connect(sockfd, &addr.any, addr.getOsSockLen());

    const some_payload: [4096]u8 = std.mem.zeroes([4096]u8);
    _ = try std.posix.write(sockfd, &some_payload);
}
```

Using an absurdly big `some_payload`,

```zig
const some_payload: [1024*1024]u8 = std.mem.zeroes([1024*1024]u8);
```

it's also easily possible to reproduce on a regular Linux install.

## Without/with the change

```
$ zig run repro.zig
unexpected errno: 40
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/debug.zig:315:31: 0x100f9a2eb in dumpCurrentStackTrace (repro)
        writeCurrentStackTrace(stderr, debug_info, io.tty.detectConfig(io.getStdErr()), start_addr) catch |err| {
                              ^
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/posix.zig:7503:40: 0x100fb4ba3 in unexpectedErrno (repro)
        std.debug.dumpCurrentStackTrace(null);
                                       ^
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/posix.zig:1282:49: 0x100fb2c5f in write (repro)
            else => |err| return unexpectedErrno(err),
                                                ^
/Users/remeh/repro.zig:13:28: 0x10102eb7b in main (repro)
    _ = try std.posix.write(sockfd, &some_payload);
                           ^
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/start.zig:656:37: 0x101033703 in main (repro)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x19a988273 in ??? (???)
???:?:?: 0x0 in ??? (???)
error: Unexpected
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/posix.zig:7505:5: 0x100fb4bab in unexpectedErrno (repro)
    return error.Unexpected;
    ^
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/posix.zig:1282:27: 0x100fb2c6f in write (repro)
            else => |err| return unexpectedErrno(err),
                          ^
/Users/remeh/repro.zig:13:9: 0x10102eb9f in main (repro)
    _ = try std.posix.write(sockfd, &some_payload);
        ^
```

while with the pull-request change applied:

```
$ zig run repro.zig
error: MessageTooBig
/Users/remeh/opt/zig-macos-aarch64-0.14.0/lib/std/posix.zig:1286:25: 0x102e22c53 in write (repro)
            .MSGSIZE => return error.MessageTooBig,
                        ^
/Users/remeh/repro.zig:13:9: 0x102e9ebe3 in main (repro)
    _ = try std.posix.write(sockfd, &some_payload);
        ^
```

