### PR TITLE
std.posix: update LFS64 interfaces for android bionic C

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -482,7 +482,7 @@ pub const Os = struct {
 
                             break :blk default_min;
                         },
-                        .android = 14,
+                        .android = 24,
                     },
                 },
                 .rtems => .{

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -7479,7 +7479,7 @@ pub fn ioctl_SIOCGIFINDEX(fd: fd_t, ifr: *ifreq) IoCtl_SIOCGIFINDEX_Error!void {
     }
 }
 
-const lfs64_abi = native_os == .linux and builtin.link_libc and builtin.abi.isGnu();
+const lfs64_abi = native_os == .linux and builtin.link_libc and (builtin.abi.isGnu() or builtin.abi.isAndroid());
 
 /// Whether or not `error.Unexpected` will print its value and a stack trace.
 ///


### PR DESCRIPTION
As of zig-0.14.0, `std.posix.mmap`(which invokes `std.c.mmap`) returns `MAP_FAILED` with error code of `EINVAL` for androideabi, while `std.c.mmap64` works fine.

Actually, android bionic C has support for `_FILE_OFFSET_BITS`, enabling `lfs64_abi` for android fixes the above issue. 

c.f.
1. https://android.googlesource.com/platform/bionic/+/HEAD/docs/32-bit-abi.md
2. https://github.com/android/ndk/issues/468

