### PR TITLE
`std.Target`: Bump minimum Linux kernel and glibc versions according to Debian LTS

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -455,7 +455,7 @@ pub const Os = struct {
                     .linux = .{
                         .range = .{
                             .min = blk: {
-                                const default_min: std.SemanticVersion = .{ .major = 4, .minor = 19, .patch = 0 };
+                                const default_min: std.SemanticVersion = .{ .major = 5, .minor = 10, .patch = 0 };
 
                                 for (std.zig.target.available_libcs) |libc| {
                                     if (libc.arch != arch or libc.os != tag or libc.abi != abi) continue;

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -470,7 +470,7 @@ pub const Os = struct {
                             .max = .{ .major = 6, .minor = 13, .patch = 4 },
                         },
                         .glibc = blk: {
-                            const default_min: std.SemanticVersion = .{ .major = 2, .minor = 28, .patch = 0 };
+                            const default_min: std.SemanticVersion = .{ .major = 2, .minor = 31, .patch = 0 };
 
                             for (std.zig.target.available_libcs) |libc| {
                                 if (libc.os != tag or libc.arch != arch or libc.abi != abi) continue;

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1149,7 +1149,7 @@ pub fn access(path: [*:0]const u8, mode: u32) usize {
 }
 
 pub fn faccessat(dirfd: i32, path: [*:0]const u8, mode: u32, flags: u32) usize {
-    return syscall4(.faccessat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode, flags);
+    return syscall4(.faccessat2, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode, flags);
 }
 
 pub fn pipe(fd: *[2]i32) usize {


### PR DESCRIPTION
Also fix #16606 which requires Linux 5.8+.