### PR TITLE
x86_64: fix packedStore miscomp by spilling EFLAGS

### DIFF
--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -1335,3 +1335,31 @@ test "assign packed struct initialized with RLS to packed struct literal field" 
     try expect(outer.inner.x == x);
     try expect(outer.x == x);
 }
+
+test "packed struct store of comparison result" {
+    if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
+
+    const S1 = packed struct {
+        val1: u3,
+        val2: u3,
+    };
+    const S2 = packed struct {
+        a: bool,
+        b: bool,
+    };
+
+    var A: S1 = .{ .val1 = 1, .val2 = 1 };
+    A.val2 += 1;
+    try expectEqual(1, A.val1);
+    try expectEqual(2, A.val2);
+    try expect((A.val2 & 1) != 1);
+    const result1: S2 = .{ .a = (A.val2 & 1) != 1, .b = (A.val1 & 1) != 1 };
+    try expect(result1.a);
+    try expect(!result1.b);
+
+    try expect((A.val2 == 3) == false);
+    try expect((A.val2 == 2) == true);
+    const result2: S2 = .{ .a = !(A.val2 == 3), .b = (A.val1 == 2) };
+    try expect(result2.a);
+    try expect(!result2.b);
+}


### PR DESCRIPTION
Fixes #20113. Fixes #20581. Fixes #22790.

AND instructions in packedStore clobbers EFLAGS.

Tested with the repro from #20113 and #20581.
```
xtex@xtex1 ~/s/z/zig (master)> build-host/out/zig run repro.zig -fno-llvm
ret: repro.Data{ .rd = 1, .rl = true }, true, true
xtex@xtex1 ~/s/z/zig (master)> zig version
0.15.0-dev.56+d0911786c
xtex@xtex1 ~/s/z/zig (master)> zig run repro.zig -fno-llvm
ret: repro.Data{ .rd = 1, .rl = false }, false, true
xtex@xtex1 ~/s/z/zig (master)> zig run repro.zig -fllvm
ret: repro.Data{ .rd = 1, .rl = true }, true, true
```

Behavior test: `1951 passed; 143 skipped; 0 failed.`