### PR TITLE
Sema/arith.zig: Fixing more typos from #23177.

### DIFF
--- a/src/Sema/arith.zig
+++ b/src/Sema/arith.zig
@@ -86,7 +86,7 @@ pub fn subMaybeWrap(
 ) CompileError!Value {
     const zcu = sema.pt.zcu;
     if (lhs.isUndef(zcu)) return lhs;
-    if (lhs.isUndef(zcu)) return rhs;
+    if (rhs.isUndef(zcu)) return rhs;
     switch (ty.zigTypeTag(zcu)) {
         .int, .comptime_int => return (try intSubWithOverflow(sema, lhs, rhs, ty)).wrapped_result,
         .float, .comptime_float => return floatSub(sema, lhs, rhs, ty),
@@ -105,7 +105,7 @@ pub fn mulMaybeWrap(
 ) CompileError!Value {
     const zcu = sema.pt.zcu;
     if (lhs.isUndef(zcu)) return lhs;
-    if (lhs.isUndef(zcu)) return rhs;
+    if (rhs.isUndef(zcu)) return rhs;
     switch (ty.zigTypeTag(zcu)) {
         .int, .comptime_int => return (try intMulWithOverflow(sema, lhs, rhs, ty)).wrapped_result,
         .float, .comptime_float => return floatMul(sema, lhs, rhs, ty),


### PR DESCRIPTION
This is a complementary PR to #23487 (I had only found one typo before).

Now I've looked at the whole `arith.zig` file, trying to find other potential problems.

Discussion about these changes:
https://github.com/ziglang/zig/pull/23177#discussion_r1997957095