### PR TITLE
Use `-unknown` when converting WASI/Emscripten target triples into LLVM triples

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -264,7 +264,12 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .eabihf => "eabihf",
         .android => "android",
         .androideabi => "androideabi",
-        .musl => "musl",
+        .musl => switch (target.os.tag) {
+            // For WASI/Emscripten, "musl" refers to the libc, not really the ABI.
+            // "unknown" provides better compatibility with LLVM-based tooling for these targets.
+            .wasi, .emscripten => "unknown",
+            else => "musl",
+        },
         .muslabin32 => "musl", // Should be muslabin32 in LLVM 20.
         .muslabi64 => "musl", // Should be muslabi64 in LLVM 20.
         .musleabi => "musleabi",


### PR DESCRIPTION
The "musl" part of the Zig target triples `wasm32-wasi-musl` and `wasm32-emscripten-musl` refers to the libc, not really the ABI.

For WASM, most LLVM-based tooling uses `wasm32-wasi`, which is normalized into `wasm32-unknown-wasi`, with an implicit `-unknown` and without `-musl`. Similarly, Emscripten uses `wasm32-unknown-emscripten` without `-musl` ([`emcc` is actually very strict and rejects anything but the canonical triple](https://github.com/emscripten-core/emscripten/blob/95518ae96eca9b9eb1224ddb4a94f06820b0b2a8/emcc.py#L1395)).

Because Zig normalizes the triple `wasm32-emscripten` to `wasm32-emscripten-musl`, which is subsequently transformed into the LLVM triple `wasm32-unknown-emscripten-musl`, and because `emcc` and most Emscripten tooling expects `wasm32-unknown-emscripten(-unknown)`, you are usually presented with lots of (harmless) warnings about mismatched target triples when passing the outputs from the Zig compilers to `emcc` for linking. I haven't personally tested but I strongly suspect external WASI tooling will run into similar warnings.

By using `-unknown` instead of `-musl` for these targets we get better compatibility with external tooling.