### PR TITLE
`zig_clang`: Fix `ZigClangAPValue` being underaligned vs `clang::APValue`.

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -63,8 +63,8 @@ pub const APValueKind = enum(c_int) {
 };
 
 pub const APValue = extern struct {
-    Kind: APValueKind,
-    Data: if (builtin.os.tag == .windows and (builtin.abi == .msvc or builtin.abi == .itanium)) [52]u8 else [68]u8,
+    Kind: APValueKind align(if (builtin.cpu.arch == .x86 and builtin.os.tag != .windows) 4 else 8),
+    Data: if (builtin.cpu.arch == .x86 and builtin.os.tag != .windows) [44]u8 else [52]u8,
 
     pub const getKind = ZigClangAPValue_getKind;
     extern fn ZigClangAPValue_getKind(*const APValue) APValueKind;

--- a/src/zig_clang.cpp
+++ b/src/zig_clang.cpp
@@ -2329,6 +2329,7 @@ static_assert((clang::UnaryExprOrTypeTrait)ZigClangUnaryExprOrTypeTrait_Kind::Zi
 static_assert((clang::UnaryExprOrTypeTrait)ZigClangUnaryExprOrTypeTrait_Kind::ZigClangUnaryExprOrTypeTrait_KindOpenMPRequiredSimdAlign == clang::UnaryExprOrTypeTrait::UETT_OpenMPRequiredSimdAlign, "");
 
 static_assert(sizeof(ZigClangAPValue) == sizeof(clang::APValue), "");
+static_assert(alignof(ZigClangAPValue) == alignof(clang::APValue), "");
 
 static_assert(sizeof(ZigClangSourceLocation) == sizeof(clang::SourceLocation), "");
 static ZigClangSourceLocation bitcast(clang::SourceLocation src) {

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -9,6 +9,7 @@
 #define ZIG_ZIG_CLANG_H
 
 #include <inttypes.h>
+#include <stdalign.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -65,16 +66,18 @@ enum ZigClangAPValueKind {
     ZigClangAPValueAddrLabelDiff,
 };
 
-struct ZigClangAPValue {
+#if defined(__i386__) && !defined(_WIN32)
+#   define ZIG_CLANG_APVALUE_SIZE  44
+#   define ZIG_CLANG_APVALUE_ALIGN 4
+#else
+#   define ZIG_CLANG_APVALUE_SIZE  52
+#   define ZIG_CLANG_APVALUE_ALIGN 8
+#endif
+
+struct alignas(ZIG_CLANG_APVALUE_ALIGN) ZigClangAPValue {
     enum ZigClangAPValueKind Kind;
     // experimentally-derived size of clang::APValue::DataType
-#if defined(_WIN32) && defined(_MSC_VER)
-    char Data[52];
-#elif defined(__i386__) && !defined(_WIN32)
-    char Data[44];
-#else
-    char Data[52];
-#endif
+    char Data[ZIG_CLANG_APVALUE_SIZE];
 };
 
 struct ZigClangExprEvalResult {


### PR DESCRIPTION
Also add a `static_assert` to catch future alignment mismatches on this type.