### PR TITLE
feat(std/fs): add support to parse home directory from /etc/passwd

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10536,6 +10536,8 @@ pub extern "c" fn recvmsg(sockfd: fd_t, msg: *msghdr, flags: u32) isize;
 
 pub extern "c" fn kill(pid: pid_t, sig: c_int) c_int;
 
+pub extern "c" fn getuid() uid_t;
+
 pub extern "c" fn setuid(uid: uid_t) c_int;
 pub extern "c" fn setgid(gid: gid_t) c_int;
 pub extern "c" fn seteuid(euid: uid_t) c_int;

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -71,6 +71,7 @@ fn getHomeDirFromPasswd() ![]u8 {
 
     var buf: [std.heap.page_size_min]u8 = undefined;
     var state = ReaderState.Start;
+    const currentUid = std.os.linux.getuid();
     var uid: posix.uid_t = 0;
     var home_dir_start: usize = 0;
     var home_dir_len: usize = 0;
@@ -104,7 +105,7 @@ fn getHomeDirFromPasswd() ![]u8 {
                 },
                 .ReadUserId => switch (byte) {
                     '\n' => return error.CorruptPasswordFile,
-                    ':' => state = if (uid == std.os.linux.getuid()) .SkipGroupId else .WaitForNextLine,
+                    ':' => state = if (uid == currentUid) .SkipGroupId else .WaitForNextLine,
                     else => {
                         const digit = switch (byte) {
                             '0'...'9' => byte - '0',

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -13,7 +13,7 @@ pub const GetAppDataDirError = error{
 
 /// Caller owns returned memory.
 /// TODO determine if we can remove the allocator requirement
-pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDirError![]u8 {
+pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) ![]u8 {
     switch (native_os) {
         .windows => {
             const local_app_data_dir = std.process.getEnvVarOwned(allocator, "LOCALAPPDATA") catch |err| switch (err) {
@@ -24,10 +24,7 @@ pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDi
             return fs.path.join(allocator, &[_][]const u8{ local_app_data_dir, appname });
         },
         .macos => {
-            const home_dir = posix.getenv("HOME") orelse {
-                // TODO look in /etc/passwd
-                return error.AppDataDirUnavailable;
-            };
+            const home_dir = posix.getenv("HOME") orelse try getHomeDirFromPasswd();
             return fs.path.join(allocator, &[_][]const u8{ home_dir, "Library", "Application Support", appname });
         },
         .linux, .freebsd, .netbsd, .dragonfly, .openbsd, .solaris, .illumos, .serenity => {
@@ -37,10 +34,7 @@ pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDi
                 }
             }
 
-            const home_dir = posix.getenv("HOME") orelse {
-                // TODO look in /etc/passwd
-                return error.AppDataDirUnavailable;
-            };
+            const home_dir = posix.getenv("HOME") orelse try getHomeDirFromPasswd();
             return fs.path.join(allocator, &[_][]const u8{ home_dir, ".local", "share", appname });
         },
         .haiku => {
@@ -54,6 +48,101 @@ pub fn getAppDataDir(allocator: mem.Allocator, appname: []const u8) GetAppDataDi
             }
         },
         else => @compileError("Unsupported OS"),
+    }
+}
+
+/// Parses home directory from /etc/passwd.
+fn getHomeDirFromPasswd() ![]u8 {
+    const ReaderState = enum {
+        Start,
+        WaitForNextLine,
+        SkipUsername,
+        SkipPassword,
+        ReadUserId,
+        SkipGroupId,
+        SkipGECOS,
+        ReadHomeDirectory,
+    };
+
+    const file = try fs.openFileAbsolute("/etc/passwd", .{});
+    defer file.close();
+
+    const reader = file.reader();
+
+    var buf: [std.heap.page_size_min]u8 = undefined;
+    var state = ReaderState.Start;
+    var uid: posix.uid_t = 0;
+    var home_dir_start: usize = 0;
+    var home_dir_len: usize = 0;
+
+    while (true) {
+        const bytes_read = try reader.read(buf[0..]);
+        for (0.., buf[0..bytes_read]) |i, byte| {
+            switch (state) {
+                .Start => switch (byte) {
+                    '\n' => return error.CorruptPasswordFile,
+                    ':' => state = .SkipPassword,
+                    else => continue,
+                },
+                .WaitForNextLine => switch (byte) {
+                    '\n' => {
+                        uid = 0;
+                        home_dir_len = 0;
+                        state = .Start;
+                    },
+                    else => continue,
+                },
+                .SkipUsername => switch (byte) {
+                    '\n' => return error.CorruptPasswordFile,
+                    ':' => std.debug.print("*", .{}),
+                    else => continue,
+                },
+                .SkipPassword => switch (byte) {
+                    '\n' => return error.CorruptPasswordFile,
+                    ':' => state = .ReadUserId,
+                    else => continue,
+                },
+                .ReadUserId => switch (byte) {
+                    '\n' => return error.CorruptPasswordFile,
+                    ':' => state = if (uid == std.os.linux.getuid()) .SkipGroupId else .WaitForNextLine,
+                    else => {
+                        const digit = switch (byte) {
+                            '0'...'9' => byte - '0',
+                            else => return error.CorruptPasswordFile,
+                        };
+                        {
+                            const ov = @mulWithOverflow(uid, 10);
+                            if (ov[1] != 0) return error.CorruptPasswordFile;
+                            uid = ov[0];
+                        }
+                        {
+                            const ov = @addWithOverflow(uid, digit);
+                            if (ov[1] != 0) return error.CorruptPasswordFile;
+                            uid = ov[0];
+                        }
+                    },
+                },
+                .SkipGroupId => switch (byte) {
+                    '\n' => return error.CorruptPasswordFile,
+                    ':' => state = .SkipGECOS,
+                    else => continue,
+                },
+                .SkipGECOS => switch (byte) {
+                    '\n' => return error.CorruptPasswordFile,
+                    ':' => {
+                        home_dir_start = i + 1;
+                        state = .ReadHomeDirectory;
+                    },
+                    else => continue,
+                },
+                .ReadHomeDirectory => switch (byte) {
+                    '\n', ':' => return buf[home_dir_start .. home_dir_start + home_dir_len],
+                    else => {
+                        home_dir_len += 1;
+                    },
+                },
+            }
+        }
     }
 }
 

--- a/lib/std/fs/get_app_data_dir.zig
+++ b/lib/std/fs/get_app_data_dir.zig
@@ -71,7 +71,7 @@ fn getHomeDirFromPasswd() ![]u8 {
 
     var buf: [std.heap.page_size_min]u8 = undefined;
     var state = ReaderState.start;
-    const currentUid = std.os.linux.getuid();
+    const currentUid = std.posix.getuid();
     var uid: posix.uid_t = 0;
     var home_dir_start: usize = 0;
     var home_dir_len: usize = 0;

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -3407,6 +3407,12 @@ pub fn readlinkatZ(dirfd: fd_t, file_path: [*:0]const u8, out_buffer: []u8) Read
     }
 }
 
+/// POSIX IEEE Std 1003.1-2024: https://pubs.opengroup.org/onlinepubs/9799919799/
+/// Conforming environments will always be successful and never modify errno.
+pub fn getuid() uid_t {
+    return system.getuid();
+}
+
 pub const SetEidError = error{
     InvalidUserId,
     PermissionDenied,


### PR DESCRIPTION
Implemented the TODO in [`get_app_data_dir.zig`](lib/std/fs/get_app_data_dir.zig) that suggests parsing the home directory from `/etc/passwd`.

### Changes

- Added `getHomeDirFromPasswd()` function, which implements the parsing logic.
- ~~Changed the return type of `getAppDataDir()` from `GetAppDataDirError![]u8` to `![]u8` to encompass errors from `fs.openFileAbsolute()` and `reader.read()`~~
- `GetAppDataDirError` retained in return type, updated the `getHomeDirFromPasswd()` function call to catch and return `error.AppDataDirUnavailable` instead (suggested by @squeek502).
- Added declaration for `getuid()` to [`c.zig`](lib/std/c.zig).
- Added wrapper function for `getuid()` to [`posix.zig`](lib/std/posix.zig).
- Changed `std.os.linux.getuid()` to `std.posix.getuid()` in [`get_app_data_dir.zig`](lib/std/fs/get_app_data_dir.zig).