### PR TITLE
Step.Compile: use LtoMode enum for lto option

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -185,7 +185,7 @@ force_undefined_symbols: std.StringHashMap(void),
 /// Overrides the default stack size
 stack_size: ?u64 = null,
 
-want_lto: ?bool = null,
+want_lto: ?LtoMode = null,
 use_llvm: ?bool,
 use_lld: ?bool,
 
@@ -288,6 +288,12 @@ pub const Kind = enum {
     lib,
     obj,
     @"test",
+};
+
+pub const LtoMode = enum {
+    none,
+    full,
+    thin,
 };
 
 pub const HeaderInstallation = union(enum) {
@@ -1711,7 +1717,15 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
     }
 
     try addFlag(&zig_args, "PIE", compile.pie);
-    try addFlag(&zig_args, "lto", compile.want_lto);
+    
+    if (compile.want_lto) |lto| {
+        try zig_args.append(switch(lto) {
+            .full => "-flto=full",
+            .thin => "-flto=thin",
+            .none => "-fno-lto",
+        });
+    }
+    
     try addFlag(&zig_args, "sanitize-coverage-trace-pc-guard", compile.sanitize_coverage_trace_pc_guard);
 
     if (compile.subsystem) |subsystem| {

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -313,6 +313,8 @@ pub const BuildId = union(enum) {
     }
 };
 
+pub const LtoMode = enum { none, full, thin };
+
 /// Renders a `std.Target.Cpu` value into a textual representation that can be parsed
 /// via the `-mcpu` flag passed to the Zig compiler.
 /// Appends the result to `buffer`.

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1074,7 +1074,6 @@ pub const CreateOptions = struct {
     /// executable this field is ignored.
     want_compiler_rt: ?bool = null,
     want_ubsan_rt: ?bool = null,
-    want_lto: ?bool = null,
     function_sections: bool = false,
     data_sections: bool = false,
     time_report: bool = false,

--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -66,7 +66,7 @@ san_cov_trace_pc_guard: bool,
 
 pub const CFrontend = enum { clang, aro };
 
-pub const LtoMode = enum { none, full, thin };
+pub const LtoMode = std.zig.LtoMode;
 
 pub const DebugFormat = union(enum) {
     strip,

--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -48,7 +48,7 @@ use_lib_llvm: bool,
 /// and updates the final binary.
 use_lld: bool,
 c_frontend: CFrontend,
-lto: LtoMode,
+lto: std.zig.LtoMode,
 /// WASI-only. Type of WASI execution model ("command" or "reactor").
 /// Always set to `command` for non-WASI targets.
 wasi_exec_model: std.builtin.WasiExecModel,
@@ -65,8 +65,6 @@ rdynamic: bool,
 san_cov_trace_pc_guard: bool,
 
 pub const CFrontend = enum { clang, aro };
-
-pub const LtoMode = std.zig.LtoMode;
 
 pub const DebugFormat = union(enum) {
     strip,
@@ -105,7 +103,7 @@ pub const Options = struct {
     use_lib_llvm: ?bool = null,
     use_lld: ?bool = null,
     use_clang: ?bool = null,
-    lto: ?LtoMode = null,
+    lto: ?std.zig.LtoMode = null,
     /// WASI-only. Type of WASI execution model ("command" or "reactor").
     wasi_exec_model: ?std.builtin.WasiExecModel = null,
     import_memory: ?bool = null,
@@ -288,7 +286,7 @@ pub fn resolve(options: Options) ResolveError!Config {
         break :b .clang;
     };
 
-    const lto: LtoMode = b: {
+    const lto: std.zig.LtoMode = b: {
         if (!use_lld) {
             // zig ld LTO support is tracked by
             // https://github.com/ziglang/zig/issues/8680

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -771,7 +771,7 @@ pub const Object = struct {
         time_report: bool,
         sanitize_thread: bool,
         fuzz: bool,
-        lto: Compilation.Config.LtoMode,
+        lto: std.zig.LtoMode,
     };
 
     pub fn emit(o: *Object, options: EmitOptions) error{ LinkFailure, OutOfMemory }!void {

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -43,12 +43,12 @@ fn add(
     switch (target.result.os.tag) {
         .windows => {
             // https://github.com/ziglang/zig/issues/8531
-            exe_cpp.want_lto = .none;
+            exe_cpp.lto = .none;
         },
         .macos => {
             // https://github.com/ziglang/zig/issues/8680
-            exe_cpp.want_lto = .none;
-            exe_c.want_lto = .none;
+            exe_cpp.lto = .none;
+            exe_c.lto = .none;
         },
         else => {},
     }

--- a/test/standalone/c_compiler/build.zig
+++ b/test/standalone/c_compiler/build.zig
@@ -43,12 +43,12 @@ fn add(
     switch (target.result.os.tag) {
         .windows => {
             // https://github.com/ziglang/zig/issues/8531
-            exe_cpp.want_lto = false;
+            exe_cpp.want_lto = .none;
         },
         .macos => {
             // https://github.com/ziglang/zig/issues/8680
-            exe_cpp.want_lto = false;
-            exe_c.want_lto = false;
+            exe_cpp.want_lto = .none;
+            exe_c.want_lto = .none;
         },
         else => {},
     }

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1681,7 +1681,7 @@ pub fn addCAbiTests(b: *std.Build, options: CAbiTestOptions) *Step {
 
             // This test is intentionally trying to check if the external ABI is
             // done properly. LTO would be a hindrance to this.
-            test_step.want_lto = false;
+            test_step.want_lto = .none;
 
             const run = b.addRunArtifact(test_step);
             run.skip_foreign_checks = true;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1681,7 +1681,7 @@ pub fn addCAbiTests(b: *std.Build, options: CAbiTestOptions) *Step {
 
             // This test is intentionally trying to check if the external ABI is
             // done properly. LTO would be a hindrance to this.
-            test_step.want_lto = .none;
+            test_step.lto = .none;
 
             const run = b.addRunArtifact(test_step);
             run.skip_foreign_checks = true;


### PR DESCRIPTION
I've noticed that the `Compile` step still uses a boolean for the LTO option, even though the command-line option for ThinLTO [`-flto=thin`] has been added months prior.
This change allows directly passing the option to select ThinLTO to the underlying `zig build-[kind]` command.

Things to consider before finally merging:
* Due to the difference in semantics, `want_lto` should probably be renamed to `lto` or similar.
* This change duplicates the `LtoMode` enum from `Compilation.Config`. This enum should be put in a shared location. But where exactly?
* Side note: it appears that `Compilation.CreateOptions.want_lto` is vestigial (i.e. never used anywhere). This field should probably be removed from the struct altogether.