### PR TITLE
`std.Target`: Move `Cpu.supportsAddressSpace()` up.

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1955,35 +1955,6 @@ pub const Cpu = struct {
     pub fn baseline(arch: Arch, os: Os) Cpu {
         return Model.baseline(arch, os).toCpu(arch);
     }
-
-    /// Returns whether this architecture supports `address_space`. If `context` is `null`, this
-    /// function simply answers the general question of whether the architecture has any concept
-    /// of `address_space`; if non-`null`, the function additionally checks whether
-    /// `address_space` is valid in that context.
-    pub fn supportsAddressSpace(
-        cpu: Cpu,
-        address_space: std.builtin.AddressSpace,
-        context: ?std.builtin.AddressSpace.Context,
-    ) bool {
-        const arch = cpu.arch;
-
-        const is_nvptx = arch.isNvptx();
-        const is_spirv = arch.isSpirV();
-        const is_gpu = is_nvptx or is_spirv or arch == .amdgcn;
-
-        return switch (address_space) {
-            .generic => true,
-            .fs, .gs, .ss => (arch == .x86_64 or arch == .x86) and (context == null or context == .pointer),
-            .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => arch == .avr, // TODO this should also check how many flash banks the cpu has
-            .cog, .hub => arch == .propeller,
-            .lut => arch == .propeller and std.Target.propeller.featureSetHas(cpu.features, .p2),
-
-            .global, .local, .shared => is_gpu,
-            .constant => is_gpu and (context == null or context == .constant),
-            .param => is_nvptx,
-            .input, .output, .uniform, .push_constant, .storage_buffer => is_spirv,
-        };
-    }
 };
 
 pub fn zigTriple(target: Target, allocator: Allocator) Allocator.Error![]u8 {
@@ -2046,6 +2017,35 @@ pub inline fn isDarwinLibC(target: Target) bool {
 
 pub inline fn isWasiLibC(target: Target) bool {
     return target.os.tag == .wasi and target.abi.isMusl();
+}
+
+/// Returns whether this target supports `address_space`. If `context` is `null`, this
+/// function simply answers the general question of whether the target has any concept
+/// of `address_space`; if non-`null`, the function additionally checks whether
+/// `address_space` is valid in that context.
+pub fn supportsAddressSpace(
+    target: Target,
+    address_space: std.builtin.AddressSpace,
+    context: ?std.builtin.AddressSpace.Context,
+) bool {
+    const arch = target.cpu.arch;
+
+    const is_nvptx = arch.isNvptx();
+    const is_spirv = arch.isSpirV();
+    const is_gpu = is_nvptx or is_spirv or arch == .amdgcn;
+
+    return switch (address_space) {
+        .generic => true,
+        .fs, .gs, .ss => (arch == .x86_64 or arch == .x86) and (context == null or context == .pointer),
+        .flash, .flash1, .flash2, .flash3, .flash4, .flash5 => arch == .avr, // TODO this should also check how many flash banks the cpu has
+        .cog, .hub => arch == .propeller,
+        .lut => arch == .propeller and std.Target.propeller.featureSetHas(target.cpu.features, .p2),
+
+        .global, .local, .shared => is_gpu,
+        .constant => is_gpu and (context == null or context == .constant),
+        .param => is_nvptx,
+        .input, .output, .uniform, .push_constant, .storage_buffer => is_spirv,
+    };
 }
 
 pub const DynamicLinker = struct {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -36764,7 +36764,7 @@ pub fn analyzeAsAddressSpace(
     const address_space = try sema.interpretBuiltinType(block, src, addrspace_val, std.builtin.AddressSpace);
     const target = pt.zcu.getTarget();
 
-    if (!target.cpu.supportsAddressSpace(address_space, ctx)) {
+    if (!target.supportsAddressSpace(address_space, ctx)) {
         // TODO error messages could be made more elaborate here
         const entity = switch (ctx) {
             .function => "functions",

--- a/src/target.zig
+++ b/src/target.zig
@@ -444,10 +444,10 @@ pub fn addrSpaceCastIsValid(
     to: AddressSpace,
 ) bool {
     switch (target.cpu.arch) {
-        .x86_64, .x86 => return target.cpu.supportsAddressSpace(from, null) and target.cpu.supportsAddressSpace(to, null),
+        .x86_64, .x86 => return target.supportsAddressSpace(from, null) and target.supportsAddressSpace(to, null),
         .nvptx64, .nvptx, .amdgcn => {
-            const to_generic = target.cpu.supportsAddressSpace(from, null) and to == .generic;
-            const from_generic = target.cpu.supportsAddressSpace(to, null) and from == .generic;
+            const to_generic = target.supportsAddressSpace(from, null) and to == .generic;
+            const from_generic = target.supportsAddressSpace(to, null) and from == .generic;
             return to_generic or from_generic;
         },
         else => return from == .generic and to == .generic,


### PR DESCRIPTION
This allows us to rule out support for certain address spaces based on the OS. This commit is just a refactor, however, and doesn't actually make use of that opportunity yet.

https://github.com/ziglang/zig/pull/22589#discussion_r1929824781