### PR TITLE
src/libunwind.zig: Fix symbol visibility macro define

### DIFF
--- a/src/libunwind.zig
+++ b/src/libunwind.zig
@@ -119,7 +119,7 @@ pub fn buildStaticLib(comp: *Compilation, prog_node: std.Progress.Node) BuildErr
         }
         try cflags.append("-I");
         try cflags.append(try comp.zig_lib_directory.join(arena, &[_][]const u8{ "libunwind", "include" }));
-        try cflags.append("-D_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS");
+        try cflags.append("-D_LIBUNWIND_HIDE_SYMBOLS");
         try cflags.append("-Wa,--noexecstack");
         try cflags.append("-fvisibility=hidden");
         try cflags.append("-fvisibility-inlines-hidden");


### PR DESCRIPTION
The define was changed in commit 729899f7b6bf6aff65988d895d7a639391a67608 in upstream llvm. This fixes #23543.

As in the related issue, before readelf produces the output
```
Symbol table '.dynsym' contains 68 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     2: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memset@GLIBC_2.2.5 (2)
     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __tls_get_addr@GLIBC_2.3 (3)
     4: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND stderr@GLIBC_2.2.5 (2)
     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fwrite@GLIBC_2.2.5 (2)
// glibc symbols ...
    29: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND pthread_rwlock_rdlock@GLIBC_2.34 (6)
    30: 0000000000026929    26 FUNC    GLOBAL DEFAULT   15 _Unwind_DeleteException
    31: 000000000002a6e0    10 FUNC    WEAK   DEFAULT   16 operator new[](unsigned long)
    32: 00000000000264dc    10 FUNC    WEAK   DEFAULT   15 operator delete(void*, std::align_val_t)
    33: 0000000000026be0    16 FUNC    WEAK   DEFAULT   15 unw_step
    34: 0000000000026a86    64 FUNC    WEAK   DEFAULT   15 unw_get_reg
    35: 0000000000026b5e    65 FUNC    WEAK   DEFAULT   15 unw_get_fpreg
    36: 00000000000265cc   238 FUNC    GLOBAL DEFAULT   15 _Unwind_RaiseException
    37: 000000000002699c   137 FUNC    GLOBAL DEFAULT   15 _Unwind_Resume
    38: 0000000000026906    35 FUNC    GLOBAL DEFAULT   15 _Unwind_GetRegionStart
    39: 0000000000026c51    15 FUNC    WEAK   DEFAULT   15 unw_is_fpreg
    40: 000000000002695f    10 FUNC    GLOBAL DEFAULT   15 _Unwind_SetGR
    41: 0000000000026458    10 FUNC    WEAK   DEFAULT   15 operator delete(void*)
    42: 0000000000026476    10 FUNC    WEAK   DEFAULT   15 operator delete[](void*)
    43: 00000000000264f0    13 FUNC    WEAK   DEFAULT   15 operator delete(void*, unsigned long, std::align_val_t)
    44: 0000000000030888     8 OBJECT  GLOBAL DEFAULT   24 unw_local_addr_space
    45: 0000000000026c39    24 FUNC    WEAK   DEFAULT   15 unw_get_proc_name
    46: 0000000000026c6e    15 FUNC    WEAK   DEFAULT   15 unw_is_signal_frame
    47: 0000000000026943    28 FUNC    GLOBAL DEFAULT   15 _Unwind_GetGR
    48: 0000000000026969    33 FUNC    GLOBAL DEFAULT   15 _Unwind_GetIP
    49: 000000000002698a    18 FUNC    GLOBAL DEFAULT   15 _Unwind_SetIP
    50: 0000000000026a28    94 FUNC    WEAK   DEFAULT   15 unw_init_local
    51: 0000000000026884    95 FUNC    GLOBAL DEFAULT   15 _Unwind_ForcedUnwind
    52: 000000000002a6ea   127 FUNC    WEAK   DEFAULT   16 operator new(unsigned long, std::align_val_t)
    53: 0000000000026511    13 FUNC    WEAK   DEFAULT   15 operator delete[](void*, unsigned long, std::align_val_t)
    54: 0000000000026c28    17 FUNC    WEAK   DEFAULT   15 unw_resume
    55: 000000000002a630     0 FUNC    WEAK   DEFAULT   15 unw_getcontext
    56: 000000000001597a    13 FUNC    GLOBAL DEFAULT   15 foo(int)
    57: 000000000002a682    94 FUNC    WEAK   DEFAULT   16 operator new(unsigned long)
    58: 000000000002a769    10 FUNC    WEAK   DEFAULT   16 operator new[](unsigned long, std::align_val_t)
    59: 000000000002646c    10 FUNC    WEAK   DEFAULT   15 operator delete(void*, unsigned long)
    60: 00000000000268e3    35 FUNC    GLOBAL DEFAULT   15 _Unwind_GetLanguageSpecificData
    61: 000000000002648a    10 FUNC    WEAK   DEFAULT   15 operator delete[](void*, unsigned long)
    62: 00000000000264fd    10 FUNC    WEAK   DEFAULT   15 operator delete[](void*, std::align_val_t)
    63: 0000000000026ac6   152 FUNC    WEAK   DEFAULT   15 unw_set_reg
    64: 0000000000026c03    37 FUNC    WEAK   DEFAULT   15 unw_get_proc_info
    65: 0000000000026c7d    10 FUNC    WEAK   DEFAULT   15 unw_iterate_dwarf_unwind_cache
    66: 0000000000026b9f    65 FUNC    WEAK   DEFAULT   15 unw_set_fpreg
    67: 0000000000026c60    14 FUNC    WEAK   DEFAULT   15 unw_regnam
```

After these changes, readelf produces the following output:
```
Symbol table '.dynsym' contains 43 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     2: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND memset@GLIBC_2.2.5 (2)
     3: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __tls_get_addr@GLIBC_2.3 (3)
     4: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND stderr@GLIBC_2.2.5 (2)
     5: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND fwrite@GLIBC_2.2.5 (2)
// glibc symbols ...
    29: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND pthread_rwlock_rdlock@GLIBC_2.34 (6)
    30: 000000000001530a    13 FUNC    GLOBAL DEFAULT   15 foo(int)
    31: 000000000002a012    94 FUNC    WEAK   DEFAULT   16 operator new(unsigned long)
    32: 000000000002a070    10 FUNC    WEAK   DEFAULT   16 operator new[](unsigned long)
    33: 0000000000025de8    10 FUNC    WEAK   DEFAULT   15 operator delete(void*)
    34: 0000000000025e06    10 FUNC    WEAK   DEFAULT   15 operator delete[](void*)
    35: 000000000002a0f9    10 FUNC    WEAK   DEFAULT   16 operator new[](unsigned long, std::align_val_t)
    36: 0000000000025e6c    10 FUNC    WEAK   DEFAULT   15 operator delete(void*, std::align_val_t)
    37: 0000000000025e80    13 FUNC    WEAK   DEFAULT   15 operator delete(void*, unsigned long, std::align_val_t)
    38: 0000000000025dfc    10 FUNC    WEAK   DEFAULT   15 operator delete(void*, unsigned long)
    39: 0000000000025e1a    10 FUNC    WEAK   DEFAULT   15 operator delete[](void*, unsigned long)
    40: 0000000000025e8d    10 FUNC    WEAK   DEFAULT   15 operator delete[](void*, std::align_val_t)
    41: 000000000002a07a   127 FUNC    WEAK   DEFAULT   16 operator new(unsigned long, std::align_val_t)
    42: 0000000000025ea1    13 FUNC    WEAK   DEFAULT   15 operator delete[](void*, unsigned long, std::align_val_t)
```