### PR TITLE
`mingw`: Rename `mingw32.lib` to `libmingw32.lib`.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -827,7 +827,7 @@ pub const MiscTask = enum {
 
     @"mingw-w64 crt2.o",
     @"mingw-w64 dllcrt2.o",
-    @"mingw-w64 mingw32.lib",
+    @"mingw-w64 libmingw32.lib",
 };
 
 pub const MiscError = struct {
@@ -1886,7 +1886,7 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
 
                     const main_crt_file: mingw.CrtFile = if (is_dyn_lib) .dllcrt2_o else .crt2_o;
                     comp.queued_jobs.mingw_crt_file[@intFromEnum(main_crt_file)] = true;
-                    comp.queued_jobs.mingw_crt_file[@intFromEnum(mingw.CrtFile.mingw32_lib)] = true;
+                    comp.queued_jobs.mingw_crt_file[@intFromEnum(mingw.CrtFile.libmingw32_lib)] = true;
                     comp.remaining_prelink_tasks += 2;
 
                     // When linking mingw-w64 there are some import libs we always need.

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -2104,7 +2104,7 @@ fn linkWithLLD(coff: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: 
                             try argv.append(try comp.crtFileAsString(arena, "crt2.obj"));
                         }
 
-                        try argv.append(try comp.crtFileAsString(arena, "mingw32.lib"));
+                        try argv.append(try comp.crtFileAsString(arena, "libmingw32.lib"));
                     } else {
                         const lib_str = switch (comp.config.link_mode) {
                             .dynamic => "",

--- a/src/mingw.zig
+++ b/src/mingw.zig
@@ -14,7 +14,7 @@ const dev = @import("dev.zig");
 pub const CrtFile = enum {
     crt2_o,
     dllcrt2_o,
-    mingw32_lib,
+    libmingw32_lib,
 };
 
 /// TODO replace anyerror with explicit error set, recording user-friendly errors with
@@ -69,7 +69,7 @@ pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progre
             });
         },
 
-        .mingw32_lib => {
+        .libmingw32_lib => {
             var c_source_files = std.ArrayList(Compilation.CSourceFile).init(arena);
 
             {
@@ -173,7 +173,7 @@ pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progre
                 }
             }
 
-            return comp.build_crt_file("mingw32", .Lib, .@"mingw-w64 mingw32.lib", prog_node, c_source_files.items, .{
+            return comp.build_crt_file("libmingw32", .Lib, .@"mingw-w64 libmingw32.lib", prog_node, c_source_files.items, .{
                 .unwind_tables = unwind_tables,
                 // https://github.com/llvm/llvm-project/issues/43698#issuecomment-2542660611
                 .allow_lto = false,


### PR DESCRIPTION
LLD expects the library file name (minus extension) to be exactly `libmingw32`. By calling it `mingw32` previously, we prevented it from being detected as being in LLD's list of libraries that are excluded from the MinGW-specific auto-export mechanism.

https://github.com/llvm/llvm-project/blob/b9d27ac252265839354fffeacaa8f39377ed7424/lld/COFF/MinGW.cpp#L30-L56

As a result, a DLL built for `*-windows-gnu` with Zig would export a bunch of internal MinGW symbols. This sometimes worked out fine, but it could break at link or run time when linking an EXE with a DLL, where both are targeting `*-windows-gnu` and thus linking separate copies of `mingw32.lib`. In #23204, this manifested as the linker getting confused about `_gnu_exception_handler()` because it was incorrectly exported by the DLL while also being defined in the `mingw32.lib` that was being linked into the EXE.

Closes #23204.

Related: #22415