### PR TITLE
`std.Build`: Demote errors for exceeding `max_rss` to warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,10 +1001,6 @@ if(NOT "${ZIG_TARGET_DYNAMIC_LINKER}" STREQUAL "")
   list(APPEND ZIG_BUILD_ARGS "-Ddynamic-linker=${ZIG_TARGET_DYNAMIC_LINKER}")
 endif()
 
-if(MINGW AND "${ZIG_HOST_TARGET_ARCH}" STREQUAL "x86")
-  list(APPEND ZIG_BUILD_ARGS --maxrss 7000000000)
-endif()
-
 
 add_custom_target(stage3 ALL
   DEPENDS "${PROJECT_BINARY_DIR}/stage3/bin/zig"

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -599,7 +599,6 @@ fn prepare(
             if (run.max_rss_is_default) {
                 std.debug.print("note: use --maxrss to override the default", .{});
             }
-            return uncleanExit();
         }
     }
 }

--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -247,7 +247,6 @@ pub fn make(s: *Step, options: MakeOptions) error{ MakeFailed, MakeSkipped }!voi
             s.result_peak_rss, s.max_rss,
         }) catch @panic("OOM");
         s.result_error_msgs.append(arena, msg) catch @panic("OOM");
-        return error.MakeFailed;
     }
 }
 


### PR DESCRIPTION
We have no control over memory usage on arbitrary systems in the wild. But we would still like to get the warnings so we can adjust the values based on observations in the official ZSF CI.

Closes #23254.
Closes #23638.