### PR TITLE
Return FileNotFound when CreateProcessW is called with a missing path

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1980,6 +1980,7 @@ pub fn CreateProcessW(
         switch (GetLastError()) {
             .FILE_NOT_FOUND => return error.FileNotFound,
             .PATH_NOT_FOUND => return error.FileNotFound,
+            .DIRECTORY => return error.FileNotFound,
             .ACCESS_DENIED => return error.AccessDenied,
             .INVALID_PARAMETER => unreachable,
             .INVALID_NAME => return error.InvalidName,

--- a/test/standalone/windows_spawn/main.zig
+++ b/test/standalone/windows_spawn/main.zig
@@ -51,6 +51,8 @@ pub fn main() anyerror!void {
     try testExec(allocator, "HeLLo.exe", "hello from exe\n");
     // without extension should find the .exe (case insensitive)
     try testExec(allocator, "heLLo", "hello from exe\n");
+    // with invalid cwd
+    try std.testing.expectError(error.FileNotFound, testExecWithCwd(allocator, "hello.exe", "missing_dir", ""));
 
     // now add a .bat
     try tmp.dir.writeFile(.{ .sub_path = "hello.bat", .data = "@echo hello from bat" });


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/19023

CreateProcessW currently returns error.Unexpected when the lpCurrentDirectory value is a directory that does not exist. 
With this PR, CreateProcessW returns error.FileNotFound in those cases.

Directory not existing and directory invalid cannot be distinguished. CreateProcessW returns [ERROR_DIRECTORY - 267 (0x10B) - The directory name is invalid.] in both cases.

Can be tested with the following test. 
```
test "test CreateProcessW with invalid path" {
    const allocator = std.testing.allocator;
    const application_name = try std.unicode.utf8ToUtf16LeAllocZ(allocator, "c:\\windows\\explorer.exe");
    defer allocator.free(application_name);
    const command_line = try std.unicode.utf8ToUtf16LeAllocZ(allocator, "");
    defer allocator.free(command_line);
    const startup_directory = try std.unicode.utf8ToUtf16LeAllocZ(allocator, "c:\\directory_that_does_not_exist");
    defer allocator.free(startup_directory);

    var startup_info = std.mem.zeroes(std.os.windows.STARTUPINFOW);
    var process_info = std.mem.zeroes(std.os.windows.PROCESS_INFORMATION);
    const inherit: std.os.windows.BOOL = 0;
    const flags = std.mem.zeroes(std.os.windows.CreateProcessFlags);

    try std.testing.expectError(error.FileNotFound, std.os.windows.CreateProcessW(
        application_name,
        command_line,
        null,
        null,
        inherit,
        flags,
        null,
        startup_directory,
        &startup_info,
        &process_info,
    ));
}
const std = @import("std");
```