### PR TITLE
std: add arch bits for m68k-linux

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1601,10 +1601,6 @@ pub const MSF = switch (native_os) {
     },
     else => void,
 };
-pub const MMAP2_UNIT = switch (native_os) {
-    .linux => linux.MMAP2_UNIT,
-    else => void,
-};
 pub const NAME_MAX = switch (native_os) {
     .linux => linux.NAME_MAX,
     .emscripten => emscripten.NAME_MAX,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -39,6 +39,7 @@ const arch_bits = switch (native_arch) {
     .riscv64 => @import("linux/riscv64.zig"),
     .sparc64 => @import("linux/sparc64.zig"),
     .loongarch64 => @import("linux/loongarch64.zig"),
+    .m68k => @import("linux/m68k.zig"),
     .mips, .mipsel => @import("linux/mips.zig"),
     .mips64, .mips64el => @import("linux/mips64.zig"),
     .powerpc, .powerpcle => @import("linux/powerpc.zig"),
@@ -279,7 +280,7 @@ pub const MAP = switch (native_arch) {
         UNINITIALIZED: bool = false,
         _: u5 = 0,
     },
-    .hexagon, .s390x => packed struct(u32) {
+    .hexagon, .m68k, .s390x => packed struct(u32) {
         TYPE: MAP_TYPE,
         FIXED: bool = false,
         ANONYMOUS: bool = false,
@@ -333,7 +334,7 @@ pub const O = switch (native_arch) {
         SYNC: bool = false,
         PATH: bool = false,
         TMPFILE: bool = false,
-        _: u9 = 0,
+        _23: u9 = 0,
     },
     .x86, .riscv32, .riscv64, .loongarch64 => packed struct(u32) {
         ACCMODE: ACCMODE = .RDONLY,
@@ -355,7 +356,7 @@ pub const O = switch (native_arch) {
         SYNC: bool = false,
         PATH: bool = false,
         TMPFILE: bool = false,
-        _: u9 = 0,
+        _23: u9 = 0,
     },
     .aarch64, .aarch64_be, .arm, .armeb, .thumb, .thumbeb => packed struct(u32) {
         ACCMODE: ACCMODE = .RDONLY,
@@ -377,7 +378,7 @@ pub const O = switch (native_arch) {
         SYNC: bool = false,
         PATH: bool = false,
         TMPFILE: bool = false,
-        _: u9 = 0,
+        _23: u9 = 0,
     },
     .sparc64 => packed struct(u32) {
         ACCMODE: ACCMODE = .RDONLY,
@@ -402,7 +403,7 @@ pub const O = switch (native_arch) {
         SYNC: bool = false,
         PATH: bool = false,
         TMPFILE: bool = false,
-        _: u6 = 0,
+        _27: u6 = 0,
     },
     .mips, .mipsel, .mips64, .mips64el => packed struct(u32) {
         ACCMODE: ACCMODE = .RDONLY,
@@ -426,7 +427,7 @@ pub const O = switch (native_arch) {
         _20: u1 = 0,
         PATH: bool = false,
         TMPFILE: bool = false,
-        _: u9 = 0,
+        _23: u9 = 0,
     },
     .powerpc, .powerpcle, .powerpc64, .powerpc64le => packed struct(u32) {
         ACCMODE: ACCMODE = .RDONLY,
@@ -448,7 +449,7 @@ pub const O = switch (native_arch) {
         SYNC: bool = false,
         PATH: bool = false,
         TMPFILE: bool = false,
-        _: u9 = 0,
+        _23: u9 = 0,
     },
     .hexagon, .s390x => packed struct(u32) {
         ACCMODE: ACCMODE = .RDONLY,
@@ -467,14 +468,35 @@ pub const O = switch (native_arch) {
         NOFOLLOW: bool = false,
         NOATIME: bool = false,
         CLOEXEC: bool = false,
-        _17: u1 = 0,
+        _20: u1 = 0,
         PATH: bool = false,
-        _: u10 = 0,
+        _22: u10 = 0,
 
         // #define O_RSYNC    04010000
         // #define O_SYNC     04010000
         // #define O_TMPFILE 020200000
         // #define O_NDELAY O_NONBLOCK
+    },
+    .m68k => packed struct(u32) {
+        ACCMODE: ACCMODE = .RDONLY,
+        _2: u4 = 0,
+        CREAT: bool = false,
+        EXCL: bool = false,
+        NOCTTY: bool = false,
+        TRUNC: bool = false,
+        APPEND: bool = false,
+        NONBLOCK: bool = false,
+        DSYNC: bool = false,
+        ASYNC: bool = false,
+        DIRECTORY: bool = false,
+        NOFOLLOW: bool = false,
+        DIRECT: bool = false,
+        LARGEFILE: bool = false,
+        NOATIME: bool = false,
+        CLOEXEC: bool = false,
+        _20: u1 = 0,
+        PATH: bool = false,
+        _22: u10 = 0,
     },
     else => @compileError("missing std.os.linux.O constants for this architecture"),
 };

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -93,7 +93,6 @@ pub const Elf_Symndx = arch_bits.Elf_Symndx;
 pub const F = arch_bits.F;
 pub const Flock = arch_bits.Flock;
 pub const HWCAP = arch_bits.HWCAP;
-pub const MMAP2_UNIT = arch_bits.MMAP2_UNIT;
 pub const REG = arch_bits.REG;
 pub const SC = arch_bits.SC;
 pub const Stat = arch_bits.Stat;
@@ -928,7 +927,7 @@ pub fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: MAP, fd: i32, of
             prot,
             @as(u32, @bitCast(flags)),
             @bitCast(@as(isize, fd)),
-            @truncate(@as(u64, @bitCast(offset)) / MMAP2_UNIT),
+            @truncate(@as(u64, @bitCast(offset)) / std.heap.pageSize()),
         );
     } else {
         // The s390x mmap() syscall existed before Linux supported syscalls with 5+ parameters, so

--- a/lib/std/os/linux/arm.zig
+++ b/lib/std/os/linux/arm.zig
@@ -170,8 +170,6 @@ pub fn restore_rt() callconv(.naked) noreturn {
     }
 }
 
-pub const MMAP2_UNIT = 4096;
-
 pub const F = struct {
     pub const DUPFD = 0;
     pub const GETFD = 1;

--- a/lib/std/os/linux/hexagon.zig
+++ b/lib/std/os/linux/hexagon.zig
@@ -251,8 +251,6 @@ pub const Stat = extern struct {
 
 pub const Elf_Symndx = u32;
 
-pub const MMAP2_UNIT = 4096;
-
 pub const VDSO = void;
 
 /// TODO

--- a/lib/std/os/linux/m68k.zig
+++ b/lib/std/os/linux/m68k.zig
@@ -261,10 +261,6 @@ pub const Stat = extern struct {
 
 pub const Elf_Symndx = u32;
 
-// m68k has multiple minimum page sizes.
-// glibc sets MMAP2_PAGE_UNIT to -1 so it is queried at runtime.
-pub const MMAP2_UNIT = -1;
-
 // No VDSO used as of glibc 112a0ae18b831bf31f44d81b82666980312511d6.
 pub const VDSO = void;
 

--- a/lib/std/os/linux/m68k.zig
+++ b/lib/std/os/linux/m68k.zig
@@ -1,0 +1,275 @@
+const builtin = @import("builtin");
+const std = @import("../../std.zig");
+const iovec = std.posix.iovec;
+const iovec_const = std.posix.iovec_const;
+const linux = std.os.linux;
+const SYS = linux.SYS;
+const uid_t = std.os.linux.uid_t;
+const gid_t = std.os.linux.uid_t;
+const pid_t = std.os.linux.pid_t;
+const sockaddr = linux.sockaddr;
+const socklen_t = linux.socklen_t;
+const timespec = std.os.linux.timespec;
+
+pub fn syscall0(number: SYS) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+        : "memory"
+    );
+}
+
+pub fn syscall1(number: SYS, arg1: usize) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+          [arg1] "{d1}" (arg1),
+        : "memory"
+    );
+}
+
+pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+          [arg1] "{d1}" (arg1),
+          [arg2] "{d2}" (arg2),
+        : "memory"
+    );
+}
+
+pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+          [arg1] "{d1}" (arg1),
+          [arg2] "{d2}" (arg2),
+          [arg3] "{d3}" (arg3),
+        : "memory"
+    );
+}
+
+pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+          [arg1] "{d1}" (arg1),
+          [arg2] "{d2}" (arg2),
+          [arg3] "{d3}" (arg3),
+          [arg4] "{d4}" (arg4),
+        : "memory"
+    );
+}
+
+pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize, arg5: usize) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+          [arg1] "{d1}" (arg1),
+          [arg2] "{d2}" (arg2),
+          [arg3] "{d3}" (arg3),
+          [arg4] "{d4}" (arg4),
+          [arg5] "{d5}" (arg5),
+        : "memory"
+    );
+}
+
+pub fn syscall6(
+    number: SYS,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+    arg6: usize,
+) usize {
+    return asm volatile ("trap #0"
+        : [ret] "={d0}" (-> usize),
+        : [number] "{d0}" (@intFromEnum(number)),
+          [arg1] "{d1}" (arg1),
+          [arg2] "{d2}" (arg2),
+          [arg3] "{d3}" (arg3),
+          [arg4] "{d4}" (arg4),
+          [arg5] "{d5}" (arg5),
+          [arg6] "{a0}" (arg6),
+        : "memory"
+    );
+}
+
+pub fn clone() callconv(.naked) usize {
+    // __clone(func, stack, flags, arg, ptid, tls, ctid)
+    //         +4,   +8,    +12,   +16, +20,  +24, +28
+    //
+    // syscall(SYS_clone, flags, stack, ptid, ctid, tls)
+    //         d0,        d1,    d2,    d3,   d4,   d5
+    asm volatile (
+        \\ // Save callee-saved registers.
+        \\ movem.l %%d2-%%d5, -(%%sp) // sp -= 16
+        \\
+        \\ // Save func and arg.
+        \\ move.l 16+4(%%sp), %%a0
+        \\ move.l 16+16(%%sp), %%a1
+        \\
+        \\ // d0 = syscall(d0, d1, d2, d3, d4, d5)
+        \\ move.l #120, %%d0 // SYS_clone
+        \\ move.l 16+12(%%sp), %%d1
+        \\ move.l 16+8(%%sp), %%d2
+        \\ move.l 16+20(%%sp), %%d3
+        \\ move.l 16+28(%%sp), %%d4
+        \\ move.l 16+24(%%sp), %%d5
+        \\ and.l #-4, %%d2 // Align the child stack pointer.
+        \\ trap #0
+        \\
+        \\ // Are we in the parent or child?
+        \\ tst.l %%d0
+        \\ beq 1f
+        \\ // Parent:
+        \\
+        \\ // Restore callee-saved registers and return.
+        \\ movem.l (%%sp)+, %%d2-%%d5 // sp += 16
+        \\ rts
+        \\
+        \\ // Child:
+        \\1:
+    );
+    if (builtin.unwind_tables != .none or !builtin.strip_debug_info) asm volatile (
+        \\ .cfi_undefined %%pc
+    );
+    asm volatile (
+        \\ suba.l %%fp, %%fp
+        \\
+        \\ // d0 = func(a1)
+        \\ move.l %%a1, -(%%sp)
+        \\ jsr (%%a0)
+        \\
+        \\ // syscall(d0, d1)
+        \\ move.l %%d0, %%d1
+        \\ move.l #1, %%d0 // SYS_exit
+        \\ trap #0
+    );
+}
+
+pub const restore = restore_rt;
+
+pub fn restore_rt() callconv(.naked) noreturn {
+    asm volatile ("trap #0"
+        :
+        : [number] "{d0}" (@intFromEnum(SYS.rt_sigreturn)),
+        : "memory"
+    );
+}
+
+pub const F = struct {
+    pub const DUPFD = 0;
+    pub const GETFD = 1;
+    pub const SETFD = 2;
+    pub const GETFL = 3;
+    pub const SETFL = 4;
+
+    pub const SETOWN = 8;
+    pub const GETOWN = 9;
+    pub const SETSIG = 10;
+    pub const GETSIG = 11;
+
+    pub const GETLK = 12;
+    pub const SETLK = 13;
+    pub const SETLKW = 14;
+
+    pub const SETOWN_EX = 15;
+    pub const GETOWN_EX = 16;
+
+    pub const GETOWNER_UIDS = 17;
+
+    pub const RDLCK = 0;
+    pub const WRLCK = 1;
+    pub const UNLCK = 2;
+};
+
+pub const blksize_t = i32;
+pub const nlink_t = u32;
+pub const time_t = i32;
+pub const mode_t = u32;
+pub const off_t = i64;
+pub const ino_t = u64;
+pub const dev_t = u64;
+pub const blkcnt_t = i64;
+
+pub const timeval = extern struct {
+    sec: time_t,
+    usec: i32,
+};
+
+pub const Flock = extern struct {
+    type: i16,
+    whence: i16,
+    start: off_t,
+    len: off_t,
+    pid: pid_t,
+};
+
+// TODO: not 100% sure of padding for msghdr
+pub const msghdr = extern struct {
+    name: ?*sockaddr,
+    namelen: socklen_t,
+    iov: [*]iovec,
+    iovlen: i32,
+    control: ?*anyopaque,
+    controllen: socklen_t,
+    flags: i32,
+};
+
+pub const msghdr_const = extern struct {
+    name: ?*const sockaddr,
+    namelen: socklen_t,
+    iov: [*]const iovec_const,
+    iovlen: i32,
+    control: ?*const anyopaque,
+    controllen: socklen_t,
+    flags: i32,
+};
+
+pub const Stat = extern struct {
+    dev: dev_t,
+    __pad: i16,
+    __ino_truncated: i32,
+    mode: mode_t,
+    nlink: nlink_t,
+    uid: uid_t,
+    gid: gid_t,
+    rdev: dev_t,
+    __pad2: i16,
+    size: off_t,
+    blksize: blksize_t,
+    blocks: blkcnt_t,
+    atim: timespec,
+    mtim: timespec,
+    ctim: timespec,
+    ino: ino_t,
+
+    pub fn atime(self: @This()) timespec {
+        return self.atim;
+    }
+
+    pub fn mtime(self: @This()) timespec {
+        return self.mtim;
+    }
+
+    pub fn ctime(self: @This()) timespec {
+        return self.ctim;
+    }
+};
+
+pub const Elf_Symndx = u32;
+
+// m68k has multiple minimum page sizes.
+// glibc sets MMAP2_PAGE_UNIT to -1 so it is queried at runtime.
+pub const MMAP2_UNIT = -1;
+
+// No VDSO used as of glibc 112a0ae18b831bf31f44d81b82666980312511d6.
+pub const VDSO = void;
+
+/// TODO
+pub const ucontext_t = void;
+
+/// TODO
+pub const getcontext = {};

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -294,8 +294,6 @@ pub const F = struct {
     pub const GETOWNER_UIDS = 17;
 };
 
-pub const MMAP2_UNIT = 4096;
-
 pub const VDSO = struct {
     pub const CGT_SYM = "__vdso_clock_gettime";
     pub const CGT_VER = "LINUX_2.6";

--- a/lib/std/os/linux/mips64.zig
+++ b/lib/std/os/linux/mips64.zig
@@ -273,8 +273,6 @@ pub const F = struct {
     pub const GETOWNER_UIDS = 17;
 };
 
-pub const MMAP2_UNIT = 4096;
-
 pub const VDSO = struct {
     pub const CGT_SYM = "__vdso_clock_gettime";
     pub const CGT_VER = "LINUX_2.6";

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -348,7 +348,5 @@ pub const ucontext_t = extern struct {
 
 pub const Elf_Symndx = u32;
 
-pub const MMAP2_UNIT = 4096;
-
 /// TODO
 pub const getcontext = {};

--- a/lib/std/os/linux/riscv32.zig
+++ b/lib/std/os/linux/riscv32.zig
@@ -256,8 +256,6 @@ pub const Stat = extern struct {
 
 pub const Elf_Symndx = u32;
 
-pub const MMAP2_UNIT = 4096;
-
 pub const VDSO = struct {
     pub const CGT_SYM = "__vdso_clock_gettime";
     pub const CGT_VER = "LINUX_4.15";

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -508,14 +508,7 @@ pub fn initStatic(phdrs: []elf.Phdr) void {
             break :blk main_thread_area_buffer[0..area_desc.size];
         }
 
-        const begin_addr = mmap(
-            null,
-            area_desc.size + area_desc.alignment - 1,
-            posix.PROT.READ | posix.PROT.WRITE,
-            .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
-            -1,
-            0,
-        );
+        const begin_addr = mmap_tls(area_desc.size + area_desc.alignment - 1);
         if (@call(.always_inline, linux.E.init, .{begin_addr}) != .SUCCESS) @trap();
 
         const area_ptr: [*]align(page_size_min) u8 = @ptrFromInt(begin_addr);
@@ -530,16 +523,19 @@ pub fn initStatic(phdrs: []elf.Phdr) void {
     setThreadPointer(tp_value);
 }
 
-inline fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: linux.MAP, fd: i32, offset: i64) usize {
+inline fn mmap_tls(length: usize) usize {
+    const prot = posix.PROT.READ | posix.PROT.WRITE;
+    const flags: linux.MAP = .{ .TYPE = .PRIVATE, .ANONYMOUS = true };
+
     if (@hasField(linux.SYS, "mmap2")) {
         return @call(.always_inline, linux.syscall6, .{
             .mmap2,
-            @intFromPtr(address),
+            0,
             length,
             prot,
             @as(u32, @bitCast(flags)),
-            @as(usize, @bitCast(@as(isize, fd))),
-            @as(usize, @truncate(@as(u64, @bitCast(offset)) / linux.MMAP2_UNIT)),
+            @as(usize, @bitCast(@as(isize, -1))),
+            0,
         });
     } else {
         // The s390x mmap() syscall existed before Linux supported syscalls with 5+ parameters, so
@@ -547,21 +543,21 @@ inline fn mmap(address: ?[*]u8, length: usize, prot: usize, flags: linux.MAP, fd
         return if (native_arch == .s390x) @call(.always_inline, linux.syscall1, .{
             .mmap,
             @intFromPtr(&[_]usize{
-                @intFromPtr(address),
+                0,
                 length,
                 prot,
                 @as(u32, @bitCast(flags)),
-                @as(usize, @bitCast(@as(isize, fd))),
-                @as(u64, @bitCast(offset)),
+                @as(usize, @bitCast(@as(isize, -1))),
+                0,
             }),
         }) else @call(.always_inline, linux.syscall6, .{
             .mmap,
-            @intFromPtr(address),
+            0,
             length,
             prot,
             @as(u32, @bitCast(flags)),
-            @as(usize, @bitCast(@as(isize, fd))),
-            @as(u64, @bitCast(offset)),
+            @as(usize, @bitCast(@as(isize, -1))),
+            0,
         });
     }
 }

--- a/lib/std/os/linux/x86.zig
+++ b/lib/std/os/linux/x86.zig
@@ -230,8 +230,6 @@ pub const F = struct {
     pub const UNLCK = 2;
 };
 
-pub const MMAP2_UNIT = 4096;
-
 pub const VDSO = struct {
     pub const CGT_SYM = "__vdso_clock_gettime";
     pub const CGT_VER = "LINUX_2.6";

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -82,7 +82,6 @@ pub const MADV = system.MADV;
 pub const MAP = system.MAP;
 pub const MAX_ADDR_LEN = system.MAX_ADDR_LEN;
 pub const MFD = system.MFD;
-pub const MMAP2_UNIT = system.MMAP2_UNIT;
 pub const MREMAP = system.MREMAP;
 pub const MSF = system.MSF;
 pub const MSG = system.MSG;

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -250,7 +250,7 @@ fn _start() callconv(.naked) noreturn {
             .csky => ".cfi_undefined lr",
             .hexagon => ".cfi_undefined r31",
             .loongarch32, .loongarch64 => ".cfi_undefined 1",
-            .m68k => ".cfi_undefined pc",
+            .m68k => ".cfi_undefined %%pc",
             .mips, .mipsel, .mips64, .mips64el => ".cfi_undefined $ra",
             .powerpc, .powerpcle, .powerpc64, .powerpc64le => ".cfi_undefined lr",
             .riscv32, .riscv64 => if (builtin.zig_backend == .stage2_riscv64)

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -343,7 +343,7 @@ fn _start() callconv(.naked) noreturn {
             \\ r30 = #0
             \\ r31 = #0
             \\ r0 = r29
-            \\ r29 = and(r29, #-16)
+            \\ r29 = and(r29, #-8)
             \\ memw(r29 + #-8) = r29
             \\ r29 = add(r29, #-8)
             \\ call %[posixCallMainAndExit]

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -366,7 +366,11 @@ fn _start() callconv(.naked) noreturn {
             // Note that the - 8 is needed because pc in the jsr instruction points into the middle
             // of the jsr instruction. (The lea is 6 bytes, the jsr is 4 bytes.)
             \\ suba.l %%fp, %%fp
-            \\ move.l %%sp, -(%%sp)
+            \\ move.l %%sp, %%a0
+            \\ move.l %%a0, %%d0
+            \\ and.l #-4, %%d0
+            \\ move.l %%d0, %%sp
+            \\ move.l %%a0, -(%%sp)
             \\ lea %[posixCallMainAndExit] - . - 8, %%a0
             \\ jsr (%%pc, %%a0)
             ,


### PR DESCRIPTION
This pr provides initial support for m68k-linux within std. 

Following https://github.com/ziglang/zig/issues/19510#issuecomment-2722895789, i can build object files, but there is still no support for m68k within lld. Therefore, I can't link programs to test with qemu.

https://github.com/ziglang/zig/issues/23089 
https://github.com/ziglang/zig/issues/22189