### PR TITLE
Remove overzealous LLVM anti-instrumentation attributes

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -1174,8 +1174,10 @@ pub const Object = struct {
             _ = try attributes.removeFnAttr(.sanitize_thread);
         }
         const is_naked = fn_info.cc == .naked;
-        if (owner_mod.fuzz and !func_analysis.disable_instrumentation and !is_naked) {
-            try attributes.addFnAttr(.optforfuzzing, &o.builder);
+        if (!func_analysis.disable_instrumentation and !is_naked) {
+            if (owner_mod.fuzz) {
+                try attributes.addFnAttr(.optforfuzzing, &o.builder);
+            }
             _ = try attributes.removeFnAttr(.skipprofile);
             _ = try attributes.removeFnAttr(.nosanitize_coverage);
         } else {


### PR DESCRIPTION
@Techatrix and I were attempting to instrument some code for coverage with LLVM and found that the unilateral application of the `nosanitize_coverage` attribute to all functions when `fuzz` is off blocked us completely.

We're trying to obtain coverage info, and it seems that the `fuzz` flag doesn't really make sense for our usecase, so we propose this change.

Now `@disableInstrumentation` always works, and the only difference between a `fuzz` and `no-fuzz` build is the `optforfuzzing` fn attr.
