### PR TITLE
std.posix.getenv: early-return comparison

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -2001,10 +2001,11 @@ pub fn getenv(key: []const u8) ?[:0]const u8 {
         var ptr = std.c.environ;
         while (ptr[0]) |line| : (ptr += 1) {
             var line_i: usize = 0;
-            while (line[line_i] != 0 and line[line_i] != '=') : (line_i += 1) {}
-            const this_key = line[0..line_i];
-
-            if (!mem.eql(u8, this_key, key)) continue;
+            while (line[line_i] != 0) : (line_i += 1) {
+                if (line_i == key.len) break;
+                if (line[line_i] != key[line_i]) break;
+            }
+            if ((line_i != key.len) or (line[line_i] != '=')) continue;
 
             return mem.sliceTo(line + line_i + 1, 0);
         }
@@ -2018,9 +2019,11 @@ pub fn getenv(key: []const u8) ?[:0]const u8 {
     // TODO see https://github.com/ziglang/zig/issues/4524
     for (std.os.environ) |ptr| {
         var line_i: usize = 0;
-        while (ptr[line_i] != 0 and ptr[line_i] != '=') : (line_i += 1) {}
-        const this_key = ptr[0..line_i];
-        if (!mem.eql(u8, key, this_key)) continue;
+        while (ptr[line_i] != 0) : (line_i += 1) {
+            if (line_i == key.len) break;
+            if (ptr[line_i] != key[line_i]) break;
+        }
+        if ((line_i != key.len) or (ptr[line_i] != '=')) continue;
 
         return mem.sliceTo(ptr + line_i + 1, 0);
     }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1997,6 +1997,9 @@ pub fn getenv(key: []const u8) ?[:0]const u8 {
     if (native_os == .windows) {
         @compileError("std.posix.getenv is unavailable for Windows because environment strings are in WTF-16 format. See std.process.getEnvVarOwned for a cross-platform API or std.process.getenvW for a Windows-specific API.");
     }
+    if (mem.indexOfScalar(u8, key, '=') != null) {
+        return null;
+    }
     if (builtin.link_libc) {
         var ptr = std.c.environ;
         while (ptr[0]) |line| : (ptr += 1) {

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -725,6 +725,9 @@ test "getenv" {
     if (native_os == .windows) {
         try expect(std.process.getenvW(&[_:0]u16{ 'B', 'O', 'G', 'U', 'S', 0x11, 0x22, 0x33, 0x44, 0x55 }) == null);
     } else {
+        try expect(std.posix.getenv("") == null);
+        try expect(std.posix.getenv("BOGUSDOESNOTEXISTENVVAR") == null);
+        try testing.expectEqualStrings(std.posix.getenv("USER") orelse "", mem.span(std.c.getenv("USER") orelse ""));
         try expect(posix.getenvZ("BOGUSDOESNOTEXISTENVVAR") == null);
     }
 }

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -725,9 +725,11 @@ test "getenv" {
     if (native_os == .windows) {
         try expect(std.process.getenvW(&[_:0]u16{ 'B', 'O', 'G', 'U', 'S', 0x11, 0x22, 0x33, 0x44, 0x55 }) == null);
     } else {
-        try expect(std.posix.getenv("") == null);
-        try expect(std.posix.getenv("BOGUSDOESNOTEXISTENVVAR") == null);
-        try testing.expectEqualStrings(std.posix.getenv("USER") orelse "", mem.span(std.c.getenv("USER") orelse ""));
+        try expect(posix.getenv("") == null);
+        try expect(posix.getenv("BOGUSDOESNOTEXISTENVVAR") == null);
+        if (builtin.link_libc) {
+            try testing.expectEqualStrings(posix.getenv("USER") orelse "", mem.span(std.c.getenv("USER") orelse ""));
+        }
         try expect(posix.getenvZ("BOGUSDOESNOTEXISTENVVAR") == null);
     }
 }


### PR DESCRIPTION
Addresses the issue described in https://github.com/ziglang/zig/issues/22917.

Possibly interferes with @andrewrk work on https://github.com/ziglang/zig/tree/main branch.

Original implementation https://github.com/ziglang/zig/blob/aa3db7cc15/lib/std/posix.zig#L2004 for each environment variable iterates until the end of its name (until `=`), and only then compares entire name to `key`.
Since some of the environment variables could be quite long (i.e. `GHOSTTY_SHELL_INTEGRATION_NO_SUDO=1`), these sizes add up.
Simply - in order to find a `key` in `environ`, it has to iterate over cumulative sizes of each env variable name before it.

Proposed implementation functionally does what `strncmp` would do: stops iterating and moves to the next variable on first character mismatch with `key`.

See the benchmarks below.
Disclaimer: this was tested on macOS, with a variation of https://github.com/ziglang/zig/pull/23264 fix applied.

```zig
// getenv-c.zig
const std = @import("std");

pub fn main() void {
    for (0..10_000_000) |_| {
        _ = std.mem.doNotOptimizeAway(std.c.getenv("FOOBAR"));
    }
}
```

```zig
// getenv-zig.zig
const std = @import("std");

pub fn main() void {
    for (0..10_000_000) |_| {
        _ = std.mem.doNotOptimizeAway(std.posix.getenv("FOOBAR"));
    }
}
```

```
> env | wc -l
      43
> hyperfine --warmup 3 ./getenv-c ./getenv-zig-aa3db7cc15 ./getenv-zig-speedup
Benchmark 1: ./getenv-c
  Time (mean ± σ):     294.1 ms ±   3.5 ms    [User: 293.1 ms, System: 0.8 ms]
  Range (min … max):   288.7 ms … 299.3 ms    10 runs

Benchmark 2: ./getenv-zig-aa3db7cc15
  Time (mean ± σ):      1.907 s ±  0.022 s    [User: 1.901 s, System: 0.005 s]
  Range (min … max):    1.881 s …  1.941 s    10 runs

Benchmark 3: ./getenv-zig-speedup
  Time (mean ± σ):     130.8 ms ±   0.5 ms    [User: 129.8 ms, System: 0.8 ms]
  Range (min … max):   129.7 ms … 131.7 ms    22 runs

Summary
  ./getenv-zig-speedup ran
    2.25 ± 0.03 times faster than ./getenv-c
   14.58 ± 0.17 times faster than ./getenv-zig-aa3db7cc15
```

To address the elephant in the room: this loop is duplicated, but I'm hesitant to refactor it in order to deduplicate because of
`// TODO see https://github.com/ziglang/zig/issues/4524` preamble and ongoing work to fix it.