### PR TITLE
std.os.uefi.protocol.File: fix some typed definitions

### DIFF
--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -239,7 +239,7 @@ pub const File = extern struct {
         self: *const File,
         comptime info: std.meta.Tag(Info),
         buffer: []u8,
-    ) GetInfoError!struct { usize, @FieldType(Info, @tagName(info)) } {
+    ) GetInfoError!*@FieldType(Info, @tagName(info)) {
         const InfoType = @FieldType(Info, @tagName(info));
 
         var len = buffer.len;
@@ -268,7 +268,7 @@ pub const File = extern struct {
 
         const attached_str: [*:0]const u16 = switch (info) {
             .file => data.getFileName(),
-            inline .file_system, .volume_label => data.getVolumeLabel(),
+            .file_system, .volume_label => data.getVolumeLabel(),
         };
         const attached_str_len = std.mem.sliceTo(attached_str, 0).len;
 

--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -316,7 +316,6 @@ pub const File = extern struct {
         read = @bitCast(Bits{ .read = true }),
         read_write = @bitCast(Bits{ .read = true, .write = true }),
         read_write_create = @bitCast(Bits{ .read = true, .write = true, .create = true }),
-        _,
     };
 
     pub const Attributes = packed struct(u64) {

--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -9,14 +9,14 @@ const Error = Status.Error;
 
 pub const File = extern struct {
     revision: u64,
-    _open: *const fn (*const File, **File, [*:0]const u16, u64, u64) callconv(cc) Status,
+    _open: *const fn (*const File, **File, [*:0]const u16, OpenMode, Attributes) callconv(cc) Status,
     _close: *const fn (*File) callconv(cc) Status,
     _delete: *const fn (*File) callconv(cc) Status,
     _read: *const fn (*File, *usize, [*]u8) callconv(cc) Status,
     _write: *const fn (*File, *usize, [*]const u8) callconv(cc) Status,
     _get_position: *const fn (*const File, *u64) callconv(cc) Status,
     _set_position: *const fn (*File, u64) callconv(cc) Status,
-    _get_info: *const fn (*const File, *align(8) const Guid, *const usize, [*]u8) callconv(cc) Status,
+    _get_info: *const fn (*const File, *align(8) const Guid, *usize, ?[*]u8) callconv(cc) Status,
     _set_info: *const fn (*File, *align(8) const Guid, usize, [*]const u8) callconv(cc) Status,
     _flush: *const fn (*File) callconv(cc) Status,
 
@@ -57,7 +57,6 @@ pub const File = extern struct {
         NoMedia,
         DeviceError,
         VolumeCorrupted,
-        BufferTooSmall,
     };
     pub const SetInfoError = uefi.UnexpectedError || error{
         Unsupported,
@@ -112,8 +111,8 @@ pub const File = extern struct {
             self,
             &new,
             file_name,
-            @intFromEnum(mode),
-            @bitCast(create_attributes),
+            mode,
+            create_attributes,
         )) {
             .success => return new,
             .not_found => return Error.NotFound,
@@ -216,21 +215,29 @@ pub const File = extern struct {
         try self.setPosition(pos);
     }
 
+    /// If the underlying function returns `.buffer_too_small`, then this function
+    /// returns `.{ len, null }`. Otherwise, the 2nd value of the tuple contains
+    /// the casted reference from the buffer.
     pub fn getInfo(
         self: *const File,
         comptime info: std.meta.Tag(Info),
-    ) GetInfoError!std.meta.TagPayload(Info, info) {
+        buffer: ?[]u8,
+    ) GetInfoError!struct { usize, ?*std.meta.TagPayload(Info, info) } {
         const InfoType = std.meta.TagPayload(Info, info);
 
-        var val: InfoType = undefined;
-        var len: usize = @sizeOf(InfoType);
-        switch (self._get_info(self, &InfoType.guid, &len, @ptrCast(&val))) {
-            .success => return val,
+        var len = if (buffer) |b| b.len else 0;
+        switch (self._get_info(
+            self,
+            &InfoType.guid,
+            &len,
+            if (buffer) |b| b else null,
+        )) {
+            .success => return .{ len, @as(*InfoType, @ptrCast(buffer.ptr)) },
+            .buffer_too_small => return .{ len, null },
             .unsupported => return Error.Unsupported,
             .no_media => return Error.NoMedia,
             .device_error => return Error.DeviceError,
             .volume_corrupted => return Error.VolumeCorrupted,
-            .buffer_too_small => return Error.BufferTooSmall,
             else => |status| return uefi.unexpectedStatus(status),
         }
     }
@@ -240,8 +247,21 @@ pub const File = extern struct {
         comptime info: std.meta.Tag(Info),
         data: *const std.meta.TagPayload(Info, info),
     ) SetInfoError!void {
-        const InfoType = @TypeOf(data);
-        switch (self._set_info(self, &InfoType.guid, @sizeOf(InfoType), @ptrCast(data))) {
+        const InfoType = std.meta.TagPayload(Info, info);
+
+        var attached_str_len: usize = 0;
+        const attached_str: [*:0]const u16 = switch (info) {
+            .file => data.getFileName(),
+            inline .file_system, .volume_label => data.getVolumeLabel(),
+        };
+
+        while (attached_str[attached_str_len] != 0) : (attached_str_len += 1) {}
+
+        // add the length (not +1 for sentinel) because `@sizeOf(InfoType)`
+        // already contains the first utf16 char
+        const len = @sizeOf(InfoType) + (attached_str_len * 2);
+
+        switch (self._set_info(self, &InfoType.guid, len, @ptrCast(data))) {
             .success => {},
             .unsupported => return Error.Unsupported,
             .no_media => return Error.NoMedia,
@@ -268,11 +288,20 @@ pub const File = extern struct {
     }
 
     pub const OpenMode = enum(u64) {
-        read = 0x0000000000000001,
-        // implies read
-        write = 0x0000000000000002,
-        // implies read+write
-        create = 0x8000000000000000,
+        pub const Bits = packed struct(u64) {
+            // 0x0000000000000001
+            read: bool = false,
+            // 0x0000000000000002
+            write: bool = false,
+            _pad: u61 = 0,
+            // 0x8000000000000000
+            create: bool = false,
+        };
+
+        read = @bitCast(Bits{ .read = true }),
+        read_write = @bitCast(Bits{ .read = true, .write = true }),
+        read_write_create = @bitCast(Bits{ .read = true, .write = true, .create = true }),
+        _,
     };
 
     pub const Attributes = packed struct(u64) {


### PR DESCRIPTION
#23214 has a few glitches, this is a PR fixing one of them :)

there were 3 issues with `File` as pointed out by #23436:

### `File.open`

in the spec, the `OpenMode` argument can only be `read`, `read|write`, or `read|write|execute`. However, currently the interface only allows `read`, `write`, and `execute`. This PR addresses this problem:
- defined an auxiliary type `OpenMode.Bits` which provides a bitfield representing those values from the spec
- `OpenMode`'s enum tags are renamed to `read`, `read_write`, and `read_write_create` for better clarity
- `OpenMode`'s enum values are implemented by bitcasting `OpenMode.Bits` values

### `File.getInfo`

The file info buffer should be larger than `@sizeOf(Info.*)`, because `Info.*` types have an attached null-terminated string at the end.

This method now requires the user to pass in a buffer which will contain the resulting info type.

To better align with the pattern being established in #23441, this function's return type is now `struct { usize, ?*Payload }`.

### `File.setInfo`

The `len` accounting as-is is wrong. It should account for the length of the attached null-terminated string.

closes #23436