### PR TITLE
build: Set `LLVM_BUILD_STATIC`/`CLANG_BUILD_STATIC` when linking statically.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,6 +698,13 @@ add_library(zigcpp STATIC ${ZIG_CPP_SOURCES})
 target_compile_features(zigcpp PRIVATE cxx_std_17)
 set_target_properties(zigcpp PROPERTIES POSITION_INDEPENDENT_CODE ${ZIG_PIE})
 
+if(LLVM_LINK_MODE STREQUAL "static")
+  target_compile_definitions(zigcpp PRIVATE
+    LLVM_BUILD_STATIC
+    CLANG_BUILD_STATIC
+  )
+endif()
+
 if(NOT MSVC)
   if(MINGW)
     target_compile_options(zigcpp PRIVATE -Wno-format)

--- a/build.zig
+++ b/build.zig
@@ -706,6 +706,9 @@ const exe_cflags = [_][]const u8{
     "-Wno-type-limits",
     "-Wno-missing-braces",
     "-Wno-comment",
+    // `exe_cflags` is only used for static linking.
+    "-DLLVM_BUILD_STATIC",
+    "-DCLANG_BUILD_STATIC",
 };
 
 fn addCmakeCfgOptionsToExe(


### PR DESCRIPTION
This is needed since LLVM 20, particularly for Windows.