### PR TITLE
Trick the meson build system into thinking `zig rc` is `rc.exe`

### DIFF
--- a/lib/compiler/resinator/cli.zig
+++ b/lib/compiler/resinator/cli.zig
@@ -17,6 +17,7 @@ pub const usage_string_after_command_name =
     \\This is necessary when the input path begins with a forward slash.
     \\
     \\Supported option prefixes are /, -, and --, so e.g. /h, -h, and --h all work.
+    \\Drop-in compatible with the Microsoft Resource Compiler.
     \\
     \\Supported Win32 RC Options:
     \\  /?, /h                  Print this help and exit.

--- a/lib/compiler/resinator/main.zig
+++ b/lib/compiler/resinator/main.zig
@@ -81,7 +81,8 @@ pub fn main() !void {
     defer options.deinit();
 
     if (options.print_help_and_exit) {
-        try cli.writeUsage(stderr.writer(), "zig rc");
+        const stdout = std.io.getStdOut();
+        try cli.writeUsage(stdout.writer(), "zig rc");
         return;
     }
 


### PR DESCRIPTION
(would appreciate this being included in 0.14.1)

---

When determining the type of RC compiler, meson passes `/?` or `--version` and then reads from `stdout` [looking for particular string(s) anywhere in the output](https://github.com/mesonbuild/meson/blob/d17df82efa5dd0b60b9b2a25f8a5e2f34477af6a/mesonbuild/modules/windows.py#L88-L93).

So, by adding the string "Microsoft Resource Compiler" to the `/?` output, meson will recognize `zig rc` as rc.exe and give it the correct options, which works fine since `zig rc` is drop-in CLI compatible with rc.exe.

This allows using `zig rc` with meson for (cross-)compiling, by either:

- Setting `WINDRES="zig rc"` or putting `windres = ['zig', 'rc']` in the cross-file
  + This will work like rc.exe, so it will output .res files. This will only link successfully if you are using a linker that can do .res -> .obj conversion (so something like zig cc, MSVC, lld)
- Setting `WINDRES="zig rc /:output-format coff"` or putting `windres = ['zig', 'rc', '/:output-format', 'coff']` in the cross-file
  + This will make meson pass flags as if it were rc.exe, but it will cause the resulting .res file to actually be a COFF object file, meaning it will work with any linker that handles COFF object files

Example cross file that uses `zig cc` (which can link `.res` files, so `/:output-format coff` is not necessary) and `zig rc`:

```
[binaries]
c = ['zig', 'cc', '--target=x86_64-windows-gnu']
windres = ['zig', 'rc']

[target_machine]
system = 'windows'
cpu_family = 'x86_64'
cpu = 'x86_64'
endian = 'little'
```

---

Using [the test project here](https://github.com/squeek502/windows-resource-cross-compiling) with the example cross file above to cross-compile from Linux:

```shellsession
$ meson setup builddir --cross-file zig-rc.txt
...
Windows resource compiler: Drop-in compatible with the Microsoft Resource Compiler.
...

$ cd builddir
$ meson compile
$ file check
check: PE32+ executable (console) x86-64, for MS Windows
$ wine ./check
hello world
```

(the `hello world` string [comes from a resource](https://github.com/squeek502/windows-resource-cross-compiling/blob/f7dc9d540340941cc29061c5f45b0b1c674907a9/resource.rc))

---

Relevant links:
- https://github.com/ziglang/zig/pull/22813 (getting this same sort of thing to work for CMake)
- https://github.com/squeek502/resinator/issues/17 (upstream resinator issue about this)