### PR TITLE
Lower `@returnAddress` to a constant 0 in Emscripten release builds because it is slow

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -183,9 +183,11 @@ pub const sys_can_stack_trace = switch (builtin.cpu.arch) {
 
     // `@returnAddress()` in LLVM 10 gives
     // "Non-Emscripten WebAssembly hasn't implemented __builtin_return_address".
+    // On Emscripten, Zig only supports `@returnAddress()` in debug builds
+    // because Emscripten's implementation is very slow.
     .wasm32,
     .wasm64,
-    => native_os == .emscripten,
+    => native_os == .emscripten and builtin.mode == .Debug,
 
     // `@returnAddress()` is unsupported in LLVM 13.
     .bpfel,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9525,7 +9525,7 @@ pub const FuncGen = struct {
         _ = inst;
         const o = self.ng.object;
         const llvm_usize = try o.lowerType(Type.usize);
-        if (!target_util.supportsReturnAddress(o.pt.zcu.getTarget())) {
+        if (!target_util.supportsReturnAddress(o.pt.zcu.getTarget(), self.ng.ownerModule().optimize_mode)) {
             // https://github.com/ziglang/zig/issues/11946
             return o.builder.intValue(llvm_usize, 0);
         }

--- a/src/target.zig
+++ b/src/target.zig
@@ -248,9 +248,14 @@ pub fn libcProvidesStackProtector(target: std.Target) bool {
     return !target.isMinGW() and target.os.tag != .wasi and !target.cpu.arch.isSpirV();
 }
 
-pub fn supportsReturnAddress(target: std.Target) bool {
+/// Returns true if `@returnAddress()` is supported by the target and has a
+/// reasonably performant implementation for the requested optimization mode.
+pub fn supportsReturnAddress(target: std.Target, optimize: std.builtin.OptimizeMode) bool {
     return switch (target.cpu.arch) {
-        .wasm32, .wasm64 => target.os.tag == .emscripten,
+        // Emscripten currently implements `emscripten_return_address()` by calling
+        // out into JavaScript and parsing a stack trace, which introduces significant
+        // overhead that we would prefer to avoid in release builds.
+        .wasm32, .wasm64 => target.os.tag == .emscripten and optimize == .Debug,
         .bpfel, .bpfeb => false,
         .spirv, .spirv32, .spirv64 => false,
         else => true,


### PR DESCRIPTION
Emscripten currently implements `emscripten_return_address()` by calling out into JavaScript and parsing a stack trace, which introduces significant overhead that we would prefer to avoid in release builds.

This is especially problematic for allocators because the generic parts of `std.mem.Allocator` make frequent use of `@returnAddress`, even though very few allocator implementations even observe the return address, which makes allocators nigh unusable for performance-critical applications like games if the compiler is unable to devirtualize the allocator calls.

To demonstrate just how detrimental this overhead is, below is a quick test application that does 10k pointless `FixedBufferAllocator` allocations in a loop:

<details><summary>Test app</summary>

Save as `build.zig`, install/activate Emscripten, build with `zig build --sysroot "$(em-config CACHE)/sysroot"` and serve with `python -m http.server -d zig-out/www`.

```zig
// build.zig
const std = @import("std");

pub fn build(b: *std.Build) void {
    const target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .emscripten, .abi = .none });
    const optimize: std.builtin.OptimizeMode = .ReleaseFast;

    const emscripten_system_include_path: std.Build.LazyPath = if (b.sysroot) |sysroot|
        .{ .cwd_relative = b.pathJoin(&.{ sysroot, "include" }) }
    else {
        std.log.err("'--sysroot' is required when building for Emscripten targets", .{});
        std.process.exit(1);
    };

    const app_mod = b.createModule(.{
        .root_source_file = b.path("build.zig"),
        .target = target,
        .optimize = optimize,
        .link_libc = true,
    });

    app_mod.addSystemIncludePath(emscripten_system_include_path);

    const app_lib = b.addLibrary(.{
        .linkage = .static,
        .name = "return_address",
        .root_module = app_mod,
    });
    app_lib.want_lto = true;

    const run_emcc = b.addSystemCommand(&.{"emcc"});

    // Pass the full set of linked artifacts as input files.
    for (app_lib.getCompileDependencies(false)) |compile| {
        run_emcc.addArtifactArg(compile);
    }

    run_emcc.addArgs(&.{
        "-O3",
        "-flto",
        "-sUSE_OFFSET_CONVERTER", // Currently required by '@returnAddress'
    });

    // Patch the default HTML shell to also display messages printed to stderr.
    run_emcc.addArg("--pre-js");
    run_emcc.addFileArg(b.addWriteFiles().add("pre.js", (
        \\Module['printErr'] ??= Module['print'];
        \\
    )));

    run_emcc.addArg("-o");
    const app_html = run_emcc.addOutputFileArg("return_address.html");

    b.getInstallStep().dependOn(&b.addInstallDirectory(.{
        .source_dir = app_html.dirname(),
        .install_dir = .{ .custom = "www" },
        .install_subdir = "",
    }).step);
}

pub const std_options: std.Options = .{ .log_level = .debug };

pub fn main() !void {
    var buf: [1024]u8 = undefined;
    var fba_state: std.heap.FixedBufferAllocator = .init(&buf);
    const allocator = fba_state.allocator();

    for (0..10) |iteration| {
        var timer: std.time.Timer = try .start();
        for (0..10_000) |_| {
            try @call(.always_inline, doAlloc, .{allocator});
        }
        const ms = @as(f64, @floatFromInt(timer.read())) / std.time.ns_per_ms;
        std.log.info("{} {d}", .{ iteration, ms });
    }

    std.log.info("---", .{});

    for (0..10) |iteration| {
        var timer: std.time.Timer = try .start();
        for (0..10_000) |_| {
            try @call(.never_inline, doAlloc, .{allocator});
        }
        const ms = @as(f64, @floatFromInt(timer.read())) / std.time.ns_per_ms;
        std.log.info("{} {d}", .{ iteration, ms });
    }
}

fn doAlloc(allocator: std.mem.Allocator) !void {
    const x = try allocator.alloc(u8, 256);
    allocator.free(x);
}
```

</details>

On my system/web browser, when the compiler is successfully able devirtualize the allocator calls and elide the uses of `@returnAddress`, performing 10k allocations and frees that takes less than 0.1 ms. When it fails, it takes ~48 ms.