### PR TITLE
translate-c: correctly translate pointers to cv-qualified values

### DIFF
--- a/lib/compiler/aro_translate_c/ast.zig
+++ b/lib/compiler/aro_translate_c/ast.zig
@@ -192,6 +192,8 @@ pub const Node = extern union {
         array_type,
         null_sentinel_array_type,
 
+        /// @import("std").zig.c_translation.Volatile(operand)
+        helpers_volatile,
         /// @import("std").zig.c_translation.sizeof(operand)
         helpers_sizeof,
         /// @import("std").zig.c_translation.FlexibleArrayType(lhs, rhs)
@@ -286,6 +288,7 @@ pub const Node = extern union {
                 .const_cast,
                 .volatile_cast,
                 .vector_zero_init,
+                .helpers_volatile,
                 => Payload.UnOp,
 
                 .add,
@@ -934,6 +937,11 @@ fn renderNode(c: *Context, node: Node) Allocator.Error!NodeIndex {
             const payload = node.castTag(.helpers_shuffle_vector_index).?.data;
             const import_node = try renderStdImport(c, &.{ "zig", "c_translation", "shuffleVectorIndex" });
             return renderCall(c, import_node, &.{ payload.lhs, payload.rhs });
+        },
+        .helpers_volatile => {
+            const payload = node.castTag(.helpers_volatile).?.data;
+            const import_node = try renderStdImport(c, &.{ "zig", "c_translation", "Volatile" });
+            return renderCall(c, import_node, &.{payload});
         },
         .vector => {
             const payload = node.castTag(.vector).?.data;
@@ -2356,6 +2364,7 @@ fn renderNodeGrouped(c: *Context, node: Node) !NodeIndex {
         .helpers_promoteIntLiteral,
         .helpers_shuffle_vector_index,
         .helpers_flexible_array_type,
+        .helpers_volatile,
         .std_mem_zeroinit,
         .integer_literal,
         .float_literal,

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -366,6 +366,42 @@ test "Flexible Array Type" {
     try testing.expectEqual(FlexibleArrayType(*const volatile Container, c_int), [*c]const volatile c_int);
 }
 
+pub fn Volatile(comptime T: type) type {
+    return extern struct {
+        inner: T = std.mem.zeroes(T),
+
+        pub inline fn ptr(v: *volatile Volatile(T)) *volatile T {
+            return @ptrCast(v);
+        }
+
+        pub inline fn constPtr(v: *const volatile Volatile(T)) *const volatile T {
+            return @ptrCast(v);
+        }
+
+        pub inline fn load(v: *const volatile Volatile(T)) T {
+            return v.constPtr().*;
+        }
+
+        pub inline fn store(v: *volatile Volatile(T), value: T) void {
+            v.ptr().* = value;
+        }
+    };
+}
+
+test "Volatile" {
+    try testing.expectEqual(@sizeOf(Volatile(c_int)), @sizeOf(c_int));
+    try testing.expectEqual(@alignOf(Volatile(c_int)), @alignOf(c_int));
+
+    try testing.expectEqual(@sizeOf([7]Volatile(c_int)), @sizeOf([7]c_int));
+    try testing.expectEqual(@alignOf([7]Volatile(c_int)), @alignOf([7]c_int));
+
+    try testing.expectEqual(@sizeOf(Volatile(u32)), @sizeOf(u32));
+    try testing.expectEqual(@alignOf(Volatile(u32)), @alignOf(u32));
+
+    try testing.expectEqual(@sizeOf(Volatile(u64)), @sizeOf(u64));
+    try testing.expectEqual(@alignOf(Volatile(u64)), @alignOf(u64));
+}
+
 /// C `%` operator for signed integers
 /// C standard states: "If the quotient a/b is representable, the expression (a/b)*b + a%b shall equal a"
 /// The quotient is not representable if denominator is zero, or if numerator is the minimum integer for

--- a/src/clang.zig
+++ b/src/clang.zig
@@ -32,6 +32,9 @@ pub const QualType = extern struct {
     pub const isVolatileQualified = ZigClangQualType_isVolatileQualified;
     extern fn ZigClangQualType_isVolatileQualified(QualType) bool;
 
+    pub const isLocalVolatileQualified = ZigClangQualType_isLocalVolatileQualified;
+    extern fn ZigClangQualType_isLocalVolatileQualified(QualType) bool;
+
     pub const isRestrictQualified = ZigClangQualType_isRestrictQualified;
     extern fn ZigClangQualType_isRestrictQualified(QualType) bool;
 };

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -4485,6 +4485,11 @@ fn transQualType(c: *Context, scope: *Scope, qt: clang.QualType, source_loc: cla
             .Record,
             .Enum,
             => return try Tag.helpers_volatile.create(c.arena, node),
+            .Elaborated, .Typedef => {
+                if (qt.isLocalVolatileQualified()) {
+                    return try Tag.helpers_volatile.create(c.arena, node);
+                }
+            },
             else => {},
         }
     }

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2789,6 +2789,11 @@ bool ZigClangQualType_isVolatileQualified(ZigClangQualType self) {
     return qt.isVolatileQualified();
 }
 
+bool ZigClangQualType_isLocalVolatileQualified(ZigClangQualType self) {
+    clang::QualType qt = bitcast(self);
+    return qt.isLocalVolatileQualified();
+}
+
 bool ZigClangQualType_isRestrictQualified(ZigClangQualType self) {
     clang::QualType qt = bitcast(self);
     return qt.isRestrictQualified();

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -1479,6 +1479,7 @@ ZIG_EXTERN_C void ZigClangQualType_addConst(struct ZigClangQualType *);
 ZIG_EXTERN_C bool ZigClangQualType_eq(struct ZigClangQualType, struct ZigClangQualType);
 ZIG_EXTERN_C bool ZigClangQualType_isConstQualified(struct ZigClangQualType);
 ZIG_EXTERN_C bool ZigClangQualType_isVolatileQualified(struct ZigClangQualType);
+ZIG_EXTERN_C bool ZigClangQualType_isLocalVolatileQualified(struct ZigClangQualType);
 ZIG_EXTERN_C bool ZigClangQualType_isRestrictQualified(struct ZigClangQualType);
 
 ZIG_EXTERN_C enum ZigClangTypeClass ZigClangType_getTypeClass(const struct ZigClangType *self);

--- a/test/cases/translate_c/cv_qualified_value.c
+++ b/test/cases/translate_c/cv_qualified_value.c
@@ -15,6 +15,14 @@ extern hw_t hw_arr[4];
 extern const mmio_int reg;
 extern mmio_int *regs;
 
+// Check name mangling
+typedef volatile unsigned int mmio_uint;
+typedef unsigned int volatile_mmio_uint;
+static unsigned int check_typenames(void) {
+    const mmio_uint x = 0u;
+    return (volatile_mmio_uint)x;
+}
+
 static int hw_reg(void) {
     return hw->reg;
 }
@@ -54,42 +62,49 @@ static int ptr_arith(void) {
 // translate-c
 // c_frontend=clang
 //
-// pub const mmio_int = c_int;
-// pub const mmio_int_ptr = [*c]volatile mmio_int;
+// pub const volatile_mmio_int = c_int;
+// pub const mmio_int_ptr = [*c]volatile volatile_mmio_int;
 // pub const hw_t = extern struct {
-//     reg: mmio_int = @import("std").mem.zeroes(mmio_int),
-//     regs: [4]mmio_int = @import("std").mem.zeroes([4]mmio_int),
-//     regm: [2][2]mmio_int = @import("std").mem.zeroes([2][2]mmio_int),
+//     reg: volatile_mmio_int = @import("std").mem.zeroes(volatile_mmio_int),
+//     regs: [4]volatile_mmio_int = @import("std").mem.zeroes([4]volatile_mmio_int),
+//     regm: [2][2]volatile_mmio_int = @import("std").mem.zeroes([2][2]volatile_mmio_int),
 //     ptr: mmio_int_ptr = @import("std").mem.zeroes(mmio_int_ptr),
 // };
 // pub extern var hw: [*c]hw_t;
 // pub extern var hw_arr: [4]hw_t;
-// pub extern const reg: mmio_int;
-// pub extern var regs: [*c]volatile mmio_int;
-// pub fn hw_reg() callconv(.c) c_int {
-//     return @as([*c]volatile mmio_int, @ptrCast(&hw.*.reg)).*;
+// pub extern const reg: volatile_mmio_int;
+// pub extern var regs: [*c]volatile volatile_mmio_int;
+// pub const volatile_mmio_uint_1 = c_uint;
+// pub const volatile_mmio_uint = c_uint;
+// pub fn check_typenames() callconv(.c) c_uint {
+//     const x: volatile_mmio_uint_1 = 0;
+//     _ = &x;
+//     return @as(volatile_mmio_uint, @bitCast(x));
 // }
-// pub fn hw_reg_ptr() callconv(.c) @TypeOf(@as([*c]volatile mmio_int, @ptrCast(&@as([*c]volatile mmio_int, @ptrCast(&hw.*.reg)).*))) {
-//     return @as([*c]volatile mmio_int, @ptrCast(&@as([*c]volatile mmio_int, @ptrCast(&hw.*.reg)).*));
+// pub fn hw_reg() callconv(.c) c_int {
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.reg)).*;
+// }
+// pub fn hw_reg_ptr() callconv(.c) @TypeOf(@as([*c]volatile volatile_mmio_int, @ptrCast(&@as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.reg)).*))) {
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&@as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.reg)).*));
 // }
 // pub fn hw_ptr() callconv(.c) mmio_int_ptr {
 //     return hw.*.ptr;
 // }
-// pub fn reg_ptr() callconv(.c) @TypeOf(@as([*c]const volatile mmio_int, @ptrCast(&reg))) {
-//     return @as([*c]const volatile mmio_int, @ptrCast(&reg));
+// pub fn reg_ptr() callconv(.c) @TypeOf(@as([*c]const volatile volatile_mmio_int, @ptrCast(&reg))) {
+//     return @as([*c]const volatile volatile_mmio_int, @ptrCast(&reg));
 // }
 // pub fn hw_regs_0() callconv(.c) c_int {
-//     return @as([*c]volatile mmio_int, @ptrCast(&hw.*.regs[@as(c_uint, 0)])).*;
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.regs[@as(c_uint, 0)])).*;
 // }
 // pub fn hw_0_regs_0() callconv(.c) c_int {
-//     return @as([*c]volatile mmio_int, @ptrCast(&hw_arr[@as(c_uint, 0)].regs[@as(c_uint, 0)])).*;
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw_arr[@as(c_uint, 0)].regs[@as(c_uint, 0)])).*;
 // }
 // pub fn hw_regm_00() callconv(.c) c_int {
-//     return @as([*c]volatile mmio_int, @ptrCast(&hw.*.regm[@as(c_uint, 0)][@as(c_uint, 0)])).*;
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.regm[@as(c_uint, 0)][@as(c_uint, 0)])).*;
 // }
 // pub fn hw_regm_0_deref() callconv(.c) c_int {
-//     return @as([*c]volatile mmio_int, @ptrCast(@as([*c]volatile mmio_int, @ptrCast(@alignCast(&hw.*.regm[@as(c_uint, 0)]))))).*;
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(@as([*c]volatile volatile_mmio_int, @ptrCast(@alignCast(&hw.*.regm[@as(c_uint, 0)]))))).*;
 // }
 // pub fn ptr_arith() callconv(.c) c_int {
-//     return @as([*c]volatile mmio_int, @ptrCast(regs + @as(c_uint, 1))).*;
+//     return @as([*c]volatile volatile_mmio_int, @ptrCast(regs + @as(c_uint, 1))).*;
 // }

--- a/test/cases/translate_c/cv_qualified_value.c
+++ b/test/cases/translate_c/cv_qualified_value.c
@@ -6,7 +6,8 @@ typedef struct {
     mmio_int reg;
     mmio_int regs[4];
     mmio_int regm[2][2];
-    mmio_int_ptr ptr;
+    volatile int regx;
+    mmio_int_ptr reg_ptr;
 } hw_t;
 
 extern hw_t *hw;
@@ -15,15 +16,13 @@ extern hw_t hw_arr[4];
 extern const mmio_int reg;
 extern mmio_int *regs;
 
-// Check name mangling
-typedef volatile unsigned int mmio_uint;
-typedef unsigned int volatile_mmio_uint;
-static unsigned int check_typenames(void) {
-    const mmio_uint x = 0u;
-    return (volatile_mmio_uint)x;
-}
-
 static int hw_reg(void) {
+    const hw_t *chw = (const hw_t *)(0xd0000000);
+    (void) *(&chw->regx);
+    (void) chw->regx;
+    (void) *(&hw->reg);
+    hw->reg = 0;
+
     return hw->reg;
 }
 
@@ -32,7 +31,7 @@ static typeof(&hw->reg) hw_reg_ptr(void) {
 }
 
 static mmio_int_ptr hw_ptr(void) {
-    return hw->ptr;
+    return hw->reg_ptr;
 }
 
 static typeof(&reg) reg_ptr(void) {
@@ -62,49 +61,49 @@ static int ptr_arith(void) {
 // translate-c
 // c_frontend=clang
 //
-// pub const volatile_mmio_int = c_int;
-// pub const mmio_int_ptr = [*c]volatile volatile_mmio_int;
+// pub const mmio_int = @import("std").zig.c_translation.Volatile(c_int);
+// pub const mmio_int_ptr = [*c]volatile mmio_int;
 // pub const hw_t = extern struct {
-//     reg: volatile_mmio_int = @import("std").mem.zeroes(volatile_mmio_int),
-//     regs: [4]volatile_mmio_int = @import("std").mem.zeroes([4]volatile_mmio_int),
-//     regm: [2][2]volatile_mmio_int = @import("std").mem.zeroes([2][2]volatile_mmio_int),
-//     ptr: mmio_int_ptr = @import("std").mem.zeroes(mmio_int_ptr),
+//     reg: mmio_int = @import("std").mem.zeroes(mmio_int),
+//     regs: [4]mmio_int = @import("std").mem.zeroes([4]mmio_int),
+//     regm: [2][2]mmio_int = @import("std").mem.zeroes([2][2]mmio_int),
+//     regx: @import("std").zig.c_translation.Volatile(c_int) = @import("std").mem.zeroes(@import("std").zig.c_translation.Volatile(c_int)),
+//     reg_ptr: mmio_int_ptr = @import("std").mem.zeroes(mmio_int_ptr),
 // };
 // pub extern var hw: [*c]hw_t;
 // pub extern var hw_arr: [4]hw_t;
-// pub extern const reg: volatile_mmio_int;
-// pub extern var regs: [*c]volatile volatile_mmio_int;
-// pub const volatile_mmio_uint_1 = c_uint;
-// pub const volatile_mmio_uint = c_uint;
-// pub fn check_typenames() callconv(.c) c_uint {
-//     const x: volatile_mmio_uint_1 = 0;
-//     _ = &x;
-//     return @as(volatile_mmio_uint, @bitCast(x));
-// }
+// pub extern const reg: mmio_int;
+// pub extern var regs: [*c]volatile mmio_int;
 // pub fn hw_reg() callconv(.c) c_int {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.reg)).*;
+//     var chw: [*c]const hw_t = @as([*c]const hw_t, @ptrFromInt(@as(c_uint, 3489660928)));
+//     _ = &chw;
+//     _ = @as([*c]const volatile c_int, @ptrCast(@as([*c]const volatile c_int, @ptrCast(&chw.*.regx)))).*;
+//     _ = @as([*c]const volatile c_int, @ptrCast(&chw.*.regx)).*;
+//     _ = @as([*c]volatile mmio_int, @ptrCast(@as([*c]volatile mmio_int, @ptrCast(hw.*.reg.ptr())))).*;
+//     hw.*.reg.ptr().* = 0;
+//     return hw.*.reg.ptr().*;
 // }
-// pub fn hw_reg_ptr() callconv(.c) @TypeOf(@as([*c]volatile volatile_mmio_int, @ptrCast(&@as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.reg)).*))) {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&@as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.reg)).*));
+// pub fn hw_reg_ptr() callconv(.c) @TypeOf(@as([*c]volatile mmio_int, @ptrCast(hw.*.reg.ptr()))) {
+//     return @as([*c]volatile mmio_int, @ptrCast(hw.*.reg.ptr()));
 // }
 // pub fn hw_ptr() callconv(.c) mmio_int_ptr {
-//     return hw.*.ptr;
+//     return hw.*.reg_ptr;
 // }
-// pub fn reg_ptr() callconv(.c) @TypeOf(@as([*c]const volatile volatile_mmio_int, @ptrCast(&reg))) {
-//     return @as([*c]const volatile volatile_mmio_int, @ptrCast(&reg));
+// pub fn reg_ptr() callconv(.c) @TypeOf(reg.constPtr()) {
+//     return reg.constPtr();
 // }
 // pub fn hw_regs_0() callconv(.c) c_int {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.regs[@as(c_uint, 0)])).*;
+//     return hw.*.regs[@as(c_uint, 0)].ptr().*;
 // }
 // pub fn hw_0_regs_0() callconv(.c) c_int {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw_arr[@as(c_uint, 0)].regs[@as(c_uint, 0)])).*;
+//     return hw_arr[@as(c_uint, 0)].regs[@as(c_uint, 0)].ptr().*;
 // }
 // pub fn hw_regm_00() callconv(.c) c_int {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(&hw.*.regm[@as(c_uint, 0)][@as(c_uint, 0)])).*;
+//     return hw.*.regm[@as(c_uint, 0)][@as(c_uint, 0)].ptr().*;
 // }
 // pub fn hw_regm_0_deref() callconv(.c) c_int {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(@as([*c]volatile volatile_mmio_int, @ptrCast(@alignCast(&hw.*.regm[@as(c_uint, 0)]))))).*;
+//     return @as([*c]volatile mmio_int, @ptrCast(@as([*c]volatile mmio_int, @ptrCast(@alignCast(&hw.*.regm[@as(c_uint, 0)]))))).*;
 // }
 // pub fn ptr_arith() callconv(.c) c_int {
-//     return @as([*c]volatile volatile_mmio_int, @ptrCast(regs + @as(c_uint, 1))).*;
+//     return @as([*c]volatile mmio_int, @ptrCast(regs + @as(c_uint, 1))).*;
 // }

--- a/test/cases/translate_c/cv_qualified_value.c
+++ b/test/cases/translate_c/cv_qualified_value.c
@@ -1,9 +1,12 @@
-typedef volatile int mmio_int;
+typedef unsigned int uint;
 
+typedef volatile int mmio_int;
+typedef volatile uint mmio_uint;
 typedef mmio_int *mmio_int_ptr;
 
 typedef struct {
     mmio_int reg;
+    mmio_uint regu;
     mmio_int regs[4];
     mmio_int regm[2][2];
     volatile int regx;
@@ -22,6 +25,9 @@ static int hw_reg(void) {
     (void) chw->regx;
     (void) *(&hw->reg);
     hw->reg = 0;
+
+    (void) hw->regu;
+    hw->regu = 0;
 
     return hw->reg;
 }
@@ -61,10 +67,13 @@ static int ptr_arith(void) {
 // translate-c
 // c_frontend=clang
 //
+// pub const uint = c_uint;
 // pub const mmio_int = @import("std").zig.c_translation.Volatile(c_int);
+// pub const mmio_uint = @import("std").zig.c_translation.Volatile(uint);
 // pub const mmio_int_ptr = [*c]volatile mmio_int;
 // pub const hw_t = extern struct {
 //     reg: mmio_int = @import("std").mem.zeroes(mmio_int),
+//     regu: mmio_uint = @import("std").mem.zeroes(mmio_uint),
 //     regs: [4]mmio_int = @import("std").mem.zeroes([4]mmio_int),
 //     regm: [2][2]mmio_int = @import("std").mem.zeroes([2][2]mmio_int),
 //     regx: @import("std").zig.c_translation.Volatile(c_int) = @import("std").mem.zeroes(@import("std").zig.c_translation.Volatile(c_int)),
@@ -81,6 +90,8 @@ static int ptr_arith(void) {
 //     _ = @as([*c]const volatile c_int, @ptrCast(&chw.*.regx)).*;
 //     _ = @as([*c]volatile mmio_int, @ptrCast(@as([*c]volatile mmio_int, @ptrCast(hw.*.reg.ptr())))).*;
 //     hw.*.reg.ptr().* = 0;
+//     _ = hw.*.regu.ptr().*;
+//     hw.*.regu.ptr().* = 0;
 //     return hw.*.reg.ptr().*;
 // }
 // pub fn hw_reg_ptr() callconv(.c) @TypeOf(@as([*c]volatile mmio_int, @ptrCast(hw.*.reg.ptr()))) {

--- a/test/cases/translate_c/cv_qualified_value.c
+++ b/test/cases/translate_c/cv_qualified_value.c
@@ -1,0 +1,95 @@
+typedef volatile int mmio_int;
+
+typedef mmio_int *mmio_int_ptr;
+
+typedef struct {
+    mmio_int reg;
+    mmio_int regs[4];
+    mmio_int regm[2][2];
+    mmio_int_ptr ptr;
+} hw_t;
+
+extern hw_t *hw;
+extern hw_t hw_arr[4];
+
+extern const mmio_int reg;
+extern mmio_int *regs;
+
+static int hw_reg(void) {
+    return hw->reg;
+}
+
+static typeof(&hw->reg) hw_reg_ptr(void) {
+    return &hw->reg;
+}
+
+static mmio_int_ptr hw_ptr(void) {
+    return hw->ptr;
+}
+
+static typeof(&reg) reg_ptr(void) {
+    return &reg;
+}
+
+static int hw_regs_0(void) {
+    return hw->regs[0u];
+}
+
+static int hw_0_regs_0(void) {
+    return hw_arr[0u].regs[0u];
+}
+
+static int hw_regm_00(void) {
+    return hw->regm[0u][0u];
+}
+
+static int hw_regm_0_deref(void) {
+    return *(hw->regm[0u]);
+}
+
+static int ptr_arith(void) {
+    return *(regs+1u);
+}
+
+// translate-c
+// c_frontend=clang
+//
+// pub const mmio_int = c_int;
+// pub const mmio_int_ptr = [*c]volatile mmio_int;
+// pub const hw_t = extern struct {
+//     reg: mmio_int = @import("std").mem.zeroes(mmio_int),
+//     regs: [4]mmio_int = @import("std").mem.zeroes([4]mmio_int),
+//     regm: [2][2]mmio_int = @import("std").mem.zeroes([2][2]mmio_int),
+//     ptr: mmio_int_ptr = @import("std").mem.zeroes(mmio_int_ptr),
+// };
+// pub extern var hw: [*c]hw_t;
+// pub extern var hw_arr: [4]hw_t;
+// pub extern const reg: mmio_int;
+// pub extern var regs: [*c]volatile mmio_int;
+// pub fn hw_reg() callconv(.c) c_int {
+//     return @as([*c]volatile mmio_int, @ptrCast(&hw.*.reg)).*;
+// }
+// pub fn hw_reg_ptr() callconv(.c) @TypeOf(@as([*c]volatile mmio_int, @ptrCast(&@as([*c]volatile mmio_int, @ptrCast(&hw.*.reg)).*))) {
+//     return @as([*c]volatile mmio_int, @ptrCast(&@as([*c]volatile mmio_int, @ptrCast(&hw.*.reg)).*));
+// }
+// pub fn hw_ptr() callconv(.c) mmio_int_ptr {
+//     return hw.*.ptr;
+// }
+// pub fn reg_ptr() callconv(.c) @TypeOf(@as([*c]const volatile mmio_int, @ptrCast(&reg))) {
+//     return @as([*c]const volatile mmio_int, @ptrCast(&reg));
+// }
+// pub fn hw_regs_0() callconv(.c) c_int {
+//     return @as([*c]volatile mmio_int, @ptrCast(&hw.*.regs[@as(c_uint, 0)])).*;
+// }
+// pub fn hw_0_regs_0() callconv(.c) c_int {
+//     return @as([*c]volatile mmio_int, @ptrCast(&hw_arr[@as(c_uint, 0)].regs[@as(c_uint, 0)])).*;
+// }
+// pub fn hw_regm_00() callconv(.c) c_int {
+//     return @as([*c]volatile mmio_int, @ptrCast(&hw.*.regm[@as(c_uint, 0)][@as(c_uint, 0)])).*;
+// }
+// pub fn hw_regm_0_deref() callconv(.c) c_int {
+//     return @as([*c]volatile mmio_int, @ptrCast(@as([*c]volatile mmio_int, @ptrCast(@alignCast(&hw.*.regm[@as(c_uint, 0)]))))).*;
+// }
+// pub fn ptr_arith() callconv(.c) c_int {
+//     return @as([*c]volatile mmio_int, @ptrCast(regs + @as(c_uint, 1))).*;
+// }


### PR DESCRIPTION
Fix #23329.

TLDR: const/volatile-qualified value-types (non-pointer types) in C are not always correctly translated when pointers to such types are taken.

For example, the following C code is mistranslated:
```c
typedef struct {
    volatile int reg;
} hw_t;
extern hw_t *hw;
// ...
const int data = hw->reg; // volatile read, equivalent to *(&hw->reg)
const typeof(&hw->reg) data2 = &hw->reg; // volatile pointer
```
The penultimate line will not be a volatile load, because the type of `reg` in the translated zig code is just a bare `int`. The last line will generate a regular non-volatile `int` pointer for the same reason.

<br/>

Fixed by explicitly casting pointers to the correct qualified types whenever the qualifiers can legally appear in zig, i.e. when taking the address of a cv-qualified value and right before dereferencing pointers thereto. ~Additionally, typedefs for volatile-qualified value-types are annotated by prefixing the typename with `volatile_`~. Volatile-qualified value-types are converted to a helper type `std.zig.c_translation.Volatile(T)`.

---

### TODO
- [ ] Remove/handle all my `todo` comments when associated notes/questions are resolved
- [ ] ~Add doc comments for `restoreValueQualifiersValue`/`restoreValueQualifiersPtr`~
- [ ] Possibly wait for #23384 and rebase when/if merged because it seems the changes in that PR deal with pointer type decay which might need updating to handle qualifiers
- [ ] Squash commits for clean history
- [ ] Fix implicit rvalue conversions which translate to volatile loads and the result type is the unqualified inner type
- [ ] Look into ABI mismatches for structs vs primitive types
    - [ ] Possibly fix by not translating function parameter types to `Volatile(T)` and bitcast/ptrcast when such types are passed to func params

