### PR TITLE
zon: add zonStringify to override the default behavior + json.dynamic…

### DIFF
--- a/lib/std/json/dynamic.zig
+++ b/lib/std/json/dynamic.zig
@@ -81,6 +81,39 @@ pub const Value = union(enum) {
         }
     }
 
+    pub fn zonStringify(value: @This(), zon_serializer: anytype, options: std.zon.stringify.ValueOptions) !void {
+        switch (value) {
+            .null => try std.fmt.format(zon_serializer.writer, "{}", .{null}),
+            .bool => |inner| try std.fmt.format(zon_serializer.writer, "{}", .{inner}),
+            .integer => |inner| try zon_serializer.int(inner),
+            .float => |inner| try zon_serializer.float(inner),
+            .number_string, .string => |inner| try zon_serializer.string(inner),
+            .array => |inner| {
+                var container = try zon_serializer.beginTuple(
+                    .{ .whitespace_style = .{ .fields = inner.items.len } },
+                );
+                for (inner.items) |item| {
+                    try container.fieldArbitraryDepth(item, options);
+                }
+                try container.end();
+            },
+            .object => |inner| {
+                var container = try zon_serializer.beginStruct(
+                    .{ .whitespace_style = .{ .fields = inner.count() } },
+                );
+                var it = inner.iterator();
+                while (it.next()) |*kv| {
+                    try container.fieldArbitraryDepth(
+                        kv.key_ptr.*,
+                        kv.value_ptr.*,
+                        options,
+                    );
+                }
+                try container.end();
+            },
+        }
+    }
+
     pub fn jsonParse(allocator: Allocator, source: anytype, options: ParseOptions) ParseError(@TypeOf(source.*))!@This() {
         // The grammar of the stack is:
         //  (.array | .object .string)*

--- a/lib/std/zon/stringify.zig
+++ b/lib/std/zon/stringify.zig
@@ -168,6 +168,7 @@ fn canSerializeTypeInner(
         .vector => |vector| canSerializeTypeInner(vector.child, visited, false),
 
         .@"struct" => |@"struct"| {
+            if (std.meta.hasFn(T, "zonStringify")) return true;
             for (visited) |V| if (T == V) return true;
             const new_visited = visited ++ .{T};
             for (@"struct".fields) |field| {
@@ -176,6 +177,7 @@ fn canSerializeTypeInner(
             return true;
         },
         .@"union" => |@"union"| {
+            if (std.meta.hasFn(T, "zonStringify")) return true;
             for (visited) |V| if (T == V) return true;
             const new_visited = visited ++ .{T};
             if (@"union".tag_type == null) return false;
@@ -542,6 +544,9 @@ pub fn Serializer(Writer: type) type {
                     }
                     try container.end();
                 } else {
+                    if (std.meta.hasFn(@TypeOf(val), "zonStringify")) {
+                        return val.zonStringify(self, options);
+                    }
                     // Decide which fields to emit
                     const fields, const skipped: [@"struct".fields.len]bool = if (options.emit_default_optional_fields) b: {
                         break :b .{ @"struct".fields.len, @splat(false) };
@@ -578,6 +583,9 @@ pub fn Serializer(Writer: type) type {
                 },
                 .@"union" => |@"union"| {
                     comptime assert(@"union".tag_type != null);
+                    if (std.meta.hasFn(@TypeOf(val), "zonStringify")) {
+                        return val.zonStringify(self, options);
+                    }
                     switch (val) {
                         inline else => |pl, tag| if (@TypeOf(pl) == void)
                             try self.writer.print(".{s}", .{@tagName(tag)})


### PR DESCRIPTION
Hi,

This PR adds the possibility to override the ZON serialization default behavior if a struct or union declares a method `pub fn zonStringify(self: *@This(), zon_serializer: anytype, options: std.zon.stringify.ValueOptions) !void`.
It also adds a naive implementation of zonStringify() for the `std.json.dynamic.Value` union (which is useful for JSON to ZON conversion).

Thank you.