### PR TITLE
Memory leak

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -181,14 +181,19 @@ pub fn parse(gpa: Allocator, source: [:0]const u8, mode: Mode) Allocator.Error!A
         .zon => try parser.parseZon(),
     }
 
+    const extra_data = try parser.extra_data.toOwnedSlice(gpa);
+    errdefer extra_data.deinit(gpa);
+    const errors = try parser.errors.toOwnedSlice(gpa);
+    errdefer errors.deinit(gpa);
+
     // TODO experiment with compacting the MultiArrayList slices here
     return Ast{
         .source = source,
         .mode = mode,
         .tokens = tokens.toOwnedSlice(),
         .nodes = parser.nodes.toOwnedSlice(),
-        .extra_data = try parser.extra_data.toOwnedSlice(gpa),
-        .errors = try parser.errors.toOwnedSlice(gpa),
+        .extra_data = extra_data,
+        .errors = errors,
     };
 }
 

--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -182,9 +182,9 @@ pub fn parse(gpa: Allocator, source: [:0]const u8, mode: Mode) Allocator.Error!A
     }
 
     const extra_data = try parser.extra_data.toOwnedSlice(gpa);
-    errdefer extra_data.deinit(gpa);
+    errdefer gpa.free(extra_data);
     const errors = try parser.errors.toOwnedSlice(gpa);
-    errdefer errors.deinit(gpa);
+    errdefer gpa.free(errors);
 
     // TODO experiment with compacting the MultiArrayList slices here
     return Ast{


### PR DESCRIPTION
`        .extra_data = try parser.extra_data.toOwnedSlice(gpa),`
could succeed, but then the next one could fail, orphaning `extra_data`
`        .errors = try parser.errors.toOwnedSlice(gpa),`