### PR TITLE
compiler: Switch default code model for loongarch64 to medium.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -668,24 +668,6 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
         .strip = options.strip,
         .sanitize_thread = options.sanitize_thread,
         .single_threaded = options.single_threaded,
-        .code_model = switch (options.target.result.cpu.arch) {
-            // NB:
-            // For loongarch, LLVM supports only small, medium and large
-            // code model. If we don't explicitly specify the code model,
-            // the default value `small' will be used.
-            //
-            // Since zig binary itself is relatively large, using a `small'
-            // code model will cause
-            //
-            // relocation R_LARCH_B26 out of range
-            //
-            // error when linking a loongarch32/loongarch64 zig binary.
-            //
-            // Here we explicitly set code model to `medium' to avoid this
-            // error.
-            .loongarch32, .loongarch64 => .medium,
-            else => .default,
-        },
         .valgrind = options.valgrind,
     });
 

--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -234,10 +234,14 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
         break :b false;
     };
 
-    const code_model = b: {
+    const code_model: std.builtin.CodeModel = b: {
         if (options.inherited.code_model) |x| break :b x;
         if (options.parent) |p| break :b p.code_model;
-        break :b .default;
+        break :b switch (target.cpu.arch) {
+            // Temporary workaround until LLVM 21: https://github.com/llvm/llvm-project/pull/132173
+            .loongarch64 => .medium,
+            else => .default,
+        };
     };
 
     const is_safe_mode = switch (optimize_mode) {


### PR DESCRIPTION
LLVM 21 will change the default, but we're making the change now to make building Zig for loongarch64 less painful.

https://github.com/llvm/llvm-project/pull/132173