### PR TITLE
std.os.uefi.protocol.HiiDatabase: manage .buffer_too_small statuses

### DIFF
--- a/lib/std/os/uefi/protocol/hii_database.zig
+++ b/lib/std/os/uefi/protocol/hii_database.zig
@@ -133,7 +133,7 @@ pub const HiiDatabase = extern struct {
         self: *const HiiDatabase,
         handle: ?hii.Handle,
         buffer: []hii.PackageList,
-    ) ExportPackageListError!struct { usize, ?[]hii.PackageList } {
+    ) ExportPackageListError![]hii.PackageList {
         var len = buffer.len;
         switch (self._export_package_lists(
             self,
@@ -141,8 +141,8 @@ pub const HiiDatabase = extern struct {
             &len,
             buffer.ptr,
         )) {
-            .success => return .{ len, buffer[0..len] },
-            .buffer_too_small => return .{ len, null },
+            .success => return buffer[0..len],
+            .buffer_too_small => return Error.BufferTooSmall,
             .invalid_parameter => return Error.InvalidParameter,
             .not_found => return Error.NotFound,
             else => |status| return uefi.unexpectedStatus(status),


### PR DESCRIPTION
similar to #23443, there's some problems with `HiiDatabase.listPackageLists` and `HiiDatabase.exportPackageLists`, in that they may return `.buffer_too_small` if the `buffer_len` argument is too small to safely return all data.

~~this PR changes these functions to return a tuple `struct { usize, ?ReturnType }` where `ReturnType` is the buffer written by the function.~~

this PR adds helper functions to determine the size of the buffers needed for these functions to succeed.