### PR TITLE
big.int: return normalized results from `{add,sub}Carry`

### DIFF
--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -726,6 +726,34 @@ test "subWrap single-multi, signed, limb aligned" {
     try testing.expect((try a.toInt(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
 }
 
+test "addWrap returns normalized result" {
+    var x = try Managed.initSet(testing.allocator, 0);
+    defer x.deinit();
+    var y = try Managed.initSet(testing.allocator, 0);
+    defer y.deinit();
+
+    // make them both non normalized "-0"
+    x.setMetadata(false, 1);
+    y.setMetadata(false, 1);
+
+    var r = try Managed.init(testing.allocator);
+    defer r.deinit();
+    try testing.expect(!(try r.addWrap(&x, &y, .unsigned, 64)));
+    try testing.expect(r.isPositive() and r.len() == 1 and r.limbs[0] == 0);
+}
+
+test "subWrap returns normalized result" {
+    var x = try Managed.initSet(testing.allocator, 0);
+    defer x.deinit();
+    var y = try Managed.initSet(testing.allocator, 0);
+    defer y.deinit();
+
+    var r = try Managed.init(testing.allocator);
+    defer r.deinit();
+    try testing.expect(!(try r.subWrap(&x, &y, .unsigned, 64)));
+    try testing.expect(r.isPositive() and r.len() == 1 and r.limbs[0] == 0);
+}
+
 test "addSat single-single, unsigned" {
     var a = try Managed.initSet(testing.allocator, maxInt(u17) - 5);
     defer a.deinit();

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -2223,7 +2223,7 @@ pub fn shlSatScalar(
     const shift: usize = @intCast(rhs.toUnsignedInt(zcu));
     const limbs = try arena.alloc(
         std.math.big.Limb,
-        std.math.big.int.calcTwosCompLimbCount(info.bits) + 1,
+        std.math.big.int.calcTwosCompLimbCount(info.bits),
     );
     var result_bigint = BigIntMutable{
         .limbs = limbs,

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -535,3 +535,12 @@ test "return from inline for" {
     };
     try std.testing.expect(!S.do());
 }
+
+test "for loop 0 length range" {
+    const map: []const u8 = &.{};
+    for (map, 0..map.len) |i, j| {
+        _ = i;
+        _ = j;
+        comptime unreachable;
+    }
+}


### PR DESCRIPTION
closes #23309

bigint functions are allowed to take non-normalized inputs (such as negative zero), however they can't return it. in this case, the operation `subWrap(0, 0)` (computing the length of the range) would result in `-0`, which would create a new internpool value. the simplest fix for this that I can think of is just a special casing both `a` and `b` being zero, similar to how it's done when one of the sides is zero.