### PR TITLE
`zig_clang`: Fix size of `ZigClangAPValue` for Clang 20.

### DIFF
--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -68,12 +68,10 @@ enum ZigClangAPValueKind {
 struct ZigClangAPValue {
     enum ZigClangAPValueKind Kind;
     // experimentally-derived size of clang::APValue::DataType
-#if defined(_WIN32) && defined(__i386__)
-    char Data[68];
-#elif defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32) && defined(_MSC_VER)
     char Data[52];
-#elif defined(__i386__)
-    char Data[48];
+#elif defined(__i386__) && !defined(_WIN32)
+    char Data[44];
 #else
     char Data[52];
 #endif


### PR DESCRIPTION
Fixes failing tarball builds for `x86-linux` and `x86-windows`.

The MSVC special case here is very sus, but that's a problem for another day.