### PR TITLE
Build: check if dynamic lib installed for symlinks

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1900,7 +1900,8 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     }
 
     if (compile.kind == .lib and compile.linkage != null and compile.linkage.? == .dynamic and
-        compile.version != null and std.Build.wantSharedLibSymLinks(compile.rootModuleTarget()))
+        compile.version != null and compile.generated_bin != null and
+        std.Build.wantSharedLibSymLinks(compile.rootModuleTarget()))
     {
         try doAtomicSymLinks(
             step,


### PR DESCRIPTION
If the library isn't actually installed, `generated_bin` will be null, causing this to panic about a missing dependency for itself; checking for this state avoids this.