### PR TITLE
`std.zig.system`: Some fixes for `getExternalExecutor()`

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -146,7 +146,7 @@ pub fn getExternalExecutor(
             }
             return bad_result;
         },
-        .macos => {
+        .driverkit, .macos => {
             if (options.allow_darling) {
                 // This check can be loosened once darling adds a QEMU-based emulation
                 // layer for non-host architectures:

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -156,7 +156,7 @@ pub fn getExternalExecutor(
                 // This check can be loosened once darling adds a QEMU-based emulation
                 // layer for non-host architectures:
                 // https://github.com/darlinghq/darling/issues/863
-                if (candidate.cpu.arch != builtin.cpu.arch) {
+                if (candidate.cpu.arch != host.cpu.arch) {
                     return bad_result;
                 }
                 return Executor{ .darling = "darling" };

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -125,6 +125,10 @@ pub fn getExternalExecutor(
         };
     }
 
+    if (options.allow_wasmtime and candidate.cpu.arch.isWasm()) {
+        return Executor{ .wasmtime = "wasmtime" };
+    }
+
     switch (candidate.os.tag) {
         .windows => {
             if (options.allow_wine) {
@@ -139,15 +143,6 @@ pub fn getExternalExecutor(
                     else => false,
                 };
                 return if (wine_supported) Executor{ .wine = "wine" } else bad_result;
-            }
-            return bad_result;
-        },
-        .wasi => {
-            if (options.allow_wasmtime) {
-                switch (candidate.ptrBitWidth()) {
-                    32 => return Executor{ .wasmtime = "wasmtime" },
-                    else => return bad_result,
-                }
             }
             return bad_result;
         },


### PR DESCRIPTION
3872778 will be the controversial part here. It attempts to fix #23411 by simply removing the use of `wine64`. I'm not actually sure that any distros still use (or did ever use?) this executable name, but I definitely welcome evidence to the contrary.

Closes #23411.