### PR TITLE
:see_no_evil: Remove legacy `zig-cache` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,3 @@ zig-out/
 /build/
 /build-*/
 /docgen_tmp/
-
-# Although this was renamed to .zig-cache, let's leave it here for a few
-# releases to make it less annoying to work with multiple branches.
-zig-cache/


### PR DESCRIPTION
This was introduced in https://github.com/ziglang/zig/commit/b2588de6ccdfee87542e2bd18b74d3a14e349d95 and so released in 0.13 and in 0.14.