### PR TITLE
link: mark prelink tasks as procesed under `-fno-emit-bin`

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -1457,8 +1457,10 @@ pub const Task = union(enum) {
 pub fn doTask(comp: *Compilation, tid: usize, task: Task) void {
     const diags = &comp.link_diags;
     switch (task) {
-        .load_explicitly_provided => if (comp.bin_file) |base| {
+        .load_explicitly_provided => {
             comp.remaining_prelink_tasks -= 1;
+            const base = comp.bin_file orelse return;
+
             const prog_node = comp.work_queue_progress_node.start("Parse Linker Inputs", comp.link_inputs.len);
             defer prog_node.end();
             for (comp.link_inputs) |input| {
@@ -1475,8 +1477,10 @@ pub fn doTask(comp: *Compilation, tid: usize, task: Task) void {
                 prog_node.completeOne();
             }
         },
-        .load_host_libc => if (comp.bin_file) |base| {
+        .load_host_libc => {
             comp.remaining_prelink_tasks -= 1;
+            const base = comp.bin_file orelse return;
+
             const prog_node = comp.work_queue_progress_node.start("Linker Parse Host libc", 0);
             defer prog_node.end();
 
@@ -1535,8 +1539,9 @@ pub fn doTask(comp: *Compilation, tid: usize, task: Task) void {
                 }
             }
         },
-        .load_object => |path| if (comp.bin_file) |base| {
+        .load_object => |path| {
             comp.remaining_prelink_tasks -= 1;
+            const base = comp.bin_file orelse return;
             const prog_node = comp.work_queue_progress_node.start("Linker Parse Object", 0);
             defer prog_node.end();
             base.openLoadObject(path) catch |err| switch (err) {
@@ -1544,8 +1549,9 @@ pub fn doTask(comp: *Compilation, tid: usize, task: Task) void {
                 else => |e| diags.addParseError(path, "failed to parse object: {s}", .{@errorName(e)}),
             };
         },
-        .load_archive => |path| if (comp.bin_file) |base| {
+        .load_archive => |path| {
             comp.remaining_prelink_tasks -= 1;
+            const base = comp.bin_file orelse return;
             const prog_node = comp.work_queue_progress_node.start("Linker Parse Archive", 0);
             defer prog_node.end();
             base.openLoadArchive(path, null) catch |err| switch (err) {
@@ -1553,8 +1559,9 @@ pub fn doTask(comp: *Compilation, tid: usize, task: Task) void {
                 else => |e| diags.addParseError(path, "failed to parse archive: {s}", .{@errorName(e)}),
             };
         },
-        .load_dso => |path| if (comp.bin_file) |base| {
+        .load_dso => |path| {
             comp.remaining_prelink_tasks -= 1;
+            const base = comp.bin_file orelse return;
             const prog_node = comp.work_queue_progress_node.start("Linker Parse Shared Library", 0);
             defer prog_node.end();
             base.openLoadDso(path, .{
@@ -1565,8 +1572,9 @@ pub fn doTask(comp: *Compilation, tid: usize, task: Task) void {
                 else => |e| diags.addParseError(path, "failed to parse shared library: {s}", .{@errorName(e)}),
             };
         },
-        .load_input => |input| if (comp.bin_file) |base| {
+        .load_input => |input| {
             comp.remaining_prelink_tasks -= 1;
+            const base = comp.bin_file orelse return;
             const prog_node = comp.work_queue_progress_node.start("Linker Parse Input", 0);
             defer prog_node.end();
             base.loadInput(input) catch |err| switch (err) {


### PR DESCRIPTION
The old logic only decremented `remaining_prelink_tasks` if `bin_file` was not `null`. This meant that on `-fno-emit-bin` builds with registered prelink tasks (e.g. C source files), we exited from `Compilation.performAllTheWorkInner` early, assuming a prelink error.

Instead, when `bin_file` is `null`, we still decrement `remaining_prelink_tasks`; we just don't do any actual work.

Resolves: #22682