### PR TITLE
rare instance could result in a memory leak

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -181,14 +181,19 @@ pub fn parse(gpa: Allocator, source: [:0]const u8, mode: Mode) Allocator.Error!A
         .zon => try parser.parseZon(),
     }
 
+    const extra_data = try parser.extra_data.toOwnedSlice(gpa);
+    errdefer extra_data.deinit(gpa);
+    const errors = try parser.errors.toOwnedSlice(gpa);
+    errdefer errors.deinit(gpa);
+
     // TODO experiment with compacting the MultiArrayList slices here
     return Ast{
         .source = source,
         .mode = mode,
         .tokens = tokens.toOwnedSlice(),
         .nodes = parser.nodes.toOwnedSlice(),
-        .extra_data = try parser.extra_data.toOwnedSlice(gpa),
-        .errors = try parser.errors.toOwnedSlice(gpa),
+        .extra_data = extra_data,
+        .errors = errors,
     };
 }
 


### PR DESCRIPTION
There is a rare instance here where the first try in returning the Parse struct for `extra_data` could be successful, but then the `errors` try could fail, orphaning `extra_data`.

I was having some issues getting zig to build locally, but I believe this should work. If not let me know and I would be happy to make any changes, and/or spend more time getting zig to run locally.