### PR TITLE
std.c: android bionic C supports arc4random_buf and getentropy

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10196,10 +10196,12 @@ pub extern "c" fn sendfile64(out_fd: fd_t, in_fd: fd_t, offset: ?*i64, count: us
 pub extern "c" fn setrlimit64(resource: rlimit_resource, rlim: *const rlimit) c_int;
 
 pub const arc4random_buf = switch (native_os) {
-    .dragonfly, .netbsd, .freebsd, .solaris, .openbsd, .macos, .ios, .tvos, .watchos, .visionos, .serenity => private.arc4random_buf,
+    .linux => if (builtin.abi.isAndroid()) private.arc4random_buf else {},
+    .dragonfly, .netbsd, .freebsd, .solaris, .openbsd, .macos, .ios, .tvos, .watchos, .visionos => private.arc4random_buf,
     else => {},
 };
 pub const getentropy = switch (native_os) {
+    .linux => if (builtin.abi.isAndroid() and versionCheck(.{ .major = 28, .minor = 0, .patch = 0 })) private.getentropy else {},
     .emscripten => private.getentropy,
     else => {},
 };


### PR DESCRIPTION
1. https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/bits/getentropy.h
2. https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/stdlib.h