### PR TITLE
Support @ctz and @popCount with comptime_ints

### DIFF
--- a/src/Value.zig
+++ b/src/Value.zig
@@ -924,13 +924,13 @@ pub fn clz(val: Value, ty: Type, zcu: *Zcu) u64 {
 pub fn ctz(val: Value, ty: Type, zcu: *Zcu) u64 {
     var bigint_buf: BigIntSpace = undefined;
     const bigint = val.toBigInt(&bigint_buf, zcu);
-    return bigint.ctz(ty.intInfo(zcu).bits);
+    return bigint.ctz(if (ty.toIntern() == .comptime_int_type) std.math.maxInt(std.math.big.Limb) else ty.intInfo(zcu).bits);
 }
 
 pub fn popCount(val: Value, ty: Type, zcu: *Zcu) u64 {
     var bigint_buf: BigIntSpace = undefined;
     const bigint = val.toBigInt(&bigint_buf, zcu);
-    return @intCast(bigint.popCount(ty.intInfo(zcu).bits));
+    return @intCast(bigint.popCount(if (ty.toIntern() == .comptime_int_type) undefined else ty.intInfo(zcu).bits));
 }
 
 pub fn bitReverse(val: Value, ty: Type, pt: Zcu.PerThread, arena: Allocator) !Value {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -166,6 +166,13 @@ fn testCtz() !void {
     try expect(testOneCtz(u16, 0b00000000) == 16);
 }
 
+test "@ctz comptime_int" {
+    try expectEqual(5, @ctz(0b10100000));
+    try expectEqual(1, @ctz(0b10001010));
+    try expectEqual(0, @ctz(-1));
+    try expectEqual(1, @ctz(-2));
+}
+
 fn testOneCtz(comptime T: type, x: T) u32 {
     return @ctz(x);
 }

--- a/test/behavior/popcount.zig
+++ b/test/behavior/popcount.zig
@@ -75,6 +75,15 @@ fn testPopCountIntegers() !void {
     }
 }
 
+test "@popCount comptime_int" {
+    try expectEqual(0, @popCount(0));
+    try expectEqual(32, @popCount(0xffffffff));
+    try expectEqual(5, @popCount(0x1f));
+    try expectEqual(4, @popCount(0xaa));
+    try expectEqual(16, @popCount(0xaaaaaaaa));
+    try expectEqual(24, @popCount(0b11111111000110001100010000100001000011000011100101010001));
+}
+
 test "@popCount vectors" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO

--- a/test/cases/compile_errors/ctz-comptime_int-zero.zig
+++ b/test/cases/compile_errors/ctz-comptime_int-zero.zig
@@ -1,0 +1,9 @@
+export fn entry() void {
+    _ = @ctz(0);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:14: error: cannot count number of least-significant zeroes in integer '0' of type 'comptime_int'

--- a/test/cases/compile_errors/popCount-negative-comptime_int.zig
+++ b/test/cases/compile_errors/popCount-negative-comptime_int.zig
@@ -1,0 +1,9 @@
+export fn entry() void {
+    _ = @popCount(-1);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :2:19: error: cannot count number of bits set in negative integer '-1' of type 'comptime_int'


### PR DESCRIPTION
This PR implements `comptime_int` support for `@ctz` and `@popCount`. If the result would be infinity (`@ctz(0)`, `@popCount(negative_number)`), a compile error is triggered.

This is my first contribution in Sema. I'm not 100% certain that I made the changes in the correct locations.