### PR TITLE
std.c: use arch's ino_t and off_t for dirent

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -7000,8 +7000,8 @@ pub const RTLD = switch (native_os) {
 
 pub const dirent = switch (native_os) {
     .linux, .emscripten => extern struct {
-        ino: c_uint,
-        off: c_uint,
+        ino: ino_t,
+        off: off_t,
         reclen: c_ushort,
         type: u8,
         name: [256]u8,


### PR DESCRIPTION
Fixes #23622. The integer types used for these fields before would not work on some platforms.