### PR TITLE
std.zon.parse: Fix typo in test "std.zon parse bool"

### DIFF
--- a/lib/std/zon/parse.zig
+++ b/lib/std/zon/parse.zig
@@ -2380,7 +2380,7 @@ test "std.zon enum literals" {
 test "std.zon parse bool" {
     const gpa = std.testing.allocator;
 
-    // Correct floats
+    // Correct bools
     try std.testing.expectEqual(true, try fromSlice(bool, gpa, "true", null, .{}));
     try std.testing.expectEqual(false, try fromSlice(bool, gpa, "false", null, .{}));
 


### PR DESCRIPTION
Replace "Correct floats" with "Correct bools".

@MasonRemaley