### PR TITLE
Deprecate std.enums.nameCast.

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -197,8 +197,7 @@ test "directEnumArrayDefault slice" {
     try testing.expectEqualSlices(u8, "default", array[2]);
 }
 
-/// Cast an enum literal, value, or string to the enum value of type E
-/// with the same name.
+/// Deprecated: Use @field(U, @tagName(tag)) or @field(U, string)
 pub fn nameCast(comptime E: type, comptime value: anytype) E {
     return comptime blk: {
         const V = @TypeOf(value);

--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -197,7 +197,7 @@ test "directEnumArrayDefault slice" {
     try testing.expectEqualSlices(u8, "default", array[2]);
 }
 
-/// Deprecated: Use @field(U, @tagName(tag)) or @field(U, string)
+/// Deprecated: Use @field(E, @tagName(tag)) or @field(E, string)
 pub fn nameCast(comptime E: type, comptime value: anytype) E {
     return comptime blk: {
         const V = @TypeOf(value);


### PR DESCRIPTION
Recently there is a tendency to remove stuff from std.meta. And std.enums.nameCast seems like a missed function since it's in a different namespace.

More specific reasons:
`@field(Enum, @tagName(tag))`
^ is just shorter to write compared to
`std.meta.nameCast(Enum, tag)`

nameCast's only advantage is that it can be used interchangeably with strings. But a search through common codebases (zig, bun, tigerbeetle, ...) only tigerbeetle uses it 3 times and only in non-generic way e.g. exclusively with strings or with tags.

It's also pretty buggy and allows usage with bizarre parameters such as `std.meta.nameCast(type, Enum)`.