### PR TITLE
Windows: Faster `getenvW` and a standalone environment variable test

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -4855,6 +4855,10 @@ pub const RTL_USER_PROCESS_PARAMETERS = extern struct {
     DllPath: UNICODE_STRING,
     ImagePathName: UNICODE_STRING,
     CommandLine: UNICODE_STRING,
+    /// Points to a NUL-terminated sequence of NUL-terminated
+    /// WTF-16 LE encoded `name=value` sequences.
+    /// Example using string literal syntax:
+    /// `"NAME=value\x00foo=bar\x00\x00"`
     Environment: [*:0]WCHAR,
     dwX: ULONG,
     dwY: ULONG,

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -419,10 +419,10 @@ pub fn getEnvVarOwned(allocator: Allocator, key: []const u8) GetEnvVarOwnedError
     }
 }
 
-/// On Windows, `key` must be valid UTF-8.
+/// On Windows, `key` must be valid WTF-8.
 pub fn hasEnvVarConstant(comptime key: []const u8) bool {
     if (native_os == .windows) {
-        const key_w = comptime unicode.utf8ToUtf16LeStringLiteral(key);
+        const key_w = comptime unicode.wtf8ToWtf16LeStringLiteral(key);
         return getenvW(key_w) != null;
     } else if (native_os == .wasi and !builtin.link_libc) {
         @compileError("hasEnvVarConstant is not supported for WASI without libc");
@@ -431,10 +431,10 @@ pub fn hasEnvVarConstant(comptime key: []const u8) bool {
     }
 }
 
-/// On Windows, `key` must be valid UTF-8.
+/// On Windows, `key` must be valid WTF-8.
 pub fn hasNonEmptyEnvVarConstant(comptime key: []const u8) bool {
     if (native_os == .windows) {
-        const key_w = comptime unicode.utf8ToUtf16LeStringLiteral(key);
+        const key_w = comptime unicode.wtf8ToWtf16LeStringLiteral(key);
         const value = getenvW(key_w) orelse return false;
         return value.len != 0;
     } else if (native_os == .wasi and !builtin.link_libc) {
@@ -451,10 +451,10 @@ pub const ParseEnvVarIntError = std.fmt.ParseIntError || error{EnvironmentVariab
 ///
 /// Since the key is comptime-known, no allocation is needed.
 ///
-/// On Windows, `key` must be valid UTF-8.
+/// On Windows, `key` must be valid WTF-8.
 pub fn parseEnvVarInt(comptime key: []const u8, comptime I: type, base: u8) ParseEnvVarIntError!I {
     if (native_os == .windows) {
-        const key_w = comptime std.unicode.utf8ToUtf16LeStringLiteral(key);
+        const key_w = comptime std.unicode.wtf8ToWtf16LeStringLiteral(key);
         const text = getenvW(key_w) orelse return error.EnvironmentVariableNotFound;
         return std.fmt.parseIntWithGenericCharacter(I, u16, text, base);
     } else if (native_os == .wasi and !builtin.link_libc) {

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -96,6 +96,9 @@
         .empty_env = .{
             .path = "empty_env",
         },
+        .env_vars = .{
+            .path = "env_vars",
+        },
         .issue_11595 = .{
             .path = "issue_11595",
         },

--- a/test/standalone/env_vars/build.zig
+++ b/test/standalone/env_vars/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn build(b: *std.Build) void {
+    const test_step = b.step("test", "Test it");
+    b.default_step = test_step;
+
+    const optimize: std.builtin.OptimizeMode = .Debug;
+
+    const main = b.addExecutable(.{
+        .name = "main",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = b.graph.host,
+            .optimize = optimize,
+        }),
+    });
+
+    const run = b.addRunArtifact(main);
+    run.clearEnvironment();
+    run.setEnvironmentVariable("FOO", "123");
+    run.setEnvironmentVariable("EQUALS", "ABC=123");
+    run.setEnvironmentVariable("NO_VALUE", "");
+    run.setEnvironmentVariable("КИРиллИЦА", "non-ascii አማርኛ \u{10FFFF}");
+    if (b.graph.host.result.os.tag == .windows) {
+        run.setEnvironmentVariable("=Hidden", "hi");
+        // \xed\xa0\x80 is a WTF-8 encoded unpaired surrogate code point
+        run.setEnvironmentVariable("INVALID_UTF16_\xed\xa0\x80", "\xed\xa0\x80");
+    }
+    run.disable_zig_progress = true;
+
+    test_step.dependOn(&run.step);
+}

--- a/test/standalone/env_vars/main.zig
+++ b/test/standalone/env_vars/main.zig
@@ -1,0 +1,173 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+// Note: the environment variables under test are set by the build.zig
+pub fn main() !void {
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // hasNonEmptyEnvVar
+    {
+        try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "FOO"));
+        try std.testing.expect(!(try std.process.hasNonEmptyEnvVar(allocator, "FOO=")));
+        try std.testing.expect(!(try std.process.hasNonEmptyEnvVar(allocator, "FO")));
+        try std.testing.expect(!(try std.process.hasNonEmptyEnvVar(allocator, "FOOO")));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "foo"));
+        }
+        try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "EQUALS"));
+        try std.testing.expect(!(try std.process.hasNonEmptyEnvVar(allocator, "EQUALS=ABC")));
+        try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "КИРиллИЦА"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "кирИЛЛица"));
+        }
+        try std.testing.expect(!(try std.process.hasNonEmptyEnvVar(allocator, "NO_VALUE")));
+        try std.testing.expect(!(try std.process.hasNonEmptyEnvVar(allocator, "NOT_SET")));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "=HIDDEN"));
+            try std.testing.expect(try std.process.hasNonEmptyEnvVar(allocator, "INVALID_UTF16_\xed\xa0\x80"));
+        }
+    }
+
+    // hasNonEmptyEnvVarContstant
+    {
+        try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("FOO"));
+        try std.testing.expect(!std.process.hasNonEmptyEnvVarConstant("FOO="));
+        try std.testing.expect(!std.process.hasNonEmptyEnvVarConstant("FO"));
+        try std.testing.expect(!std.process.hasNonEmptyEnvVarConstant("FOOO"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("foo"));
+        }
+        try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("EQUALS"));
+        try std.testing.expect(!std.process.hasNonEmptyEnvVarConstant("EQUALS=ABC"));
+        try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("КИРиллИЦА"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("кирИЛЛица"));
+        }
+        try std.testing.expect(!(std.process.hasNonEmptyEnvVarConstant("NO_VALUE")));
+        try std.testing.expect(!(std.process.hasNonEmptyEnvVarConstant("NOT_SET")));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("=HIDDEN"));
+            try std.testing.expect(std.process.hasNonEmptyEnvVarConstant("INVALID_UTF16_\xed\xa0\x80"));
+        }
+    }
+
+    // hasEnvVar
+    {
+        try std.testing.expect(try std.process.hasEnvVar(allocator, "FOO"));
+        try std.testing.expect(!(try std.process.hasEnvVar(allocator, "FOO=")));
+        try std.testing.expect(!(try std.process.hasEnvVar(allocator, "FO")));
+        try std.testing.expect(!(try std.process.hasEnvVar(allocator, "FOOO")));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(try std.process.hasEnvVar(allocator, "foo"));
+        }
+        try std.testing.expect(try std.process.hasEnvVar(allocator, "EQUALS"));
+        try std.testing.expect(!(try std.process.hasEnvVar(allocator, "EQUALS=ABC")));
+        try std.testing.expect(try std.process.hasEnvVar(allocator, "КИРиллИЦА"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(try std.process.hasEnvVar(allocator, "кирИЛЛица"));
+        }
+        try std.testing.expect(try std.process.hasEnvVar(allocator, "NO_VALUE"));
+        try std.testing.expect(!(try std.process.hasEnvVar(allocator, "NOT_SET")));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(try std.process.hasEnvVar(allocator, "=HIDDEN"));
+            try std.testing.expect(try std.process.hasEnvVar(allocator, "INVALID_UTF16_\xed\xa0\x80"));
+        }
+    }
+
+    // hasEnvVarConstant
+    {
+        try std.testing.expect(std.process.hasEnvVarConstant("FOO"));
+        try std.testing.expect(!std.process.hasEnvVarConstant("FOO="));
+        try std.testing.expect(!std.process.hasEnvVarConstant("FO"));
+        try std.testing.expect(!std.process.hasEnvVarConstant("FOOO"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(std.process.hasEnvVarConstant("foo"));
+        }
+        try std.testing.expect(std.process.hasEnvVarConstant("EQUALS"));
+        try std.testing.expect(!std.process.hasEnvVarConstant("EQUALS=ABC"));
+        try std.testing.expect(std.process.hasEnvVarConstant("КИРиллИЦА"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(std.process.hasEnvVarConstant("кирИЛЛица"));
+        }
+        try std.testing.expect(std.process.hasEnvVarConstant("NO_VALUE"));
+        try std.testing.expect(!(std.process.hasEnvVarConstant("NOT_SET")));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expect(std.process.hasEnvVarConstant("=HIDDEN"));
+            try std.testing.expect(std.process.hasEnvVarConstant("INVALID_UTF16_\xed\xa0\x80"));
+        }
+    }
+
+    // getEnvVarOwned
+    {
+        try std.testing.expectEqualSlices(u8, "123", try std.process.getEnvVarOwned(arena, "FOO"));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.getEnvVarOwned(arena, "FOO="));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.getEnvVarOwned(arena, "FO"));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.getEnvVarOwned(arena, "FOOO"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqualSlices(u8, "123", try std.process.getEnvVarOwned(arena, "foo"));
+        }
+        try std.testing.expectEqualSlices(u8, "ABC=123", try std.process.getEnvVarOwned(arena, "EQUALS"));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.getEnvVarOwned(arena, "EQUALS=ABC"));
+        try std.testing.expectEqualSlices(u8, "non-ascii አማርኛ \u{10FFFF}", try std.process.getEnvVarOwned(arena, "КИРиллИЦА"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqualSlices(u8, "non-ascii አማርኛ \u{10FFFF}", try std.process.getEnvVarOwned(arena, "кирИЛЛица"));
+        }
+        try std.testing.expectEqualSlices(u8, "", try std.process.getEnvVarOwned(arena, "NO_VALUE"));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.getEnvVarOwned(arena, "NOT_SET"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqualSlices(u8, "hi", try std.process.getEnvVarOwned(arena, "=HIDDEN"));
+            try std.testing.expectEqualSlices(u8, "\xed\xa0\x80", try std.process.getEnvVarOwned(arena, "INVALID_UTF16_\xed\xa0\x80"));
+        }
+    }
+
+    // parseEnvVarInt
+    {
+        try std.testing.expectEqual(123, try std.process.parseEnvVarInt("FOO", u32, 10));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.parseEnvVarInt("FO", u32, 10));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.parseEnvVarInt("FOOO", u32, 10));
+        try std.testing.expectEqual(0x123, try std.process.parseEnvVarInt("FOO", u32, 16));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqual(123, try std.process.parseEnvVarInt("foo", u32, 10));
+        }
+        try std.testing.expectError(error.InvalidCharacter, std.process.parseEnvVarInt("EQUALS", u32, 10));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.parseEnvVarInt("EQUALS=ABC", u32, 10));
+        try std.testing.expectError(error.InvalidCharacter, std.process.parseEnvVarInt("КИРиллИЦА", u32, 10));
+        try std.testing.expectError(error.InvalidCharacter, std.process.parseEnvVarInt("NO_VALUE", u32, 10));
+        try std.testing.expectError(error.EnvironmentVariableNotFound, std.process.parseEnvVarInt("NOT_SET", u32, 10));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectError(error.InvalidCharacter, std.process.parseEnvVarInt("=HIDDEN", u32, 10));
+            try std.testing.expectError(error.InvalidCharacter, std.process.parseEnvVarInt("INVALID_UTF16_\xed\xa0\x80", u32, 10));
+        }
+    }
+
+    // EnvMap
+    {
+        var env_map = try std.process.getEnvMap(allocator);
+        defer env_map.deinit();
+
+        try std.testing.expectEqualSlices(u8, "123", env_map.get("FOO").?);
+        try std.testing.expectEqual(null, env_map.get("FO"));
+        try std.testing.expectEqual(null, env_map.get("FOOO"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqualSlices(u8, "123", env_map.get("foo").?);
+        }
+        try std.testing.expectEqualSlices(u8, "ABC=123", env_map.get("EQUALS").?);
+        try std.testing.expectEqual(null, env_map.get("EQUALS=ABC"));
+        try std.testing.expectEqualSlices(u8, "non-ascii አማርኛ \u{10FFFF}", env_map.get("КИРиллИЦА").?);
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqualSlices(u8, "non-ascii አማርኛ \u{10FFFF}", env_map.get("кирИЛЛица").?);
+        }
+        try std.testing.expectEqualSlices(u8, "", env_map.get("NO_VALUE").?);
+        try std.testing.expectEqual(null, env_map.get("NOT_SET"));
+        if (builtin.os.tag == .windows) {
+            try std.testing.expectEqualSlices(u8, "hi", env_map.get("=HIDDEN").?);
+            try std.testing.expectEqualSlices(u8, "\xed\xa0\x80", env_map.get("INVALID_UTF16_\xed\xa0\x80").?);
+        }
+    }
+}


### PR DESCRIPTION
Inspired by https://github.com/ziglang/zig/pull/23265, I thought I'd try applying the same strategy to the Windows implementation. The strategy itself didn't end up having the same benefit, but optimizations were still found while exploring it.

Also adds a standalone test to make sure the functionality remains the same.

---

Both sliceTo and indexOfScalarPos use SIMD when available to speed up the search. On my x86_64 machine, this leads to getenvW being around 2-3x faster overall.

Additionally, any future improvements to sliceTo/indexOfScalarPos will benefit getenvW.

---

<details>
<summary>Benchmark code</summary>

```zig
const std = @import("std");

pub fn main() !void {
    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
    defer arena.deinit();
    const allocator = arena.allocator();

    const Bench = enum {
        all,
        found,
        short,
        long,
        random,
        empty,
    };

    var args = try std.process.argsWithAllocator(allocator);
    defer args.deinit();

    _ = args.next();
    const bench: Bench = bench: {
        const str = args.next() orelse break :bench .all;
        break :bench std.meta.stringToEnum(Bench, str) orelse {
            std.debug.print("bench not recognized: {s}\n", .{str});
            std.process.exit(1);
        };
    };

    const num_iterations = 1000000;

    var env_map = try std.process.getEnvMap(allocator);
    defer env_map.deinit();

    var names: std.ArrayListUnmanaged([]const u8) = try .initCapacity(allocator, env_map.count());
    defer names.deinit(allocator);
    var longest_name: usize = 0;
    var it = env_map.iterator();
    while (it.next()) |entry| {
        if (entry.key_ptr.*.len > longest_name) longest_name = entry.key_ptr.*.len;
        names.appendAssumeCapacity(entry.key_ptr.*);
    }

    var name_mod_buf: std.ArrayListUnmanaged(u8) = try .initCapacity(allocator, longest_name + 1);
    defer name_mod_buf.deinit(allocator);

    var timer = try std.time.Timer.start();
    var prng = std.Random.DefaultPrng.init(0);
    const rand = prng.random();

    if (bench == .found or bench == .all) {
        const elapsed = elapsed: {
            timer.reset();
            for (0..num_iterations) |_| {
                const name = names.items[rand.uintLessThan(usize, names.items.len)];
                const value = try std.process.getEnvVarOwned(allocator, name);
                std.mem.doNotOptimizeAway(&value);
            }
            break :elapsed timer.read();
        };
        std.debug.print("found: {}/lookup\n", .{std.fmt.fmtDuration(elapsed / num_iterations)});
    }

    if (bench == .long or bench == .all) {
        const elapsed = elapsed: {
            timer.reset();
            for (0..num_iterations) |_| {
                const name = names.items[rand.uintLessThan(usize, names.items.len)];
                name_mod_buf.clearRetainingCapacity();
                name_mod_buf.appendSliceAssumeCapacity(name);
                // Append a random ascii character
                name_mod_buf.appendAssumeCapacity(rand.int(u7));
                const value = std.process.getEnvVarOwned(allocator, name_mod_buf.items) catch |err| switch (err) {
                    error.EnvironmentVariableNotFound => continue,
                    error.InvalidWtf8 => unreachable,
                    error.OutOfMemory => |e| return e,
                };
                std.mem.doNotOptimizeAway(&value);
            }
            break :elapsed timer.read();
        };
        std.debug.print("one char too long: {}/lookup\n", .{std.fmt.fmtDuration(elapsed / num_iterations)});
    }

    if (bench == .short or bench == .all) {
        const elapsed = elapsed: {
            timer.reset();
            for (0..num_iterations) |_| {
                const name = names.items[rand.uintLessThan(usize, names.items.len)];
                const name_trunc = name[0 .. name.len - 1];
                const value = std.process.getEnvVarOwned(allocator, name_trunc) catch |err| switch (err) {
                    error.EnvironmentVariableNotFound => continue,
                    error.InvalidWtf8 => unreachable,
                    error.OutOfMemory => |e| return e,
                };
                std.mem.doNotOptimizeAway(&value);
            }
            break :elapsed timer.read();
        };
        std.debug.print("one char too short: {}/lookup\n", .{std.fmt.fmtDuration(elapsed / num_iterations)});
    }

    if (bench == .random or bench == .all) {
        const elapsed = elapsed: {
            timer.reset();
            for (0..num_iterations) |_| {
                const len = rand.uintAtMost(usize, longest_name);
                name_mod_buf.items.len = len;
                for (name_mod_buf.items) |*c| {
                    c.* = rand.int(u7);
                }
                const value = std.process.getEnvVarOwned(allocator, name_mod_buf.items) catch |err| switch (err) {
                    error.EnvironmentVariableNotFound => continue,
                    error.InvalidWtf8 => unreachable,
                    error.OutOfMemory => |e| return e,
                };
                std.mem.doNotOptimizeAway(&value);
            }
            break :elapsed timer.read();
        };
        std.debug.print("random ascii: {}/lookup\n", .{std.fmt.fmtDuration(elapsed / num_iterations)});
    }

    if (bench == .empty or bench == .all) {
        const elapsed = elapsed: {
            timer.reset();
            for (0..num_iterations) |_| {
                const value = std.process.getEnvVarOwned(allocator, "") catch |err| switch (err) {
                    error.EnvironmentVariableNotFound => continue,
                    error.InvalidWtf8 => unreachable,
                    error.OutOfMemory => |e| return e,
                };
                std.mem.doNotOptimizeAway(&value);
            }
            break :elapsed timer.read();
        };
        std.debug.print("empty name: {}/lookup\n", .{std.fmt.fmtDuration(elapsed / num_iterations)});
    }
}
```

</details>

```
// all environment variable lookups are found
  'benchenv.exe found' ran
    2.50 ± 0.62 times faster than 'benchenv-master.exe found'

// all environment variable lookups have their name truncated by one byte
  'benchenv.exe short' ran
    2.85 ± 0.44 times faster than 'benchenv-master.exe short'

// all environment variable lookups have an extra ASCII character added to the name
  'benchenv.exe long' ran
    2.59 ± 0.54 times faster than 'benchenv-master.exe long'

// all environment variable lookups are random strings of ASCII characters
  'benchenv.exe random' ran
    3.13 ± 0.58 times faster than 'benchenv-master.exe random'

// looking up a zero-length string as the name
  'benchenv.exe empty' ran
    3.26 ± 0.42 times faster than 'benchenv-master.exe empty'
```

(presumably, the magnitude of any speedup would also (on average) increase as the number of environment variables in the environment increases)

---

Initially, I tried using the same early return loop strategy as https://github.com/ziglang/zig/pull/23265, but later realized that the switch to using `sliceTo` to find the `NUL` terminator was accounting for pretty much all of the speed gains. The early return loop version can be found here:

https://github.com/squeek502/zig/commit/573e7075594b4240bdf900af37b48e4db5eda1c8

The version currently in this PR is *slightly* faster and easier to understand IMO, so that's what I went with.

<details>
<summary>benchmark results comparing the implementations</summary>

`benchenv-sliceto-indexof.exe` is the implementation in this PR currently, `benchenv-loop.exe` is https://github.com/squeek502/zig/commit/573e7075594b4240bdf900af37b48e4db5eda1c8

```
Benchmark 1: benchenv-master.exe found
  Time (mean ± σ):      1.390 s ±  0.338 s    [User: 1.364 s, System: 0.028 s]
  Range (min … max):    0.912 s …  1.797 s    10 runs

Benchmark 2: benchenv-loop.exe found
  Time (mean ± σ):     635.9 ms ±  22.0 ms    [User: 614.1 ms, System: 24.7 ms]
  Range (min … max):   608.2 ms … 669.3 ms    10 runs

Benchmark 3: benchenv-sliceto-indexof.exe found
  Time (mean ± σ):     556.1 ms ±  23.0 ms    [User: 534.4 ms, System: 18.4 ms]
  Range (min … max):   522.0 ms … 582.0 ms    10 runs

Summary
  'benchenv-sliceto-indexof.exe found' ran
    1.14 ± 0.06 times faster than 'benchenv-loop.exe found'
    2.50 ± 0.62 times faster than 'benchenv-master.exe found'



Benchmark 1: benchenv-master.exe short
  Time (mean ± σ):      2.352 s ±  0.361 s    [User: 2.333 s, System: 0.008 s]
  Range (min … max):    1.639 s …  2.784 s    10 runs

Benchmark 2: benchenv-loop.exe short
  Time (mean ± σ):     930.4 ms ±  33.4 ms    [User: 918.4 ms, System: 9.1 ms]
  Range (min … max):   888.9 ms … 981.1 ms    10 runs

Benchmark 3: benchenv-sliceto-indexof.exe short
  Time (mean ± σ):     826.5 ms ±  23.7 ms    [User: 820.0 ms, System: 10.6 ms]
  Range (min … max):   784.0 ms … 857.3 ms    10 runs

Summary
  'benchenv-sliceto-indexof.exe short' ran
    1.13 ± 0.05 times faster than 'benchenv-loop.exe short'
    2.85 ± 0.44 times faster than 'benchenv-master.exe short'



Benchmark 1: benchenv-master.exe long
  Time (mean ± σ):      2.179 s ±  0.446 s    [User: 2.158 s, System: 0.008 s]
  Range (min … max):    1.652 s …  2.762 s    10 runs

Benchmark 2: benchenv-loop.exe long
  Time (mean ± σ):     950.2 ms ±  24.2 ms    [User: 936.6 ms, System: 9.7 ms]
  Range (min … max):   913.0 ms … 981.4 ms    10 runs

Benchmark 3: benchenv-sliceto-indexof.exe long
  Time (mean ± σ):     839.9 ms ±  29.1 ms    [User: 830.3 ms, System: 6.2 ms]
  Range (min … max):   779.9 ms … 879.0 ms    10 runs

Summary
  'benchenv-sliceto-indexof.exe long' ran
    1.13 ± 0.05 times faster than 'benchenv-loop.exe long'
    2.59 ± 0.54 times faster than 'benchenv-master.exe long'



Benchmark 1: benchenv-master.exe random
  Time (mean ± σ):      2.314 s ±  0.420 s    [User: 2.301 s, System: 0.008 s]
  Range (min … max):    1.667 s …  2.878 s    10 runs

Benchmark 2: benchenv-loop.exe random
  Time (mean ± σ):     764.2 ms ±  37.0 ms    [User: 755.3 ms, System: 8.4 ms]
  Range (min … max):   717.5 ms … 813.3 ms    10 runs

Benchmark 3: benchenv-sliceto-indexof.exe random
  Time (mean ± σ):     739.4 ms ±  28.5 ms    [User: 728.8 ms, System: 16.2 ms]
  Range (min … max):   705.9 ms … 780.1 ms    10 runs

Summary
  'benchenv-sliceto-indexof.exe random' ran
    1.03 ± 0.06 times faster than 'benchenv-loop.exe random'
    3.13 ± 0.58 times faster than 'benchenv-master.exe random'



Benchmark 1: benchenv-master.exe empty
  Time (mean ± σ):      2.362 s ±  0.292 s    [User: 2.355 s, System: 0.006 s]
  Range (min … max):    1.625 s …  2.662 s    10 runs

Benchmark 2: benchenv-loop.exe empty
  Time (mean ± σ):     732.4 ms ±  24.1 ms    [User: 726.9 ms, System: 6.9 ms]
  Range (min … max):   691.5 ms … 768.2 ms    10 runs

Benchmark 3: benchenv-sliceto-indexof.exe empty
  Time (mean ± σ):     725.1 ms ±  29.9 ms    [User: 717.5 ms, System: 8.5 ms]
  Range (min … max):   687.2 ms … 768.2 ms    10 runs

Summary
  'benchenv-sliceto-indexof.exe empty' ran
    1.01 ± 0.05 times faster than 'benchenv-loop.exe empty'
    3.26 ± 0.42 times faster than 'benchenv-master.exe empty'
```

</details>