### PR TITLE
lib/std/start: allow return uefi error union in main

### DIFF
--- a/lib/std/os/uefi.zig
+++ b/lib/std/os/uefi.zig
@@ -7,6 +7,7 @@ pub const hii = @import("uefi/hii.zig");
 
 /// Status codes returned by EFI interfaces
 pub const Status = @import("uefi/status.zig").Status;
+pub const Error = UnexpectedError || Status.Error;
 pub const tables = @import("uefi/tables.zig");
 
 /// The memory type to allocate when using the pool.

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -200,8 +200,6 @@ fn wasi_start() callconv(.c) void {
 }
 
 fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv(.c) usize {
-    const Status = uefi.Status;
-
     uefi.handle = handle;
     uefi.system_table = system_table;
 
@@ -213,14 +211,14 @@ fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv
             root.main();
             return 0;
         },
-        Status => {
+        uefi.Status => {
             return @intFromEnum(root.main());
         },
         uefi.Error!void => {
             root.main() catch |err| switch (err) {
                 error.Unexpected => @panic("EfiMain: unexpected error"),
                 else => {
-                    const status = Status.fromError(@errorCast(err));
+                    const status = uefi.Status.fromError(@errorCast(err));
                     return @intFromEnum(status);
                 },
             };

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -229,7 +229,7 @@ fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv
         },
         else => @compileError(
             "expected return type of main to be 'void', 'noreturn', " ++
-                "'uefi.Status', 'uefi.Error!void', or 'uefi.Error!noreturn'",
+                "'uefi.Status', or 'uefi.Error!void'",
         ),
     }
 }

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -220,13 +220,12 @@ fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv
             return @intFromEnum(root.main());
         },
         Status.Error!void => {
-            root.main() catch |err| {
-                // if (err == error.Unexpected) {
-                //     unreachable;
-                // }
-
-                const status = Status.fromError(err);
-                return status;
+            root.main() catch |err| switch (err) {
+                error.Unexpected => @panic("EfiMain: unexpected error"),
+                else => {
+                    const status = Status.fromError(@errorCast(err));
+                    return @intFromEnum(status);
+                }
             };
 
             return 0;

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -213,24 +213,24 @@ fn EfiMain(handle: uefi.Handle, system_table: *uefi.tables.SystemTable) callconv
             root.main();
             return 0;
         },
-        usize => {
-            return root.main();
-        },
         Status => {
             return @intFromEnum(root.main());
         },
-        Status.Error!void => {
+        uefi.Error!void => {
             root.main() catch |err| switch (err) {
                 error.Unexpected => @panic("EfiMain: unexpected error"),
                 else => {
                     const status = Status.fromError(@errorCast(err));
                     return @intFromEnum(status);
-                }
+                },
             };
 
             return 0;
         },
-        else => @compileError("expected return type of main to be 'void', 'noreturn', 'usize', 'std.os.uefi.Status', or 'std.os.uefi.Status.Error!void"),
+        else => @compileError(
+            "expected return type of main to be 'void', 'noreturn', " ++
+                "'uefi.Status', 'uefi.Error!void', or 'uefi.Error!noreturn'",
+        ),
     }
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/ziglang/zig/pull/23214#pullrequestreview-2730502337, it'd be nice to support returning `uefi.Status.Error!void` from your main function out of the box :)

this PR updates the `EfiMain` implementation in `lib/std/start.zig` to support such main definitions.