### PR TITLE
std.process: linux.sysinfo for totalSystemMemory

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2610,6 +2610,71 @@ pub fn map_shadow_stack(addr: u64, size: u64, flags: u32) usize {
     return syscall3(.map_shadow_stack, addr, size, flags);
 }
 
+pub const Sysinfo = switch (native_abi) {
+    .gnux32, .muslx32 => extern struct {
+        /// Seconds since boot
+        uptime: i64,
+        /// 1, 5, and 15 minute load averages
+        loads: [3]u64,
+        /// Total usable main memory size
+        totalram: u64,
+        /// Available memory size
+        freeram: u64,
+        /// Amount of shared memory
+        sharedram: u64,
+        /// Memory used by buffers
+        bufferram: u64,
+        /// Total swap space size
+        totalswap: u64,
+        /// swap space still available
+        freeswap: u64,
+        /// Number of current processes
+        procs: u16,
+        /// Explicit padding for m68k
+        pad: u16,
+        /// Total high memory size
+        totalhigh: u64,
+        /// Available high memory size
+        freehigh: u64,
+        /// Memory unit size in bytes
+        mem_unit: u32,
+    },
+    else => extern struct {
+        /// Seconds since boot
+        uptime: isize,
+        /// 1, 5, and 15 minute load averages
+        loads: [3]usize,
+        /// Total usable main memory size
+        totalram: usize,
+        /// Available memory size
+        freeram: usize,
+        /// Amount of shared memory
+        sharedram: usize,
+        /// Memory used by buffers
+        bufferram: usize,
+        /// Total swap space size
+        totalswap: usize,
+        /// swap space still available
+        freeswap: usize,
+        /// Number of current processes
+        procs: u16,
+        /// Explicit padding for m68k
+        pad: u16,
+        /// Total high memory size
+        totalhigh: usize,
+        /// Available high memory size
+        freehigh: usize,
+        /// Memory unit size in bytes
+        mem_unit: u32,
+        /// Pad
+        _f: [20 - 2 * @sizeOf(usize) - @sizeOf(u32)]u8,
+    },
+};
+
+pub fn sysinfo(info: *Sysinfo) usize {
+    return syscall1(.sysinfo, @intFromPtr(info));
+}
+
 pub const E = switch (native_arch) {
     .mips, .mipsel, .mips64, .mips64el => enum(u16) {
         /// No error occurred.

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -165,6 +165,15 @@ test "sigset_t" {
     try expectEqual(sigset[2], 0);
 }
 
+test "sysinfo" {
+    var info: linux.Sysinfo = undefined;
+    const result: usize = linux.sysinfo(&info);
+    try expect(std.os.linux.E.init(result) == .SUCCESS);
+
+    try expect(info.mem_unit > 0);
+    try expect(info.mem_unit <= std.heap.page_size_max);
+}
+
 test {
     _ = linux.IoUring;
 }


### PR DESCRIPTION
Looking for memory information I found this function std.process.totalSystemMemoryLinux()

Which currently parses out the human readable /proc/meminfo for use in totalSystemMemory()'s .linux case.

I knew there was a syscall for this so I found and ported the related struct

https://github.com/torvalds/linux/blob/master/include/uapi/linux/sysinfo.h

It's Linux only, but I think its useful in the std.process context.

This PR would add sysinfo_t and sysinfo(*sysinfo_t) to std.os.linux
Also replaces std.process.totalSystemMemory()'s .linux case to use the new function.