### PR TITLE
deprecate O(n) union field type helpers in std.meta

### DIFF
--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -693,8 +693,10 @@ test activeTag {
     try testing.expect(activeTag(u) == UE.Float);
 }
 
+/// Deprecated: Use @FieldType(U, tag_name)
 const TagPayloadType = TagPayload;
 
+/// Deprecated: Use @FieldType(U, tag_name)
 pub fn TagPayloadByName(comptime U: type, comptime tag_name: []const u8) type {
     const info = @typeInfo(U).@"union";
 
@@ -706,8 +708,7 @@ pub fn TagPayloadByName(comptime U: type, comptime tag_name: []const u8) type {
     @compileError("no field '" ++ tag_name ++ "' in union '" ++ @typeName(U) ++ "'");
 }
 
-/// Given a tagged union type, and an enum, return the type of the union field
-/// corresponding to the enum tag.
+/// Deprecated: Use @FieldType(U, @tagName(tag))
 pub fn TagPayload(comptime U: type, comptime tag: Tag(U)) type {
     return TagPayloadByName(U, @tagName(tag));
 }


### PR DESCRIPTION
Users should be using @FieldType() instead.