### PR TITLE
check result of mmap() call to handle a large base_addr value correctly

### DIFF
--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -516,7 +516,7 @@ pub fn initStatic(phdrs: []elf.Phdr) void {
             -1,
             0,
         );
-        if (@as(isize, @bitCast(begin_addr)) < 0) @trap();
+        if (@call(.always_inline, linux.E.init, .{begin_addr}) != .SUCCESS) @trap();
 
         const area_ptr: [*]align(page_size_min) u8 = @ptrFromInt(begin_addr);
 


### PR DESCRIPTION
Proposed fix as supplied by @alexrp in #23377

Closes #23377.