### PR TITLE
Make std.os.{argv,environ} optional.

### DIFF
--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -602,10 +602,14 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
         },
         .openbsd, .haiku => {
             // OpenBSD doesn't support getting the path of a running process, so try to guess it
-            if (std.os.argv.len == 0)
+            if (std.os.argv == null)
                 return error.FileNotFound;
 
-            const argv0 = mem.span(std.os.argv[0]);
+            const argv = std.os.argv.?;
+            if (argv.len == 0)
+                return error.FileNotFound;
+
+            const argv0 = mem.span(argv[0]);
             if (mem.indexOf(u8, argv0, "/") != null) {
                 // argv[0] is a path (relative or absolute): use realpath(3) directly
                 var real_path_buf: [max_path_bytes]u8 = undefined;
@@ -627,7 +631,7 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
                     var resolved_path_buf: [max_path_bytes - 1:0]u8 = undefined;
                     const resolved_path = std.fmt.bufPrintZ(&resolved_path_buf, "{s}/{s}", .{
                         a_path,
-                        std.os.argv[0],
+                        argv[0],
                     }) catch continue;
 
                     var real_path_buf: [max_path_bytes]u8 = undefined;

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -42,17 +42,15 @@ test {
 }
 
 /// See also `getenv`. Populated by startup code before main().
-/// TODO this is a footgun because the value will be undefined when using `zig build-lib`.
-/// https://github.com/ziglang/zig/issues/4524
-pub var environ: [][*:0]u8 = undefined;
+pub var environ: ?[][*:0]u8 = null;
 
 /// Populated by startup code before main().
 /// Not available on WASI or Windows without libc. See `std.process.argsAlloc`
 /// or `std.process.argsWithAllocator` for a cross-platform alternative.
-pub var argv: [][*:0]u8 = if (builtin.link_libc) undefined else switch (native_os) {
+pub var argv: ?[][*:0]u8 = if (builtin.link_libc) null else switch (native_os) {
     .windows => @compileError("argv isn't supported on Windows: use std.process.argsAlloc instead"),
     .wasi => @compileError("argv isn't supported on WASI: use std.process.argsAlloc instead"),
-    else => undefined,
+    else => null,
 };
 
 /// Call from Windows-specific code if you already have a WTF-16LE encoded, null terminated string.

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -2021,16 +2021,15 @@ pub fn getenv(key: []const u8) ?[:0]const u8 {
     if (native_os == .wasi) {
         @compileError("std.posix.getenv is unavailable for WASI. See std.process.getEnvMap or std.process.getEnvVarOwned for a cross-platform API.");
     }
-    // The simplified start logic doesn't populate environ.
-    if (std.start.simplified_logic) return null;
-    // TODO see https://github.com/ziglang/zig/issues/4524
-    for (std.os.environ) |ptr| {
-        var line_i: usize = 0;
-        while (ptr[line_i] != 0 and ptr[line_i] != '=') : (line_i += 1) {}
-        const this_key = ptr[0..line_i];
-        if (!mem.eql(u8, key, this_key)) continue;
+    if (std.os.environ) |environ| {
+        for (environ) |ptr| {
+            var line_i: usize = 0;
+            while (ptr[line_i] != 0 and ptr[line_i] != '=') : (line_i += 1) {}
+            const this_key = ptr[0..line_i];
+            if (!mem.eql(u8, key, this_key)) continue;
 
-        return mem.sliceTo(ptr + line_i + 1, 0);
+            return mem.sliceTo(ptr + line_i + 1, 0);
+        }
     }
     return null;
 }


### PR DESCRIPTION
This makes their status with respect to start code clear and also allows
alternative start code to set them up.

Fixes #23372
Affects #4524