### PR TITLE
std.zig.render: Fix multiple fmt invocations needed for array initializers with switch expressions

### DIFF
--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -6107,6 +6107,39 @@ test "zig fmt: indentation of comments within catch, else, orelse" {
     );
 }
 
+test "zig fmt: array initializer with switch expression - canonical" {
+    try testCanonical(
+        \\const bar = .{
+        \\    .{switch ({}) {
+        \\        else => {},
+        \\    }},
+        \\    .{},
+        \\    .{},
+        \\    .{},
+        \\};
+        \\
+    );
+}
+
+test "zig fmt: array initializer with switch expression - transformation" {
+    try testTransform(
+        \\const bar = .{ .{ switch ({}) {
+        \\        else => {},
+        \\    } }, .{}, .{}, .{},
+        \\};
+        \\
+    ,
+        \\const bar = .{
+        \\    .{switch ({}) {
+        \\        else => {},
+        \\    }},
+        \\    .{}, .{},
+        \\    .{},
+        \\};
+        \\
+    );
+}
+
 test "recovery: top level" {
     try testError(
         \\test "" {inline}

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2076,8 +2076,9 @@ fn renderArrayInit(
 
     const contains_comment = hasComment(tree, array_init.ast.lbrace, rbrace);
     const contains_multiline_string = hasMultilineString(tree, array_init.ast.lbrace, rbrace);
+    const contains_switch = containsSwitch(tree, array_init.ast.elements);
 
-    if (!trailing_comma and !contains_comment and !contains_multiline_string) {
+    if (!trailing_comma and !contains_comment and !contains_multiline_string and !contains_switch) {
         // Render all on one line, no trailing comma.
         if (array_init.ast.elements.len == 1) {
             // If there is only one element, we don't use spaces
@@ -2258,6 +2259,27 @@ fn renderArrayInit(
 
     ais.popIndent();
     return renderToken(r, rbrace, space); // rbrace
+}
+
+/// Returns true if any array element is or contains a switch expression
+fn containsSwitch(tree: Ast, elements: []const Ast.Node.Index) bool {
+    const tags = tree.nodes.items(.tag);
+
+    for (elements) |elem| {
+        const tag = tags[@intFromEnum(elem)];
+
+        if (tag == .switch_case or
+            tag == .switch_case_inline or
+            tag == .switch_case_one or
+            tag == .switch_case_inline_one or
+            tag == .@"switch" or
+            tag == .switch_comma)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 fn renderContainerDecl(

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1299,50 +1299,6 @@ pub fn addCliTests(b: *std.Build) *Step {
         });
         check6.step.dependOn(&run6.step);
 
-        // Test `zig fmt` handling switch expressions in array initializers
-        const switch_in_array_code =
-            \\const bar = .{ .{ switch ({}) {
-            \\        else => {},
-            \\    } }, .{}, .{}, .{},
-            \\};
-            \\
-        ;
-
-        const fmt7_path = b.pathJoin(&.{ tmp_path, "fmt7.zig" });
-        const write7 = b.addUpdateSourceFiles();
-        write7.addBytesToSource(switch_in_array_code, fmt7_path);
-        write7.step.dependOn(&check6.step);
-
-        // Test `zig fmt` handling switch expressions in array initializers
-        const run7 = b.addSystemCommand(&.{ b.graph.zig_exe, "fmt", "fmt7.zig" });
-        run7.setName("run zig fmt on array with switch");
-        run7.setCwd(.{ .cwd_relative = tmp_path });
-        run7.has_side_effects = true;
-        run7.expectStdOutEqual("fmt7.zig\n");
-        run7.step.dependOn(&write7.step);
-
-        // Check that the file is formatted correctly after a single fmt invocation
-        const check7 = b.addCheckFile(.{ .cwd_relative = fmt7_path }, .{
-            .expected_matches = &.{
-                "const bar = .{",
-                "    .{switch ({}) {",
-                "        else => {},",
-                "    }},",
-                "    .{},",
-                "    .{},",
-                "    .{},",
-                "};",
-            },
-        });
-        check7.step.dependOn(&run7.step);
-
-        // Run fmt again to verify that no further changes are made (idempotence)
-        const run8 = b.addSystemCommand(&.{ b.graph.zig_exe, "fmt", "fmt7.zig" });
-        run8.setName("run zig fmt again on array with switch");
-        run8.setCwd(.{ .cwd_relative = tmp_path });
-        run8.has_side_effects = true;
-        run8.step.dependOn(&check7.step);
-
         const cleanup = b.addRemoveDirTree(.{ .cwd_relative = tmp_path });
         cleanup.step.dependOn(&check6.step);
 


### PR DESCRIPTION
Fixes #22778