### PR TITLE
autodoc: Lookup file-as-a-struct doctests using the stem of the filename

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -599,6 +599,7 @@
       const members = namespaceMembers(decl_index, false).slice();
       const fields = declFields(decl_index).slice();
       renderNamespace(decl_index, members, fields);
+      renderDocTests(decl_index);
     }
 
     function operatorCompare(a, b) {

--- a/lib/docs/wasm/Walk.zig
+++ b/lib/docs/wasm/Walk.zig
@@ -537,6 +537,13 @@ fn struct_decl(
     try w.file.get().scopes.putNoClobber(gpa, node, &namespace.base);
     try w.scanDecls(namespace, container_decl.ast.members);
 
+    // TODO: Support for doctests on file-as-a-struct types without using
+    // the filename to find the associated test.
+    const stem = std.fs.path.stem(w.file.path());
+    if (namespace.doctests.get(stem)) |doctest_node| {
+        try w.file.get().doctests.put(gpa, parent_decl.get().ast_node, doctest_node);
+    }
+
     for (container_decl.ast.members) |member| switch (ast.nodeTag(member)) {
         .container_field_init,
         .container_field_align,


### PR DESCRIPTION
This is not a perfect solution and relies on the convention that file-as-a-struct types have the same file name as the type name. Fixes #23614

Example with FixedBufferAllocator:

![image](https://github.com/user-attachments/assets/8374749a-e97d-47b8-a10d-09c7212ff354)

Primarily motivated by https://github.com/ziglang/zig/pull/23613 which adds a much more useful doctest.