### PR TITLE
std.math.big.int: fix a bug in `llshl` and update test syntax

### DIFF
--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -4244,7 +4244,6 @@ test "llshl shift by whole number of limb" {
 
     var r: [10]Limb = @splat(padding);
 
-    // arbitrary numbers known to fit ?
     const A: Limb = @truncate(0xCCCCCCCCCCCCCCCCCCCCCCC);
     const B: Limb = @truncate(0x22222222222222222222222);
 
@@ -4270,62 +4269,57 @@ test llshl {
     const maxint: Limb = 0xFFFFFFFFFFFFFFFF;
 
     // zig fmt: off
-    const cases: Cases = &.{
-        .{0,  &.{0},                               &.{0}},
-        .{0,  &.{1},                               &.{1}},
-        .{0,  &.{125484842448},                    &.{125484842448}},
-        .{0,  &.{0xdeadbeef},                      &.{0xdeadbeef}},
-        .{0,  &.{maxint},                          &.{maxint}},
-        .{0,  &.{left_one},                        &.{left_one}},
-        .{0,  &.{0, 1},                            &.{0, 1}},
-        .{0,  &.{1, 2},                            &.{1, 2}},
-        .{0,  &.{left_one, 1},                     &.{left_one, 1}},
-        .{1,  &.{0},                               &.{0}},
-        .{1,  &.{2},                               &.{1}},
-        .{1,  &.{250969684896},                    &.{125484842448}},
-        .{1,  &.{0x1bd5b7dde},                     &.{0xdeadbeef}},
-        .{1,  &.{0xfffffffffffffffe, 1},           &.{maxint}},
-        .{1,  &.{0, 1},                            &.{left_one}},
-        .{1,  &.{0, 2},                            &.{0, 1}},
-        .{1,  &.{2, 4},                            &.{1, 2}},
-        .{1,  &.{0, 3},                            &.{left_one, 1}},
-        .{5,  &.{32},                              &.{1}},
-        .{5,  &.{4015514958336},                   &.{125484842448}},
-        .{5,  &.{0x1bd5b7dde0},                    &.{0xdeadbeef}},
-        .{5,  &.{0xffffffffffffffe0, 0x1f},        &.{maxint}},
-        .{5,  &.{0, 16},                           &.{left_one}},
-        .{5,  &.{0, 32},                           &.{0, 1}},
-        .{5,  &.{32, 64},                          &.{1, 2}},
-        .{5,  &.{0, 48},                           &.{left_one, 1}},
-        .{64, &.{0, 1},                            &.{1}},
-        .{64, &.{0, 125484842448},                 &.{125484842448}},
-        .{64, &.{0, 0xdeadbeef},                   &.{0xdeadbeef}},
-        .{64, &.{0, maxint},                       &.{maxint}},
-        .{64, &.{0, left_one},                     &.{left_one}},
-        .{64, &.{0, 0, 1},                         &.{0, 1}},
-        .{64, &.{0, 1, 2},                         &.{1, 2}},
-        .{64, &.{0, left_one, 1},                  &.{left_one, 1}},
-        .{35, &.{0x800000000},                     &.{1}},
-        .{35, &.{13534986488655118336, 233},       &.{125484842448}},
-        .{35, &.{0xf56df77800000000, 6},           &.{0xdeadbeef}},
-        .{35, &.{0xfffffff800000000, 0x7ffffffff}, &.{maxint}},
-        .{35, &.{0, 17179869184},                  &.{left_one}},
-        .{35, &.{0, 0x800000000},                  &.{0, 1}},
-        .{35, &.{0x800000000, 0x1000000000},       &.{1, 2}},
-        .{35, &.{0, 0xc00000000},                  &.{left_one, 1}},
-        .{70, &.{0, 64},                           &.{1}},
-        .{70, &.{0, 8031029916672},                &.{125484842448}},
-        .{70, &.{0, 0x37ab6fbbc0},                 &.{0xdeadbeef}},
-        .{70, &.{0, 0xffffffffffffffc0, 63},       &.{maxint}},
-        .{70, &.{0, 0, 32},                        &.{left_one}},
-        .{70, &.{0, 0, 64},                        &.{0, 1}},
-        .{70, &.{0, 64, 128},                      &.{1, 2}},
-        .{70, &.{0, 0, 0x60},                      &.{left_one, 1}},
-    };
+    try testOneShiftCase(.llshl, .{0,  &.{0},                               &.{0}});
+    try testOneShiftCase(.llshl, .{0,  &.{1},                               &.{1}});
+    try testOneShiftCase(.llshl, .{0,  &.{125484842448},                    &.{125484842448}});
+    try testOneShiftCase(.llshl, .{0,  &.{0xdeadbeef},                      &.{0xdeadbeef}});
+    try testOneShiftCase(.llshl, .{0,  &.{maxint},                          &.{maxint}});
+    try testOneShiftCase(.llshl, .{0,  &.{left_one},                        &.{left_one}});
+    try testOneShiftCase(.llshl, .{0,  &.{0, 1},                            &.{0, 1}});
+    try testOneShiftCase(.llshl, .{0,  &.{1, 2},                            &.{1, 2}});
+    try testOneShiftCase(.llshl, .{0,  &.{left_one, 1},                     &.{left_one, 1}});
+    try testOneShiftCase(.llshl, .{1,  &.{0},                               &.{0}});
+    try testOneShiftCase(.llshl, .{1,  &.{2},                               &.{1}});
+    try testOneShiftCase(.llshl, .{1,  &.{250969684896},                    &.{125484842448}});
+    try testOneShiftCase(.llshl, .{1,  &.{0x1bd5b7dde},                     &.{0xdeadbeef}});
+    try testOneShiftCase(.llshl, .{1,  &.{0xfffffffffffffffe, 1},           &.{maxint}});
+    try testOneShiftCase(.llshl, .{1,  &.{0, 1},                            &.{left_one}});
+    try testOneShiftCase(.llshl, .{1,  &.{0, 2},                            &.{0, 1}});
+    try testOneShiftCase(.llshl, .{1,  &.{2, 4},                            &.{1, 2}});
+    try testOneShiftCase(.llshl, .{1,  &.{0, 3},                            &.{left_one, 1}});
+    try testOneShiftCase(.llshl, .{5,  &.{32},                              &.{1}});
+    try testOneShiftCase(.llshl, .{5,  &.{4015514958336},                   &.{125484842448}});
+    try testOneShiftCase(.llshl, .{5,  &.{0x1bd5b7dde0},                    &.{0xdeadbeef}});
+    try testOneShiftCase(.llshl, .{5,  &.{0xffffffffffffffe0, 0x1f},        &.{maxint}});
+    try testOneShiftCase(.llshl, .{5,  &.{0, 16},                           &.{left_one}});
+    try testOneShiftCase(.llshl, .{5,  &.{0, 32},                           &.{0, 1}});
+    try testOneShiftCase(.llshl, .{5,  &.{32, 64},                          &.{1, 2}});
+    try testOneShiftCase(.llshl, .{5,  &.{0, 48},                           &.{left_one, 1}});
+    try testOneShiftCase(.llshl, .{64, &.{0, 1},                            &.{1}});
+    try testOneShiftCase(.llshl, .{64, &.{0, 125484842448},                 &.{125484842448}});
+    try testOneShiftCase(.llshl, .{64, &.{0, 0xdeadbeef},                   &.{0xdeadbeef}});
+    try testOneShiftCase(.llshl, .{64, &.{0, maxint},                       &.{maxint}});
+    try testOneShiftCase(.llshl, .{64, &.{0, left_one},                     &.{left_one}});
+    try testOneShiftCase(.llshl, .{64, &.{0, 0, 1},                         &.{0, 1}});
+    try testOneShiftCase(.llshl, .{64, &.{0, 1, 2},                         &.{1, 2}});
+    try testOneShiftCase(.llshl, .{64, &.{0, left_one, 1},                  &.{left_one, 1}});
+    try testOneShiftCase(.llshl, .{35, &.{0x800000000},                     &.{1}});
+    try testOneShiftCase(.llshl, .{35, &.{13534986488655118336, 233},       &.{125484842448}});
+    try testOneShiftCase(.llshl, .{35, &.{0xf56df77800000000, 6},           &.{0xdeadbeef}});
+    try testOneShiftCase(.llshl, .{35, &.{0xfffffff800000000, 0x7ffffffff}, &.{maxint}});
+    try testOneShiftCase(.llshl, .{35, &.{0, 17179869184},                  &.{left_one}});
+    try testOneShiftCase(.llshl, .{35, &.{0, 0x800000000},                  &.{0, 1}});
+    try testOneShiftCase(.llshl, .{35, &.{0x800000000, 0x1000000000},       &.{1, 2}});
+    try testOneShiftCase(.llshl, .{35, &.{0, 0xc00000000},                  &.{left_one, 1}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 64},                           &.{1}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 8031029916672},                &.{125484842448}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 0x37ab6fbbc0},                 &.{0xdeadbeef}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 0xffffffffffffffc0, 63},       &.{maxint}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 0, 32},                        &.{left_one}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 0, 64},                        &.{0, 1}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 64, 128},                      &.{1, 2}});
+    try testOneShiftCase(.llshl, .{70, &.{0, 0, 0x60},                      &.{left_one, 1}});
     // zig fmt: on
-
-    try test_shift_cases(llshl, cases);
-    try test_shift_cases_aliasing(llshl, cases, -1);
 }
 
 test "llshl shift 0" {
@@ -4333,68 +4327,58 @@ test "llshl shift 0" {
     if (n <= 20) return error.SkipZigTest;
 
     // zig fmt: off
-    const cases = &.{
-        .{0,   &.{0},    &.{0}},
-        .{1,   &.{0},    &.{0}},
-        .{5,   &.{0},    &.{0}},
-        .{13,  &.{0},    &.{0}},
-        .{20,  &.{0},    &.{0}},
-        .{0,   &.{0, 0}, &.{0, 0}},
-        .{2,   &.{0, 0}, &.{0, 0}},
-        .{7,   &.{0, 0}, &.{0, 0}},
-        .{11,  &.{0, 0}, &.{0, 0}},
-        .{19,  &.{0, 0}, &.{0, 0}},
+    try testOneShiftCase(.llshl, .{0,   &.{0},    &.{0}});
+    try testOneShiftCase(.llshl, .{1,   &.{0},    &.{0}});
+    try testOneShiftCase(.llshl, .{5,   &.{0},    &.{0}});
+    try testOneShiftCase(.llshl, .{13,  &.{0},    &.{0}});
+    try testOneShiftCase(.llshl, .{20,  &.{0},    &.{0}});
+    try testOneShiftCase(.llshl, .{0,   &.{0, 0}, &.{0, 0}});
+    try testOneShiftCase(.llshl, .{2,   &.{0, 0}, &.{0, 0}});
+    try testOneShiftCase(.llshl, .{7,   &.{0, 0}, &.{0, 0}});
+    try testOneShiftCase(.llshl, .{11,  &.{0, 0}, &.{0, 0}});
+    try testOneShiftCase(.llshl, .{19,  &.{0, 0}, &.{0, 0}});
 
-        .{0,   &.{0},                &.{0}},
-        .{n,   &.{0, 0},             &.{0}},
-        .{2*n, &.{0, 0, 0},          &.{0}},
-        .{3*n, &.{0, 0, 0, 0},       &.{0}},
-        .{4*n, &.{0, 0, 0, 0, 0},    &.{0}},
-        .{0,   &.{0, 0},             &.{0, 0}},
-        .{n,   &.{0, 0, 0},          &.{0, 0}},
-        .{2*n, &.{0, 0, 0, 0},       &.{0, 0}},
-        .{3*n, &.{0, 0, 0, 0, 0},    &.{0, 0}},
-        .{4*n, &.{0, 0, 0, 0, 0, 0}, &.{0, 0}},
-    };
+    try testOneShiftCase(.llshl, .{0,   &.{0},                &.{0}});
+    try testOneShiftCase(.llshl, .{n,   &.{0, 0},             &.{0}});
+    try testOneShiftCase(.llshl, .{2*n, &.{0, 0, 0},          &.{0}});
+    try testOneShiftCase(.llshl, .{3*n, &.{0, 0, 0, 0},       &.{0}});
+    try testOneShiftCase(.llshl, .{4*n, &.{0, 0, 0, 0, 0},    &.{0}});
+    try testOneShiftCase(.llshl, .{0,   &.{0, 0},             &.{0, 0}});
+    try testOneShiftCase(.llshl, .{n,   &.{0, 0, 0},          &.{0, 0}});
+    try testOneShiftCase(.llshl, .{2*n, &.{0, 0, 0, 0},       &.{0, 0}});
+    try testOneShiftCase(.llshl, .{3*n, &.{0, 0, 0, 0, 0},    &.{0, 0}});
+    try testOneShiftCase(.llshl, .{4*n, &.{0, 0, 0, 0, 0, 0}, &.{0, 0}});
     // zig fmt: on
-
-    try test_shift_cases(llshl, cases);
-    try test_shift_cases_aliasing(llshl, cases, -1);
 }
 
 test "llshr shift 0" {
     const n = @bitSizeOf(Limb);
 
     // zig fmt: off
-    const cases = &.{
-        .{0,   &.{0},    &.{0}},
-        .{1,   &.{0},    &.{0}},
-        .{5,   &.{0},    &.{0}},
-        .{13,  &.{0},    &.{0}},
-        .{20,  &.{0},    &.{0}},
-        .{0,   &.{0, 0}, &.{0, 0}},
-        .{2,   &.{0},    &.{0, 0}},
-        .{7,   &.{0},    &.{0, 0}},
-        .{11,  &.{0},    &.{0, 0}},
-        .{19,  &.{0},    &.{0, 0}},
+    try testOneShiftCase(.llshr, .{0,   &.{0},    &.{0}});
+    try testOneShiftCase(.llshr, .{1,   &.{0},    &.{0}});
+    try testOneShiftCase(.llshr, .{5,   &.{0},    &.{0}});
+    try testOneShiftCase(.llshr, .{13,  &.{0},    &.{0}});
+    try testOneShiftCase(.llshr, .{20,  &.{0},    &.{0}});
+    try testOneShiftCase(.llshr, .{0,   &.{0, 0}, &.{0, 0}});
+    try testOneShiftCase(.llshr, .{2,   &.{0},    &.{0, 0}});
+    try testOneShiftCase(.llshr, .{7,   &.{0},    &.{0, 0}});
+    try testOneShiftCase(.llshr, .{11,  &.{0},    &.{0, 0}});
+    try testOneShiftCase(.llshr, .{19,  &.{0},    &.{0, 0}});
 
-        .{n,   &.{0}, &.{0}},
-        .{2*n, &.{0}, &.{0}},
-        .{3*n, &.{0}, &.{0}},
-        .{4*n, &.{0}, &.{0}},
-        .{n,   &.{0}, &.{0, 0}},
-        .{2*n, &.{0}, &.{0, 0}},
-        .{3*n, &.{0}, &.{0, 0}},
-        .{4*n, &.{0}, &.{0, 0}},
+    try testOneShiftCase(.llshr, .{n,   &.{0}, &.{0}});
+    try testOneShiftCase(.llshr, .{2*n, &.{0}, &.{0}});
+    try testOneShiftCase(.llshr, .{3*n, &.{0}, &.{0}});
+    try testOneShiftCase(.llshr, .{4*n, &.{0}, &.{0}});
+    try testOneShiftCase(.llshr, .{n,   &.{0}, &.{0, 0}});
+    try testOneShiftCase(.llshr, .{2*n, &.{0}, &.{0, 0}});
+    try testOneShiftCase(.llshr, .{3*n, &.{0}, &.{0, 0}});
+    try testOneShiftCase(.llshr, .{4*n, &.{0}, &.{0, 0}});
 
-        .{1,  &.{}, &.{}},
-        .{2,  &.{}, &.{}},
-        .{64, &.{}, &.{}},
-    };
+    try testOneShiftCase(.llshr, .{1,  &.{}, &.{}});
+    try testOneShiftCase(.llshr, .{2,  &.{}, &.{}});
+    try testOneShiftCase(.llshr, .{64, &.{}, &.{}});
     // zig fmt: on
-
-    try test_shift_cases(llshr, cases);
-    try test_shift_cases_aliasing(llshr, cases, 1);
 }
 
 test "llshr to 0" {
@@ -4402,19 +4386,14 @@ test "llshr to 0" {
     if (n != 64 and n != 32) return error.SkipZigTest;
 
     // zig fmt: off
-    const cases = &.{
-        .{1,   &.{0}, &.{0}},
-        .{1,   &.{0}, &.{1}},
-        .{5,   &.{0}, &.{1}},
-        .{65,  &.{0}, &.{0, 1}},
-        .{193, &.{0}, &.{0, 0, std.math.maxInt(Limb)}},
-        .{193, &.{0}, &.{std.math.maxInt(Limb), 1, std.math.maxInt(Limb)}},
-        .{193, &.{0}, &.{0xdeadbeef, 0xabcdefab, 0x1234}},
-    };
+    try testOneShiftCase(.llshr, .{1,   &.{0}, &.{0}});
+    try testOneShiftCase(.llshr, .{1,   &.{0}, &.{1}});
+    try testOneShiftCase(.llshr, .{5,   &.{0}, &.{1}});
+    try testOneShiftCase(.llshr, .{65,  &.{0}, &.{0, 1}});
+    try testOneShiftCase(.llshr, .{193, &.{0}, &.{0, 0, std.math.maxInt(Limb)}});
+    try testOneShiftCase(.llshr, .{193, &.{0}, &.{std.math.maxInt(Limb), 1, std.math.maxInt(Limb)}});
+    try testOneShiftCase(.llshr, .{193, &.{0}, &.{0xdeadbeef, 0xabcdefab, 0x1234}});
     // zig fmt: on
-
-    try test_shift_cases(llshr, cases);
-    try test_shift_cases_aliasing(llshr, cases, 1);
 }
 
 test "llshr single" {
@@ -4425,30 +4404,25 @@ test "llshr single" {
     const maxint: Limb = 0xFFFFFFFFFFFFFFFF;
 
     // zig fmt: off
-    const cases: Cases = &.{
-        .{0,  &.{0},                  &.{0}},
-        .{0,  &.{1},                  &.{1}},
-        .{0,  &.{125484842448},       &.{125484842448}},
-        .{0,  &.{0xdeadbeef},         &.{0xdeadbeef}},
-        .{0,  &.{maxint},             &.{maxint}},
-        .{0,  &.{left_one},           &.{left_one}},
-        .{1,  &.{0},                  &.{0}},
-        .{1,  &.{1},                  &.{2}},
-        .{1,  &.{62742421224},        &.{125484842448}},
-        .{1,  &.{62742421223},        &.{125484842447}},
-        .{1,  &.{0x6f56df77},         &.{0xdeadbeef}},
-        .{1,  &.{0x7fffffffffffffff}, &.{maxint}},
-        .{1,  &.{0x4000000000000000}, &.{left_one}},
-        .{8,  &.{1},                  &.{256}},
-        .{8,  &.{490175165},          &.{125484842448}},
-        .{8,  &.{0xdeadbe},           &.{0xdeadbeef}},
-        .{8,  &.{0xffffffffffffff},   &.{maxint}},
-        .{8,  &.{0x80000000000000},   &.{left_one}},
-    };
+    try testOneShiftCase(.llshr, .{0,  &.{0},                  &.{0}});
+    try testOneShiftCase(.llshr, .{0,  &.{1},                  &.{1}});
+    try testOneShiftCase(.llshr, .{0,  &.{125484842448},       &.{125484842448}});
+    try testOneShiftCase(.llshr, .{0,  &.{0xdeadbeef},         &.{0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{0,  &.{maxint},             &.{maxint}});
+    try testOneShiftCase(.llshr, .{0,  &.{left_one},           &.{left_one}});
+    try testOneShiftCase(.llshr, .{1,  &.{0},                  &.{0}});
+    try testOneShiftCase(.llshr, .{1,  &.{1},                  &.{2}});
+    try testOneShiftCase(.llshr, .{1,  &.{62742421224},        &.{125484842448}});
+    try testOneShiftCase(.llshr, .{1,  &.{62742421223},        &.{125484842447}});
+    try testOneShiftCase(.llshr, .{1,  &.{0x6f56df77},         &.{0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{1,  &.{0x7fffffffffffffff}, &.{maxint}});
+    try testOneShiftCase(.llshr, .{1,  &.{0x4000000000000000}, &.{left_one}});
+    try testOneShiftCase(.llshr, .{8,  &.{1},                  &.{256}});
+    try testOneShiftCase(.llshr, .{8,  &.{490175165},          &.{125484842448}});
+    try testOneShiftCase(.llshr, .{8,  &.{0xdeadbe},           &.{0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{8,  &.{0xffffffffffffff},   &.{maxint}});
+    try testOneShiftCase(.llshr, .{8,  &.{0x80000000000000},   &.{left_one}});
     // zig fmt: on
-
-    try test_shift_cases(llshr, cases);
-    try test_shift_cases_aliasing(llshr, cases, 1);
 }
 
 test llshr {
@@ -4459,65 +4433,65 @@ test llshr {
     const maxint: Limb = 0xFFFFFFFFFFFFFFFF;
 
     // zig fmt: off
-    const cases: Cases = &.{
-        .{0,  &.{0, 0},                           &.{0, 0}},
-        .{0,  &.{0, 1},                           &.{0, 1}},
-        .{0,  &.{15, 1},                          &.{15, 1}},
-        .{0,  &.{987656565, 123456789456},        &.{987656565, 123456789456}},
-        .{0,  &.{0xfeebdaed, 0xdeadbeef},         &.{0xfeebdaed, 0xdeadbeef}},
-        .{0,  &.{1, maxint},                      &.{1, maxint}},
-        .{0,  &.{0, left_one},                    &.{0, left_one}},
-        .{1,  &.{0},                              &.{0, 0}},
-        .{1,  &.{left_one},                       &.{0, 1}},
-        .{1,  &.{0x8000000000000007},             &.{15, 1}},
-        .{1,  &.{493828282, 61728394728},         &.{987656565, 123456789456}},
-        .{1,  &.{0x800000007f75ed76, 0x6f56df77}, &.{0xfeebdaed, 0xdeadbeef}},
-        .{1,  &.{left_one, 0x7fffffffffffffff},   &.{1, maxint}},
-        .{1,  &.{0, 0x4000000000000000},          &.{0, left_one}},
-        .{64, &.{0},                              &.{0, 0}},
-        .{64, &.{1},                              &.{0, 1}},
-        .{64, &.{1},                              &.{15, 1}},
-        .{64, &.{123456789456},                   &.{987656565, 123456789456}},
-        .{64, &.{0xdeadbeef},                     &.{0xfeebdaed, 0xdeadbeef}},
-        .{64, &.{maxint},                         &.{1, maxint}},
-        .{64, &.{left_one},                       &.{0, left_one}},
-        .{72, &.{0},                              &.{0, 0}},
-        .{72, &.{0},                              &.{0, 1}},
-        .{72, &.{0},                              &.{15, 1}},
-        .{72, &.{482253083},                      &.{987656565, 123456789456}},
-        .{72, &.{0xdeadbe},                       &.{0xfeebdaed, 0xdeadbeef}},
-        .{72, &.{0xffffffffffffff},               &.{1, maxint}},
-        .{72, &.{0x80000000000000},               &.{0, left_one}},
-    };
+    try testOneShiftCase(.llshr, .{0,  &.{0, 0},                           &.{0, 0}});
+    try testOneShiftCase(.llshr, .{0,  &.{0, 1},                           &.{0, 1}});
+    try testOneShiftCase(.llshr, .{0,  &.{15, 1},                          &.{15, 1}});
+    try testOneShiftCase(.llshr, .{0,  &.{987656565, 123456789456},        &.{987656565, 123456789456}});
+    try testOneShiftCase(.llshr, .{0,  &.{0xfeebdaed, 0xdeadbeef},         &.{0xfeebdaed, 0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{0,  &.{1, maxint},                      &.{1, maxint}});
+    try testOneShiftCase(.llshr, .{0,  &.{0, left_one},                    &.{0, left_one}});
+    try testOneShiftCase(.llshr, .{1,  &.{0},                              &.{0, 0}});
+    try testOneShiftCase(.llshr, .{1,  &.{left_one},                       &.{0, 1}});
+    try testOneShiftCase(.llshr, .{1,  &.{0x8000000000000007},             &.{15, 1}});
+    try testOneShiftCase(.llshr, .{1,  &.{493828282, 61728394728},         &.{987656565, 123456789456}});
+    try testOneShiftCase(.llshr, .{1,  &.{0x800000007f75ed76, 0x6f56df77}, &.{0xfeebdaed, 0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{1,  &.{left_one, 0x7fffffffffffffff},   &.{1, maxint}});
+    try testOneShiftCase(.llshr, .{1,  &.{0, 0x4000000000000000},          &.{0, left_one}});
+    try testOneShiftCase(.llshr, .{64, &.{0},                              &.{0, 0}});
+    try testOneShiftCase(.llshr, .{64, &.{1},                              &.{0, 1}});
+    try testOneShiftCase(.llshr, .{64, &.{1},                              &.{15, 1}});
+    try testOneShiftCase(.llshr, .{64, &.{123456789456},                   &.{987656565, 123456789456}});
+    try testOneShiftCase(.llshr, .{64, &.{0xdeadbeef},                     &.{0xfeebdaed, 0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{64, &.{maxint},                         &.{1, maxint}});
+    try testOneShiftCase(.llshr, .{64, &.{left_one},                       &.{0, left_one}});
+    try testOneShiftCase(.llshr, .{72, &.{0},                              &.{0, 0}});
+    try testOneShiftCase(.llshr, .{72, &.{0},                              &.{0, 1}});
+    try testOneShiftCase(.llshr, .{72, &.{0},                              &.{15, 1}});
+    try testOneShiftCase(.llshr, .{72, &.{482253083},                      &.{987656565, 123456789456}});
+    try testOneShiftCase(.llshr, .{72, &.{0xdeadbe},                       &.{0xfeebdaed, 0xdeadbeef}});
+    try testOneShiftCase(.llshr, .{72, &.{0xffffffffffffff},               &.{1, maxint}});
+    try testOneShiftCase(.llshr, .{72, &.{0x80000000000000},               &.{0, left_one}});
     // zig fmt: on
-
-    try test_shift_cases(llshr, cases);
-    try test_shift_cases_aliasing(llshr, cases, 1);
 }
 
-const Cases = []const struct { usize, []const Limb, []const Limb };
-fn test_shift_cases(func: fn ([]Limb, []const Limb, usize) usize, cases: Cases) !void {
+const Case = struct { usize, []const Limb, []const Limb };
+
+fn testOneShiftCase(comptime function: enum { llshr, llshl }, case: Case) !void {
+    const func = if (function == .llshl) llshl else llshr;
+    const shift_direction = if (function == .llshl) -1 else 1;
+
+    try testOneShiftCaseNoAliasing(func, case);
+    try testOneShiftCaseAliasing(func, case, shift_direction);
+}
+
+fn testOneShiftCaseNoAliasing(func: fn ([]Limb, []const Limb, usize) usize, case: Case) !void {
     const padding = std.math.maxInt(Limb);
     var r: [20]Limb = @splat(padding);
 
-    for (cases) |case| {
-        const shift = case[0];
-        const expected = case[1];
-        const data = case[2];
+    const shift = case[0];
+    const expected = case[1];
+    const data = case[2];
 
-        std.debug.assert(expected.len <= 20);
+    std.debug.assert(expected.len <= 20);
 
-        @memset(&r, padding);
-        const len = func(&r, data, shift);
+    const len = func(&r, data, shift);
 
-        try std.testing.expectEqual(expected.len, len);
-        try std.testing.expectEqualSlices(Limb, expected, r[0..len]);
-        for (r[len..]) |x|
-            try std.testing.expectEqual(padding, x);
-    }
+    try std.testing.expectEqual(expected.len, len);
+    try std.testing.expectEqualSlices(Limb, expected, r[0..len]);
+    try std.testing.expect(mem.allEqual(Limb, r[len..], padding));
 }
 
-fn test_shift_cases_aliasing(func: fn ([]Limb, []const Limb, usize) usize, cases: Cases, shift_direction: isize) !void {
+fn testOneShiftCaseAliasing(func: fn ([]Limb, []const Limb, usize) usize, case: Case, shift_direction: isize) !void {
     const padding = std.math.maxInt(Limb);
     var r: [60]Limb = @splat(padding);
     const base = 20;
@@ -4525,22 +4499,20 @@ fn test_shift_cases_aliasing(func: fn ([]Limb, []const Limb, usize) usize, cases
     assert(shift_direction == 1 or shift_direction == -1);
 
     for (0..10) |limb_shift| {
-        for (cases) |case| {
-            const shift = case[0];
-            const expected = case[1];
-            const data = case[2];
+        const shift = case[0];
+        const expected = case[1];
+        const data = case[2];
 
-            std.debug.assert(expected.len <= 20);
+        std.debug.assert(expected.len <= 20);
 
-            @memset(&r, padding);
-            const final_limb_base: usize = @intCast(base + shift_direction * @as(isize, @intCast(limb_shift)));
-            const written_data = r[final_limb_base..][0..data.len];
-            @memcpy(written_data, data);
+        @memset(&r, padding);
+        const final_limb_base: usize = @intCast(base + shift_direction * @as(isize, @intCast(limb_shift)));
+        const written_data = r[final_limb_base..][0..data.len];
+        @memcpy(written_data, data);
 
-            const len = func(r[base..], written_data, shift);
+        const len = func(r[base..], written_data, shift);
 
-            try std.testing.expectEqual(expected.len, len);
-            try std.testing.expectEqualSlices(Limb, expected, r[base .. base + len]);
-        }
+        try std.testing.expectEqual(expected.len, len);
+        try std.testing.expectEqualSlices(Limb, expected, r[base .. base + len]);
     }
 }

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -17,7 +17,6 @@ const Endian = std.builtin.Endian;
 const Signedness = std.builtin.Signedness;
 const native_endian = builtin.cpu.arch.endian();
 
-const debug_safety = false;
 
 /// Returns the number of limbs needed to store `scalar`, which must be a
 /// primitive integer value.
@@ -92,8 +91,6 @@ pub fn calcTwosCompLimbCount(bit_count: usize) usize {
 
 /// a + b * c + *carry, sets carry to the overflow bits
 pub fn addMulLimbWithCarry(a: Limb, b: Limb, c: Limb, carry: *Limb) Limb {
-    @setRuntimeSafety(debug_safety);
-
     // ov1[0] = a + *carry
     const ov1 = @addWithOverflow(a, carry.*);
 
@@ -3277,7 +3274,6 @@ const AccOp = enum {
 ///
 /// The result is computed modulo `r.len`. When `r.len >= a.len + b.len`, no overflow occurs.
 fn llmulacc(comptime op: AccOp, opt_allocator: ?Allocator, r: []Limb, a: []const Limb, b: []const Limb) void {
-    @setRuntimeSafety(debug_safety);
     assert(r.len >= a.len);
     assert(r.len >= b.len);
 
@@ -3316,7 +3312,6 @@ fn llmulaccKaratsuba(
     a: []const Limb,
     b: []const Limb,
 ) error{OutOfMemory}!void {
-    @setRuntimeSafety(debug_safety);
     assert(r.len >= a.len);
     assert(a.len >= b.len);
 
@@ -3479,7 +3474,6 @@ fn llmulaccKaratsuba(
 /// r = r (op) a.
 /// The result is computed modulo `r.len`.
 fn llaccum(comptime op: AccOp, r: []Limb, a: []const Limb) void {
-    @setRuntimeSafety(debug_safety);
     if (op == .sub) {
         _ = llsubcarry(r, r, a);
         return;
@@ -3508,7 +3502,6 @@ fn llaccum(comptime op: AccOp, r: []Limb, a: []const Limb) void {
 
 /// Returns -1, 0, 1 if |a| < |b|, |a| == |b| or |a| > |b| respectively for limbs.
 pub fn llcmp(a: []const Limb, b: []const Limb) i8 {
-    @setRuntimeSafety(debug_safety);
     const a_len = llnormalize(a);
     const b_len = llnormalize(b);
     if (a_len < b_len) {
@@ -3537,7 +3530,6 @@ pub fn llcmp(a: []const Limb, b: []const Limb) i8 {
 /// r = r (op) y * xi
 /// The result is computed modulo `r.len`. When `r.len >= a.len + b.len`, no overflow occurs.
 fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb) void {
-    @setRuntimeSafety(debug_safety);
     assert(r.len >= a.len);
     assert(a.len >= b.len);
 
@@ -3551,7 +3543,6 @@ fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb)
 /// The result is computed modulo `r.len`.
 /// Returns whether the operation overflowed.
 fn llmulLimb(comptime op: AccOp, acc: []Limb, y: []const Limb, xi: Limb) bool {
-    @setRuntimeSafety(debug_safety);
     if (xi == 0) {
         return false;
     }
@@ -3598,7 +3589,6 @@ fn llmulLimb(comptime op: AccOp, acc: []Limb, y: []const Limb, xi: Limb) bool {
 
 /// returns the min length the limb could be.
 fn llnormalize(a: []const Limb) usize {
-    @setRuntimeSafety(debug_safety);
     var j = a.len;
     while (j > 0) : (j -= 1) {
         if (a[j - 1] != 0) {
@@ -3612,7 +3602,6 @@ fn llnormalize(a: []const Limb) usize {
 
 /// Knuth 4.3.1, Algorithm S.
 fn llsubcarry(r: []Limb, a: []const Limb, b: []const Limb) Limb {
-    @setRuntimeSafety(debug_safety);
     assert(a.len != 0 and b.len != 0);
     assert(a.len >= b.len);
     assert(r.len >= a.len);
@@ -3638,14 +3627,12 @@ fn llsubcarry(r: []Limb, a: []const Limb, b: []const Limb) Limb {
 }
 
 fn llsub(r: []Limb, a: []const Limb, b: []const Limb) void {
-    @setRuntimeSafety(debug_safety);
     assert(a.len > b.len or (a.len == b.len and a[a.len - 1] >= b[b.len - 1]));
     assert(llsubcarry(r, a, b) == 0);
 }
 
 /// Knuth 4.3.1, Algorithm A.
 fn lladdcarry(r: []Limb, a: []const Limb, b: []const Limb) Limb {
-    @setRuntimeSafety(debug_safety);
     assert(a.len != 0 and b.len != 0);
     assert(a.len >= b.len);
     assert(r.len >= a.len);
@@ -3671,14 +3658,12 @@ fn lladdcarry(r: []Limb, a: []const Limb, b: []const Limb) Limb {
 }
 
 fn lladd(r: []Limb, a: []const Limb, b: []const Limb) void {
-    @setRuntimeSafety(debug_safety);
     assert(r.len >= a.len + 1);
     r[a.len] = lladdcarry(r, a, b);
 }
 
 /// Knuth 4.3.1, Exercise 16.
 fn lldiv1(quo: []Limb, rem: *Limb, a: []const Limb, b: Limb) void {
-    @setRuntimeSafety(debug_safety);
     assert(a.len > 1 or a[0] >= b);
     assert(quo.len >= a.len);
 
@@ -3704,7 +3689,6 @@ fn lldiv1(quo: []Limb, rem: *Limb, a: []const Limb, b: Limb) void {
 }
 
 fn lldiv0p5(quo: []Limb, rem: *Limb, a: []const Limb, b: HalfLimb) void {
-    @setRuntimeSafety(debug_safety);
     assert(a.len > 1 or a[0] >= b);
     assert(quo.len >= a.len);
 
@@ -3788,7 +3772,6 @@ fn llshr(r: []Limb, a: []const Limb, shift: usize) void {
 
 // r = ~r
 fn llnot(r: []Limb) void {
-    @setRuntimeSafety(debug_safety);
 
     for (r) |*elem| {
         elem.* = ~elem.*;
@@ -3802,7 +3785,6 @@ fn llnot(r: []Limb) void {
 // When b is positive, r requires at least `a.len` limbs of storage.
 // When b is negative, r requires at least `b.len` limbs of storage.
 fn llsignedor(r: []Limb, a: []const Limb, a_positive: bool, b: []const Limb, b_positive: bool) bool {
-    @setRuntimeSafety(debug_safety);
     assert(r.len >= a.len);
     assert(a.len >= b.len);
 
@@ -3933,7 +3915,6 @@ fn llsignedor(r: []Limb, a: []const Limb, a_positive: bool, b: []const Limb, b_p
 // 2. when b is negative but a is positive, r requires at least `a.len` limbs of storage,
 // 3. when both a and b are negative, r requires at least `a.len + 1` limbs of storage.
 fn llsignedand(r: []Limb, a: []const Limb, a_positive: bool, b: []const Limb, b_positive: bool) bool {
-    @setRuntimeSafety(debug_safety);
     assert(a.len != 0 and b.len != 0);
     assert(a.len >= b.len);
     assert(r.len >= if (b_positive) b.len else if (a_positive) a.len else a.len + 1);
@@ -4043,7 +4024,6 @@ fn llsignedand(r: []Limb, a: []const Limb, a_positive: bool, b: []const Limb, b_
 // If the sign of a and b is equal, then r requires at least `@max(a.len, b.len)` limbs are required.
 // Otherwise, r requires at least `@max(a.len, b.len) + 1` limbs.
 fn llsignedxor(r: []Limb, a: []const Limb, a_positive: bool, b: []const Limb, b_positive: bool) bool {
-    @setRuntimeSafety(debug_safety);
     assert(a.len != 0 and b.len != 0);
     assert(r.len >= a.len);
     assert(a.len >= b.len);
@@ -4102,8 +4082,6 @@ fn llsignedxor(r: []Limb, a: []const Limb, a_positive: bool, b: []const Limb, b_
 
 /// r MUST NOT alias x.
 fn llsquareBasecase(r: []Limb, x: []const Limb) void {
-    @setRuntimeSafety(debug_safety);
-
     const x_norm = x;
     assert(r.len >= 2 * x_norm.len + 1);
 

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -29,7 +29,7 @@ test "comptime_int set" {
         const result = @as(Limb, s & maxInt(Limb));
         s >>= @typeInfo(Limb).int.bits / 2;
         s >>= @typeInfo(Limb).int.bits / 2;
-        try testing.expect(a.limbs[i] == result);
+        try testing.expectEqual(result, a.limbs[i]);
     }
 }
 
@@ -37,37 +37,37 @@ test "comptime_int set negative" {
     var a = try Managed.initSet(testing.allocator, -10);
     defer a.deinit();
 
-    try testing.expect(a.limbs[0] == 10);
-    try testing.expect(a.isPositive() == false);
+    try testing.expectEqual(10, a.limbs[0]);
+    try testing.expectEqual(false, a.isPositive());
 }
 
 test "int set unaligned small" {
     var a = try Managed.initSet(testing.allocator, @as(u7, 45));
     defer a.deinit();
 
-    try testing.expect(a.limbs[0] == 45);
-    try testing.expect(a.isPositive() == true);
+    try testing.expectEqual(45, a.limbs[0]);
+    try testing.expectEqual(true, a.isPositive());
 }
 
 test "comptime_int to" {
     var a = try Managed.initSet(testing.allocator, 0xefffffff00000001eeeeeeefaaaaaaab);
     defer a.deinit();
 
-    try testing.expect((try a.toInt(u128)) == 0xefffffff00000001eeeeeeefaaaaaaab);
+    try testing.expectEqual(0xefffffff00000001eeeeeeefaaaaaaab, try a.toInt(u128));
 }
 
 test "sub-limb to" {
     var a = try Managed.initSet(testing.allocator, 10);
     defer a.deinit();
 
-    try testing.expect((try a.toInt(u8)) == 10);
+    try testing.expectEqual(10, try a.toInt(u8));
 }
 
 test "set negative minimum" {
     var a = try Managed.initSet(testing.allocator, @as(i64, minInt(i64)));
     defer a.deinit();
 
-    try testing.expect((try a.toInt(i64)) == minInt(i64));
+    try testing.expectEqual(minInt(i64), try a.toInt(i64));
 }
 
 test "set double-width maximum then zero" {
@@ -95,22 +95,22 @@ test "normalize" {
     a.limbs[2] = 3;
     a.limbs[3] = 0;
     a.normalize(4);
-    try testing.expect(a.len() == 3);
+    try testing.expectEqual(3, a.len());
 
     a.limbs[0] = 1;
     a.limbs[1] = 2;
     a.limbs[2] = 3;
     a.normalize(3);
-    try testing.expect(a.len() == 3);
+    try testing.expectEqual(3, a.len());
 
     a.limbs[0] = 0;
     a.limbs[1] = 0;
     a.normalize(2);
-    try testing.expect(a.len() == 1);
+    try testing.expectEqual(1, a.len());
 
     a.limbs[0] = 0;
     a.normalize(1);
-    try testing.expect(a.len() == 1);
+    try testing.expectEqual(1, a.len());
 }
 
 test "normalize multi" {
@@ -123,24 +123,24 @@ test "normalize multi" {
     a.limbs[2] = 0;
     a.limbs[3] = 0;
     a.normalize(4);
-    try testing.expect(a.len() == 2);
+    try testing.expectEqual(2, a.len());
 
     a.limbs[0] = 1;
     a.limbs[1] = 2;
     a.limbs[2] = 3;
     a.normalize(3);
-    try testing.expect(a.len() == 3);
+    try testing.expectEqual(3, a.len());
 
     a.limbs[0] = 0;
     a.limbs[1] = 0;
     a.limbs[2] = 0;
     a.limbs[3] = 0;
     a.normalize(4);
-    try testing.expect(a.len() == 1);
+    try testing.expectEqual(1, a.len());
 
     a.limbs[0] = 0;
     a.normalize(1);
-    try testing.expect(a.len() == 1);
+    try testing.expectEqual(1, a.len());
 }
 
 test "parity" {
@@ -161,26 +161,26 @@ test "bitcount + sizeInBaseUpperBound" {
     defer a.deinit();
 
     try a.set(0b100);
-    try testing.expect(a.bitCountAbs() == 3);
+    try testing.expectEqual(3, a.bitCountAbs());
     try testing.expect(a.sizeInBaseUpperBound(2) >= 3);
     try testing.expect(a.sizeInBaseUpperBound(10) >= 1);
 
     a.negate();
-    try testing.expect(a.bitCountAbs() == 3);
+    try testing.expectEqual(3, a.bitCountAbs());
     try testing.expect(a.sizeInBaseUpperBound(2) >= 4);
     try testing.expect(a.sizeInBaseUpperBound(10) >= 2);
 
     try a.set(0xffffffff);
-    try testing.expect(a.bitCountAbs() == 32);
+    try testing.expectEqual(32, a.bitCountAbs());
     try testing.expect(a.sizeInBaseUpperBound(2) >= 32);
     try testing.expect(a.sizeInBaseUpperBound(10) >= 10);
 
     try a.shiftLeft(&a, 5000);
-    try testing.expect(a.bitCountAbs() == 5032);
+    try testing.expectEqual(5032, a.bitCountAbs());
     try testing.expect(a.sizeInBaseUpperBound(2) >= 5032);
     a.setSign(false);
 
-    try testing.expect(a.bitCountAbs() == 5032);
+    try testing.expectEqual(5032, a.bitCountAbs());
     try testing.expect(a.sizeInBaseUpperBound(2) >= 5033);
 }
 
@@ -189,30 +189,30 @@ test "bitcount/to" {
     defer a.deinit();
 
     try a.set(0);
-    try testing.expect(a.bitCountTwosComp() == 0);
+    try testing.expectEqual(0, a.bitCountTwosComp());
 
-    try testing.expect((try a.toInt(u0)) == 0);
-    try testing.expect((try a.toInt(i0)) == 0);
+    try testing.expectEqual(0, try a.toInt(u0));
+    try testing.expectEqual(0, try a.toInt(i0));
 
     try a.set(-1);
-    try testing.expect(a.bitCountTwosComp() == 1);
-    try testing.expect((try a.toInt(i1)) == -1);
+    try testing.expectEqual(1, a.bitCountTwosComp());
+    try testing.expectEqual(-1, try a.toInt(i1));
 
     try a.set(-8);
-    try testing.expect(a.bitCountTwosComp() == 4);
-    try testing.expect((try a.toInt(i4)) == -8);
+    try testing.expectEqual(4, a.bitCountTwosComp());
+    try testing.expectEqual(-8, try a.toInt(i4));
 
     try a.set(127);
-    try testing.expect(a.bitCountTwosComp() == 7);
-    try testing.expect((try a.toInt(u7)) == 127);
+    try testing.expectEqual(7, a.bitCountTwosComp());
+    try testing.expectEqual(127, try a.toInt(u7));
 
     try a.set(-128);
-    try testing.expect(a.bitCountTwosComp() == 8);
-    try testing.expect((try a.toInt(i8)) == -128);
+    try testing.expectEqual(8, a.bitCountTwosComp());
+    try testing.expectEqual(-128, try a.toInt(i8));
 
     try a.set(-129);
-    try testing.expect(a.bitCountTwosComp() == 9);
-    try testing.expect((try a.toInt(i9)) == -129);
+    try testing.expectEqual(9, a.bitCountTwosComp());
+    try testing.expectEqual(-129, try a.toInt(i9));
 }
 
 test "fits" {
@@ -248,7 +248,7 @@ test "string set" {
     defer a.deinit();
 
     try a.setString(10, "120317241209124781241290847124");
-    try testing.expect((try a.toInt(u128)) == 120317241209124781241290847124);
+    try testing.expectEqual(120317241209124781241290847124, try a.toInt(u128));
 }
 
 test "string negative" {
@@ -256,7 +256,7 @@ test "string negative" {
     defer a.deinit();
 
     try a.setString(10, "-1023");
-    try testing.expect((try a.toInt(i32)) == -1023);
+    try testing.expectEqual(-1023, try a.toInt(i32));
 }
 
 test "string set number with underscores" {
@@ -264,7 +264,7 @@ test "string set number with underscores" {
     defer a.deinit();
 
     try a.setString(10, "__1_2_0_3_1_7_2_4_1_2_0_____9_1__2__4_7_8_1_2_4_1_2_9_0_8_4_7_1_2_4___");
-    try testing.expect((try a.toInt(u128)) == 120317241209124781241290847124);
+    try testing.expectEqual(120317241209124781241290847124, try a.toInt(u128));
 }
 
 test "string set case insensitive number" {
@@ -272,7 +272,7 @@ test "string set case insensitive number" {
     defer a.deinit();
 
     try a.setString(16, "aB_cD_eF");
-    try testing.expect((try a.toInt(u32)) == 0xabcdef);
+    try testing.expectEqual(0xabcdef, try a.toInt(u32));
 }
 
 test "string set base 36" {
@@ -280,7 +280,7 @@ test "string set base 36" {
     defer a.deinit();
 
     try a.setString(36, "fifvthrv1mzt79ez9");
-    try testing.expect((try a.to(u128)) == 123456789123456789123456789);
+    try testing.expectEqual(123456789123456789123456789, try a.to(u128));
 }
 
 test "string set bad char error" {
@@ -314,11 +314,11 @@ fn testTwosComplementLimit(comptime T: type) !void {
 
     try a.setTwosCompIntLimit(.max, int_info.signedness, int_info.bits);
     const max: T = maxInt(T);
-    try testing.expect(max == try a.toInt(T));
+    try testing.expectEqual(max, try a.toInt(T));
 
     try a.setTwosCompIntLimit(.min, int_info.signedness, int_info.bits);
     const min: T = minInt(T);
-    try testing.expect(min == try a.toInt(T));
+    try testing.expectEqual(min, try a.toInt(T));
 }
 
 test "string to" {
@@ -400,12 +400,12 @@ test "clone" {
     var b = try a.clone();
     defer b.deinit();
 
-    try testing.expect((try a.toInt(u32)) == 1234);
-    try testing.expect((try b.toInt(u32)) == 1234);
+    try testing.expectEqual(1234, try a.toInt(u32));
+    try testing.expectEqual(1234, try b.toInt(u32));
 
     try a.set(77);
-    try testing.expect((try a.toInt(u32)) == 77);
-    try testing.expect((try b.toInt(u32)) == 1234);
+    try testing.expectEqual(77, try a.toInt(u32));
+    try testing.expectEqual(1234, try b.toInt(u32));
 }
 
 test "swap" {
@@ -414,20 +414,20 @@ test "swap" {
     var b = try Managed.initSet(testing.allocator, 5678);
     defer b.deinit();
 
-    try testing.expect((try a.toInt(u32)) == 1234);
-    try testing.expect((try b.toInt(u32)) == 5678);
+    try testing.expectEqual(1234, try a.toInt(u32));
+    try testing.expectEqual(5678, try b.toInt(u32));
 
     a.swap(&b);
 
-    try testing.expect((try a.toInt(u32)) == 5678);
-    try testing.expect((try b.toInt(u32)) == 1234);
+    try testing.expectEqual(5678, try a.toInt(u32));
+    try testing.expectEqual(1234, try b.toInt(u32));
 }
 
 test "to negative" {
     var a = try Managed.initSet(testing.allocator, -10);
     defer a.deinit();
 
-    try testing.expect((try a.toInt(i32)) == -10);
+    try testing.expectEqual(-10, try a.toInt(i32));
 }
 
 test "compare" {
@@ -436,8 +436,8 @@ test "compare" {
     var b = try Managed.initSet(testing.allocator, 10);
     defer b.deinit();
 
-    try testing.expect(a.orderAbs(b) == .gt);
-    try testing.expect(a.order(b) == .lt);
+    try testing.expectEqual(.gt, a.orderAbs(b));
+    try testing.expectEqual(.lt, a.order(b));
 }
 
 test "compare similar" {
@@ -446,8 +446,8 @@ test "compare similar" {
     var b = try Managed.initSet(testing.allocator, 0xffffffffeeeeeeeeffffffffeeeeeeef);
     defer b.deinit();
 
-    try testing.expect(a.orderAbs(b) == .lt);
-    try testing.expect(b.orderAbs(a) == .gt);
+    try testing.expectEqual(.lt, a.orderAbs(b));
+    try testing.expectEqual(.gt, b.orderAbs(a));
 }
 
 test "compare different limb size" {
@@ -456,8 +456,8 @@ test "compare different limb size" {
     var b = try Managed.initSet(testing.allocator, 1);
     defer b.deinit();
 
-    try testing.expect(a.orderAbs(b) == .gt);
-    try testing.expect(b.orderAbs(a) == .lt);
+    try testing.expectEqual(.gt, a.orderAbs(b));
+    try testing.expectEqual(.lt, b.orderAbs(a));
 }
 
 test "compare multi-limb" {
@@ -466,8 +466,8 @@ test "compare multi-limb" {
     var b = try Managed.initSet(testing.allocator, 0x7777777799999999ffffeeeeffffeeeeffffeeeee);
     defer b.deinit();
 
-    try testing.expect(a.orderAbs(b) == .gt);
-    try testing.expect(a.order(b) == .lt);
+    try testing.expectEqual(.gt, a.orderAbs(b));
+    try testing.expectEqual(.lt, a.order(b));
 }
 
 test "equality" {
@@ -485,10 +485,10 @@ test "abs" {
     defer a.deinit();
 
     a.abs();
-    try testing.expect((try a.toInt(u32)) == 5);
+    try testing.expectEqual(5, try a.toInt(u32));
 
     a.abs();
-    try testing.expect((try a.toInt(u32)) == 5);
+    try testing.expectEqual(5, try a.toInt(u32));
 }
 
 test "negate" {
@@ -496,10 +496,10 @@ test "negate" {
     defer a.deinit();
 
     a.negate();
-    try testing.expect((try a.toInt(i32)) == -5);
+    try testing.expectEqual(-5, try a.toInt(i32));
 
     a.negate();
-    try testing.expect((try a.toInt(i32)) == 5);
+    try testing.expectEqual(5, try a.toInt(i32));
 }
 
 test "add single-single" {
@@ -512,7 +512,7 @@ test "add single-single" {
     defer c.deinit();
     try c.add(&a, &b);
 
-    try testing.expect((try c.toInt(u32)) == 55);
+    try testing.expectEqual(55, try c.toInt(u32));
 }
 
 test "add multi-single" {
@@ -525,10 +525,10 @@ test "add multi-single" {
     defer c.deinit();
 
     try c.add(&a, &b);
-    try testing.expect((try c.toInt(DoubleLimb)) == maxInt(Limb) + 2);
+    try testing.expectEqual(maxInt(Limb) + 2, try c.toInt(DoubleLimb));
 
     try c.add(&b, &a);
-    try testing.expect((try c.toInt(DoubleLimb)) == maxInt(Limb) + 2);
+    try testing.expectEqual(maxInt(Limb) + 2, try c.toInt(DoubleLimb));
 }
 
 test "add multi-multi" {
@@ -546,7 +546,7 @@ test "add multi-multi" {
     defer c.deinit();
     try c.add(&a, &b);
 
-    try testing.expect((try c.toInt(u128)) == op1 + op2);
+    try testing.expectEqual(op1 + op2, try c.toInt(u128));
 }
 
 test "add zero-zero" {
@@ -559,7 +559,7 @@ test "add zero-zero" {
     defer c.deinit();
     try c.add(&a, &b);
 
-    try testing.expect((try c.toInt(u32)) == 0);
+    try testing.expectEqual(0, try c.toInt(u32));
 }
 
 test "add alias multi-limb nonzero-zero" {
@@ -571,7 +571,7 @@ test "add alias multi-limb nonzero-zero" {
 
     try a.add(&a, &b);
 
-    try testing.expect((try a.toInt(u128)) == op1);
+    try testing.expectEqual(op1, try a.toInt(u128));
 }
 
 test "add sign" {
@@ -588,16 +588,16 @@ test "add sign" {
     defer neg_two.deinit();
 
     try a.add(&one, &two);
-    try testing.expect((try a.toInt(i32)) == 3);
+    try testing.expectEqual(3, try a.toInt(i32));
 
     try a.add(&neg_one, &two);
-    try testing.expect((try a.toInt(i32)) == 1);
+    try testing.expectEqual(1, try a.toInt(i32));
 
     try a.add(&one, &neg_two);
-    try testing.expect((try a.toInt(i32)) == -1);
+    try testing.expectEqual(-1, try a.toInt(i32));
 
     try a.add(&neg_one, &neg_two);
-    try testing.expect((try a.toInt(i32)) == -3);
+    try testing.expectEqual(-3, try a.toInt(i32));
 }
 
 test "add comptime scalar" {
@@ -608,7 +608,7 @@ test "add comptime scalar" {
     defer b.deinit();
     try b.addScalar(&a, 5);
 
-    try testing.expect((try b.toInt(u32)) == 55);
+    try testing.expectEqual(55, try b.toInt(u32));
 }
 
 test "add scalar" {
@@ -619,7 +619,7 @@ test "add scalar" {
     defer b.deinit();
     try b.addScalar(&a, @as(u32, 31));
 
-    try testing.expect((try b.toInt(u32)) == 154);
+    try testing.expectEqual(154, try b.toInt(u32));
 }
 
 test "addWrap single-single, unsigned" {
@@ -632,7 +632,7 @@ test "addWrap single-single, unsigned" {
     const wrapped = try a.addWrap(&a, &b, .unsigned, 17);
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(u17)) == 9);
+    try testing.expectEqual(9, try a.toInt(u17));
 }
 
 test "subWrap single-single, unsigned" {
@@ -645,7 +645,7 @@ test "subWrap single-single, unsigned" {
     const wrapped = try a.subWrap(&a, &b, .unsigned, 17);
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(u17)) == 1);
+    try testing.expectEqual(1, try a.toInt(u17));
 }
 
 test "addWrap multi-multi, unsigned, limb aligned" {
@@ -658,7 +658,7 @@ test "addWrap multi-multi, unsigned, limb aligned" {
     const wrapped = try a.addWrap(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(DoubleLimb) - 1);
+    try testing.expectEqual(maxInt(DoubleLimb) - 1, try a.toInt(DoubleLimb));
 }
 
 test "subWrap single-multi, unsigned, limb aligned" {
@@ -671,7 +671,7 @@ test "subWrap single-multi, unsigned, limb aligned" {
     const wrapped = try a.subWrap(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(DoubleLimb) - 88);
+    try testing.expectEqual(maxInt(DoubleLimb) - 88, try a.toInt(DoubleLimb));
 }
 
 test "addWrap single-single, signed" {
@@ -684,7 +684,7 @@ test "addWrap single-single, signed" {
     const wrapped = try a.addWrap(&a, &b, .signed, @bitSizeOf(i21));
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(i21)) == minInt(i21));
+    try testing.expectEqual(minInt(i21), try a.toInt(i21));
 }
 
 test "subWrap single-single, signed" {
@@ -697,7 +697,7 @@ test "subWrap single-single, signed" {
     const wrapped = try a.subWrap(&a, &b, .signed, @bitSizeOf(i21));
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(i21)) == maxInt(i21));
+    try testing.expectEqual(maxInt(i21), try a.toInt(i21));
 }
 
 test "addWrap multi-multi, signed, limb aligned" {
@@ -710,7 +710,7 @@ test "addWrap multi-multi, signed, limb aligned" {
     const wrapped = try a.addWrap(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -2);
+    try testing.expectEqual(-2, try a.toInt(SignedDoubleLimb));
 }
 
 test "subWrap single-multi, signed, limb aligned" {
@@ -723,7 +723,7 @@ test "subWrap single-multi, signed, limb aligned" {
     const wrapped = try a.subWrap(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
     try testing.expect(wrapped);
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
+    try testing.expectEqual(maxInt(SignedDoubleLimb), try a.toInt(SignedDoubleLimb));
 }
 
 test "addWrap returns normalized result" {
@@ -763,7 +763,7 @@ test "addSat single-single, unsigned" {
 
     try a.addSat(&a, &b, .unsigned, 17);
 
-    try testing.expect((try a.toInt(u17)) == maxInt(u17));
+    try testing.expectEqual(maxInt(u17), try a.toInt(u17));
 }
 
 test "subSat single-single, unsigned" {
@@ -775,7 +775,7 @@ test "subSat single-single, unsigned" {
 
     try a.subSat(&a, &b, .unsigned, 17);
 
-    try testing.expect((try a.toInt(u17)) == 0);
+    try testing.expectEqual(0, try a.toInt(u17));
 }
 
 test "addSat multi-multi, unsigned, limb aligned" {
@@ -787,7 +787,7 @@ test "addSat multi-multi, unsigned, limb aligned" {
 
     try a.addSat(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(DoubleLimb));
+    try testing.expectEqual(maxInt(DoubleLimb), try a.toInt(DoubleLimb));
 }
 
 test "subSat single-multi, unsigned, limb aligned" {
@@ -799,7 +799,7 @@ test "subSat single-multi, unsigned, limb aligned" {
 
     try a.subSat(&a, &b, .unsigned, @bitSizeOf(DoubleLimb));
 
-    try testing.expect((try a.toInt(DoubleLimb)) == 0);
+    try testing.expectEqual(0, try a.toInt(DoubleLimb));
 }
 
 test "addSat single-single, signed" {
@@ -811,7 +811,7 @@ test "addSat single-single, signed" {
 
     try a.addSat(&a, &b, .signed, @bitSizeOf(i14));
 
-    try testing.expect((try a.toInt(i14)) == maxInt(i14));
+    try testing.expectEqual(maxInt(i14), try a.toInt(i14));
 }
 
 test "subSat single-single, signed" {
@@ -823,7 +823,7 @@ test "subSat single-single, signed" {
 
     try a.subSat(&a, &b, .signed, @bitSizeOf(i21));
 
-    try testing.expect((try a.toInt(i21)) == minInt(i21));
+    try testing.expectEqual(minInt(i21), try a.toInt(i21));
 }
 
 test "addSat multi-multi, signed, limb aligned" {
@@ -835,7 +835,7 @@ test "addSat multi-multi, signed, limb aligned" {
 
     try a.addSat(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
+    try testing.expectEqual(maxInt(SignedDoubleLimb), try a.toInt(SignedDoubleLimb));
 }
 
 test "subSat single-multi, signed, limb aligned" {
@@ -847,7 +847,7 @@ test "subSat single-multi, signed, limb aligned" {
 
     try a.subSat(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == minInt(SignedDoubleLimb));
+    try testing.expectEqual(minInt(SignedDoubleLimb), try a.toInt(SignedDoubleLimb));
 }
 
 test "sub single-single" {
@@ -860,7 +860,7 @@ test "sub single-single" {
     defer c.deinit();
     try c.sub(&a, &b);
 
-    try testing.expect((try c.toInt(u32)) == 45);
+    try testing.expectEqual(45, try c.toInt(u32));
 }
 
 test "sub multi-single" {
@@ -873,7 +873,7 @@ test "sub multi-single" {
     defer c.deinit();
     try c.sub(&a, &b);
 
-    try testing.expect((try c.toInt(Limb)) == maxInt(Limb));
+    try testing.expectEqual(maxInt(Limb), try c.toInt(Limb));
 }
 
 test "sub multi-multi" {
@@ -890,7 +890,7 @@ test "sub multi-multi" {
     defer c.deinit();
     try c.sub(&a, &b);
 
-    try testing.expect((try c.toInt(u128)) == op1 - op2);
+    try testing.expectEqual(op1 - op2, try c.toInt(u128));
 }
 
 test "sub equal" {
@@ -903,7 +903,7 @@ test "sub equal" {
     defer c.deinit();
     try c.sub(&a, &b);
 
-    try testing.expect((try c.toInt(u32)) == 0);
+    try testing.expectEqual(0, try c.toInt(u32));
 }
 
 test "sub sign" {
@@ -920,19 +920,19 @@ test "sub sign" {
     defer neg_two.deinit();
 
     try a.sub(&one, &two);
-    try testing.expect((try a.toInt(i32)) == -1);
+    try testing.expectEqual(-1, try a.toInt(i32));
 
     try a.sub(&neg_one, &two);
-    try testing.expect((try a.toInt(i32)) == -3);
+    try testing.expectEqual(-3, try a.toInt(i32));
 
     try a.sub(&one, &neg_two);
-    try testing.expect((try a.toInt(i32)) == 3);
+    try testing.expectEqual(3, try a.toInt(i32));
 
     try a.sub(&neg_one, &neg_two);
-    try testing.expect((try a.toInt(i32)) == 1);
+    try testing.expectEqual(1, try a.toInt(i32));
 
     try a.sub(&neg_two, &neg_one);
-    try testing.expect((try a.toInt(i32)) == -1);
+    try testing.expectEqual(-1, try a.toInt(i32));
 }
 
 test "mul single-single" {
@@ -945,7 +945,7 @@ test "mul single-single" {
     defer c.deinit();
     try c.mul(&a, &b);
 
-    try testing.expect((try c.toInt(u64)) == 250);
+    try testing.expectEqual(250, try c.toInt(u64));
 }
 
 test "mul multi-single" {
@@ -958,7 +958,7 @@ test "mul multi-single" {
     defer c.deinit();
     try c.mul(&a, &b);
 
-    try testing.expect((try c.toInt(DoubleLimb)) == 2 * maxInt(Limb));
+    try testing.expectEqual(2 * maxInt(Limb), try c.toInt(DoubleLimb));
 }
 
 test "mul multi-multi" {
@@ -977,7 +977,7 @@ test "mul multi-multi" {
     defer c.deinit();
     try c.mul(&a, &b);
 
-    try testing.expect((try c.toInt(u256)) == op1 * op2);
+    try testing.expectEqual(op1 * op2, try c.toInt(u256));
 }
 
 test "mul alias r with a" {
@@ -988,7 +988,7 @@ test "mul alias r with a" {
 
     try a.mul(&a, &b);
 
-    try testing.expect((try a.toInt(DoubleLimb)) == 2 * maxInt(Limb));
+    try testing.expectEqual(2 * maxInt(Limb), try a.toInt(DoubleLimb));
 }
 
 test "mul alias r with b" {
@@ -999,7 +999,7 @@ test "mul alias r with b" {
 
     try a.mul(&b, &a);
 
-    try testing.expect((try a.toInt(DoubleLimb)) == 2 * maxInt(Limb));
+    try testing.expectEqual(2 * maxInt(Limb), try a.toInt(DoubleLimb));
 }
 
 test "mul alias r with a and b" {
@@ -1008,7 +1008,7 @@ test "mul alias r with a and b" {
 
     try a.mul(&a, &a);
 
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(Limb) * maxInt(Limb));
+    try testing.expectEqual(maxInt(Limb) * maxInt(Limb), try a.toInt(DoubleLimb));
 }
 
 test "mul a*0" {
@@ -1021,7 +1021,7 @@ test "mul a*0" {
     defer c.deinit();
     try c.mul(&a, &b);
 
-    try testing.expect((try c.toInt(u32)) == 0);
+    try testing.expectEqual(0, try c.toInt(u32));
 }
 
 test "mul 0*0" {
@@ -1034,7 +1034,7 @@ test "mul 0*0" {
     defer c.deinit();
     try c.mul(&a, &b);
 
-    try testing.expect((try c.toInt(u32)) == 0);
+    try testing.expectEqual(0, try c.toInt(u32));
 }
 
 test "mul large" {
@@ -1068,7 +1068,7 @@ test "mulWrap single-single unsigned" {
     defer c.deinit();
     try c.mulWrap(&a, &b, .unsigned, 17);
 
-    try testing.expect((try c.toInt(u17)) == 59836);
+    try testing.expectEqual(59836, try c.toInt(u17));
 }
 
 test "mulWrap single-single signed" {
@@ -1081,7 +1081,7 @@ test "mulWrap single-single signed" {
     defer c.deinit();
     try c.mulWrap(&a, &b, .signed, 17);
 
-    try testing.expect((try c.toInt(i17)) == -59836);
+    try testing.expectEqual(-59836, try c.toInt(i17));
 }
 
 test "mulWrap multi-multi unsigned" {
@@ -1100,7 +1100,7 @@ test "mulWrap multi-multi unsigned" {
     defer c.deinit();
     try c.mulWrap(&a, &b, .unsigned, 65);
 
-    try testing.expect((try c.toInt(u256)) == (op1 * op2) & ((1 << 65) - 1));
+    try testing.expectEqual((op1 * op2) & ((1 << 65) - 1), try c.toInt(u256));
 }
 
 test "mulWrap multi-multi signed" {
@@ -1118,7 +1118,7 @@ test "mulWrap multi-multi signed" {
     defer c.deinit();
     try c.mulWrap(&a, &b, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try c.toInt(SignedDoubleLimb)) == minInt(SignedDoubleLimb) + 2);
+    try testing.expectEqual(minInt(SignedDoubleLimb) + 2, try c.toInt(SignedDoubleLimb));
 }
 
 test "mulWrap large" {
@@ -1157,8 +1157,8 @@ test "div single-half no rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u32)) == 10);
-    try testing.expect((try r.toInt(u32)) == 0);
+    try testing.expectEqual(10, try q.toInt(u32));
+    try testing.expectEqual(0, try r.toInt(u32));
 }
 
 test "div single-half with rem" {
@@ -1173,8 +1173,8 @@ test "div single-half with rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u32)) == 9);
-    try testing.expect((try r.toInt(u32)) == 4);
+    try testing.expectEqual(9, try q.toInt(u32));
+    try testing.expectEqual(4, try r.toInt(u32));
 }
 
 test "div single-single no rem" {
@@ -1190,8 +1190,8 @@ test "div single-single no rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u32)) == 131072);
-    try testing.expect((try r.toInt(u32)) == 0);
+    try testing.expectEqual(131072, try q.toInt(u32));
+    try testing.expectEqual(0, try r.toInt(u32));
 }
 
 test "div single-single with rem" {
@@ -1206,8 +1206,8 @@ test "div single-single with rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u64)) == 131072);
-    try testing.expect((try r.toInt(u64)) == 8589934592);
+    try testing.expectEqual(131072, try q.toInt(u64));
+    try testing.expectEqual(8589934592, try r.toInt(u64));
 }
 
 test "div multi-single no rem" {
@@ -1226,8 +1226,8 @@ test "div multi-single no rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u64)) == op1 / op2);
-    try testing.expect((try r.toInt(u64)) == 0);
+    try testing.expectEqual(op1 / op2, try q.toInt(u64));
+    try testing.expectEqual(0, try r.toInt(u64));
 }
 
 test "div multi-single with rem" {
@@ -1246,8 +1246,8 @@ test "div multi-single with rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u64)) == op1 / op2);
-    try testing.expect((try r.toInt(u64)) == 3);
+    try testing.expectEqual(op1 / op2, try q.toInt(u64));
+    try testing.expectEqual(3, try r.toInt(u64));
 }
 
 test "div multi>2-single" {
@@ -1266,8 +1266,8 @@ test "div multi>2-single" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == op1 / op2);
-    try testing.expect((try r.toInt(u32)) == 0x3e4e);
+    try testing.expectEqual(op1 / op2, try q.toInt(u128));
+    try testing.expectEqual(0x3e4e, try r.toInt(u32));
 }
 
 test "div single-single q < r" {
@@ -1282,8 +1282,8 @@ test "div single-single q < r" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u64)) == 0);
-    try testing.expect((try r.toInt(u64)) == 0x0078f432);
+    try testing.expectEqual(0, try q.toInt(u64));
+    try testing.expectEqual(0x0078f432, try r.toInt(u64));
 }
 
 test "div single-single q == r" {
@@ -1298,8 +1298,8 @@ test "div single-single q == r" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u64)) == 1);
-    try testing.expect((try r.toInt(u64)) == 0);
+    try testing.expectEqual(1, try q.toInt(u64));
+    try testing.expectEqual(0, try r.toInt(u64));
 }
 
 test "div q=0 alias" {
@@ -1310,8 +1310,8 @@ test "div q=0 alias" {
 
     try Managed.divTrunc(&a, &b, &a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0);
-    try testing.expect((try b.toInt(u64)) == 3);
+    try testing.expectEqual(0, try a.toInt(u64));
+    try testing.expectEqual(3, try b.toInt(u64));
 }
 
 test "div multi-multi q < r" {
@@ -1330,8 +1330,8 @@ test "div multi-multi q < r" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0);
-    try testing.expect((try r.toInt(u128)) == op1);
+    try testing.expectEqual(0, try q.toInt(u128));
+    try testing.expectEqual(op1, try r.toInt(u128));
 }
 
 test "div trunc single-single +/+" {
@@ -1354,8 +1354,8 @@ test "div trunc single-single +/+" {
     const eq = @divTrunc(u, v);
     const er = @mod(u, v);
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div trunc single-single -/+" {
@@ -1378,8 +1378,8 @@ test "div trunc single-single -/+" {
     const eq = -1;
     const er = -2;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div trunc single-single +/-" {
@@ -1402,8 +1402,8 @@ test "div trunc single-single +/-" {
     const eq = -1;
     const er = 2;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div trunc single-single -/-" {
@@ -1426,8 +1426,8 @@ test "div trunc single-single -/-" {
     const eq = 1;
     const er = -2;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "divTrunc #15535" {
@@ -1440,7 +1440,7 @@ test "divTrunc #15535" {
     var q = try Managed.init(testing.allocator);
     defer q.deinit();
     try q.divTrunc(&r, &x, &x);
-    try testing.expect(r.order(one) == std.math.Order.lt);
+    try testing.expectEqual(std.math.Order.lt, r.order(one));
 }
 
 test "divFloor #10932" {
@@ -1463,8 +1463,8 @@ test "divFloor #10932" {
 
     const ress = try res.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(ress);
-    try testing.expect(std.mem.eql(u8, ress, "194bd136316c046d070b763396297bf8869a605030216b52597015902a172b2a752f62af1568dcd431602f03725bfa62b0be71ae86616210972c0126e173503011ca48c5747ff066d159c95e46b69cbb14c8fc0bd2bf0919f921be96463200000000000000000000000000000000000000000000000000000000000000000000000000000000"));
-    try testing.expect((try mod.toInt(i32)) == 0);
+    try testing.expectEqualStrings("194bd136316c046d070b763396297bf8869a605030216b52597015902a172b2a752f62af1568dcd431602f03725bfa62b0be71ae86616210972c0126e173503011ca48c5747ff066d159c95e46b69cbb14c8fc0bd2bf0919f921be96463200000000000000000000000000000000000000000000000000000000000000000000000000000000", ress);
+    try testing.expectEqual(0, try mod.toInt(i32));
 }
 
 test "divFloor #11166" {
@@ -1487,11 +1487,11 @@ test "divFloor #11166" {
 
     const ress = try res.toString(testing.allocator, 10, .lower);
     defer testing.allocator.free(ress);
-    try testing.expect(std.mem.eql(u8, ress, "1000000700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+    try testing.expectEqualStrings("1000000700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", ress);
 
     const mods = try mod.toString(testing.allocator, 10, .lower);
     defer testing.allocator.free(mods);
-    try testing.expect(std.mem.eql(u8, mods, "870000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+    try testing.expectEqualStrings("870000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", mods);
 }
 
 test "gcd #10932" {
@@ -1511,7 +1511,7 @@ test "gcd #10932" {
 
     const ress = try res.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(ress);
-    try testing.expect(std.mem.eql(u8, ress, "1a974a5c9734476ff5a3604bcc678a756beacfc21b4427d1f2c1f56f5d4e411a162c56136e20000000000000000000000000000000"));
+    try testing.expectEqualStrings("1a974a5c9734476ff5a3604bcc678a756beacfc21b4427d1f2c1f56f5d4e411a162c56136e20000000000000000000000000000000", ress);
 }
 
 test "bitAnd #10932" {
@@ -1529,7 +1529,7 @@ test "bitAnd #10932" {
 
     try res.bitAnd(&a, &b);
 
-    try testing.expect((try res.toInt(i32)) == 0);
+    try testing.expectEqual(0, try res.toInt(i32));
 }
 
 test "bit And #19235" {
@@ -1542,7 +1542,7 @@ test "bit And #19235" {
 
     try r.bitAnd(&a, &b);
 
-    try testing.expect((try r.toInt(i128)) == 0x10000000000000000);
+    try testing.expectEqual(0x10000000000000000, try r.toInt(i128));
 }
 
 test "div floor single-single +/+" {
@@ -1565,8 +1565,8 @@ test "div floor single-single +/+" {
     const eq = 1;
     const er = 2;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div floor single-single -/+" {
@@ -1589,8 +1589,8 @@ test "div floor single-single -/+" {
     const eq = -2;
     const er = 1;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div floor single-single +/-" {
@@ -1613,8 +1613,8 @@ test "div floor single-single +/-" {
     const eq = -2;
     const er = -1;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div floor single-single -/-" {
@@ -1637,8 +1637,8 @@ test "div floor single-single -/-" {
     const eq = 1;
     const er = -2;
 
-    try testing.expect((try q.toInt(i32)) == eq);
-    try testing.expect((try r.toInt(i32)) == er);
+    try testing.expectEqual(eq, try q.toInt(i32));
+    try testing.expectEqual(er, try r.toInt(i32));
 }
 
 test "div floor no remainder negative quotient" {
@@ -1656,8 +1656,8 @@ test "div floor no remainder negative quotient" {
     defer r.deinit();
     try Managed.divFloor(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(i32)) == -0x80000000);
-    try testing.expect((try r.toInt(i32)) == 0);
+    try testing.expectEqual(-0x80000000, try q.toInt(i32));
+    try testing.expectEqual(0, try r.toInt(i32));
 }
 
 test "div floor negative close to zero" {
@@ -1675,8 +1675,8 @@ test "div floor negative close to zero" {
     defer r.deinit();
     try Managed.divFloor(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(i32)) == -1);
-    try testing.expect((try r.toInt(i32)) == 10);
+    try testing.expectEqual(-1, try q.toInt(i32));
+    try testing.expectEqual(10, try r.toInt(i32));
 }
 
 test "div floor positive close to zero" {
@@ -1694,8 +1694,8 @@ test "div floor positive close to zero" {
     defer r.deinit();
     try Managed.divFloor(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(i32)) == 0);
-    try testing.expect((try r.toInt(i32)) == 10);
+    try testing.expectEqual(0, try q.toInt(i32));
+    try testing.expectEqual(10, try r.toInt(i32));
 }
 
 test "div multi-multi with rem" {
@@ -1712,8 +1712,8 @@ test "div multi-multi with rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0xe38f38e39161aaabd03f0f1b);
-    try testing.expect((try r.toInt(u128)) == 0x28de0acacd806823638);
+    try testing.expectEqual(0xe38f38e39161aaabd03f0f1b, try q.toInt(u128));
+    try testing.expectEqual(0x28de0acacd806823638, try r.toInt(u128));
 }
 
 test "div multi-multi no rem" {
@@ -1730,8 +1730,8 @@ test "div multi-multi no rem" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0xe38f38e39161aaabd03f0f1b);
-    try testing.expect((try r.toInt(u128)) == 0);
+    try testing.expectEqual(0xe38f38e39161aaabd03f0f1b, try q.toInt(u128));
+    try testing.expectEqual(0, try r.toInt(u128));
 }
 
 test "div multi-multi (2 branch)" {
@@ -1748,8 +1748,8 @@ test "div multi-multi (2 branch)" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0x10000000000000000);
-    try testing.expect((try r.toInt(u128)) == 0x44444443444444431111111111111111);
+    try testing.expectEqual(0x10000000000000000, try q.toInt(u128));
+    try testing.expectEqual(0x44444443444444431111111111111111, try r.toInt(u128));
 }
 
 test "div multi-multi (3.1/3.3 branch)" {
@@ -1766,8 +1766,8 @@ test "div multi-multi (3.1/3.3 branch)" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0xfffffffffffffffffff);
-    try testing.expect((try r.toInt(u256)) == 0x1111111111111111111110b12222222222222222282);
+    try testing.expectEqual(0xfffffffffffffffffff, try q.toInt(u128));
+    try testing.expectEqual(0x1111111111111111111110b12222222222222222282, try r.toInt(u256));
 }
 
 test "div multi-single zero-limb trailing" {
@@ -1804,11 +1804,11 @@ test "div multi-multi zero-limb trailing (with rem)" {
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0x10000000000000000);
+    try testing.expectEqual(0x10000000000000000, try q.toInt(u128));
 
     const rs = try r.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(rs);
-    try testing.expect(std.mem.eql(u8, rs, "4444444344444443111111111111111100000000000000000000000000000000"));
+    try testing.expectEqualStrings("4444444344444443111111111111111100000000000000000000000000000000", rs);
 }
 
 test "div multi-multi zero-limb trailing (with rem) and dividend zero-limb count > divisor zero-limb count" {
@@ -1825,11 +1825,11 @@ test "div multi-multi zero-limb trailing (with rem) and dividend zero-limb count
     defer r.deinit();
     try Managed.divTrunc(&q, &r, &a, &b);
 
-    try testing.expect((try q.toInt(u128)) == 0x1);
+    try testing.expectEqual(0x1, try q.toInt(u128));
 
     const rs = try r.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(rs);
-    try testing.expect(std.mem.eql(u8, rs, "444444434444444311111111111111110000000000000000"));
+    try testing.expectEqualStrings("444444434444444311111111111111110000000000000000", rs);
 }
 
 test "div multi-multi zero-limb trailing (with rem) and dividend zero-limb count < divisor zero-limb count" {
@@ -1848,11 +1848,11 @@ test "div multi-multi zero-limb trailing (with rem) and dividend zero-limb count
 
     const qs = try q.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(qs);
-    try testing.expect(std.mem.eql(u8, qs, "10000000000000000820820803105186f"));
+    try testing.expectEqualStrings("10000000000000000820820803105186f", qs);
 
     const rs = try r.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(rs);
-    try testing.expect(std.mem.eql(u8, rs, "4e11f2baa5896a321d463b543d0104e30000000000000000"));
+    try testing.expectEqualStrings("4e11f2baa5896a321d463b543d0104e30000000000000000", rs);
 }
 
 test "div multi-multi fuzz case #1" {
@@ -1872,11 +1872,11 @@ test "div multi-multi fuzz case #1" {
 
     const qs = try q.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(qs);
-    try testing.expect(std.mem.eql(u8, qs, "3ffffffffffffffffffffffffffff0000000000000000000000000000000000001ffffffffffffffffffffffffffff7fffffffe000000000000000000000000000180000000000000000000003fffffbfffffffdfffffffffffffeffff800000100101000000100000000020003fffffdfbfffffe3ffffffffffffeffff7fffc00800a100000017ffe000002000400007efbfff7fe9f00000037ffff3fff7fffa004006100000009ffe00000190038200bf7d2ff7fefe80400060000f7d7f8fbf9401fe38e0403ffc0bdffffa51102c300d7be5ef9df4e5060007b0127ad3fa69f97d0f820b6605ff617ddf7f32ad7a05c0d03f2e7bc78a6000e087a8bbcdc59e07a5a079128a7861f553ddebed7e8e56701756f9ead39b48cd1b0831889ea6ec1fddf643d0565b075ff07e6caea4e2854ec9227fd635ed60a2f5eef2893052ffd54718fa08604acbf6a15e78a467c4a3c53c0278af06c4416573f925491b195e8fd79302cb1aaf7caf4ecfc9aec1254cc969786363ac729f914c6ddcc26738d6b0facd54eba026580aba2eb6482a088b0d224a8852420b91ec1"));
+    try testing.expectEqualStrings("3ffffffffffffffffffffffffffff0000000000000000000000000000000000001ffffffffffffffffffffffffffff7fffffffe000000000000000000000000000180000000000000000000003fffffbfffffffdfffffffffffffeffff800000100101000000100000000020003fffffdfbfffffe3ffffffffffffeffff7fffc00800a100000017ffe000002000400007efbfff7fe9f00000037ffff3fff7fffa004006100000009ffe00000190038200bf7d2ff7fefe80400060000f7d7f8fbf9401fe38e0403ffc0bdffffa51102c300d7be5ef9df4e5060007b0127ad3fa69f97d0f820b6605ff617ddf7f32ad7a05c0d03f2e7bc78a6000e087a8bbcdc59e07a5a079128a7861f553ddebed7e8e56701756f9ead39b48cd1b0831889ea6ec1fddf643d0565b075ff07e6caea4e2854ec9227fd635ed60a2f5eef2893052ffd54718fa08604acbf6a15e78a467c4a3c53c0278af06c4416573f925491b195e8fd79302cb1aaf7caf4ecfc9aec1254cc969786363ac729f914c6ddcc26738d6b0facd54eba026580aba2eb6482a088b0d224a8852420b91ec1", qs);
 
     const rs = try r.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(rs);
-    try testing.expect(std.mem.eql(u8, rs, "310d1d4c414426b4836c2635bad1df3a424e50cbdd167ffccb4dfff57d36b4aae0d6ca0910698220171a0f3373c1060a046c2812f0027e321f72979daa5e7973214170d49e885de0c0ecc167837d44502430674a82522e5df6a0759548052420b91ec1"));
+    try testing.expectEqualStrings("310d1d4c414426b4836c2635bad1df3a424e50cbdd167ffccb4dfff57d36b4aae0d6ca0910698220171a0f3373c1060a046c2812f0027e321f72979daa5e7973214170d49e885de0c0ecc167837d44502430674a82522e5df6a0759548052420b91ec1", rs);
 }
 
 test "div multi-multi fuzz case #2" {
@@ -1896,11 +1896,11 @@ test "div multi-multi fuzz case #2" {
 
     const qs = try q.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(qs);
-    try testing.expect(std.mem.eql(u8, qs, "40100400fe3f8fe3f8fe3f8fe3f8fe3f8fe4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f91e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4992649926499264991e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4792e4b92e4b92e4b92e4b92a4a92a4a92a4"));
+    try testing.expectEqualStrings("40100400fe3f8fe3f8fe3f8fe3f8fe3f8fe4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f93e4f91e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4992649926499264991e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4791e4792e4b92e4b92e4b92e4b92a4a92a4a92a4", qs);
 
     const rs = try r.toString(testing.allocator, 16, .lower);
     defer testing.allocator.free(rs);
-    try testing.expect(std.mem.eql(u8, rs, "a900000000000000000000000000000000000000000000000000"));
+    try testing.expectEqualStrings("a900000000000000000000000000000000000000000000000000", rs);
 }
 
 test "truncate single unsigned" {
@@ -1909,7 +1909,7 @@ test "truncate single unsigned" {
 
     try a.truncate(&a, .unsigned, 17);
 
-    try testing.expect((try a.toInt(u17)) == maxInt(u17));
+    try testing.expectEqual(maxInt(u17), try a.toInt(u17));
 }
 
 test "truncate single signed" {
@@ -1918,7 +1918,7 @@ test "truncate single signed" {
 
     try a.truncate(&a, .signed, 17);
 
-    try testing.expect((try a.toInt(i17)) == minInt(i17));
+    try testing.expectEqual(minInt(i17), try a.toInt(i17));
 }
 
 test "truncate multi to single unsigned" {
@@ -1927,7 +1927,7 @@ test "truncate multi to single unsigned" {
 
     try a.truncate(&a, .unsigned, 27);
 
-    try testing.expect((try a.toInt(u27)) == 0x2BC_DEF0);
+    try testing.expectEqual(0x2BC_DEF0, try a.toInt(u27));
 }
 
 test "truncate multi to single signed" {
@@ -1936,7 +1936,7 @@ test "truncate multi to single signed" {
 
     try a.truncate(&a, .signed, @bitSizeOf(i11));
 
-    try testing.expect((try a.toInt(i11)) == minInt(i11));
+    try testing.expectEqual(minInt(i11), try a.toInt(i11));
 }
 
 test "truncate multi to multi unsigned" {
@@ -1948,7 +1948,7 @@ test "truncate multi to multi unsigned" {
 
     try a.truncate(&a, .unsigned, bits - 1);
 
-    try testing.expect((try a.toInt(Int)) == maxInt(Int));
+    try testing.expectEqual(maxInt(Int), try a.toInt(Int));
 }
 
 test "truncate multi to multi signed" {
@@ -1957,7 +1957,7 @@ test "truncate multi to multi signed" {
 
     try a.truncate(&a, .signed, @bitSizeOf(Limb) + 1);
 
-    try testing.expect((try a.toInt(std.meta.Int(.signed, @bitSizeOf(Limb) + 1))) == -1 << @bitSizeOf(Limb));
+    try testing.expectEqual(-1 << @bitSizeOf(Limb), try a.toInt(std.meta.Int(.signed, @bitSizeOf(Limb) + 1)));
 }
 
 test "truncate negative multi to single" {
@@ -1966,7 +1966,7 @@ test "truncate negative multi to single" {
 
     try a.truncate(&a, .signed, @bitSizeOf(i17));
 
-    try testing.expect((try a.toInt(i17)) == 0);
+    try testing.expectEqual(0, try a.toInt(i17));
 }
 
 test "truncate multi unsigned many" {
@@ -1978,7 +1978,7 @@ test "truncate multi unsigned many" {
     defer b.deinit();
     try b.truncate(&a, .signed, @bitSizeOf(i1));
 
-    try testing.expect((try b.toInt(i1)) == 0);
+    try testing.expectEqual(0, try b.toInt(i1));
 }
 
 test "truncate to mutable with fewer limbs" {
@@ -2067,7 +2067,7 @@ test "saturate single signed positive" {
 
     try a.saturate(&a, .signed, 17);
 
-    try testing.expect((try a.toInt(i17)) == maxInt(i17));
+    try testing.expectEqual(maxInt(i17), try a.toInt(i17));
 }
 
 test "saturate single signed negative" {
@@ -2076,7 +2076,7 @@ test "saturate single signed negative" {
 
     try a.saturate(&a, .signed, 17);
 
-    try testing.expect((try a.toInt(i17)) == minInt(i17));
+    try testing.expectEqual(minInt(i17), try a.toInt(i17));
 }
 
 test "saturate single signed" {
@@ -2085,7 +2085,7 @@ test "saturate single signed" {
 
     try a.saturate(&a, .signed, 17);
 
-    try testing.expect((try a.toInt(i17)) == maxInt(i17) - 1);
+    try testing.expectEqual(maxInt(i17) - 1, try a.toInt(i17));
 }
 
 test "saturate multi signed" {
@@ -2094,7 +2094,7 @@ test "saturate multi signed" {
 
     try a.saturate(&a, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == maxInt(SignedDoubleLimb));
+    try testing.expectEqual(maxInt(SignedDoubleLimb), try a.toInt(SignedDoubleLimb));
 }
 
 test "saturate single unsigned" {
@@ -2103,7 +2103,7 @@ test "saturate single unsigned" {
 
     try a.saturate(&a, .unsigned, 23);
 
-    try testing.expect((try a.toInt(u23)) == maxInt(u23));
+    try testing.expectEqual(maxInt(u23), try a.toInt(u23));
 }
 
 test "saturate multi unsigned zero" {
@@ -2121,7 +2121,7 @@ test "saturate multi unsigned" {
 
     try a.saturate(&a, .unsigned, @bitSizeOf(DoubleLimb));
 
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(DoubleLimb));
+    try testing.expectEqual(maxInt(DoubleLimb), try a.toInt(DoubleLimb));
 }
 
 test "shift-right single" {
@@ -2129,7 +2129,7 @@ test "shift-right single" {
     defer a.deinit();
     try a.shiftRight(&a, 16);
 
-    try testing.expect((try a.toInt(u32)) == 0xffff);
+    try testing.expectEqual(0xffff, try a.toInt(u32));
 }
 
 test "shift-right multi" {
@@ -2137,7 +2137,7 @@ test "shift-right multi" {
     defer a.deinit();
     try a.shiftRight(&a, 67);
 
-    try testing.expect((try a.toInt(u64)) == 0x1fffe0001dddc222);
+    try testing.expectEqual(0x1fffe0001dddc222, try a.toInt(u64));
 
     try a.set(0xffff0000eeee1111dddd2222cccc3333);
     try a.shiftRight(&a, 63);
@@ -2154,8 +2154,8 @@ test "shift-right multi" {
     );
     defer testing.allocator.free(string);
     try std.testing.expectEqualStrings(
-        string,
         "ffff0000eeee1111dddd2222cccc3333",
+        string,
     );
 }
 
@@ -2164,7 +2164,7 @@ test "shift-left single" {
     defer a.deinit();
     try a.shiftLeft(&a, 16);
 
-    try testing.expect((try a.toInt(u64)) == 0xffff0000);
+    try testing.expectEqual(0xffff0000, try a.toInt(u64));
 }
 
 test "shift-left multi" {
@@ -2172,7 +2172,7 @@ test "shift-left multi" {
     defer a.deinit();
     try a.shiftLeft(&a, 67);
 
-    try testing.expect((try a.toInt(u128)) == 0xffff0000eeee11100000000000000000);
+    try testing.expectEqual(0xffff0000eeee11100000000000000000, try a.toInt(u128));
 }
 
 test "shift-right negative" {
@@ -2182,43 +2182,43 @@ test "shift-right negative" {
     var arg = try Managed.initSet(testing.allocator, -20);
     defer arg.deinit();
     try a.shiftRight(&arg, 2);
-    try testing.expect((try a.toInt(i32)) == -5); // -20 >> 2 == -5
+    try testing.expectEqual(-5, try a.toInt(i32)); // -20 >> 2 == -5
 
     var arg2 = try Managed.initSet(testing.allocator, -5);
     defer arg2.deinit();
     try a.shiftRight(&arg2, 10);
-    try testing.expect((try a.toInt(i32)) == -1); // -5 >> 10 == -1
+    try testing.expectEqual(-1, try a.toInt(i32)); // -5 >> 10 == -1
 
     var arg3 = try Managed.initSet(testing.allocator, -10);
     defer arg3.deinit();
     try a.shiftRight(&arg3, 1232);
-    try testing.expect((try a.toInt(i32)) == -1); // -10 >> 1232 == -1
+    try testing.expectEqual(-1, try a.toInt(i32)); // -10 >> 1232 == -1
 
     var arg4 = try Managed.initSet(testing.allocator, -5);
     defer arg4.deinit();
     try a.shiftRight(&arg4, 2);
-    try testing.expect(try a.toInt(i32) == -2); // -5 >> 2 == -2
+    try testing.expectEqual(-2, try a.toInt(i32)); // -5 >> 2 == -2
 
     var arg5 = try Managed.initSet(testing.allocator, -0xffff0000eeee1111dddd2222cccc3333);
     defer arg5.deinit();
     try a.shiftRight(&arg5, 67);
-    try testing.expect(try a.toInt(i64) == -0x1fffe0001dddc223);
+    try testing.expectEqual(-0x1fffe0001dddc223, try a.toInt(i64));
 
     var arg6 = try Managed.initSet(testing.allocator, -0x1ffffffffffffffff);
     defer arg6.deinit();
     try a.shiftRight(&arg6, 1);
     try a.shiftRight(&a, 1);
     a.setSign(true);
-    try testing.expect(try a.toInt(u64) == 0x8000000000000000);
+    try testing.expectEqual(0x8000000000000000, try a.toInt(u64));
 
     var arg7 = try Managed.initSet(testing.allocator, -32767);
     defer arg7.deinit();
     a.setSign(false);
     try a.shiftRight(&arg7, 4);
-    try testing.expect(try a.toInt(i16) == -2048);
+    try testing.expectEqual(-2048, try a.toInt(i16));
     a.setSign(true);
     try a.shiftRight(&arg7, 4);
-    try testing.expect(try a.toInt(i16) == -2048);
+    try testing.expectEqual(-2048, try a.toInt(i16));
 
     var arg8_limbs: [1]Limb = undefined;
     var arg8: Mutable = .{
@@ -2235,7 +2235,7 @@ test "sat shift-left simple unsigned" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 16, .unsigned, 21);
 
-    try testing.expect((try a.toInt(u64)) == 0x1fffff);
+    try testing.expectEqual(0x1fffff, try a.toInt(u64));
 }
 
 test "sat shift-left simple unsigned no sat" {
@@ -2243,7 +2243,7 @@ test "sat shift-left simple unsigned no sat" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 16, .unsigned, 21);
 
-    try testing.expect((try a.toInt(u64)) == 0x10000);
+    try testing.expectEqual(0x10000, try a.toInt(u64));
 }
 
 test "sat shift-left multi unsigned" {
@@ -2251,7 +2251,7 @@ test "sat shift-left multi unsigned" {
     defer a.deinit();
     try a.shiftLeftSat(&a, @bitSizeOf(DoubleLimb) - 3, .unsigned, @bitSizeOf(DoubleLimb) - 1);
 
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(DoubleLimb) >> 1);
+    try testing.expectEqual(maxInt(DoubleLimb) >> 1, try a.toInt(DoubleLimb));
 }
 
 test "sat shift-left unsigned shift > bitcount" {
@@ -2259,7 +2259,7 @@ test "sat shift-left unsigned shift > bitcount" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 10, .unsigned, 10);
 
-    try testing.expect((try a.toInt(u10)) == maxInt(u10));
+    try testing.expectEqual(maxInt(u10), try a.toInt(u10));
 }
 
 test "sat shift-left unsigned zero" {
@@ -2267,7 +2267,7 @@ test "sat shift-left unsigned zero" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 1, .unsigned, 0);
 
-    try testing.expect((try a.toInt(u64)) == 0);
+    try testing.expectEqual(0, try a.toInt(u64));
 }
 
 test "sat shift-left unsigned negative" {
@@ -2275,7 +2275,7 @@ test "sat shift-left unsigned negative" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 0, .unsigned, 0);
 
-    try testing.expect((try a.toInt(u64)) == 0);
+    try testing.expectEqual(0, try a.toInt(u64));
 }
 
 test "sat shift-left signed simple negative" {
@@ -2283,7 +2283,7 @@ test "sat shift-left signed simple negative" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 3, .signed, 10);
 
-    try testing.expect((try a.toInt(i10)) == minInt(i10));
+    try testing.expectEqual(minInt(i10), try a.toInt(i10));
 }
 
 test "sat shift-left signed simple positive" {
@@ -2291,7 +2291,7 @@ test "sat shift-left signed simple positive" {
     defer a.deinit();
     try a.shiftLeftSat(&a, 3, .signed, 10);
 
-    try testing.expect((try a.toInt(i10)) == maxInt(i10));
+    try testing.expectEqual(maxInt(i10), try a.toInt(i10));
 }
 
 test "sat shift-left signed multi positive" {
@@ -2306,7 +2306,7 @@ test "sat shift-left signed multi positive" {
     defer a.deinit();
     try a.shiftLeftSat(&a, shift, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == x <<| shift);
+    try testing.expectEqual(x <<| shift, try a.toInt(SignedDoubleLimb));
 }
 
 test "sat shift-left signed multi negative" {
@@ -2321,7 +2321,7 @@ test "sat shift-left signed multi negative" {
     defer a.deinit();
     try a.shiftLeftSat(&a, shift, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == x <<| shift);
+    try testing.expectEqual(x <<| shift, try a.toInt(SignedDoubleLimb));
 }
 
 test "bitNotWrap unsigned simple" {
@@ -2333,7 +2333,7 @@ test "bitNotWrap unsigned simple" {
 
     try a.bitNotWrap(&a, .unsigned, 10);
 
-    try testing.expect((try a.toInt(u10)) == ~x);
+    try testing.expectEqual(~x, try a.toInt(u10));
 }
 
 test "bitNotWrap unsigned multi" {
@@ -2342,7 +2342,7 @@ test "bitNotWrap unsigned multi" {
 
     try a.bitNotWrap(&a, .unsigned, @bitSizeOf(DoubleLimb));
 
-    try testing.expect((try a.toInt(DoubleLimb)) == maxInt(DoubleLimb));
+    try testing.expectEqual(maxInt(DoubleLimb), try a.toInt(DoubleLimb));
 }
 
 test "bitNotWrap signed simple" {
@@ -2354,7 +2354,7 @@ test "bitNotWrap signed simple" {
 
     try a.bitNotWrap(&a, .signed, 11);
 
-    try testing.expect((try a.toInt(i11)) == ~x);
+    try testing.expectEqual(~x, try a.toInt(i11));
 }
 
 test "bitNotWrap signed multi" {
@@ -2363,7 +2363,7 @@ test "bitNotWrap signed multi" {
 
     try a.bitNotWrap(&a, .signed, @bitSizeOf(SignedDoubleLimb));
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -1);
+    try testing.expectEqual(-1, try a.toInt(SignedDoubleLimb));
 }
 
 test "bitNotWrap more than two limbs" {
@@ -2400,7 +2400,7 @@ test "bitwise and simple" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0xeeeeeeee00000000);
+    try testing.expectEqual(0xeeeeeeee00000000, try a.toInt(u64));
 }
 
 test "bitwise and multi-limb" {
@@ -2411,7 +2411,7 @@ test "bitwise and multi-limb" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(u128)) == 0);
+    try testing.expectEqual(0, try a.toInt(u128));
 }
 
 test "bitwise and negative-positive simple" {
@@ -2422,7 +2422,7 @@ test "bitwise and negative-positive simple" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0x22222222);
+    try testing.expectEqual(0x22222222, try a.toInt(u64));
 }
 
 test "bitwise and negative-positive multi-limb" {
@@ -2444,7 +2444,7 @@ test "bitwise and positive-negative simple" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0x1111111111111110);
+    try testing.expectEqual(0x1111111111111110, try a.toInt(u64));
 }
 
 test "bitwise and positive-negative multi-limb" {
@@ -2466,7 +2466,7 @@ test "bitwise and negative-negative simple" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(i128)) == -0xffffffff33333332);
+    try testing.expectEqual(-0xffffffff33333332, try a.toInt(i128));
 }
 
 test "bitwise and negative-negative multi-limb" {
@@ -2477,7 +2477,7 @@ test "bitwise and negative-negative multi-limb" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(i128)) == -maxInt(Limb) * 2 - 2);
+    try testing.expectEqual(-maxInt(Limb) * 2 - 2, try a.toInt(i128));
 }
 
 test "bitwise and negative overflow" {
@@ -2488,7 +2488,7 @@ test "bitwise and negative overflow" {
 
     try a.bitAnd(&a, &b);
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -maxInt(Limb) - 1);
+    try testing.expectEqual(-maxInt(Limb) - 1, try a.toInt(SignedDoubleLimb));
 }
 
 test "bitwise xor simple" {
@@ -2499,7 +2499,7 @@ test "bitwise xor simple" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0x1111111133333333);
+    try testing.expectEqual(0x1111111133333333, try a.toInt(u64));
 }
 
 test "bitwise xor multi-limb" {
@@ -2514,7 +2514,7 @@ test "bitwise xor multi-limb" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(DoubleLimb)) == x ^ y);
+    try testing.expectEqual(x ^ y, try a.toInt(DoubleLimb));
 }
 
 test "bitwise xor single negative simple" {
@@ -2525,7 +2525,7 @@ test "bitwise xor single negative simple" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(i64)) == -0x2efed94fcb932ef9);
+    try testing.expectEqual(-0x2efed94fcb932ef9, try a.toInt(i64));
 }
 
 test "bitwise xor single negative multi-limb" {
@@ -2536,7 +2536,7 @@ test "bitwise xor single negative multi-limb" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(i128)) == -0x6a50889abd8834a24db1f19650d3999a);
+    try testing.expectEqual(-0x6a50889abd8834a24db1f19650d3999a, try a.toInt(i128));
 }
 
 test "bitwise xor single negative overflow" {
@@ -2547,7 +2547,7 @@ test "bitwise xor single negative overflow" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -(maxInt(Limb) + 1));
+    try testing.expectEqual(-(maxInt(Limb) + 1), try a.toInt(SignedDoubleLimb));
 }
 
 test "bitwise xor double negative simple" {
@@ -2558,7 +2558,7 @@ test "bitwise xor double negative simple" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0xc39c47081a6eb759);
+    try testing.expectEqual(0xc39c47081a6eb759, try a.toInt(u64));
 }
 
 test "bitwise xor double negative multi-limb" {
@@ -2569,7 +2569,7 @@ test "bitwise xor double negative multi-limb" {
 
     try a.bitXor(&a, &b);
 
-    try testing.expect((try a.toInt(u128)) == 0xa3492ec28e62c410dff92bf0549bf771);
+    try testing.expectEqual(0xa3492ec28e62c410dff92bf0549bf771, try a.toInt(u128));
 }
 
 test "bitwise or simple" {
@@ -2580,7 +2580,7 @@ test "bitwise or simple" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(u64)) == 0xffffffff33333333);
+    try testing.expectEqual(0xffffffff33333333, try a.toInt(u64));
 }
 
 test "bitwise or multi-limb" {
@@ -2591,7 +2591,7 @@ test "bitwise or multi-limb" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(DoubleLimb)) == (maxInt(Limb) + 1) + maxInt(Limb));
+    try testing.expectEqual((maxInt(Limb) + 1) + maxInt(Limb), try a.toInt(DoubleLimb));
 }
 
 test "bitwise or negative-positive simple" {
@@ -2602,7 +2602,7 @@ test "bitwise or negative-positive simple" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(i64)) == -0x1111111111111111);
+    try testing.expectEqual(-0x1111111111111111, try a.toInt(i64));
 }
 
 test "bitwise or negative-positive multi-limb" {
@@ -2613,7 +2613,7 @@ test "bitwise or negative-positive multi-limb" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -maxInt(Limb));
+    try testing.expectEqual(-maxInt(Limb), try a.toInt(SignedDoubleLimb));
 }
 
 test "bitwise or positive-negative simple" {
@@ -2624,7 +2624,7 @@ test "bitwise or positive-negative simple" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(i64)) == -0x22222221);
+    try testing.expectEqual(-0x22222221, try a.toInt(i64));
 }
 
 test "bitwise or positive-negative multi-limb" {
@@ -2635,7 +2635,7 @@ test "bitwise or positive-negative multi-limb" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -1);
+    try testing.expectEqual(-1, try a.toInt(SignedDoubleLimb));
 }
 
 test "bitwise or negative-negative simple" {
@@ -2646,7 +2646,7 @@ test "bitwise or negative-negative simple" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(i128)) == -0xeeeeeeee00000001);
+    try testing.expectEqual(-0xeeeeeeee00000001, try a.toInt(i128));
 }
 
 test "bitwise or negative-negative multi-limb" {
@@ -2657,7 +2657,7 @@ test "bitwise or negative-negative multi-limb" {
 
     try a.bitOr(&a, &b);
 
-    try testing.expect((try a.toInt(SignedDoubleLimb)) == -maxInt(Limb));
+    try testing.expectEqual(-maxInt(Limb), try a.toInt(SignedDoubleLimb));
 }
 
 test "var args" {
@@ -2667,11 +2667,11 @@ test "var args" {
     var b = try Managed.initSet(testing.allocator, 6);
     defer b.deinit();
     try a.add(&a, &b);
-    try testing.expect((try a.toInt(u64)) == 11);
+    try testing.expectEqual(11, try a.toInt(u64));
 
     var c = try Managed.initSet(testing.allocator, 11);
     defer c.deinit();
-    try testing.expect(a.order(c) == .eq);
+    try testing.expectEqual(.eq, a.order(c));
 
     var d = try Managed.initSet(testing.allocator, 14);
     defer d.deinit();
@@ -2688,7 +2688,7 @@ test "gcd non-one small" {
 
     try r.gcd(&a, &b);
 
-    try testing.expect((try r.toInt(u32)) == 1);
+    try testing.expectEqual(1, try r.toInt(u32));
 }
 
 test "gcd non-one medium" {
@@ -2701,7 +2701,7 @@ test "gcd non-one medium" {
 
     try r.gcd(&a, &b);
 
-    try testing.expect((try r.toInt(u32)) == 38);
+    try testing.expectEqual(38, try r.toInt(u32));
 }
 
 test "gcd non-one large" {
@@ -2714,7 +2714,7 @@ test "gcd non-one large" {
 
     try r.gcd(&a, &b);
 
-    try testing.expect((try r.toInt(u32)) == 4369);
+    try testing.expectEqual(4369, try r.toInt(u32));
 }
 
 test "gcd large multi-limb result" {
@@ -2730,7 +2730,7 @@ test "gcd large multi-limb result" {
     try r.gcd(&a, &b);
 
     const answer = (try r.toInt(u256));
-    try testing.expect(answer == 0xf000000ff00000fff0000ffff000fffff00ffffff1);
+    try testing.expectEqual(0xf000000ff00000fff0000ffff000fffff00ffffff1, answer);
 }
 
 test "gcd one large" {
@@ -2743,7 +2743,7 @@ test "gcd one large" {
 
     try r.gcd(&a, &b);
 
-    try testing.expect((try r.toInt(u64)) == 1);
+    try testing.expectEqual(1, try r.toInt(u64));
 }
 
 test "mutable to managed" {
@@ -2863,7 +2863,7 @@ test "regression test for 1 limb overflow with alias" {
     try a.ensureAddCapacity(a.toConst(), b.toConst());
     try a.add(&a, &b);
 
-    try testing.expect(a.toConst().orderAgainstScalar(19740274219868223167) == .eq);
+    try testing.expectEqual(.eq, a.toConst().orderAgainstScalar(19740274219868223167));
 }
 
 test "regression test for realloc with alias" {
@@ -2877,7 +2877,7 @@ test "regression test for realloc with alias" {
     try a.ensureAddCapacity(a.toConst(), b.toConst());
     try a.add(&a, &b);
 
-    try testing.expect(a.toConst().orderAgainstScalar(14691098406862188148944207245954912110548093601382197697835) == .eq);
+    try testing.expectEqual(.eq, a.toConst().orderAgainstScalar(14691098406862188148944207245954912110548093601382197697835));
 }
 
 test "big int popcount" {
@@ -2977,12 +2977,12 @@ test "big int conversion read/write twos complement" {
         // Writing to buffer and back should not change anything
         a.toConst().writeTwosComplement(buffer1[0..abi_size], endian);
         m.readTwosComplement(buffer1[0..abi_size], 493, endian, .unsigned);
-        try testing.expect(m.toConst().order(a.toConst()) == .eq);
+        try testing.expectEqual(.eq, m.toConst().order(a.toConst()));
 
         // Equivalent to @bitCast(i493, @as(u493, intMax(u493))
         a.toConst().writeTwosComplement(buffer1[0..abi_size], endian);
         m.readTwosComplement(buffer1[0..abi_size], 493, endian, .signed);
-        try testing.expect(m.toConst().orderAgainstScalar(-1) == .eq);
+        try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(-1));
     }
 }
 
@@ -3076,19 +3076,19 @@ test "big int conversion write twos complement with padding" {
 
     buffer = &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0xb };
     m.readTwosComplement(buffer[0..13], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d));
 
     buffer = &[_]u8{ 0xb, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd };
     m.readTwosComplement(buffer[0..13], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d));
 
     buffer = &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0xab, 0xaa, 0xaa, 0xaa };
     m.readTwosComplement(buffer[0..16], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d));
 
     buffer = &[_]u8{ 0xaa, 0xaa, 0xaa, 0xab, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd };
     m.readTwosComplement(buffer[0..16], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x01_02030405_06070809_0a0b0c0d));
 
     bit_count = @sizeOf(Limb) * 8;
 
@@ -3096,19 +3096,19 @@ test "big int conversion write twos complement with padding" {
 
     buffer = &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0xaa };
     m.readTwosComplement(buffer[0..13], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaa_02030405_06070809_0a0b0c0d))) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaa_02030405_06070809_0a0b0c0d))));
 
     buffer = &[_]u8{ 0xaa, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd };
     m.readTwosComplement(buffer[0..13], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaa_02030405_06070809_0a0b0c0d))) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaa_02030405_06070809_0a0b0c0d))));
 
     buffer = &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0xaa, 0xaa, 0xaa, 0xaa };
     m.readTwosComplement(buffer[0..16], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaaaaaaaa_02030405_06070809_0a0b0c0d))) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaaaaaaaa_02030405_06070809_0a0b0c0d))));
 
     buffer = &[_]u8{ 0xaa, 0xaa, 0xaa, 0xaa, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd };
     m.readTwosComplement(buffer[0..16], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaaaaaaaa_02030405_06070809_0a0b0c0d))) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(@as(Limb, @truncate(0xaaaaaaaa_02030405_06070809_0a0b0c0d))));
 
     bit_count = 12 * 8 + 2;
 
@@ -3116,42 +3116,42 @@ test "big int conversion write twos complement with padding" {
 
     buffer = &[_]u8{ 0xf3, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0x02 };
     m.readTwosComplement(buffer[0..13], bit_count, .little, .signed);
-    try testing.expect(m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d));
 
     buffer = &[_]u8{ 0x02, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf3 };
     m.readTwosComplement(buffer[0..13], bit_count, .big, .signed);
-    try testing.expect(m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d));
 
     buffer = &[_]u8{ 0xf3, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0x02, 0xaa, 0xaa, 0xaa };
     m.readTwosComplement(buffer[0..16], bit_count, .little, .signed);
-    try testing.expect(m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d));
 
     buffer = &[_]u8{ 0xaa, 0xaa, 0xaa, 0x02, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf3 };
     m.readTwosComplement(buffer[0..16], bit_count, .big, .signed);
-    try testing.expect(m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(-0x01_02030405_06070809_0a0b0c0d));
 
     // Test 0
 
     buffer = &([_]u8{0} ** 16);
     m.readTwosComplement(buffer[0..13], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..13], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..16], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..16], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
 
     bit_count = 0;
     buffer = &([_]u8{0xaa} ** 16);
     m.readTwosComplement(buffer[0..13], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..13], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..16], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..16], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
 }
 
 test "big int conversion write twos complement zero" {
@@ -3170,15 +3170,15 @@ test "big int conversion write twos complement zero" {
 
     buffer = &([_]u8{0} ** 13);
     m.readTwosComplement(buffer[0..13], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..13], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
 
     buffer = &([_]u8{0} ** 16);
     m.readTwosComplement(buffer[0..16], bit_count, .little, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
     m.readTwosComplement(buffer[0..16], bit_count, .big, .unsigned);
-    try testing.expect(m.toConst().orderAgainstScalar(0x0) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(0x0));
 }
 
 fn bitReverseTest(comptime T: type, comptime input: comptime_int, comptime expected_output: comptime_int) !void {
@@ -3191,7 +3191,7 @@ fn bitReverseTest(comptime T: type, comptime input: comptime_int, comptime expec
     try a.ensureCapacity(calcTwosCompLimbCount(bit_count));
     var m = a.toMutable();
     m.bitReverse(a.toConst(), signedness, bit_count);
-    try testing.expect(m.toConst().orderAgainstScalar(expected_output) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(expected_output));
 }
 
 test "big int bit reverse" {
@@ -3238,7 +3238,7 @@ fn byteSwapTest(comptime T: type, comptime input: comptime_int, comptime expecte
     try a.ensureCapacity(calcTwosCompLimbCount(8 * byte_count));
     var m = a.toMutable();
     m.byteSwap(a.toConst(), signedness, byte_count);
-    try testing.expect(m.toConst().orderAgainstScalar(expected_output) == .eq);
+    try testing.expectEqual(.eq, m.toConst().orderAgainstScalar(expected_output));
 }
 
 test "big int byte swap" {
@@ -3449,111 +3449,111 @@ test "clz" {
         .limbs = &.{ 1, maxInt(Limb) - 1 },
         .positive = false,
     };
-    try testing.expect(neg_limb_max_squared.clz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_max_squared.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_max_squared_plus_one: std.math.big.int.Const = .{
         .limbs = &.{ 0, maxInt(Limb) - 1 },
         .positive = false,
     };
-    try testing.expect(neg_limb_max_squared_plus_one.clz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_max_squared_plus_one.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_msb_squared: std.math.big.int.Const = .{
         .limbs = &.{ 0, 1 << @bitSizeOf(Limb) - 2 },
         .positive = false,
     };
-    try testing.expect(neg_limb_msb_squared.clz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(neg_limb_msb_squared.clz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_msb_squared.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, neg_limb_msb_squared.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_max: std.math.big.int.Const = .{
         .limbs = &.{maxInt(Limb)},
         .positive = false,
     };
-    try testing.expect(neg_limb_max.clz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(neg_limb_max.clz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(neg_limb_max.clz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(neg_limb_max.clz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_max.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, neg_limb_max.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, neg_limb_max.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, neg_limb_max.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_msb: std.math.big.int.Const = .{
         .limbs = &.{1 << @bitSizeOf(Limb) - 1},
         .positive = false,
     };
-    try testing.expect(neg_limb_msb.clz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(neg_limb_msb.clz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(neg_limb_msb.clz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(neg_limb_msb.clz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(neg_limb_msb.clz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_msb.clz(@bitSizeOf(Limb)));
+    try testing.expectEqual(0, neg_limb_msb.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, neg_limb_msb.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, neg_limb_msb.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, neg_limb_msb.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_one: std.math.big.int.Const = .{
         .limbs = &.{1},
         .positive = false,
     };
-    try testing.expect(neg_one.clz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(neg_one.clz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(neg_one.clz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(neg_one.clz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(neg_one.clz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_one.clz(@bitSizeOf(Limb)));
+    try testing.expectEqual(0, neg_one.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, neg_one.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, neg_one.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, neg_one.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const zero: std.math.big.int.Const = .{
         .limbs = &.{0},
         .positive = true,
     };
-    try testing.expect(zero.clz(@bitSizeOf(Limb)) == @bitSizeOf(Limb));
-    try testing.expect(zero.clz(@bitSizeOf(Limb) + 1) == @bitSizeOf(Limb) + 1);
-    try testing.expect(zero.clz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) * 2 - 1);
-    try testing.expect(zero.clz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) * 2);
-    try testing.expect(zero.clz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) * 2 + 1);
+    try testing.expectEqual(@bitSizeOf(Limb), zero.clz(@bitSizeOf(Limb)));
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, zero.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 1, zero.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2, zero.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 + 1, zero.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const one: std.math.big.int.Const = .{
         .limbs = &.{1},
         .positive = true,
     };
-    try testing.expect(one.clz(@bitSizeOf(Limb)) == @bitSizeOf(Limb) - 1);
-    try testing.expect(one.clz(@bitSizeOf(Limb) + 1) == @bitSizeOf(Limb));
-    try testing.expect(one.clz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) * 2 - 2);
-    try testing.expect(one.clz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) * 2 - 1);
-    try testing.expect(one.clz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) * 2);
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, one.clz(@bitSizeOf(Limb)));
+    try testing.expectEqual(@bitSizeOf(Limb), one.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 2, one.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 1, one.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2, one.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_msb: std.math.big.int.Const = .{
         .limbs = &.{1 << @bitSizeOf(Limb) - 1},
         .positive = true,
     };
-    try testing.expect(limb_msb.clz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(limb_msb.clz(@bitSizeOf(Limb) + 1) == 1);
-    try testing.expect(limb_msb.clz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) - 1);
-    try testing.expect(limb_msb.clz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb));
-    try testing.expect(limb_msb.clz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) + 1);
+    try testing.expectEqual(0, limb_msb.clz(@bitSizeOf(Limb)));
+    try testing.expectEqual(1, limb_msb.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_msb.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb), limb_msb.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, limb_msb.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_max: std.math.big.int.Const = .{
         .limbs = &.{maxInt(Limb)},
         .positive = true,
     };
-    try testing.expect(limb_max.clz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(limb_max.clz(@bitSizeOf(Limb) + 1) == 1);
-    try testing.expect(limb_max.clz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) - 1);
-    try testing.expect(limb_max.clz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb));
-    try testing.expect(limb_max.clz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) + 1);
+    try testing.expectEqual(0, limb_max.clz(@bitSizeOf(Limb)));
+    try testing.expectEqual(1, limb_max.clz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_max.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb), limb_max.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, limb_max.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_msb_squared: std.math.big.int.Const = .{
         .limbs = &.{ 0, 1 << @bitSizeOf(Limb) - 2 },
         .positive = true,
     };
-    try testing.expect(limb_msb_squared.clz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(limb_msb_squared.clz(@bitSizeOf(Limb) * 2) == 1);
-    try testing.expect(limb_msb_squared.clz(@bitSizeOf(Limb) * 2 + 1) == 2);
+    try testing.expectEqual(0, limb_msb_squared.clz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(1, limb_msb_squared.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(2, limb_msb_squared.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_max_squared_minus_one: std.math.big.int.Const = .{
         .limbs = &.{ 0, maxInt(Limb) - 1 },
         .positive = true,
     };
-    try testing.expect(limb_max_squared_minus_one.clz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(limb_max_squared_minus_one.clz(@bitSizeOf(Limb) * 2 + 1) == 1);
+    try testing.expectEqual(0, limb_max_squared_minus_one.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(1, limb_max_squared_minus_one.clz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_max_squared: std.math.big.int.Const = .{
         .limbs = &.{ 1, maxInt(Limb) - 1 },
         .positive = true,
     };
-    try testing.expect(limb_max_squared.clz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(limb_max_squared.clz(@bitSizeOf(Limb) * 2 + 1) == 1);
+    try testing.expectEqual(0, limb_max_squared.clz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(1, limb_max_squared.clz(@bitSizeOf(Limb) * 2 + 1));
 }
 
 test "ctz" {
@@ -3561,109 +3561,109 @@ test "ctz" {
         .limbs = &.{ 1, maxInt(Limb) - 1 },
         .positive = false,
     };
-    try testing.expect(neg_limb_max_squared.ctz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_max_squared.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_max_squared_plus_one: std.math.big.int.Const = .{
         .limbs = &.{ 0, maxInt(Limb) - 1 },
         .positive = false,
     };
-    try testing.expect(neg_limb_max_squared_plus_one.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) + 1);
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, neg_limb_max_squared_plus_one.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_msb_squared: std.math.big.int.Const = .{
         .limbs = &.{ 0, 1 << @bitSizeOf(Limb) - 2 },
         .positive = false,
     };
-    try testing.expect(neg_limb_msb_squared.ctz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) * 2 - 2);
-    try testing.expect(neg_limb_msb_squared.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) * 2 - 2);
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 2, neg_limb_msb_squared.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 2, neg_limb_msb_squared.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_max: std.math.big.int.Const = .{
         .limbs = &.{maxInt(Limb)},
         .positive = false,
     };
-    try testing.expect(neg_limb_max.ctz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(neg_limb_max.ctz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(neg_limb_max.ctz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(neg_limb_max.ctz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_limb_max.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, neg_limb_max.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, neg_limb_max.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, neg_limb_max.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_limb_msb: std.math.big.int.Const = .{
         .limbs = &.{1 << @bitSizeOf(Limb) - 1},
         .positive = false,
     };
-    try testing.expect(neg_limb_msb.ctz(@bitSizeOf(Limb)) == @bitSizeOf(Limb) - 1);
-    try testing.expect(neg_limb_msb.ctz(@bitSizeOf(Limb) + 1) == @bitSizeOf(Limb) - 1);
-    try testing.expect(neg_limb_msb.ctz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) - 1);
-    try testing.expect(neg_limb_msb.ctz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) - 1);
-    try testing.expect(neg_limb_msb.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) - 1);
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, neg_limb_msb.ctz(@bitSizeOf(Limb)));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, neg_limb_msb.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, neg_limb_msb.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, neg_limb_msb.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, neg_limb_msb.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const neg_one: std.math.big.int.Const = .{
         .limbs = &.{1},
         .positive = false,
     };
-    try testing.expect(neg_one.ctz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(neg_one.ctz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(neg_one.ctz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(neg_one.ctz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(neg_one.ctz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, neg_one.ctz(@bitSizeOf(Limb)));
+    try testing.expectEqual(0, neg_one.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, neg_one.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, neg_one.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, neg_one.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const zero: std.math.big.int.Const = .{
         .limbs = &.{0},
         .positive = true,
     };
-    try testing.expect(zero.ctz(@bitSizeOf(Limb)) == @bitSizeOf(Limb));
-    try testing.expect(zero.ctz(@bitSizeOf(Limb) + 1) == @bitSizeOf(Limb) + 1);
-    try testing.expect(zero.ctz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) * 2 - 1);
-    try testing.expect(zero.ctz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) * 2);
-    try testing.expect(zero.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) * 2 + 1);
+    try testing.expectEqual(@bitSizeOf(Limb), zero.ctz(@bitSizeOf(Limb)));
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, zero.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 1, zero.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2, zero.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 + 1, zero.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const one: std.math.big.int.Const = .{
         .limbs = &.{1},
         .positive = true,
     };
-    try testing.expect(one.ctz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(one.ctz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(one.ctz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(one.ctz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(one.ctz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, one.ctz(@bitSizeOf(Limb)));
+    try testing.expectEqual(0, one.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, one.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, one.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, one.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_msb: std.math.big.int.Const = .{
         .limbs = &.{1 << @bitSizeOf(Limb) - 1},
         .positive = true,
     };
-    try testing.expect(limb_msb.ctz(@bitSizeOf(Limb)) == @bitSizeOf(Limb) - 1);
-    try testing.expect(limb_msb.ctz(@bitSizeOf(Limb) + 1) == @bitSizeOf(Limb) - 1);
-    try testing.expect(limb_msb.ctz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) - 1);
-    try testing.expect(limb_msb.ctz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) - 1);
-    try testing.expect(limb_msb.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) - 1);
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_msb.ctz(@bitSizeOf(Limb)));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_msb.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_msb.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_msb.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) - 1, limb_msb.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_max: std.math.big.int.Const = .{
         .limbs = &.{maxInt(Limb)},
         .positive = true,
     };
-    try testing.expect(limb_max.ctz(@bitSizeOf(Limb)) == 0);
-    try testing.expect(limb_max.ctz(@bitSizeOf(Limb) + 1) == 0);
-    try testing.expect(limb_max.ctz(@bitSizeOf(Limb) * 2 - 1) == 0);
-    try testing.expect(limb_max.ctz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(limb_max.ctz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, limb_max.ctz(@bitSizeOf(Limb)));
+    try testing.expectEqual(0, limb_max.ctz(@bitSizeOf(Limb) + 1));
+    try testing.expectEqual(0, limb_max.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(0, limb_max.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, limb_max.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_msb_squared: std.math.big.int.Const = .{
         .limbs = &.{ 0, 1 << @bitSizeOf(Limb) - 2 },
         .positive = true,
     };
-    try testing.expect(limb_msb_squared.ctz(@bitSizeOf(Limb) * 2 - 1) == @bitSizeOf(Limb) * 2 - 2);
-    try testing.expect(limb_msb_squared.ctz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) * 2 - 2);
-    try testing.expect(limb_msb_squared.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) * 2 - 2);
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 2, limb_msb_squared.ctz(@bitSizeOf(Limb) * 2 - 1));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 2, limb_msb_squared.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) * 2 - 2, limb_msb_squared.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_max_squared_minus_one: std.math.big.int.Const = .{
         .limbs = &.{ 0, maxInt(Limb) - 1 },
         .positive = true,
     };
-    try testing.expect(limb_max_squared_minus_one.ctz(@bitSizeOf(Limb) * 2) == @bitSizeOf(Limb) + 1);
-    try testing.expect(limb_max_squared_minus_one.ctz(@bitSizeOf(Limb) * 2 + 1) == @bitSizeOf(Limb) + 1);
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, limb_max_squared_minus_one.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(@bitSizeOf(Limb) + 1, limb_max_squared_minus_one.ctz(@bitSizeOf(Limb) * 2 + 1));
 
     const limb_max_squared: std.math.big.int.Const = .{
         .limbs = &.{ 1, maxInt(Limb) - 1 },
         .positive = true,
     };
-    try testing.expect(limb_max_squared.ctz(@bitSizeOf(Limb) * 2) == 0);
-    try testing.expect(limb_max_squared.ctz(@bitSizeOf(Limb) * 2 + 1) == 0);
+    try testing.expectEqual(0, limb_max_squared.ctz(@bitSizeOf(Limb) * 2));
+    try testing.expectEqual(0, limb_max_squared.ctz(@bitSizeOf(Limb) * 2 + 1));
 }


### PR DESCRIPTION
There was a bug in `llshl` where, if `a` and `r` were the same size, `llshl` would write to `r[a.len]` which is out of bounds. Since runtime safety was disabled, it was not caught by out of bounds check.

This PR rewrites `llshl` (and `llshr` so they both look similar) to fix the bug, and removes the runtime safety override. It also updates the tests in `int_test.zig` (change `expect(a == b)` to `expectEqual(b, a)`, ...) and add tests to `llshl` and `llshr` (and an overlapping check to 2 other functions).

I have not benchmarked the new functions for performance improvement, but a quick test seemed to show a speed-up. Also, the new functions now produce simd shift instructions, so I think they should be quicker ([godbolt link](https://godbolt.org/z/dx5Ezozjz)).

Some doubts I have about my PR:
- Is there any reason to keep the runtime safety disabled while in debug and safe modes ?
- Is it ok to test `llshl` and `llshr` directly ? I'm guessing the reason why such functions are not tested is that they are heavily architecture dependent (with the size of `Limb`).
