### PR TITLE
linux.zig: epoll_wait: pass kernel sigset size

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2242,7 +2242,7 @@ pub fn epoll_pwait(epoll_fd: i32, events: [*]epoll_event, maxevents: u32, timeou
         @as(usize, @intCast(maxevents)),
         @as(usize, @bitCast(@as(isize, timeout))),
         @intFromPtr(sigmask),
-        @sizeOf(sigset_t),
+        NSIG / 8,
     );
 }
 


### PR DESCRIPTION
Linux kernel syscalls expect to be given the number of bits of sigset that they're built for, not the full 1024-bit sigsets that glibc supports.

I audited the other syscalls in here that use `sigset_t` and they're all using `NSIG / 8`.

Fixes #12715