### PR TITLE
[0.14.x] `Compilation`: Use trapping UBSan if `-fno-ubsan-rt` is passed.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -6053,7 +6053,9 @@ pub fn addCCArgs(
                         // function was called.
                         try argv.append("-fno-sanitize=function");
 
-                        if (mod.optimize_mode == .ReleaseSafe) {
+                        // If we want to sanitize C, but the ubsan runtime has been turned off,
+                        // we'll switch to just trapping.
+                        if (comp.ubsan_rt_strat == .none or mod.optimize_mode == .ReleaseSafe) {
                             // It's recommended to use the minimal runtime in production
                             // environments due to the security implications of the full runtime.
                             // The minimal runtime doesn't provide much benefit over simply


### PR DESCRIPTION
This is a mitigation of #23216 meant only for 0.14.x.

Patch by @Rexicon226: https://github.com/ziglang/zig/issues/23216#issuecomment-2783472009

I'll send a separate PR with the proper fix for master, which will allow `zig build-exe -fsanitize-c=trap` and `zig cc -fsanitize-trap=undefined`. We can't backport that because it will require `std.Build` API changes.