### PR TITLE
zig fmt / std.zig.Ast: count addrspace tokens correctly

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -1195,6 +1195,9 @@ pub fn lastToken(tree: Ast, node: Node.Index) TokenIndex {
                 if (extra.section_node.unwrap()) |section_node| {
                     end_offset += 1; // for the rparen
                     n = section_node;
+                } else if (extra.addrspace_node.unwrap()) |addrspace_node| {
+                    end_offset += 1; // for the rparen
+                    n = addrspace_node;
                 } else if (extra.align_node.unwrap()) |align_node| {
                     end_offset += 1; // for the rparen
                     n = align_node;

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -6074,6 +6074,16 @@ test "zig fmt: do not canonicalize invalid cast builtins" {
     );
 }
 
+test "zig fmt: extern addrspace in struct" {
+    try testCanonical(
+        \\const namespace = struct {
+        \\    extern const num: u8 addrspace(.generic);
+        \\};
+        \\// comment
+        \\
+    );
+}
+
 test "recovery: top level" {
     try testError(
         \\test "" {inline}


### PR DESCRIPTION
Before this PR this

```zig
const namespace = struct {
    extern const num: u8 addrspace(.generic);
};
// comment
```

got formatted to this

```zig
const namespace = struct {
    extern const num: u8 addrspace(.generic);
(
```