### PR TITLE
compiler: allow emitting tests to an object file

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -1019,6 +1019,10 @@ pub const TestOptions = struct {
     use_llvm: ?bool = null,
     use_lld: ?bool = null,
     zig_lib_dir: ?LazyPath = null,
+    /// Emits an object file instead of a test binary.
+    /// The object must be linked separately.
+    /// Usually used in conjunction with a custom `test_runner`.
+    emit_object: bool = false,
 
     /// Prefer populating this field (using e.g. `createModule`) instead of populating
     /// the following fields (`root_source_file` etc). In a future release, those fields
@@ -1067,7 +1071,7 @@ pub fn addTest(b: *Build, options: TestOptions) *Step.Compile {
     }
     return .create(b, .{
         .name = options.name,
-        .kind = .@"test",
+        .kind = if (options.emit_object) .test_obj else .@"test",
         .root_module = options.root_module orelse b.createModule(.{
             .root_source_file = options.root_source_file orelse @panic("`root_module` and `root_source_file` cannot both be null"),
             .target = options.target orelse b.graph.host,

--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -474,7 +474,7 @@ pub fn addObjectFile(m: *Module, object: LazyPath) void {
 }
 
 pub fn addObject(m: *Module, object: *Step.Compile) void {
-    assert(object.kind == .obj);
+    assert(object.kind == .obj or object.kind == .test_obj);
     m.linkLibraryOrObject(object);
 }
 

--- a/lib/std/Build/Step/InstallArtifact.zig
+++ b/lib/std/Build/Step/InstallArtifact.zig
@@ -56,7 +56,7 @@ pub fn create(owner: *std.Build, artifact: *Step.Compile, options: Options) *Ins
     const dest_dir: ?InstallDir = switch (options.dest_dir) {
         .disabled => null,
         .default => switch (artifact.kind) {
-            .obj => @panic("object files have no standard installation procedure"),
+            .obj, .test_obj => @panic("object files have no standard installation procedure"),
             .exe, .@"test" => .bin,
             .lib => if (artifact.isDll()) .bin else .lib,
         },

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -5,6 +5,9 @@
         .simple = .{
             .path = "simple",
         },
+        .test_obj_link_run = .{
+            .path = "test_obj_link_run",
+        },
         .test_runner_path = .{
             .path = "test_runner_path",
         },

--- a/test/standalone/test_obj_link_run/build.zig
+++ b/test/standalone/test_obj_link_run/build.zig
@@ -1,0 +1,32 @@
+pub fn build(b: *std.Build) void {
+    // To avoid having to explicitly link required system libraries into the final test
+    // executable (e.g. ntdll on Windows), we'll just link everything with libc here.
+
+    const test_obj = b.addTest(.{
+        .emit_object = true,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = b.graph.host,
+            .link_libc = true,
+        }),
+    });
+
+    const test_exe_mod = b.createModule(.{
+        .root_source_file = null,
+        .target = b.graph.host,
+        .link_libc = true,
+    });
+    test_exe_mod.addObject(test_obj);
+    const test_exe = b.addExecutable(.{
+        .name = "test",
+        .root_module = test_exe_mod,
+    });
+
+    const test_step = b.step("test", "Test the program");
+    b.default_step = test_step;
+
+    const test_run = b.addRunArtifact(test_exe);
+    test_step.dependOn(&test_run.step);
+}
+
+const std = @import("std");

--- a/test/standalone/test_obj_link_run/src/main.zig
+++ b/test/standalone/test_obj_link_run/src/main.zig
@@ -1,0 +1,17 @@
+test {
+    try std.testing.expect(true);
+}
+
+test "equality" {
+    try std.testing.expect(one() == 1);
+}
+
+test "arithmetic" {
+    try std.testing.expect(one() + 2 == 3);
+}
+
+fn one() u32 {
+    return 1;
+}
+
+const std = @import("std");


### PR DESCRIPTION
This is fairly straightforward; the actual compiler changes are limited to the CLI, since `Compilation` already supports this combination.

A new `std.Build` API is introduced to allow representing this. By passing the `emit_object` option to `std.Build.addTest`, you get a `Step.Compile` which emits an object file; you can then use that as you would any other object, such as either installing it for external use, or linking it into another step.

A standalone test is added to cover the build system API. It builds a test into an object, and links it into a final executable, which it then runs.

Using this build system mechanism prevents the build system from noticing that you're running a `zig test`, so the build runner and test runner do not communicate over stdio. However, that's okay, because the real-world use cases for this feature don't want to do that anyway!

Resolves: #23374