### PR TITLE
Fix sigaddset/sigdelset bit-fiddling math

### DIFF
--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -128,28 +128,41 @@ test "fadvise" {
 test "sigset_t" {
     var sigset = linux.empty_sigset;
 
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), false);
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), false);
+    // See that none are set, then set each one, see that they're all set, then
+    // remove them all, and then see that none are set.
+    for (1..linux.NSIG) |i| {
+        try expectEqual(linux.sigismember(&sigset, @truncate(i)), false);
+    }
+    for (1..linux.NSIG) |i| {
+        linux.sigaddset(&sigset, @truncate(i));
+    }
+    for (1..linux.NSIG) |i| {
+        try expectEqual(linux.sigismember(&sigset, @truncate(i)), true);
+        try expectEqual(linux.sigismember(&linux.empty_sigset, @truncate(i)), false);
+    }
+    for (1..linux.NSIG) |i| {
+        linux.sigdelset(&sigset, @truncate(i));
+    }
+    for (1..linux.NSIG) |i| {
+        try expectEqual(linux.sigismember(&sigset, @truncate(i)), false);
+    }
 
-    linux.sigaddset(&sigset, linux.SIG.USR1);
+    linux.sigaddset(&sigset, 1);
+    try expectEqual(sigset[0], 1);
+    try expectEqual(sigset[1], 0);
 
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), true);
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), false);
+    linux.sigaddset(&sigset, 31);
+    try expectEqual(sigset[0], 0x4000_0001);
+    try expectEqual(sigset[1], 0);
 
-    linux.sigaddset(&sigset, linux.SIG.USR2);
+    linux.sigaddset(&sigset, 36);
+    try expectEqual(sigset[0], 0x4000_0001);
+    try expectEqual(sigset[1], 0x8);
 
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), true);
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), true);
-
-    linux.sigdelset(&sigset, linux.SIG.USR1);
-
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), false);
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), true);
-
-    linux.sigdelset(&sigset, linux.SIG.USR2);
-
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR1), false);
-    try expectEqual(linux.sigismember(&sigset, linux.SIG.USR2), false);
+    linux.sigaddset(&sigset, 64);
+    try expectEqual(sigset[0], 0x4000_0001);
+    try expectEqual(sigset[1], 0x8000_0008);
+    try expectEqual(sigset[2], 0);
 }
 
 test {


### PR DESCRIPTION
The code was using `u32` and `usize` interchangably, which doesn't work on 64-bit systems.  This: `pub const sigset_t = [1024 / 32]u32;` is not consistent with this: `const shift = @as(u5, @intCast(s & (usize_bits - 1)));`

However, normal signal numbers are less than 31, so the bad math doesn't matter much.  Also, despite support for 1024 signals in the set, only setting signals between 1 and `NSIG` (which is mostly 65, but sometimes 128) is defined.  The existing tests only exercised signal numbers in the first 31 bits so they didn't trigger the overflow.

The C library `sigaddset` will return `EINVAL` if given an out of bounds signal number.  I made the Zig code just silently ignore any out of bounds signal numbers.

I moved all the `sigset` related declarations to be adjacent in the source, too.

The `filled_sigset` seems non-standard to me.  I think it is meant to be used like `empty_sigset`, but it only contains 31 set signals, which seems wrong (should be 64 or 128, aka `NSIG`).  It's also unused.  The oddly named but similar `all_mask` is used (by `posix.zig`) but sets all 1024 bits (which I understood to be undefined behavior but seems to work just fine).  For comparison the musl `sigfillset` only fills in 64 bits (or 128 bits).