### PR TITLE
std.posix: add getuid()/geteuid()

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10547,6 +10547,8 @@ pub extern "c" fn setregid(rgid: gid_t, egid: gid_t) c_int;
 pub extern "c" fn setresuid(ruid: uid_t, euid: uid_t, suid: uid_t) c_int;
 pub extern "c" fn setresgid(rgid: gid_t, egid: gid_t, sgid: gid_t) c_int;
 pub extern "c" fn setpgid(pid: pid_t, pgid: pid_t) c_int;
+pub extern "c" fn getuid() uid_t;
+pub extern "c" fn geteuid() uid_t;
 
 pub extern "c" fn malloc(usize) ?*anyopaque;
 pub extern "c" fn calloc(usize, usize) ?*anyopaque;

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -3500,6 +3500,14 @@ pub fn setpgid(pid: pid_t, pgid: pid_t) SetPgidError!void {
     }
 }
 
+pub fn getuid() uid_t {
+    return system.getuid();
+}
+
+pub fn geteuid() uid_t {
+    return system.geteuid();
+}
+
 /// Test whether a file descriptor refers to a terminal.
 pub fn isatty(handle: fd_t) bool {
     if (native_os == .windows) {

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -509,6 +509,12 @@ test "getcwd" {
     _ = posix.getcwd(&buf) catch undefined;
 }
 
+test "getuid" {
+    if (native_os == .windows or native_os == .wasi) return error.SkipZigTest;
+    _ = posix.getuid();
+    _ = posix.geteuid();
+}
+
 test "sigaltstack" {
     if (native_os == .windows or native_os == .wasi) return error.SkipZigTest;
 


### PR DESCRIPTION
This PR adds the `getuid()` and `geteuid()` functions from `unistd.h` that are to the best of my knowledge available on all POSIX-compliant systems.