### PR TITLE
greatly improve capabilities of the fuzzer

### DIFF
--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const io = std.io;
 const testing = std.testing;
 const assert = std.debug.assert;
+const fuzz_abi = std.Build.Fuzz.abi;
 
 pub const std_options: std.Options = .{
     .logFn = log,
@@ -36,7 +37,6 @@ pub fn main() void {
 
     var listen = false;
     var opt_cache_dir: ?[]const u8 = null;
-
     for (args[1..]) |arg| {
         if (std.mem.eql(u8, arg, "--listen=-")) {
             listen = true;
@@ -53,7 +53,7 @@ pub fn main() void {
     fba.reset();
     if (builtin.fuzz) {
         const cache_dir = opt_cache_dir orelse @panic("missing --cache-dir=[path] argument");
-        fuzzer_init(FuzzerSlice.fromSlice(cache_dir));
+        fuzzer_init(.fromSlice(cache_dir));
     }
 
     if (listen) {
@@ -148,14 +148,19 @@ fn mainServer() !void {
                 });
             },
             .start_fuzzing => {
+                // This ensures that this code won't be analyzed and hence reference fuzzer symbols
+                // since they are not present.
                 if (!builtin.fuzz) unreachable;
+
                 const index = try server.receiveBody_u32();
                 const test_fn = builtin.test_functions[index];
                 const entry_addr = @intFromPtr(test_fn.func);
+
                 try server.serveU64Message(.fuzz_start_addr, entry_addr);
                 defer if (testing.allocator_instance.deinit() == .leak) std.process.exit(1);
                 is_fuzz_test = false;
-                fuzzer_set_name(test_fn.name.ptr, test_fn.name.len);
+                fuzz_test_index = index;
+
                 test_fn.func() catch |err| switch (err) {
                     error.SkipZigTest => return,
                     else => {
@@ -180,6 +185,8 @@ fn mainServer() !void {
 
 fn mainTerminal() void {
     @disableInstrumentation();
+    if (builtin.fuzz) @panic("fuzz test requires server");
+
     const test_fn_list = builtin.test_functions;
     var ok_count: usize = 0;
     var skip_count: usize = 0;
@@ -330,28 +337,15 @@ pub fn mainSimple() anyerror!void {
     if (failed != 0) std.process.exit(1);
 }
 
-const FuzzerSlice = extern struct {
-    ptr: [*]const u8,
-    len: usize,
-
-    /// Inline to avoid fuzzer instrumentation.
-    inline fn toSlice(s: FuzzerSlice) []const u8 {
-        return s.ptr[0..s.len];
-    }
-
-    /// Inline to avoid fuzzer instrumentation.
-    inline fn fromSlice(s: []const u8) FuzzerSlice {
-        return .{ .ptr = s.ptr, .len = s.len };
-    }
-};
-
 var is_fuzz_test: bool = undefined;
+var fuzz_test_index: u32 = undefined;
 
-extern fn fuzzer_set_name(name_ptr: [*]const u8, name_len: usize) void;
-extern fn fuzzer_init(cache_dir: FuzzerSlice) void;
-extern fn fuzzer_init_corpus_elem(input_ptr: [*]const u8, input_len: usize) void;
-extern fn fuzzer_start(testOne: *const fn ([*]const u8, usize) callconv(.c) void) void;
+extern fn fuzzer_init(cache_dir_path: fuzz_abi.Slice) void;
 extern fn fuzzer_coverage_id() u64;
+const FuzzerTestOne = *const fn (fuzz_abi.Slice) callconv(.c) void;
+extern fn fuzzer_init_test(test_one: FuzzerTestOne, unit_test_name: fuzz_abi.Slice) void;
+extern fn fuzzer_new_input(bytes: fuzz_abi.Slice) void;
+extern fn fuzzer_main() void;
 
 pub fn fuzz(
     context: anytype,
@@ -382,12 +376,12 @@ pub fn fuzz(
     const global = struct {
         var ctx: @TypeOf(context) = undefined;
 
-        fn fuzzer_one(input_ptr: [*]const u8, input_len: usize) callconv(.c) void {
+        fn test_one(input: fuzz_abi.Slice) callconv(.c) void {
             @disableInstrumentation();
             testing.allocator_instance = .{};
             defer if (testing.allocator_instance.deinit() == .leak) std.process.exit(1);
             log_err_count = 0;
-            testOne(ctx, input_ptr[0..input_len]) catch |err| switch (err) {
+            testOne(ctx, input.toSlice()) catch |err| switch (err) {
                 error.SkipZigTest => return,
                 else => {
                     std.debug.lockStdErr();
@@ -408,10 +402,10 @@ pub fn fuzz(
         testing.allocator_instance = .{};
         defer testing.allocator_instance = prev_allocator_state;
 
-        for (options.corpus) |elem| fuzzer_init_corpus_elem(elem.ptr, elem.len);
-
+        fuzzer_init_test(&global.test_one, .fromSlice(builtin.test_functions[fuzz_test_index].name));
+        for (options.corpus) |elem| fuzzer_new_input(.fromSlice(elem));
         global.ctx = context;
-        fuzzer_start(&global.fuzzer_one);
+        fuzzer_main();
         return;
     }
 

--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -1,15 +1,17 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const Allocator = std.mem.Allocator;
+const mem = std.mem;
+const math = std.math;
+const Allocator = mem.Allocator;
 const assert = std.debug.assert;
 const fatal = std.process.fatal;
-const SeenPcsHeader = std.Build.Fuzz.abi.SeenPcsHeader;
+const abi = std.Build.Fuzz.abi;
+const native_endian = builtin.cpu.arch.endian();
 
 pub const std_options = std.Options{
     .logFn = logOverride,
+    .log_level = if (builtin.mode == .Debug) .debug else .info,
 };
-
-var log_file: ?std.fs.File = null;
 
 fn logOverride(
     comptime level: std.log.Level,
@@ -17,497 +19,1357 @@ fn logOverride(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    const f = if (log_file) |f| f else f: {
-        const f = fuzzer.cache_dir.createFile("tmp/libfuzzer.log", .{}) catch
-            @panic("failed to open fuzzer log file");
-        log_file = f;
-        break :f f;
-    };
+    const log_file = exec.cache_tmp.createFile("libfuzzer.log", .{
+        .truncate = false,
+        .lock = .exclusive,
+    }) catch |e|
+        std.debug.panic("failed to open fuzzer log file 'libfuzzer.log': {s}", .{@errorName(e)});
+    defer log_file.close();
+    log_file.seekFromEnd(0) catch |e|
+        std.debug.panic("failed to seek fuzzer log file 'libfuzzer.log': {s}", .{@errorName(e)});
+
     const prefix1 = comptime level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
-    f.writer().print(prefix1 ++ prefix2 ++ format ++ "\n", args) catch @panic("failed to write to fuzzer log");
-}
-
-/// Helps determine run uniqueness in the face of recursion.
-export threadlocal var __sancov_lowest_stack: usize = 0;
-
-export fn __sanitizer_cov_trace_const_cmp1(arg1: u8, arg2: u8) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_cmp1(arg1: u8, arg2: u8) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_const_cmp2(arg1: u16, arg2: u16) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_cmp2(arg1: u16, arg2: u16) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_const_cmp4(arg1: u32, arg2: u32) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_cmp4(arg1: u32, arg2: u32) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_const_cmp8(arg1: u64, arg2: u64) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_cmp8(arg1: u64, arg2: u64) void {
-    handleCmp(@returnAddress(), arg1, arg2);
-}
-
-export fn __sanitizer_cov_trace_switch(val: u64, cases_ptr: [*]u64) void {
-    const pc = @returnAddress();
-    const len = cases_ptr[0];
-    const val_size_in_bits = cases_ptr[1];
-    const cases = cases_ptr[2..][0..len];
-    fuzzer.traceValue(pc ^ val);
-    _ = val_size_in_bits;
-    _ = cases;
-    //std.log.debug("0x{x}: switch on value {d} ({d} bits) with {d} cases", .{
-    //    pc, val, val_size_in_bits, cases.len,
-    //});
-}
-
-export fn __sanitizer_cov_trace_pc_indir(callee: usize) void {
-    // Not valuable because we already have pc tracing via 8bit counters.
-    _ = callee;
-    //const pc = @returnAddress();
-    //fuzzer.traceValue(pc ^ callee);
-    //std.log.debug("0x{x}: indirect call to 0x{x}", .{ pc, callee });
-}
-export fn __sanitizer_cov_8bit_counters_init(start: usize, end: usize) void {
-    // clang will emit a call to this function when compiling with code coverage instrumentation.
-    // however fuzzer_init() does not need this information, since it directly reads from the symbol table.
-    _ = start;
-    _ = end;
-}
-export fn __sanitizer_cov_pcs_init(start: usize, end: usize) void {
-    // clang will emit a call to this function when compiling with code coverage instrumentation.
-    // however fuzzer_init() does not need this information, since it directly reads from the symbol table.
-    _ = start;
-    _ = end;
-}
-
-fn handleCmp(pc: usize, arg1: u64, arg2: u64) void {
-    fuzzer.traceValue(pc ^ arg1 ^ arg2);
-    //std.log.debug("0x{x}: comparison of {d} and {d}", .{ pc, arg1, arg2 });
-}
-
-const Fuzzer = struct {
-    rng: std.Random.DefaultPrng,
-    pcs: []const usize,
-    pc_counters: []u8,
-    n_runs: usize,
-    traced_comparisons: std.AutoArrayHashMapUnmanaged(usize, void),
-    /// Tracks which PCs have been seen across all runs that do not crash the fuzzer process.
-    /// Stored in a memory-mapped file so that it can be shared with other
-    /// processes and viewed while the fuzzer is running.
-    seen_pcs: MemoryMappedList,
-    cache_dir: std.fs.Dir,
-    /// Identifies the file name that will be used to store coverage
-    /// information, available to other processes.
-    coverage_id: u64,
-    unit_test_name: []const u8,
-
-    /// The index corresponds to the file name within the f/ subdirectory.
-    /// The string is the input.
-    /// This data is read-only; it caches what is on the filesystem.
-    corpus: std.ArrayListUnmanaged(Input),
-    corpus_directory: std.Build.Cache.Directory,
-
-    /// The next input that will be given to the testOne function. When the
-    /// current process crashes, this memory-mapped file is used to recover the
-    /// input.
-    ///
-    /// The file size corresponds to the capacity. The length is not stored
-    /// and that is the next thing to work on!
-    input: MemoryMappedList,
-
-    const Input = struct {
-        bytes: []u8,
-        last_traced_comparison: usize,
-    };
-
-    const Slice = extern struct {
-        ptr: [*]const u8,
-        len: usize,
-
-        fn toZig(s: Slice) []const u8 {
-            return s.ptr[0..s.len];
-        }
-
-        fn fromZig(s: []const u8) Slice {
-            return .{
-                .ptr = s.ptr,
-                .len = s.len,
-            };
-        }
-    };
-
-    fn init(f: *Fuzzer, cache_dir: std.fs.Dir, pc_counters: []u8, pcs: []const usize) !void {
-        f.cache_dir = cache_dir;
-        f.pc_counters = pc_counters;
-        f.pcs = pcs;
-
-        // Choose a file name for the coverage based on a hash of the PCs that will be stored within.
-        const pc_digest = std.hash.Wyhash.hash(0, std.mem.sliceAsBytes(pcs));
-        f.coverage_id = pc_digest;
-        const hex_digest = std.fmt.hex(pc_digest);
-        const coverage_file_path = "v/" ++ hex_digest;
-
-        // Layout of this file:
-        // - Header
-        // - list of PC addresses (usize elements)
-        // - list of hit flag, 1 bit per address (stored in u8 elements)
-        const coverage_file = createFileBail(cache_dir, coverage_file_path, .{
-            .read = true,
-            .truncate = false,
-        });
-        const n_bitset_elems = (pcs.len + @bitSizeOf(usize) - 1) / @bitSizeOf(usize);
-        comptime assert(SeenPcsHeader.trailing[0] == .pc_bits_usize);
-        comptime assert(SeenPcsHeader.trailing[1] == .pc_addr);
-        const bytes_len = @sizeOf(SeenPcsHeader) +
-            n_bitset_elems * @sizeOf(usize) +
-            pcs.len * @sizeOf(usize);
-        const existing_len = coverage_file.getEndPos() catch |err| {
-            fatal("unable to check len of coverage file: {s}", .{@errorName(err)});
-        };
-        if (existing_len == 0) {
-            coverage_file.setEndPos(bytes_len) catch |err| {
-                fatal("unable to set len of coverage file: {s}", .{@errorName(err)});
-            };
-        } else if (existing_len != bytes_len) {
-            fatal("incompatible existing coverage file (differing lengths)", .{});
-        }
-        f.seen_pcs = MemoryMappedList.init(coverage_file, existing_len, bytes_len) catch |err| {
-            fatal("unable to init coverage memory map: {s}", .{@errorName(err)});
-        };
-        if (existing_len != 0) {
-            const existing_pcs_bytes = f.seen_pcs.items[@sizeOf(SeenPcsHeader) + @sizeOf(usize) * n_bitset_elems ..][0 .. pcs.len * @sizeOf(usize)];
-            const existing_pcs = std.mem.bytesAsSlice(usize, existing_pcs_bytes);
-            for (existing_pcs, pcs, 0..) |old, new, i| {
-                if (old != new) {
-                    fatal("incompatible existing coverage file (differing PC at index {d}: {x} != {x})", .{
-                        i, old, new,
-                    });
-                }
-            }
-        } else {
-            const header: SeenPcsHeader = .{
-                .n_runs = 0,
-                .unique_runs = 0,
-                .pcs_len = pcs.len,
-            };
-            f.seen_pcs.appendSliceAssumeCapacity(std.mem.asBytes(&header));
-            f.seen_pcs.appendNTimesAssumeCapacity(0, n_bitset_elems * @sizeOf(usize));
-            f.seen_pcs.appendSliceAssumeCapacity(std.mem.sliceAsBytes(pcs));
-        }
-    }
-
-    fn initNextInput(f: *Fuzzer) void {
-        while (true) {
-            const i = f.corpus.items.len;
-            var buf: [30]u8 = undefined;
-            const input_sub_path = std.fmt.bufPrint(&buf, "{d}", .{i}) catch unreachable;
-            const input = f.corpus_directory.handle.readFileAlloc(gpa, input_sub_path, 1 << 31) catch |err| switch (err) {
-                error.FileNotFound => {
-                    // Make this one the next input.
-                    const input_file = f.corpus_directory.handle.createFile(input_sub_path, .{
-                        .exclusive = true,
-                        .truncate = false,
-                        .read = true,
-                    }) catch |e| switch (e) {
-                        error.PathAlreadyExists => continue,
-                        else => fatal("unable to create '{}{d}: {s}", .{ f.corpus_directory, i, @errorName(err) }),
-                    };
-                    errdefer input_file.close();
-                    // Initialize the mmap for the current input.
-                    f.input = MemoryMappedList.create(input_file, 0, std.heap.page_size_max) catch |e| {
-                        fatal("unable to init memory map for input at '{}{d}': {s}", .{
-                            f.corpus_directory, i, @errorName(e),
-                        });
-                    };
-                    break;
-                },
-                else => fatal("unable to read '{}{d}': {s}", .{ f.corpus_directory, i, @errorName(err) }),
-            };
-            errdefer gpa.free(input);
-            f.corpus.append(gpa, .{
-                .bytes = input,
-                .last_traced_comparison = 0,
-            }) catch |err| oom(err);
-        }
-    }
-
-    fn addCorpusElem(f: *Fuzzer, input: []const u8) !void {
-        try f.corpus.append(gpa, .{
-            .bytes = try gpa.dupe(u8, input),
-            .last_traced_comparison = 0,
-        });
-    }
-
-    fn start(f: *Fuzzer) !void {
-        const rng = fuzzer.rng.random();
-
-        // Grab the corpus which is namespaced based on `unit_test_name`.
-        {
-            if (f.unit_test_name.len == 0) fatal("test runner never set unit test name", .{});
-            const sub_path = try std.fmt.allocPrint(gpa, "f/{s}", .{f.unit_test_name});
-            f.corpus_directory = .{
-                .handle = f.cache_dir.makeOpenPath(sub_path, .{}) catch |err|
-                    fatal("unable to open corpus directory 'f/{s}': {s}", .{ sub_path, @errorName(err) }),
-                .path = sub_path,
-            };
-            initNextInput(f);
-        }
-
-        assert(f.n_runs == 0);
-
-        // If the corpus is empty, synthesize one input.
-        if (f.corpus.items.len == 0) {
-            const len = rng.uintLessThanBiased(usize, 200);
-            const slice = try gpa.alloc(u8, len);
-            rng.bytes(slice);
-            f.input.appendSliceAssumeCapacity(slice);
-            try f.corpus.append(gpa, .{
-                .bytes = slice,
-                .last_traced_comparison = 0,
-            });
-            runOne(f, 0);
-        }
-
-        while (true) {
-            const chosen_index = rng.uintLessThanBiased(usize, f.corpus.items.len);
-            const modification = rng.enumValue(Mutation);
-            f.mutateAndRunOne(chosen_index, modification);
-        }
-    }
-
-    /// `x` represents a possible branch. It is the PC address of the possible
-    /// branch site, hashed together with the value(s) used that determine to
-    /// where it branches.
-    fn traceValue(f: *Fuzzer, x: usize) void {
-        errdefer |err| oom(err);
-        try f.traced_comparisons.put(gpa, x, {});
-    }
-
-    const Mutation = enum {
-        remove_byte,
-        modify_byte,
-        add_byte,
-    };
-
-    fn mutateAndRunOne(f: *Fuzzer, corpus_index: usize, mutation: Mutation) void {
-        const rng = fuzzer.rng.random();
-        f.input.clearRetainingCapacity();
-        const old_input = f.corpus.items[corpus_index].bytes;
-        f.input.ensureTotalCapacity(old_input.len + 1) catch @panic("mmap file resize failed");
-        switch (mutation) {
-            .remove_byte => {
-                const omitted_index = rng.uintLessThanBiased(usize, old_input.len);
-                f.input.appendSliceAssumeCapacity(old_input[0..omitted_index]);
-                f.input.appendSliceAssumeCapacity(old_input[omitted_index + 1 ..]);
-            },
-            .modify_byte => {
-                const modified_index = rng.uintLessThanBiased(usize, old_input.len);
-                f.input.appendSliceAssumeCapacity(old_input);
-                f.input.items[modified_index] = rng.int(u8);
-            },
-            .add_byte => {
-                const modified_index = rng.uintLessThanBiased(usize, old_input.len);
-                f.input.appendSliceAssumeCapacity(old_input[0..modified_index]);
-                f.input.appendAssumeCapacity(rng.int(u8));
-                f.input.appendSliceAssumeCapacity(old_input[modified_index..]);
-            },
-        }
-        runOne(f, corpus_index);
-    }
-
-    fn runOne(f: *Fuzzer, corpus_index: usize) void {
-        const header: *volatile SeenPcsHeader = @ptrCast(f.seen_pcs.items[0..@sizeOf(SeenPcsHeader)]);
-
-        f.traced_comparisons.clearRetainingCapacity();
-        @memset(f.pc_counters, 0);
-        __sancov_lowest_stack = std.math.maxInt(usize);
-
-        fuzzer_one(@volatileCast(f.input.items.ptr), f.input.items.len);
-
-        f.n_runs += 1;
-        _ = @atomicRmw(usize, &header.n_runs, .Add, 1, .monotonic);
-
-        // Track code coverage from all runs.
-        comptime assert(SeenPcsHeader.trailing[0] == .pc_bits_usize);
-        const header_end_ptr: [*]volatile usize = @ptrCast(f.seen_pcs.items[@sizeOf(SeenPcsHeader)..]);
-        const remainder = f.pcs.len % @bitSizeOf(usize);
-        const aligned_len = f.pcs.len - remainder;
-        const seen_pcs = header_end_ptr[0..aligned_len];
-        const pc_counters = std.mem.bytesAsSlice([@bitSizeOf(usize)]u8, f.pc_counters[0..aligned_len]);
-        const V = @Vector(@bitSizeOf(usize), u8);
-        const zero_v: V = @splat(0);
-        var fresh = false;
-        var superset = true;
-
-        for (header_end_ptr[0..pc_counters.len], pc_counters) |*elem, *array| {
-            const v: V = array.*;
-            const mask: usize = @bitCast(v != zero_v);
-            const prev = @atomicRmw(usize, elem, .Or, mask, .monotonic);
-            fresh = fresh or (prev | mask) != prev;
-            superset = superset and (prev | mask) != mask;
-        }
-        if (remainder > 0) {
-            const i = pc_counters.len;
-            const elem = &seen_pcs[i];
-            var mask: usize = 0;
-            for (f.pc_counters[i * @bitSizeOf(usize) ..][0..remainder], 0..) |byte, bit_index| {
-                mask |= @as(usize, @intFromBool(byte != 0)) << @intCast(bit_index);
-            }
-            const prev = @atomicRmw(usize, elem, .Or, mask, .monotonic);
-            fresh = fresh or (prev | mask) != prev;
-            superset = superset and (prev | mask) != mask;
-        }
-
-        // First check if this is a better version of an already existing
-        // input, replacing that input.
-        if (superset or f.traced_comparisons.entries.len >= f.corpus.items[corpus_index].last_traced_comparison) {
-            const new_input = gpa.realloc(f.corpus.items[corpus_index].bytes, f.input.items.len) catch |err| oom(err);
-            f.corpus.items[corpus_index] = .{
-                .bytes = new_input,
-                .last_traced_comparison = f.traced_comparisons.count(),
-            };
-            @memcpy(new_input, @volatileCast(f.input.items));
-            _ = @atomicRmw(usize, &header.unique_runs, .Add, 1, .monotonic);
-            return;
-        }
-
-        if (!fresh) return;
-
-        // Input is already committed to the file system, we just need to open a new file
-        // for the next input.
-        // Pre-add it to the corpus list so that it does not get redundantly picked up.
-        f.corpus.append(gpa, .{
-            .bytes = gpa.dupe(u8, @volatileCast(f.input.items)) catch |err| oom(err),
-            .last_traced_comparison = f.traced_comparisons.entries.len,
-        }) catch |err| oom(err);
-        f.input.deinit();
-        initNextInput(f);
-
-        // TODO: also mark input as "hot" so it gets prioritized for checking mutations above others.
-
-        _ = @atomicRmw(usize, &header.unique_runs, .Add, 1, .monotonic);
-    }
-};
-
-fn createFileBail(dir: std.fs.Dir, sub_path: []const u8, flags: std.fs.File.CreateFlags) std.fs.File {
-    return dir.createFile(sub_path, flags) catch |err| switch (err) {
-        error.FileNotFound => {
-            const dir_name = std.fs.path.dirname(sub_path).?;
-            dir.makePath(dir_name) catch |e| {
-                fatal("unable to make path '{s}': {s}", .{ dir_name, @errorName(e) });
-            };
-            return dir.createFile(sub_path, flags) catch |e| {
-                fatal("unable to create file '{s}': {s}", .{ sub_path, @errorName(e) });
-            };
-        },
-        else => fatal("unable to create file '{s}': {s}", .{ sub_path, @errorName(err) }),
-    };
-}
-
-fn oom(err: anytype) noreturn {
-    switch (err) {
-        error.OutOfMemory => @panic("out of memory"),
-    }
+    log_file.writer().print(
+        "[{?s}] " ++ prefix1 ++ prefix2 ++ format ++ "\n",
+        .{current_test_name} ++ args,
+    ) catch |e|
+        std.debug.panic("failed to write to fuzzer log file 'libfuzzer.log': {s}", .{@errorName(e)});
 }
 
 var debug_allocator: std.heap.GeneralPurposeAllocator(.{}) = .init;
-
 const gpa = switch (builtin.mode) {
     .Debug => debug_allocator.allocator(),
     .ReleaseFast, .ReleaseSmall, .ReleaseSafe => std.heap.smp_allocator,
 };
 
-var fuzzer: Fuzzer = .{
-    .rng = std.Random.DefaultPrng.init(0),
-    .input = undefined,
-    .pcs = undefined,
-    .pc_counters = undefined,
-    .n_runs = 0,
-    .cache_dir = undefined,
-    .seen_pcs = undefined,
-    .coverage_id = undefined,
-    .unit_test_name = &.{},
-    .corpus = .empty,
-    .corpus_directory = undefined,
-    .traced_comparisons = .empty,
+var exec: Executable = undefined;
+var inst: Instrumentation = undefined;
+var fuzzer: Fuzzer = undefined;
+var current_test_name: ?[]const u8 = undefined;
+
+fn bitsetUsizes(elems: usize) usize {
+    return math.divCeil(usize, elems, @bitSizeOf(usize)) catch unreachable;
+}
+
+const Executable = struct {
+    /// Tracks the hit count for each pc as updated by the process's instrumentation.
+    pc_counters: []u8,
+    /// Read-only memory section containing compiled-in constants found from parsing the executable
+    rodata_addr: usize,
+    rodata_size: usize,
+
+    cache_f: std.fs.Dir,
+    cache_tmp: std.fs.Dir,
+    /// Shared copy of all pcs that have been hit stored in a memory-mapped file that can viewed
+    /// while the fuzzer is running.
+    shared_seen_pcs: MemoryMappedList,
+    /// Hash of pcs used to uniquely identify the shared coverage file
+    pc_digest: u64,
+
+    /// Always inits rodata_addr and rodata_size to valid values, even on error
+    fn initRodata(self: *Executable) !void {
+        errdefer {
+            self.rodata_addr = 0;
+            self.rodata_size = 0;
+        }
+
+        const exec_path = std.fs.selfExePathAlloc(gpa) catch |e|
+            if (e == error.OutOfMemory) @panic("OOM") else return e;
+        defer gpa.free(exec_path);
+        const exec_file = try std.fs.cwd().openFile(exec_path, .{});
+        defer exec_file.close();
+
+        const ehdr: std.elf.Header = try .read(exec_file);
+        if (ehdr.shstrndx == 0) return error.NoElfStringTable;
+        var shdr_it = ehdr.section_header_iterator(exec_file);
+        shdr_it.index = ehdr.shstrndx;
+        const str_tab_shdr = try shdr_it.next() orelse return error.InvalidElfSection;
+        const str_tab_off = str_tab_shdr.sh_offset;
+
+        shdr_it.index = 0;
+        while (try shdr_it.next()) |shdr| {
+            const flags: packed struct(u64) {
+                write: bool,
+                alloc: bool,
+                execinstr: bool,
+                _: u61,
+            } = @bitCast(shdr.sh_flags);
+
+            if (shdr.sh_addr == 0 or shdr.sh_size == 0 or
+                !flags.alloc or flags.write or flags.execinstr) continue;
+            try exec_file.seekTo(try math.add(u64, str_tab_off, shdr.sh_name));
+            if (!try exec_file.reader().isBytes(".rodata\x00")) continue;
+
+            const addr = math.cast(usize, shdr.sh_addr) orelse return error.Overflow;
+            const size = math.cast(usize, shdr.sh_size) orelse return error.Overflow;
+            _ = try math.add(usize, addr, size);
+            self.rodata_addr = addr;
+            self.rodata_size = size;
+            return;
+        }
+        return error.NoRodataSection;
+    }
+
+    fn getCoverageFile(cache_dir: std.fs.Dir, pcs: []const usize, pc_digest: u64) MemoryMappedList {
+        const pc_bitset_usizes = bitsetUsizes(pcs.len);
+        const coverage_file_name = std.fmt.hex(pc_digest);
+        comptime assert(abi.SeenPcsHeader.trailing[0] == .pc_bits_usize);
+        comptime assert(abi.SeenPcsHeader.trailing[1] == .pc_addr);
+        const coverage_file_len = @sizeOf(abi.SeenPcsHeader) +
+            pc_bitset_usizes * @sizeOf(usize) +
+            pcs.len * @sizeOf(usize);
+
+        var v = cache_dir.makeOpenPath("v", .{}) catch |e|
+            fatal("failed to open directory 'v': {s}", .{@errorName(e)});
+        defer v.close();
+        const coverage_file = v.createFile(&coverage_file_name, .{
+            .read = true,
+            .truncate = false,
+            // Block other fuzzing processes while we populate the coverage file
+            .lock = .exclusive,
+            // We only want an exclusive lock if we are the first to access the file
+            .lock_nonblocking = true,
+        }) catch |e| switch (e) {
+            error.WouldBlock => v.openFile(&coverage_file_name, .{
+                .mode = .read_write,
+                .lock = .shared,
+            }) catch |e2| fatal(
+                "failed to open coverage file '{s}': {s}",
+                .{ &coverage_file_name, @errorName(e2) },
+            ),
+            else => fatal(
+                "failed to create coverage file '{s}': {s}",
+                .{ &coverage_file_name, @errorName(e) },
+            ),
+        };
+        defer coverage_file.lock(.shared) catch |e| fatal(
+            "failed to demote lock for coverage file '{s}': {s}",
+            .{ &coverage_file_name, @errorName(e) },
+        );
+
+        const size = coverage_file.getEndPos() catch |e| fatal(
+            "failed to stat coverage file '{s}': {s}",
+            .{ &coverage_file_name, @errorName(e) },
+        );
+        if (size == 0) {
+            var map = MemoryMappedList.create(coverage_file, 0, coverage_file_len) catch |e2|
+                fatal(
+                    "failed to init memory map for coverage file '{s}': {s}",
+                    .{ &coverage_file_name, @errorName(e2) },
+                );
+            map.appendSliceAssumeCapacity(mem.asBytes(&abi.SeenPcsHeader{
+                .n_runs = 0,
+                .unique_runs = 0,
+                .pcs_len = pcs.len,
+            }));
+            map.appendNTimesAssumeCapacity(0, pc_bitset_usizes * @sizeOf(usize));
+            map.appendSliceAssumeCapacity(mem.sliceAsBytes(pcs));
+            return map;
+        } else {
+            if (size != coverage_file_len) fatal(
+                "incompatible existing coverage file '{s}' (differing lengths: {} != {})",
+                .{ &coverage_file_name, size, coverage_file_len },
+            );
+
+            const map = MemoryMappedList.init(
+                coverage_file,
+                coverage_file_len,
+                coverage_file_len,
+            ) catch |e| fatal(
+                "failed to map for coverage file '{s}': {s}",
+                .{ &coverage_file_name, @errorName(e) },
+            );
+
+            const seen_pcs_header: *const abi.SeenPcsHeader = @ptrCast(map.items);
+            if (seen_pcs_header.pcs_len != pcs.len) fatal(
+                "incompatible existing coverage file '{s}' (differing pcs length: {} != {})",
+                .{ &coverage_file_name, seen_pcs_header.pcs_len, pcs.len },
+            );
+            if (mem.indexOfDiff(usize, seen_pcs_header.pcAddrs(), pcs)) |i| fatal(
+                "incompatible existing coverage file '{s}' (differing pc at index {d}: {x} != {x})",
+                .{ &coverage_file_name, i, seen_pcs_header.pcAddrs()[i], pcs[i] },
+            );
+
+            return map;
+        }
+    }
+
+    pub fn init(cache_dir_path: []const u8) Executable {
+        var self: Executable = undefined;
+
+        const cache_dir = std.fs.cwd().makeOpenPath(cache_dir_path, .{}) catch |e|
+            fatal("failed to open directory '{s}': {s}", .{ cache_dir_path, @errorName(e) });
+        self.cache_f = cache_dir.makeOpenPath("f", .{}) catch |e|
+            fatal("failed to open directory 'f': {s}", .{@errorName(e)});
+        self.cache_tmp = cache_dir.makeOpenPath("tmp", .{}) catch |e|
+            fatal("failed to open directory 'tmp': {s}", .{@errorName(e)});
+
+        self.pc_counters = blk: {
+            // Linkers are expected to automatically add `__start_<section>` and
+            // `__stop_<section>` symbols when section names are valid C identifiers.
+            const pc_counters_start = @extern([*]u8, .{
+                .name = "__start___sancov_cntrs",
+                .linkage = .weak,
+            }) orelse fatal("missing __start___sancov_cntrs symbol", .{});
+
+            const pc_counters_end = @extern([*]u8, .{
+                .name = "__stop___sancov_cntrs",
+                .linkage = .weak,
+            }) orelse fatal("missing __stop___sancov_cntrs symbol", .{});
+
+            break :blk pc_counters_start[0 .. pc_counters_end - pc_counters_start];
+        };
+
+        const pcs = blk: {
+            const pcs_start = @extern([*]usize, .{
+                .name = "__start___sancov_pcs1",
+                .linkage = .weak,
+            }) orelse fatal("missing __start___sancov_pcs1 symbol", .{});
+
+            const pcs_end = @extern([*]usize, .{
+                .name = "__stop___sancov_pcs1",
+                .linkage = .weak,
+            }) orelse fatal("missing __stop___sancov_pcs1 symbol", .{});
+
+            break :blk pcs_start[0 .. pcs_end - pcs_start];
+        };
+
+        if (self.pc_counters.len != pcs.len) fatal(
+            "pc counters length and pcs length do not match ({} != {})",
+            .{ self.pc_counters.len, pcs.len },
+        );
+
+        self.initRodata() catch |e| {
+            std.log.warn("failed to enumerate read-only memory: {s}", .{@errorName(e)});
+            std.log.warn("efficiency will be severely reduced", .{});
+        };
+
+        self.pc_digest = std.hash.Wyhash.hash(0, mem.sliceAsBytes(pcs));
+        self.shared_seen_pcs = getCoverageFile(cache_dir, pcs, self.pc_digest);
+
+        return self;
+    }
+
+    pub fn pcBitsetIterator(self: Executable) PcBitsetIterator {
+        return .{ .pc_counters = self.pc_counters };
+    }
+
+    /// Iterates over pc_counters returning a bitset for if each of them have been hit
+    pub const PcBitsetIterator = struct {
+        index: usize = 0,
+        pc_counters: []u8,
+
+        pub fn next(self: *PcBitsetIterator) usize {
+            const rest = self.pc_counters[self.index..];
+            if (rest.len >= @bitSizeOf(usize)) {
+                defer self.index += @bitSizeOf(usize);
+                const V = @Vector(@bitSizeOf(usize), u8);
+                return @as(usize, @bitCast(@as(V, @splat(0)) != rest[0..@bitSizeOf(usize)].*));
+            } else if (rest.len != 0) {
+                defer self.index += rest.len;
+                var res: usize = 0;
+                for (0.., rest) |bit_index, byte| {
+                    res |= @shlExact(@as(usize, @intFromBool(byte != 0)), @intCast(bit_index));
+                }
+                return res;
+            } else unreachable;
+        }
+    };
 };
+
+/// Data gathered from instrumentation functions
+/// Seperate from Executable since its state is resetable and changes
+/// Seperate from Fuzzer since it may be needed before fuzzing starts
+const Instrumentation = struct {
+    /// Bitset of seen pcs across all runs excluding fresh pcs.
+    /// This is seperate then shared_seen_pcs because multiple fuzzing processes are likely using
+    /// it which causes contention and unrelated pcs to our campaign being set.
+    seen_pcs: []usize,
+    /// Bitset of seen rodata bytes read across all runs
+    seen_rodata_loads: []usize,
+
+    /// Bitset of run's read bytes that weren't present in seen_loads
+    /// Elements are always zero if !any_new_data_loads
+    new_rodata_loads: []usize,
+    any_new_rodata_loads: bool,
+
+    /// Stores a fresh input's new pcs
+    fresh_pcs: []usize,
+    /// Stores a fresh input's new reads
+    /// Elements are always zero if !any_fresh_rodata_loads
+    fresh_rodata_loads: []usize,
+    any_fresh_rodata_loads: bool,
+
+    /// Pcs which __sanitizer_cov_trace_switch and __sanitizer_cov_trace_const_cmpx
+    /// have been called from and have had their already been added to const_x_vals
+    const_pcs: std.AutoArrayHashMapUnmanaged(usize, void) = .empty,
+    /// Values that have been constant operands in comparisons, switch cases, or memory reads
+    /// There may be duplicates in this array if they came from different addresses, which is
+    /// fine as they are likely more important and hence more likely to be selected.
+    const_vals2: std.ArrayListUnmanaged(u16) = .empty,
+    const_vals4: std.ArrayListUnmanaged(u32) = .empty,
+    const_vals8: std.ArrayListUnmanaged(u64) = .empty,
+    const_vals16: std.ArrayListUnmanaged(u128) = .empty,
+
+    pub fn init() Instrumentation {
+        const pc_bitset_usizes = bitsetUsizes(exec.pc_counters.len);
+        const rodata_bitset_usizes = bitsetUsizes(exec.rodata_size);
+        const alloc_usizes = pc_bitset_usizes * 2 + rodata_bitset_usizes * 3;
+        const buf = gpa.alloc(u8, alloc_usizes * @sizeOf(usize)) catch @panic("OOM");
+        var fba_ctx: std.heap.FixedBufferAllocator = .init(buf);
+        const fba = fba_ctx.allocator();
+
+        var self: Instrumentation = .{
+            .seen_pcs = fba.alloc(usize, pc_bitset_usizes) catch unreachable,
+            .seen_rodata_loads = fba.alloc(usize, rodata_bitset_usizes) catch unreachable,
+            .new_rodata_loads = fba.alloc(usize, rodata_bitset_usizes) catch unreachable,
+            .any_new_rodata_loads = undefined,
+            .fresh_pcs = fba.alloc(usize, pc_bitset_usizes) catch unreachable,
+            .fresh_rodata_loads = fba.alloc(usize, rodata_bitset_usizes) catch unreachable,
+            .any_fresh_rodata_loads = undefined,
+        };
+        self.reset();
+        return self;
+    }
+
+    pub fn reset(self: *Instrumentation) void {
+        @memset(self.seen_pcs, 0);
+        @memset(self.seen_rodata_loads, 0);
+        @memset(self.new_rodata_loads, 0);
+        self.any_new_rodata_loads = false;
+        @memset(self.fresh_pcs, 0);
+        @memset(self.fresh_rodata_loads, 0);
+        self.any_fresh_rodata_loads = false;
+        self.const_pcs.clearRetainingCapacity();
+        self.const_vals2.clearRetainingCapacity();
+        self.const_vals4.clearRetainingCapacity();
+        self.const_vals8.clearRetainingCapacity();
+        self.const_vals16.clearRetainingCapacity();
+    }
+
+    /// If false is returned, then the pc is added to const_pcs
+    pub fn constPcSeen(self: *Instrumentation, pc: usize) bool {
+        return (self.const_pcs.getOrPut(gpa, pc) catch @panic("OOM")).found_existing;
+    }
+
+    pub fn clearNewRodataLoads(self: *Instrumentation) void {
+        if (self.any_new_rodata_loads) {
+            @memset(self.new_rodata_loads, 0);
+            self.any_new_rodata_loads = false;
+        }
+    }
+
+    pub fn isFresh(self: *Instrumentation) bool {
+        if (self.any_new_rodata_loads) return true;
+
+        var hit_pcs = exec.pcBitsetIterator();
+        for (self.seen_pcs) |seen_pcs| {
+            if (hit_pcs.next() & ~seen_pcs != 0) return true;
+        }
+
+        return false;
+    }
+
+    /// Updates fresh_pcs and fresh_rodata_loads
+    /// any_new_rodata_loads and elements of new_rodata_loads are unspecified
+    /// afterwards, but still valid.
+    pub fn setFresh(self: *Instrumentation) void {
+        var hit_pcs = exec.pcBitsetIterator();
+        for (self.seen_pcs, self.fresh_pcs) |seen_pcs, *fresh_pcs| {
+            fresh_pcs.* = hit_pcs.next() & ~seen_pcs;
+        }
+
+        mem.swap([]usize, &self.fresh_rodata_loads, &self.new_rodata_loads);
+        mem.swap(bool, &self.any_fresh_rodata_loads, &self.any_new_rodata_loads);
+    }
+
+    /// Returns if exec.pc_counters and new_rodata_loads are the same or a superset of fresh_pcs and
+    /// fresh_rodata_loads respectively.
+    pub fn atleastFresh(self: *Instrumentation) bool {
+        var hit_pcs = exec.pcBitsetIterator();
+        for (self.fresh_pcs) |fresh_pcs| {
+            if (fresh_pcs & hit_pcs.next() != fresh_pcs) return false;
+        }
+
+        if (self.any_fresh_rodata_loads) {
+            if (!self.any_new_rodata_loads) return false;
+            for (self.new_rodata_loads, self.fresh_rodata_loads) |n, f| {
+                if (n & f != f) return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// Updates based off fresh_pcs and fresh_rodata_loads
+    fn updateSeen(self: *Instrumentation) void {
+        comptime assert(abi.SeenPcsHeader.trailing[0] == .pc_bits_usize);
+        const shared_seen_pcs: [*]usize = @ptrCast(
+            exec.shared_seen_pcs.items[@sizeOf(abi.SeenPcsHeader)..].ptr,
+        );
+
+        for (self.seen_pcs, shared_seen_pcs, self.fresh_pcs) |*seen, *shared_seen, fresh| {
+            seen.* |= fresh;
+            if (fresh != 0)
+                _ = @atomicRmw(usize, shared_seen, .Or, fresh, .monotonic);
+        }
+
+        if (self.any_fresh_rodata_loads) {
+            for (self.seen_rodata_loads, self.fresh_rodata_loads) |*s, f|
+                s.* |= f;
+        }
+    }
+};
+
+const Fuzzer = struct {
+    pub const TestOne = *const fn (input: abi.Slice) callconv(.c) void;
+
+    arena_ctx: std.heap.ArenaAllocator = .init(gpa),
+    rng: std.Random.DefaultPrng = .init(0),
+    test_one: TestOne,
+    /// The next input that will be given to the testOne function. When the
+    /// current process crashes, this memory-mapped file is used to recover the
+    /// input.
+    input: MemoryMappedList,
+
+    /// Minimized past inputs leading to new pcs or rodata reads. These are randomly mutated in
+    /// round-robin fashion
+    /// Element zero is always an empty input. It is gauraunteed no other elements are empty.
+    corpus: std.ArrayListUnmanaged([]const u8),
+    corpus_pos: usize,
+    /// List of past mutations that have led to new inputs. This way, the mutations that are the
+    /// most effective are the most likely to be selected again. Starts with one of each mutation.
+    mutations: std.ArrayListUnmanaged(Mutation) = .empty,
+
+    /// Filesystem directory containing found inputs for future runs
+    corpus_dir: std.fs.Dir,
+    corpus_dir_idx: usize = 0,
+
+    pub fn init(test_one: TestOne, unit_test_name: []const u8) Fuzzer {
+        var self: Fuzzer = .{
+            .test_one = test_one,
+            .input = undefined,
+            .corpus = .empty,
+            .corpus_pos = 0,
+            .mutations = .empty,
+            .corpus_dir = undefined,
+        };
+        const arena = self.arena_ctx.allocator();
+
+        self.corpus_dir = exec.cache_f.makeOpenPath(unit_test_name, .{}) catch |e|
+            fatal("failed to open directory '{s}': {s}", .{ unit_test_name, @errorName(e) });
+        self.input = in: {
+            const f = self.corpus_dir.createFile("in", .{
+                .read = true,
+                .truncate = false,
+            }) catch |e|
+                fatal("failed to create input file 'in': {s}", .{@errorName(e)});
+            const size = f.getEndPos() catch |e|
+                fatal("failed to stat input file 'in': {s}", .{@errorName(e)});
+            const map = (if (size < std.heap.page_size_max)
+                MemoryMappedList.create(f, 8, std.heap.page_size_max)
+            else
+                MemoryMappedList.init(f, size, size)) catch |e|
+                fatal("failed to memory map input file 'in': {s}", .{@errorName(e)});
+
+            // Perform a dry-run of the stored input if there was one in case it might reproduce a
+            // crash.
+            const old_in_len = mem.readInt(u64, map.items[0..8], .little);
+            if (size >= 8 and old_in_len != 0 and map.items.len - 8 < old_in_len) {
+                test_one(.fromSlice(map.items[8..][0..old_in_len]));
+            }
+
+            break :in map;
+        };
+        inst.reset();
+
+        self.mutations.appendSlice(gpa, std.meta.tags(Mutation)) catch @panic("OOM");
+        // Ensure there is never an empty corpus. Additionally, an empty input usually leads to
+        // new inputs.
+        self.addInput(&.{});
+
+        while (true) {
+            var name_buf: [@sizeOf(usize) * 2]u8 = undefined;
+            const bytes = self.corpus_dir.readFileAlloc(
+                arena,
+                std.fmt.bufPrint(&name_buf, "{x}", .{self.corpus_dir_idx}) catch unreachable,
+                math.maxInt(usize),
+            ) catch |e| switch (e) {
+                error.FileNotFound => break,
+                else => fatal(
+                    "failed to read corpus file '{x}': {s}",
+                    .{ self.corpus_dir_idx, @errorName(e) },
+                ),
+            };
+            // No corpus file of length zero will ever be created
+            if (bytes.len == 0)
+                fatal("corrupt corpus file '{x}' (len of zero)", .{self.corpus_dir_idx});
+            self.addInput(bytes);
+            self.corpus_dir_idx += 1;
+        }
+
+        return self;
+    }
+
+    pub fn deinit(self: *Fuzzer) void {
+        self.input.deinit();
+        self.corpus.deinit(gpa);
+        self.mutations.deinit(gpa);
+        self.corpus_dir.close();
+        self.arena_ctx.deinit();
+        self.* = undefined;
+    }
+
+    pub fn addInput(self: *Fuzzer, bytes: []const u8) void {
+        self.corpus.append(gpa, bytes) catch @panic("OOM");
+        self.input.clearRetainingCapacity();
+        self.input.ensureTotalCapacity(8 + bytes.len) catch |e|
+            fatal("could not resize shared input file: {s}", .{@errorName(e)});
+        self.input.items.len = 8;
+        self.input.appendSliceAssumeCapacity(bytes);
+        self.run();
+        inst.setFresh();
+        inst.updateSeen();
+        inst.clearNewRodataLoads();
+    }
+
+    /// Assumes fresh_pcs and fresh_rodata_loads correspond to the input
+    fn minimizeInput(self: *Fuzzer) void {
+        // The minimization technique is kept relatively simple, we sequentially try to remove each
+        // byte and check that the new pcs and memory loads are still hit.
+        var i = self.input.items.len;
+        while (i != 8) {
+            i -= 1;
+            const old = self.input.orderedRemove(i);
+
+            @memset(exec.pc_counters, 0);
+            inst.clearNewRodataLoads();
+            self.run();
+
+            if (!inst.atleastFresh()) {
+                self.input.insertAssumeCapacity(i, old);
+            } else {
+                // This removal may have led to new pcs or memory loads being hit, so we need to
+                // update them to avoid duplicates.
+                inst.setFresh();
+            }
+        }
+    }
+
+    fn run(self: *Fuzzer) void {
+        // We don't need to clear pc_counters here; all we care about is new hits and not already
+        // seen hits. Ideally, we wouldn't even have these counters and do something similiar to
+        // what we do for tracking memory (i.e. a __sanitizer_cov function that updates a flag on a
+        // new hit.)
+        assert(!inst.any_new_rodata_loads);
+        @atomicStore(
+            usize,
+            mem.bytesAsValue(usize, self.input.items[0..8]),
+            mem.nativeToLittle(usize, self.input.items.len - 8),
+            // This also ensures that all the input bytes have been written
+            .release,
+        );
+        self.test_one(.fromSlice(self.input.items[8..]));
+
+        const header = mem.bytesAsValue(
+            abi.SeenPcsHeader,
+            exec.shared_seen_pcs.items[0..@sizeOf(abi.SeenPcsHeader)],
+        );
+        _ = @atomicRmw(usize, &header.n_runs, .Add, 1, .monotonic);
+    }
+
+    pub fn cycle(self: *Fuzzer) void {
+        const input = self.corpus.items[self.corpus_pos];
+        self.corpus_pos += 1;
+        if (self.corpus_pos == self.corpus.items.len)
+            self.corpus_pos = 0;
+
+        const rng = self.rng.random();
+        while (true) {
+            const m = self.mutations.items[rng.uintLessThanBiased(usize, self.mutations.items.len)];
+            if (!m.mutate(
+                rng,
+                input,
+                &self.input,
+                self.corpus.items,
+                inst.const_vals2.items,
+                inst.const_vals4.items,
+                inst.const_vals8.items,
+                inst.const_vals16.items,
+            )) continue;
+
+            self.run();
+            if (inst.isFresh()) {
+                @branchHint(.unlikely);
+
+                const header = mem.bytesAsValue(
+                    abi.SeenPcsHeader,
+                    exec.shared_seen_pcs.items[0..@sizeOf(abi.SeenPcsHeader)],
+                );
+                _ = @atomicRmw(usize, &header.unique_runs, .Add, 1, .monotonic);
+
+                inst.setFresh();
+                self.minimizeInput();
+                inst.updateSeen();
+                inst.clearNewRodataLoads();
+
+                // An empty-input has always been tried, so if an empty input is fresh then the
+                // test has to be non-deterministic. This has to be checked as duplicate empty
+                // entries are not allowed.
+                if (self.input.items.len - 8 == 0) {
+                    std.log.warn("non-deterministic test (empty input produces different hits)", .{});
+                    _ = @atomicRmw(usize, &header.unique_runs, .Sub, 1, .monotonic);
+                    return;
+                }
+
+                const arena = self.arena_ctx.allocator();
+                const bytes = arena.dupe(u8, self.input.items[8..]) catch @panic("OOM");
+
+                self.corpus.append(gpa, bytes) catch @panic("OOM");
+                self.mutations.appendNTimes(gpa, m, 6) catch @panic("OOM");
+
+                // Write new corpus to cache
+                var name_buf: [@sizeOf(usize) * 2]u8 = undefined;
+                self.corpus_dir.writeFile(.{
+                    .sub_path = std.fmt.bufPrint(
+                        &name_buf,
+                        "{x}",
+                        .{self.corpus_dir_idx},
+                    ) catch unreachable,
+                    .data = bytes,
+                }) catch |e| fatal(
+                    "could not write corpus file '{x}': {s}",
+                    .{ self.corpus_dir_idx, @errorName(e) },
+                );
+                self.corpus_dir_idx += 1;
+            }
+
+            break;
+        }
+    }
+};
+
+/// Instrumentation must not be triggered before this function is called
+export fn fuzzer_init(cache_dir_path: abi.Slice) void {
+    exec = .init(cache_dir_path.toSlice());
+    inst = .init();
+}
 
 /// Invalid until `fuzzer_init` is called.
 export fn fuzzer_coverage_id() u64 {
-    return fuzzer.coverage_id;
+    return exec.pc_digest;
 }
 
-var fuzzer_one: *const fn (input_ptr: [*]const u8, input_len: usize) callconv(.c) void = undefined;
-
-export fn fuzzer_start(testOne: @TypeOf(fuzzer_one)) void {
-    fuzzer_one = testOne;
-    fuzzer.start() catch |err| oom(err);
+/// fuzzer_init must be called beforehand
+export fn fuzzer_init_test(test_one: Fuzzer.TestOne, unit_test_name: abi.Slice) void {
+    current_test_name = unit_test_name.toSlice();
+    fuzzer = .init(test_one, unit_test_name.toSlice());
 }
 
-export fn fuzzer_set_name(name_ptr: [*]const u8, name_len: usize) void {
-    fuzzer.unit_test_name = name_ptr[0..name_len];
+/// fuzzer_init_test must be called beforehand
+/// The callee owns the memory of bytes and must not free it until the fuzzer is finished.
+export fn fuzzer_new_input(bytes: abi.Slice) void {
+    // An entry of length zero is always added and duplicates of it are not allowed.
+    if (bytes.len != 0)
+        fuzzer.addInput(bytes.toSlice());
 }
 
-export fn fuzzer_init(cache_dir_struct: Fuzzer.Slice) void {
-    // Linkers are expected to automatically add `__start_<section>` and
-    // `__stop_<section>` symbols when section names are valid C identifiers.
+/// fuzzer_init_test must be called first
+export fn fuzzer_main() void {
+    while (true) {
+        fuzzer.cycle();
+    }
+}
 
-    const pc_counters_start = @extern([*]u8, .{
-        .name = "__start___sancov_cntrs",
-        .linkage = .weak,
-    }) orelse fatal("missing __start___sancov_cntrs symbol", .{});
+/// Helps determine run uniqueness in the face of recursion.
+/// Currently not used by the fuzzer.
+export threadlocal var __sancov_lowest_stack: usize = 0;
 
-    const pc_counters_end = @extern([*]u8, .{
-        .name = "__stop___sancov_cntrs",
-        .linkage = .weak,
-    }) orelse fatal("missing __stop___sancov_cntrs symbol", .{});
+/// Inline since the return address of the callee is required
+inline fn genericConstCmp(T: anytype, val: T, comptime const_vals_field: []const u8) void {
+    if (!inst.constPcSeen(@returnAddress())) {
+        @branchHint(.unlikely);
+        @field(inst, const_vals_field).append(gpa, val) catch @panic("OOM");
+    }
+}
 
-    const pc_counters = pc_counters_start[0 .. pc_counters_end - pc_counters_start];
+export fn __sanitizer_cov_trace_const_cmp1(const_arg: u8, arg: u8) void {
+    _ = const_arg;
+    _ = arg;
+}
 
-    const pcs_start = @extern([*]usize, .{
-        .name = "__start___sancov_pcs1",
-        .linkage = .weak,
-    }) orelse fatal("missing __start___sancov_pcs1 symbol", .{});
+export fn __sanitizer_cov_trace_const_cmp2(const_arg: u16, arg: u16) void {
+    _ = arg;
+    genericConstCmp(u16, const_arg, "const_vals2");
+}
 
-    const pcs_end = @extern([*]usize, .{
-        .name = "__stop___sancov_pcs1",
-        .linkage = .weak,
-    }) orelse fatal("missing __stop___sancov_pcs1 symbol", .{});
+export fn __sanitizer_cov_trace_const_cmp4(const_arg: u32, arg: u32) void {
+    _ = arg;
+    genericConstCmp(u32, const_arg, "const_vals4");
+}
 
-    const pcs = pcs_start[0 .. pcs_end - pcs_start];
+export fn __sanitizer_cov_trace_const_cmp8(const_arg: u64, arg: u64) void {
+    _ = arg;
+    genericConstCmp(u64, const_arg, "const_vals8");
+}
 
-    const cache_dir_path = cache_dir_struct.toZig();
-    const cache_dir = if (cache_dir_path.len == 0)
-        std.fs.cwd()
-    else
-        std.fs.cwd().makeOpenPath(cache_dir_path, .{ .iterate = true }) catch |err| {
-            fatal("unable to open fuzz directory '{s}': {s}", .{ cache_dir_path, @errorName(err) });
+export fn __sanitizer_cov_trace_switch(val: u64, cases: [*]const u64) void {
+    _ = val;
+    if (!inst.constPcSeen(@returnAddress())) {
+        @branchHint(.unlikely);
+        const case_bits = cases[1];
+        const cases_slice = cases[2..][0..cases[0]];
+        switch (case_bits) {
+            // 8-bit cases are ignored because they are likely to be randomly generated
+            0...8 => {},
+            9...16 => for (cases_slice) |c|
+                inst.const_vals2.append(gpa, @truncate(c)) catch @panic("OOM"),
+            17...32 => for (cases_slice) |c|
+                inst.const_vals4.append(gpa, @truncate(c)) catch @panic("OOM"),
+            33...64 => for (cases_slice) |c|
+                inst.const_vals8.append(gpa, @truncate(c)) catch @panic("OOM"),
+            else => {}, // Should be impossible
+        }
+    }
+}
+
+fn genericLoad(T: anytype, ptr: *const T, comptime opt_const_vals_field: ?[]const u8) void {
+    const addr = @intFromPtr(ptr);
+    const off = addr -% exec.rodata_addr;
+    if (off >= exec.rodata_size) return;
+
+    const i = off / @bitSizeOf(usize);
+    const new = @shlExact(
+        @as(usize, (1 << @sizeOf(T)) - 1),
+        @intCast(off % @bitSizeOf(usize)),
+    ) & ~inst.seen_rodata_loads[i];
+    inst.new_rodata_loads[i] |= new;
+    inst.any_new_rodata_loads = inst.any_new_rodata_loads or new != 0;
+
+    if (opt_const_vals_field) |const_vals_field| {
+        // This may have already been hit and this run is just being used for evaluating the
+        // input, in which case we do not want to readd the same value.
+        if (new & ~inst.fresh_rodata_loads[i] != 0) {
+            @field(inst, const_vals_field).append(gpa, ptr.*) catch @panic("OOM");
+        }
+    }
+}
+
+export fn __sanitizer_cov_load1(ptr: *const u8) void {
+    genericLoad(u8, ptr, null);
+}
+
+export fn __sanitizer_cov_load2(ptr: *const u16) void {
+    genericLoad(u16, ptr, "const_vals2");
+}
+
+export fn __sanitizer_cov_load4(ptr: *const u32) void {
+    genericLoad(u32, ptr, "const_vals4");
+}
+
+export fn __sanitizer_cov_load8(ptr: *const u64) void {
+    genericLoad(u64, ptr, "const_vals8");
+}
+
+export fn __sanitizer_cov_load16(ptr: *const u128) void {
+    genericLoad(u128, ptr, "const_vals16");
+}
+
+export fn __sanitizer_cov_trace_cmp1(arg1: u8, arg2: u8) void {
+    _ = arg1;
+    _ = arg2;
+}
+
+export fn __sanitizer_cov_trace_cmp2(arg1: u16, arg2: u16) void {
+    _ = arg1;
+    _ = arg2;
+}
+
+export fn __sanitizer_cov_trace_cmp4(arg1: u32, arg2: u32) void {
+    _ = arg1;
+    _ = arg2;
+}
+
+export fn __sanitizer_cov_trace_cmp8(arg1: u64, arg2: u64) void {
+    _ = arg1;
+    _ = arg2;
+}
+
+export fn __sanitizer_cov_trace_pc_indir(callee: usize) void {
+    // Not valuable because we already have pc tracing via 8bit counters.
+    _ = callee;
+}
+export fn __sanitizer_cov_8bit_counters_init(start: usize, end: usize) void {
+    // clang will emit a call to this function when compiling with code coverage instrumentation.
+    // however, fuzzer_init() does not need this information since it directly reads from the
+    // symbol table.
+    _ = start;
+    _ = end;
+}
+export fn __sanitizer_cov_pcs_init(start: usize, end: usize) void {
+    // clang will emit a call to this function when compiling with code coverage instrumentation.
+    // however, fuzzer_init() does not need this information since it directly reads from the
+    // symbol table.
+    _ = start;
+    _ = end;
+}
+
+const Mutation = enum {
+    /// Applies .insert_*_span, .push_*_span
+    /// For wtf-8, this limits code units, not code points
+    const max_insert_len = 12;
+    /// Applies to .insert_large_*_span and .push_large_*_span
+    /// 4096 is used as it is a common sector size
+    const max_large_insert_len = 4096;
+    /// Applies to .delete_span and .pop_span
+    const max_delete_len = 16;
+    /// Applies to .set_*span, .move_span, .set_existing_span
+    const max_set_len = 12;
+    const max_replicate_len = 64;
+    const AddValue = i6;
+    const SmallValue = i10;
+
+    delete_byte,
+    delete_span,
+    /// Removes the last byte from the input
+    pop_byte,
+    pop_span,
+    /// Inserts a group of bytes which is already in the input and removes the original copy.
+    move_span,
+    /// Replaces a group of bytes in the input with another group of bytes in the input
+    set_existing_span,
+    insert_existing_span,
+    push_existing_span,
+    set_rng_byte,
+    set_rng_span,
+    insert_rng_byte,
+    insert_rng_span,
+    /// Adds a byte to the end of the input
+    push_rng_byte,
+    push_rng_span,
+    set_zero_byte,
+    set_zero_span,
+    insert_zero_byte,
+    insert_zero_span,
+    push_zero_byte,
+    push_zero_span,
+    /// Inserts a lot of zeros to the end of the input
+    /// This is intended to work with fuzz tests that require data in (large) blocks
+    push_large_zero_span,
+    /// Inserts a group of ascii printable character
+    insert_print_span,
+    /// Inserts a group of character from a...z, A...Z, 0...9, _, and ' '
+    insert_common_span,
+    /// Inserts a group of ascii digits possibly preceded by a `-`
+    insert_integer,
+    /// Code units are evenly distributed between one to four
+    insert_wtf8_char,
+    insert_wtf8_span,
+    /// Inserts a group of bytes from another input
+    insert_splice_span,
+    // utf16 is not yet included since insertion of random bytes should adaquetly check
+    // BMP character, surrogate handling, and occasionally chacters outside of the BMP.
+    set_print_span,
+    set_common_span,
+    set_splice_span,
+    /// Similar to set_splice_span, but the bytes are copied to the same index instead of a random
+    replicate_splice_span,
+    push_print_span,
+    push_common_span,
+    push_integer,
+    push_wtf8_char,
+    push_wtf8_span,
+    push_splice_span,
+    /// Clears a random amount of high bits of a byte
+    truncate_8,
+    truncate_16le,
+    truncate_16be,
+    truncate_32le,
+    truncate_32be,
+    truncate_64le,
+    truncate_64be,
+    /// Flips a random bit
+    xor_1,
+    /// Swaps up to three bits of a byte biased to less bits
+    xor_few_8,
+    /// Swaps up to six bits of a 16-bit value biased to less bits
+    xor_few_16,
+    /// Swaps up to nine bits of a 32-bit value biased to less bits
+    xor_few_32,
+    /// Swaps up to twelve bits of 64-bit value biased to less bits
+    xor_few_64,
+    /// Adds to a byte a value of type AddValue
+    add_8,
+    add_16le,
+    add_16be,
+    add_32le,
+    add_32be,
+    add_64le,
+    add_64be,
+    /// Sets a 16-bit little-endian value to a value of type SmallValue
+    set_small_16le,
+    set_small_16be,
+    set_small_32le,
+    set_small_32be,
+    set_small_64le,
+    set_small_64be,
+    insert_small_16le,
+    insert_small_16be,
+    insert_small_32le,
+    insert_small_32be,
+    insert_small_64le,
+    insert_small_64be,
+    push_small_16le,
+    push_small_16be,
+    push_small_32le,
+    push_small_32be,
+    push_small_64le,
+    push_small_64be,
+    set_const_16,
+    set_const_32,
+    set_const_64,
+    set_const_128,
+    insert_const_16,
+    insert_const_32,
+    insert_const_64,
+    insert_const_128,
+    push_const_16,
+    push_const_32,
+    push_const_64,
+    push_const_128,
+    /// Sets a byte with up to three bits set biased to less bits
+    set_few_8,
+    /// Sets a 16-bit value with up to six bits set biased to less bits
+    set_few_16,
+    /// Sets a 32-bit value with up to nine bits set biased to less bits
+    set_few_32,
+    /// Sets a 64-bit value with up to twelve bits set biased to less bits
+    set_few_64,
+    insert_few_8,
+    insert_few_16,
+    insert_few_32,
+    insert_few_64,
+    push_few_8,
+    push_few_16,
+    push_few_32,
+    push_few_64,
+    /// Randomizes a random contigous group of bits in a byte
+    packed_set_rng_8,
+    packed_set_rng_16le,
+    packed_set_rng_16be,
+    packed_set_rng_32le,
+    packed_set_rng_32be,
+    packed_set_rng_64le,
+    packed_set_rng_64be,
+
+    fn fewValue(rng: std.Random, T: type, comptime bits: u16) T {
+        var result: T = 0;
+        var remaining_bits = rng.intRangeAtMostBiased(u16, 1, bits);
+        while (remaining_bits > 0) {
+            result |= @shlExact(@as(T, 1), rng.int(math.Log2Int(T)));
+            remaining_bits -= 1;
+        }
+        return result;
+    }
+
+    /// Returns if the mutation was applicable to the input
+    pub fn mutate(
+        mutation: Mutation,
+        rng: std.Random,
+        in: []const u8,
+        out: *MemoryMappedList,
+        corpus: []const []const u8,
+        const_vals2: []const u16,
+        const_vals4: []const u32,
+        const_vals8: []const u64,
+        const_vals16: []const u128,
+    ) bool {
+        out.clearRetainingCapacity();
+        const new_capacity = 8 + in.len + @max(
+            16, // builtin 128 value
+            Mutation.max_insert_len,
+            Mutation.max_large_insert_len,
+        );
+        out.ensureTotalCapacity(new_capacity) catch |e|
+            fatal("could not resize shared input file: {s}", .{@errorName(e)});
+        out.items.len = 8; // Length field
+
+        const applied = switch (mutation) {
+            inline else => |m| m.comptimeMutate(
+                rng,
+                in,
+                out,
+                corpus,
+                const_vals2,
+                const_vals4,
+                const_vals8,
+                const_vals16,
+            ),
+        };
+        if (!applied)
+            assert(out.items.len == 8)
+        else
+            assert(out.items.len <= new_capacity);
+        return applied;
+    }
+
+    /// Assumes out has already been cleared
+    fn comptimeMutate(
+        comptime mutation: Mutation,
+        rng: std.Random,
+        in: []const u8,
+        out: *MemoryMappedList,
+        corpus: []const []const u8,
+        const_vals2: []const u16,
+        const_vals4: []const u32,
+        const_vals8: []const u64,
+        const_vals16: []const u128,
+    ) bool {
+        const Class = enum { new, remove, rmw, move_span, replicate_splice_span };
+        const class: Class, const class_ctx = switch (mutation) {
+            // zig fmt: off
+            .move_span => .{ .move_span, null },
+            .replicate_splice_span => .{ .replicate_splice_span, null },
+
+            .delete_byte => .{ .remove, .{ .delete, 1 } },
+            .delete_span => .{ .remove, .{ .delete, max_delete_len } },
+
+            .pop_byte => .{ .remove, .{ .pop, 1 } },
+            .pop_span => .{ .remove, .{ .pop, max_delete_len } },
+
+            .set_rng_byte         => .{ .new, .{ .set   ,  1, .rng     , .one              } },
+            .set_zero_byte        => .{ .new, .{ .set   ,  1, .zero    , .one              } },
+            .set_rng_span         => .{ .new, .{ .set   ,  1, .rng     , .many             } },
+            .set_zero_span        => .{ .new, .{ .set   ,  1, .zero    , .many             } },
+            .set_common_span      => .{ .new, .{ .set   ,  1, .common  , .many             } },
+            .set_print_span       => .{ .new, .{ .set   ,  1, .print   , .many             } },
+            .set_existing_span    => .{ .new, .{ .set   ,  2, .existing, .many             } },
+            .set_splice_span      => .{ .new, .{ .set   ,  1, .splice  , .many             } },
+            .set_const_16         => .{ .new, .{ .set   ,  2, .@"const", const_vals2       } },
+            .set_const_32         => .{ .new, .{ .set   ,  4, .@"const", const_vals4       } },
+            .set_const_64         => .{ .new, .{ .set   ,  8, .@"const", const_vals8       } },
+            .set_const_128        => .{ .new, .{ .set   , 16, .@"const", const_vals16      } },
+            .set_small_16le       => .{ .new, .{ .set   ,  2, .small   , .{ i16, .little } } },
+            .set_small_32le       => .{ .new, .{ .set   ,  4, .small   , .{ i32, .little } } },
+            .set_small_64le       => .{ .new, .{ .set   ,  8, .small   , .{ i64, .little } } },
+            .set_small_16be       => .{ .new, .{ .set   ,  2, .small   , .{ i16, .big    } } },
+            .set_small_32be       => .{ .new, .{ .set   ,  4, .small   , .{ i32, .big    } } },
+            .set_small_64be       => .{ .new, .{ .set   ,  8, .small   , .{ i64, .big    } } },
+            .set_few_8            => .{ .new, .{ .set   ,  1, .few     , .{ u8 , 3  }      } },
+            .set_few_16           => .{ .new, .{ .set   ,  2, .few     , .{ u16, 6  }      } },
+            .set_few_32           => .{ .new, .{ .set   ,  4, .few     , .{ u32, 9  }      } },
+            .set_few_64           => .{ .new, .{ .set   ,  8, .few     , .{ u64, 12 }      } },
+
+            .insert_rng_byte      => .{ .new, .{ .insert,  0, .rng     , .one              } },
+            .insert_zero_byte     => .{ .new, .{ .insert,  0, .zero    , .one              } },
+            .insert_rng_span      => .{ .new, .{ .insert,  0, .rng     , .many             } },
+            .insert_zero_span     => .{ .new, .{ .insert,  0, .zero    , .many             } },
+            .insert_print_span    => .{ .new, .{ .insert,  0, .print   , .many             } },
+            .insert_common_span   => .{ .new, .{ .insert,  0, .common  , .many             } },
+            .insert_integer       => .{ .new, .{ .insert,  0, .integer , .many             } },
+            .insert_wtf8_char     => .{ .new, .{ .insert,  0, .wtf8    , .one              } },
+            .insert_wtf8_span     => .{ .new, .{ .insert,  0, .wtf8    , .many             } },
+            .insert_existing_span => .{ .new, .{ .insert,  1, .existing, .many             } },
+            .insert_splice_span   => .{ .new, .{ .insert,  0, .splice  , .many             } },
+            .insert_const_16      => .{ .new, .{ .insert,  0, .@"const", const_vals2       } },
+            .insert_const_32      => .{ .new, .{ .insert,  0, .@"const", const_vals4       } },
+            .insert_const_64      => .{ .new, .{ .insert,  0, .@"const", const_vals8       } },
+            .insert_const_128     => .{ .new, .{ .insert,  0, .@"const", const_vals16      } },
+            .insert_small_16le    => .{ .new, .{ .insert,  0, .small   , .{ i16, .little } } },
+            .insert_small_32le    => .{ .new, .{ .insert,  0, .small   , .{ i32, .little } } },
+            .insert_small_64le    => .{ .new, .{ .insert,  0, .small   , .{ i64, .little } } },
+            .insert_small_16be    => .{ .new, .{ .insert,  0, .small   , .{ i16, .big    } } },
+            .insert_small_32be    => .{ .new, .{ .insert,  0, .small   , .{ i32, .big    } } },
+            .insert_small_64be    => .{ .new, .{ .insert,  0, .small   , .{ i64, .big    } } },
+            .insert_few_8         => .{ .new, .{ .insert,  0, .few     , .{ u8 , 3  }      } },
+            .insert_few_16        => .{ .new, .{ .insert,  0, .few     , .{ u16, 6  }      } },
+            .insert_few_32        => .{ .new, .{ .insert,  0, .few     , .{ u32, 9  }      } },
+            .insert_few_64        => .{ .new, .{ .insert,  0, .few     , .{ u64, 12 }      } },
+
+            .push_rng_byte        => .{ .new, .{ .push  ,  0, .rng     , .one              } },
+            .push_zero_byte       => .{ .new, .{ .push  ,  0, .zero    , .one              } },
+            .push_rng_span        => .{ .new, .{ .push  ,  0, .rng     , .many             } },
+            .push_zero_span       => .{ .new, .{ .push  ,  0, .zero    , .many             } },
+            .push_print_span      => .{ .new, .{ .push  ,  0, .print   , .many             } },
+            .push_common_span     => .{ .new, .{ .push  ,  0, .common  , .many             } },
+            .push_integer         => .{ .new, .{ .push  ,  0, .integer , .many             } },
+            .push_large_zero_span => .{ .new, .{ .push  ,  0, .zero    , .large            } },
+            .push_wtf8_char       => .{ .new, .{ .push  ,  0, .wtf8    , .one              } },
+            .push_wtf8_span       => .{ .new, .{ .push  ,  0, .wtf8    , .many             } },
+            .push_existing_span   => .{ .new, .{ .push  ,  1, .existing, .many             } },
+            .push_splice_span     => .{ .new, .{ .push  ,  0, .splice  , .many             } },
+            .push_const_16        => .{ .new, .{ .push  ,  0, .@"const", const_vals2       } },
+            .push_const_32        => .{ .new, .{ .push  ,  0, .@"const", const_vals4       } },
+            .push_const_64        => .{ .new, .{ .push  ,  0, .@"const", const_vals8       } },
+            .push_const_128       => .{ .new, .{ .push  ,  0, .@"const", const_vals16      } },
+            .push_small_16le      => .{ .new, .{ .push  ,  0, .small   , .{ i16, .little } } },
+            .push_small_32le      => .{ .new, .{ .push  ,  0, .small   , .{ i32, .little } } },
+            .push_small_64le      => .{ .new, .{ .push  ,  0, .small   , .{ i64, .little } } },
+            .push_small_16be      => .{ .new, .{ .push  ,  0, .small   , .{ i16, .big    } } },
+            .push_small_32be      => .{ .new, .{ .push  ,  0, .small   , .{ i32, .big    } } },
+            .push_small_64be      => .{ .new, .{ .push  ,  0, .small   , .{ i64, .big    } } },
+            .push_few_8           => .{ .new, .{ .push  ,  0, .few     , .{ u8 , 3  }      } },
+            .push_few_16          => .{ .new, .{ .push  ,  0, .few     , .{ u16, 6  }      } },
+            .push_few_32          => .{ .new, .{ .push  ,  0, .few     , .{ u32, 9  }      } },
+            .push_few_64          => .{ .new, .{ .push  ,  0, .few     , .{ u64, 12 }      } },
+
+            .xor_1               => .{ .rmw, .{ .xor       , u8 , native_endian, 1  } },
+            .xor_few_8           => .{ .rmw, .{ .xor       , u8 , native_endian, 3  } },
+            .xor_few_16          => .{ .rmw, .{ .xor       , u16, native_endian, 6  } },
+            .xor_few_32          => .{ .rmw, .{ .xor       , u32, native_endian, 9  } },
+            .xor_few_64          => .{ .rmw, .{ .xor       , u64, native_endian, 12 } },
+
+            .truncate_8          => .{ .rmw, .{ .truncate  , u8 , native_endian, {} } },
+            .truncate_16le       => .{ .rmw, .{ .truncate  , u16, .little      , {} } },
+            .truncate_32le       => .{ .rmw, .{ .truncate  , u32, .little      , {} } },
+            .truncate_64le       => .{ .rmw, .{ .truncate  , u64, .little      , {} } },
+            .truncate_16be       => .{ .rmw, .{ .truncate  , u16, .big         , {} } },
+            .truncate_32be       => .{ .rmw, .{ .truncate  , u32, .big         , {} } },
+            .truncate_64be       => .{ .rmw, .{ .truncate  , u64, .big         , {} } },
+
+            .add_8               => .{ .rmw, .{ .add       , i8 , native_endian, {} } },
+            .add_16le            => .{ .rmw, .{ .add       , i16, .little      , {} } },
+            .add_32le            => .{ .rmw, .{ .add       , i32, .little      , {} } },
+            .add_64le            => .{ .rmw, .{ .add       , i64, .little      , {} } },
+            .add_16be            => .{ .rmw, .{ .add       , i16, .big         , {} } },
+            .add_32be            => .{ .rmw, .{ .add       , i32, .big         , {} } },
+            .add_64be            => .{ .rmw, .{ .add       , i64, .big         , {} } },
+
+            .packed_set_rng_8    => .{ .rmw, .{ .packed_rng, u8 , native_endian, {} } },
+            .packed_set_rng_16le => .{ .rmw, .{ .packed_rng, u16, .little      , {} } },
+            .packed_set_rng_32le => .{ .rmw, .{ .packed_rng, u32, .little      , {} } },
+            .packed_set_rng_64le => .{ .rmw, .{ .packed_rng, u64, .little      , {} } },
+            .packed_set_rng_16be => .{ .rmw, .{ .packed_rng, u16, .big         , {} } },
+            .packed_set_rng_32be => .{ .rmw, .{ .packed_rng, u32, .big         , {} } },
+            .packed_set_rng_64be => .{ .rmw, .{ .packed_rng, u64, .big         , {} } },
+            // zig fmt: on
         };
 
-    fuzzer.init(cache_dir, pc_counters, pcs) catch |err|
-        fatal("unable to init fuzzer: {s}", .{@errorName(err)});
-}
+        switch (class) {
+            .new => {
+                const op: enum {
+                    set,
+                    insert,
+                    push,
 
-export fn fuzzer_init_corpus_elem(input_ptr: [*]const u8, input_len: usize) void {
-    fuzzer.addCorpusElem(input_ptr[0..input_len]) catch |err|
-        fatal("failed to add corpus element: {s}", .{@errorName(err)});
-}
+                    pub fn maxLen(comptime op: @This(), in_len: usize) usize {
+                        return switch (op) {
+                            .set => @min(in_len, max_set_len),
+                            .insert, .push => max_insert_len,
+                        };
+                    }
+                }, const min_in_len, const data: enum {
+                    rng,
+                    zero,
+                    common,
+                    print,
+                    integer,
+                    wtf8,
+                    existing,
+                    splice,
+                    @"const",
+                    small,
+                    few,
+                }, const data_ctx = class_ctx;
+                const Size = enum { one, many, large };
+                if (in.len < min_in_len) return false;
+                if (data == .@"const" and data_ctx.len == 0) return false;
+
+                const splice_i = if (data == .splice) blk: {
+                    // Element zero always holds an empty input, so we do not select it
+                    if (corpus.len == 1) return false;
+                    break :blk rng.intRangeLessThanBiased(usize, 1, corpus.len);
+                } else undefined;
+
+                // Only needs to be followed for set
+                const len = switch (data) {
+                    else => switch (@as(Size, data_ctx)) {
+                        .one => 1,
+                        .many => rng.intRangeAtMostBiased(usize, 1, op.maxLen(in.len)),
+                        .large => rng.intRangeAtMostBiased(usize, 1, max_large_insert_len),
+                    },
+                    .wtf8 => undefined, // varies by size of each code unit
+                    .splice => rng.intRangeAtMostBiased(usize, 1, @min(
+                        corpus[splice_i].len,
+                        op.maxLen(in.len),
+                    )),
+                    .existing => rng.intRangeAtMostBiased(usize, 1, @min(
+                        in.len,
+                        op.maxLen(in.len),
+                    )),
+                    .@"const" => @sizeOf(@typeInfo(@TypeOf(data_ctx)).pointer.child),
+                    .small, .few => @sizeOf(data_ctx[0]),
+                };
+
+                const i = switch (op) {
+                    .set => rng.uintAtMostBiased(usize, in.len - len),
+                    .insert => rng.uintAtMostBiased(usize, in.len),
+                    .push => in.len,
+                };
+
+                out.appendSliceAssumeCapacity(in[0..i]);
+                switch (data) {
+                    .rng => {
+                        var bytes: [@max(max_insert_len, max_set_len)]u8 = undefined;
+                        rng.bytes(bytes[0..len]);
+                        out.appendSliceAssumeCapacity(bytes[0..len]);
+                    },
+                    .zero => out.appendNTimesAssumeCapacity(0, len),
+                    .common => for (out.addManyAsSliceAssumeCapacity(len)) |*c| {
+                        c.* = switch (rng.int(u6)) {
+                            0 => ' ',
+                            1...10 => |x| '0' + (@as(u8, x) - 1),
+                            11...36 => |x| 'A' + (@as(u8, x) - 11),
+                            37 => '_',
+                            38...63 => |x| 'a' + (@as(u8, x) - 38),
+                        };
+                    },
+                    .print => for (out.addManyAsSliceAssumeCapacity(len)) |*c| {
+                        c.* = rng.intRangeAtMostBiased(u8, 0x20, 0x7E);
+                    },
+                    .integer => {
+                        const negative = len != 0 and rng.boolean();
+                        if (negative) {
+                            out.appendAssumeCapacity('-');
+                        }
+
+                        for (out.addManyAsSliceAssumeCapacity(len - @intFromBool(negative))) |*c| {
+                            c.* = rng.intRangeAtMostBiased(u8, '0', '9');
+                        }
+                    },
+                    .wtf8 => {
+                        comptime assert(op != .set);
+                        var codepoints: usize = if (data_ctx == .one)
+                            1
+                        else
+                            rng.intRangeAtMostBiased(usize, 1, Mutation.max_insert_len / 4);
+
+                        while (true) {
+                            const units1 = rng.int(u2);
+                            const value = switch (units1) {
+                                0 => rng.int(u7),
+                                1 => rng.intRangeAtMostBiased(u11, 0x000080, 0x0007FF),
+                                2 => rng.intRangeAtMostBiased(u16, 0x000800, 0x00FFFF),
+                                3 => rng.intRangeAtMostBiased(u21, 0x010000, 0x10FFFF),
+                            };
+                            const units = @as(u3, units1) + 1;
+
+                            var buf: [4]u8 = undefined;
+                            assert(std.unicode.wtf8Encode(value, &buf) catch unreachable == units);
+                            out.appendSliceAssumeCapacity(buf[0..units]);
+
+                            codepoints -= 1;
+                            if (codepoints == 0) break;
+                        }
+                    },
+                    .existing => {
+                        const j = rng.uintAtMostBiased(usize, in.len - len);
+                        out.appendSliceAssumeCapacity(in[j..][0..len]);
+                    },
+                    .splice => {
+                        const j = rng.uintAtMostBiased(usize, corpus[splice_i].len - len);
+                        out.appendSliceAssumeCapacity(corpus[splice_i][j..][0..len]);
+                    },
+                    .@"const" => out.appendSliceAssumeCapacity(mem.asBytes(
+                        &data_ctx[rng.uintLessThanBiased(usize, data_ctx.len)],
+                    )),
+                    .small => out.appendSliceAssumeCapacity(mem.asBytes(
+                        &mem.nativeTo(data_ctx[0], rng.int(SmallValue), data_ctx[1]),
+                    )),
+                    .few => out.appendSliceAssumeCapacity(mem.asBytes(
+                        &fewValue(rng, data_ctx[0], data_ctx[1]),
+                    )),
+                }
+                switch (op) {
+                    .set => out.appendSliceAssumeCapacity(in[i + len ..]),
+                    .insert => out.appendSliceAssumeCapacity(in[i..]),
+                    .push => {},
+                }
+            },
+            .remove => {
+                if (in.len == 0) return false;
+                const Op = enum { delete, pop };
+                const op: Op, const max_len = class_ctx;
+                // LessThan is used so we don't delete the entire span (which is unproductive since
+                // an empty input has always been tried)
+                const len = if (max_len == 1) 1 else rng.uintLessThanBiased(
+                    usize,
+                    @min(max_len + 1, in.len),
+                );
+                switch (op) {
+                    .delete => {
+                        const i = rng.uintAtMostBiased(usize, in.len - len);
+                        out.appendSliceAssumeCapacity(in[0..i]);
+                        out.appendSliceAssumeCapacity(in[i + len ..]);
+                    },
+                    .pop => out.appendSliceAssumeCapacity(in[0 .. in.len - len]),
+                }
+            },
+            .rmw => {
+                const Op = enum { xor, truncate, add, packed_rng };
+                const op: Op, const T, const endian, const xor_bits = class_ctx;
+                if (in.len < @sizeOf(T)) return false;
+                const Log2T = math.Log2Int(T);
+
+                const idx = rng.uintAtMostBiased(usize, in.len - @sizeOf(T));
+                const old = mem.readInt(T, in[idx..][0..@sizeOf(T)], endian);
+                const new = switch (op) {
+                    .xor => old ^ fewValue(rng, T, xor_bits),
+                    .truncate => old & (@as(T, math.maxInt(T)) >> rng.int(Log2T)),
+                    .add => old +% addend: {
+                        const val = rng.int(Mutation.AddValue);
+                        break :addend if (val == 0) 1 else val;
+                    },
+                    .packed_rng => blk: {
+                        const bits = rng.int(math.Log2Int(T)) +| 1;
+                        break :blk old ^ (rng.int(T) >> bits << rng.uintAtMostBiased(Log2T, bits));
+                    },
+                };
+                out.appendSliceAssumeCapacity(in);
+                mem.writeInt(T, out.items[8..][idx..][0..@sizeOf(T)], new, endian);
+            },
+            .move_span => {
+                if (in.len < 2) return false;
+                // One less since moving whole output will never change anything
+                const len = rng.intRangeAtMostBiased(usize, 1, @min(
+                    in.len - 1,
+                    Mutation.max_set_len,
+                ));
+
+                const src = rng.uintAtMostBiased(usize, in.len - len);
+                // This indexes into the final input
+                const dst = blk: {
+                    const res = rng.uintAtMostBiased(usize, in.len - len - 1);
+                    break :blk res + @intFromBool(res >= src);
+                };
+
+                if (src < dst) {
+                    out.appendSliceAssumeCapacity(in[0..src]);
+                    out.appendSliceAssumeCapacity(in[src + len .. dst + len]);
+                    out.appendSliceAssumeCapacity(in[src..][0..len]);
+                    out.appendSliceAssumeCapacity(in[dst + len ..]);
+                } else {
+                    out.appendSliceAssumeCapacity(in[0..dst]);
+                    out.appendSliceAssumeCapacity(in[src..][0..len]);
+                    out.appendSliceAssumeCapacity(in[dst..src]);
+                    out.appendSliceAssumeCapacity(in[src + len ..]);
+                }
+            },
+            .replicate_splice_span => {
+                if (in.len == 0) return false;
+                if (corpus.len == 1) return false;
+                const from = corpus[rng.intRangeLessThanBiased(usize, 1, corpus.len)];
+                const len = rng.uintLessThanBiased(usize, @min(in.len, from.len, max_replicate_len));
+                const i = rng.uintAtMostBiased(usize, @min(in.len, from.len) - len);
+                out.appendSliceAssumeCapacity(in[0..i]);
+                out.appendSliceAssumeCapacity(from[i..][0..len]);
+                out.appendSliceAssumeCapacity(in[i + len ..]);
+            },
+        }
+        return true;
+    }
+};
 
 /// Like `std.ArrayListUnmanaged(u8)` but backed by memory mapping.
 pub const MemoryMappedList = struct {
@@ -517,7 +1379,7 @@ pub const MemoryMappedList = struct {
     /// of this ArrayList in accordance with the respective documentation. In
     /// all cases, "invalidated" means that the memory has been passed to this
     /// allocator's resize or free function.
-    items: []align(std.heap.page_size_min) volatile u8,
+    items: []align(std.heap.page_size_min) u8,
     /// How many bytes this list can hold without allocating additional memory.
     capacity: usize,
     /// The file is kept open so that it can be resized.
@@ -546,7 +1408,7 @@ pub const MemoryMappedList = struct {
 
     pub fn deinit(l: *MemoryMappedList) void {
         l.file.close();
-        std.posix.munmap(@volatileCast(l.items.ptr[0..l.capacity]));
+        std.posix.munmap(l.items.ptr[0..l.capacity]);
         l.* = undefined;
     }
 
@@ -569,7 +1431,7 @@ pub const MemoryMappedList = struct {
     pub fn ensureTotalCapacityPrecise(l: *MemoryMappedList, new_capacity: usize) !void {
         if (l.capacity >= new_capacity) return;
 
-        std.posix.munmap(@volatileCast(l.items.ptr[0..l.capacity]));
+        std.posix.munmap(l.items.ptr[0..l.capacity]);
         try l.file.setEndPos(new_capacity);
         l.* = try init(l.file, l.items.len, new_capacity);
     }
@@ -601,7 +1463,7 @@ pub const MemoryMappedList = struct {
     /// The returned pointer becomes invalid when the list is resized.
     /// Never invalidates element pointers.
     /// Asserts that the list can hold one additional item.
-    pub fn addOneAssumeCapacity(l: *MemoryMappedList) *volatile u8 {
+    pub fn addOneAssumeCapacity(l: *MemoryMappedList) *u8 {
         assert(l.items.len < l.capacity);
         l.items.len += 1;
         return &l.items[l.items.len - 1];
@@ -624,7 +1486,7 @@ pub const MemoryMappedList = struct {
     /// Never invalidates element pointers.
     /// The returned pointer becomes invalid when the list is resized.
     /// Asserts that the list can hold the additional items.
-    pub fn addManyAsSliceAssumeCapacity(l: *MemoryMappedList, n: usize) []volatile u8 {
+    pub fn addManyAsSliceAssumeCapacity(l: *MemoryMappedList, n: usize) []u8 {
         assert(l.items.len + n <= l.capacity);
         const prev_len = l.items.len;
         l.items.len += n;
@@ -636,8 +1498,23 @@ pub const MemoryMappedList = struct {
     fn growCapacity(current: usize, minimum: usize) usize {
         var new = current;
         while (true) {
-            new = std.mem.alignForward(usize, new + new / 2, std.heap.page_size_max);
+            new = mem.alignForward(usize, new + new / 2, std.heap.page_size_max);
             if (new >= minimum) return new;
         }
+    }
+
+    pub fn insertAssumeCapacity(l: *MemoryMappedList, i: usize, item: u8) void {
+        assert(l.items.len + 1 <= l.capacity);
+        l.items.len += 1;
+        mem.copyBackwards(u8, l.items[i + 1 ..], l.items[i .. l.items.len - 1]);
+        l.items[i] = item;
+    }
+
+    pub fn orderedRemove(l: *MemoryMappedList, i: usize) u8 {
+        assert(l.items.len + 1 <= l.capacity);
+        const old = l.items[i];
+        mem.copyForwards(u8, l.items[i .. l.items.len - 1], l.items[i + 1 ..]);
+        l.items.len -= 1;
+        return old;
     }
 };

--- a/lib/std/Build/Fuzz/WebServer.zig
+++ b/lib/std/Build/Fuzz/WebServer.zig
@@ -421,9 +421,9 @@ fn sendCoverageContext(
     const seen_pcs = cov_header.seenBits();
     const n_runs = @atomicLoad(usize, &cov_header.n_runs, .monotonic);
     const unique_runs = @atomicLoad(usize, &cov_header.unique_runs, .monotonic);
-    if (prev_unique_runs.* != unique_runs) {
-        // There has been an update.
-        if (prev_unique_runs.* == 0) {
+
+    {
+        if (unique_runs != 0 and prev_unique_runs.* == 0) {
             // We need to send initial context.
             const header: abi.SourceIndexHeader = .{
                 .flags = .{},

--- a/lib/std/Build/Fuzz/abi.zig
+++ b/lib/std/Build/Fuzz/abi.zig
@@ -3,6 +3,19 @@
 //! host computer, and the fuzzing web interface webassembly code running in
 //! the browser. All of these components interface to some degree via an ABI.
 
+pub const Slice = extern struct {
+    ptr: [*]const u8,
+    len: usize,
+
+    pub fn toSlice(s: Slice) []const u8 {
+        return s.ptr[0..s.len];
+    }
+
+    pub fn fromSlice(s: []const u8) Slice {
+        return .{ .ptr = s.ptr, .len = s.len };
+    }
+};
+
 /// libfuzzer uses this and its usize is the one that counts. To match the ABI,
 /// make the ints be the size of the target used with libfuzzer.
 ///

--- a/lib/std/compress/flate.zig
+++ b/lib/std/compress/flate.zig
@@ -475,3 +475,38 @@ fn testInterface(comptime pkg: type, gzip_data: []const u8, plain_data: []const 
         }
     }
 }
+
+test "fuzz compress decompress match" {
+    try std.testing.fuzz({}, fuzzTestCompressDecompress, .{});
+}
+
+fn fuzzTestCompressDecompress(ctx: void, input: []const u8) anyerror!void {
+    _ = ctx;
+    // The first byte of the input holds the compression level
+    if (input.len == 0) return;
+    const level: deflate.Level = switch (input[0] % 9) {
+        0 => .fast,
+        1 => .level_4,
+        2 => .level_5,
+        3 => .default,
+        4 => .level_6,
+        5 => .level_7,
+        6 => .level_8,
+        7 => .best,
+        8 => .level_9,
+        else => unreachable,
+    };
+    const bytes = input[1..];
+    if (bytes.len > 4096) return;
+    var in_fbs = std.io.fixedBufferStream(bytes);
+
+    var compress_buf: [4096]u8 = undefined;
+    var c_fbs = std.io.fixedBufferStream(&compress_buf);
+    compress(in_fbs.reader(), c_fbs.writer(), .{ .level = level }) catch return;
+    c_fbs.reset();
+
+    var decompress_buf: [4096]u8 = undefined;
+    var d_fbs = std.io.fixedBufferStream(&decompress_buf);
+    try decompress(c_fbs.reader(), d_fbs.writer());
+    try std.testing.expectEqualSlices(u8, bytes, d_fbs.getWritten());
+}

--- a/lib/std/compress/flate/inflate.zig
+++ b/lib/std/compress/flate/inflate.zig
@@ -568,3 +568,24 @@ test "bug 19895" {
     var buf: [0]u8 = undefined;
     try testing.expectEqual(0, try decomp.read(&buf));
 }
+
+test "fuzz" {
+    try std.testing.fuzz({}, fuzzTestOne, .{});
+}
+
+fn fuzzTestOne(ctx: void, input: []const u8) anyerror!void {
+    _ = ctx;
+    var fbs = std.io.fixedBufferStream(input);
+    var stream = decompressor(.raw, fbs.reader());
+
+    var buf: [16384]u8 = undefined;
+    // According to https://stackoverflow.com/a/16794960, the maximum decompression ratio for a
+    // flate stream is 1032:1, so we will ensure that this property is upheld.
+    var rem_bytes: usize = input.len *| 1032;
+
+    while (true) {
+        const bytes = stream.read(&buf) catch return;
+        if (bytes == 0) break;
+        rem_bytes = try std.math.sub(usize, rem_bytes, bytes);
+    }
+}

--- a/lib/std/json/scanner_test.zig
+++ b/lib/std/json/scanner_test.zig
@@ -517,3 +517,21 @@ test isNumberFormattedLikeAnInteger {
     try std.testing.expect(!isNumberFormattedLikeAnInteger("1e10"));
     try std.testing.expect(!isNumberFormattedLikeAnInteger("1E10"));
 }
+
+test "fuzz" {
+    try std.testing.fuzz({}, fuzzTestOne, .{});
+}
+
+fn fuzzTestOne(ctx: void, input: []const u8) anyerror!void {
+    _ = ctx;
+    var buf: [16384]u8 = undefined;
+    var fba: std.heap.FixedBufferAllocator = .init(&buf);
+
+    var scanner = JsonScanner.initCompleteInput(fba.allocator(), input);
+    // Property: There are at most input.len tokens
+    var tokens: usize = 0;
+    while ((scanner.next() catch return) != .end_of_document) {
+        tokens += 1;
+        if (tokens > input.len) return error.Overflow;
+    }
+}

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -6528,3 +6528,20 @@ fn testError(source: [:0]const u8, expected_errors: []const Error) !void {
         try std.testing.expectEqual(expected, tree.errors[i].tag);
     }
 }
+
+test "fuzz" {
+    try std.testing.fuzz({}, fuzzTestOne, .{});
+}
+
+fn fuzzTestOne(ctx: void, input: []const u8) anyerror!void {
+    _ = ctx;
+    // The first byte holds if zig / zon
+    if (input.len == 0) return;
+    const mode: std.zig.Ast.Mode = if (input[0] & 1 == 0) .zig else .zon;
+    const bytes = input[1..];
+
+    var fba: std.heap.FixedBufferAllocator = .init(&fixed_buffer_mem);
+    const allocator = fba.allocator();
+    const source = allocator.dupeZ(u8, bytes) catch return;
+    _ = std.zig.Ast.parse(allocator, source, mode) catch return;
+}

--- a/lib/std/zig/tokenizer.zig
+++ b/lib/std/zig/tokenizer.zig
@@ -1759,18 +1759,15 @@ fn testPropertiesUpheld(context: void, source: []const u8) anyerror!void {
         }
     }
 
-    if (source0.len > 0) for (source0, source0[1..][0..source0.len]) |cur, next| {
+    if (tokenization_failed) return;
+    for (source0) |cur| {
         // Property: No null byte allowed except at end.
         if (cur == 0) {
-            try std.testing.expect(tokenization_failed);
+            return error.TestUnexpectedResult;
         }
-        // Property: No ASCII control characters other than \n and \t are allowed.
-        if (std.ascii.isControl(cur) and cur != '\n' and cur != '\t') {
-            try std.testing.expect(tokenization_failed);
+        // Property: No ASCII control characters other than \n, \t, and \r are allowed.
+        if (std.ascii.isControl(cur) and cur != '\n' and cur != '\t' and cur != '\r') {
+            return error.TestUnexpectedResult;
         }
-        // Property: All '\r' must be followed by '\n'.
-        if (cur == '\r' and next != '\n') {
-            try std.testing.expect(tokenization_failed);
-        }
-    };
+    }
 }

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1079,7 +1079,7 @@ pub const Object = struct {
                 .NoPrune = false,
                 // Workaround for https://github.com/llvm/llvm-project/pull/106464
                 .StackDepth = true,
-                .TraceLoads = false,
+                .TraceLoads = options.fuzz,
                 .TraceStores = false,
                 .CollectControlFlow = false,
             },


### PR DESCRIPTION
This PR significantly improves the capabilities of the fuzzer. For comparison, here is a ten minute head to head between the old and new fuzzer implementations (with newly included fuzz tests):

-- Old --
```
Total Runs: 49020931
Unique Runs: 1044131 (2.1%)
Speed (Runs/Second): 81696
Coverage: 2069 / 15866 (13.0%)
```
(note: Unique Runs is highly inflated due of the inefficiency of the old implementation)

-- New --
```
Total Runs: 537039526
Unique Runs: 1511 (0.0%)
Speed (Runs/Second): 894950
Coverage: 3000 / 15719 (19.1%)
```
```
Examples: `while(C)i(){}else|`
          `{y:n()align(b)addrspace`
          `switch(P){else=>`
          `[:l]align(_:r:l)R`
          `(if(b){defer{nosuspend`
          `union(enum(I))`
```
NOTE: You have to rebuild the compiler due to new fuzzing instrumentation being enabled for memory loads.

The changes made to the fuzzer to accomplish this feat mostly include tracking memory reads from .rodata to determine new runs, new mutations (especially the ones that insert const values from .rodata reads and __sanitizer_conv_const_cmp), and minimizing found inputs. Additionally, the runs per second has greatly been increased due to generating smaller inputs and avoiding clearing the 8-bit pc counters.

An additional feature added is that the length of the input file is now stored and the old input file is rerun upon start, though this does not close #20803 since it does not output the input (though it can be very easily retrieved from the cache directory.)

Other changes made to the fuzzer include more logical initialization, using one shared file `in` for inputs, creating corpus files with proper sizes, and using hexadecimal-numbered corpus files for simplicity. Additionally, volatile was removed from MemoryMappedList since all that is needed is a guarantee that compiler has done the writes, which is already accomplished with atomic ordering.

Furthermore, I added several new fuzz tests to gauge the fuzzer's efficiency. I also tried to add a test for zstandard decompression, which it crashed within 60,000 runs (less than a second.)

Bug fixes include:
* Fixed a race conditions when multiple fuzzer processes needed to use the same coverage file.
* Web interface stats now update even when unique runs is not changing.
* Fixed tokenizer.testPropertiesUpheld to allow stray carriage returns since they are valid whitespace.
* Closes #23180

Possible Improvements:
* Remove the 8-bit pc counting code prefer a call to a sanitizer function that updates a flag if a new pc hit happened (similar to how the __sanitizer_cov_load functions already operate).
* Less basic input minimization function. It could also try splitting inputs into two between each byte to see if they both hit the same pcs. This is useful as smaller inputs are usually much more efficient.
* Deterministic mutations when a new input is found.
* Culling out corpus inputs that are redundant due to smaller inputs already hitting their pcs and memory addresses.
* Applying multiple mutations during dry spells.
* Prioritizing some corpus inputs.
* Creating a list of the most successful input splices (which would likely contain grammar keywords) and creating a custom mutation for adding them.
* Removing some less-efficient mutations.
* Store effective mutations to the disk for the benefit of future runs.
* Counting __sanitizer_cov `@returnAddress`es in determining unique runs.
* Optimize __sanitizer_cov_trace_const_cmp methods (the use of an ArrayHashMap is not too fast).
* Processor affinity
* Exclude fuzzer's .rodata

Nevertheless, I feel like the fuzzer is in a viable place to start being useful (as demonstrated with the find in #23413)