### PR TITLE
`std.Build.Step`: Don't capture a stack trace if `!std.debug.sys_can_stack_trace`

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -202,6 +202,7 @@ pub fn init(options: StepOptions) Step {
         .state = .precheck_unstarted,
         .max_rss = options.max_rss,
         .debug_stack_trace = blk: {
+            if (!std.debug.sys_can_stack_trace) break :blk &.{};
             const addresses = arena.alloc(usize, options.owner.debug_stack_frames_count) catch @panic("OOM");
             @memset(addresses, 0);
             const first_ret_addr = options.first_ret_addr orelse @returnAddress();


### PR DESCRIPTION
Should fix some of the timeouts that appeared in CI since #23549. This apparently only worked by coincidence until now.