### PR TITLE
Sema/arith.zig: fixing typo from "lhs" to "rhs"

### DIFF
--- a/src/Sema/arith.zig
+++ b/src/Sema/arith.zig
@@ -67,7 +67,7 @@ pub fn addMaybeWrap(
 ) CompileError!Value {
     const zcu = sema.pt.zcu;
     if (lhs.isUndef(zcu)) return lhs;
-    if (lhs.isUndef(zcu)) return rhs;
+    if (rhs.isUndef(zcu)) return rhs;
     switch (ty.zigTypeTag(zcu)) {
         .int, .comptime_int => return (try intAddWithOverflow(sema, lhs, rhs, ty)).wrapped_result,
         .float, .comptime_float => return floatAdd(sema, lhs, rhs, ty),


### PR DESCRIPTION
Maintainter 'mlugg' wanted to fix that typo, 4 weeks without changes, might be forgotten.

```
https://github.com/ziglang/zig/pull/23177#discussion_r1997957095
```