### PR TITLE
increase upper bounds of main zig executable to 9G

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -679,7 +679,7 @@ fn addCompilerStep(b: *std.Build, options: AddCompilerStepOptions) *std.Build.St
 
     const exe = b.addExecutable(.{
         .name = "zig",
-        .max_rss = 7_800_000_000,
+        .max_rss = 9_000_000_000,
         .root_module = compiler_mod,
     });
     exe.stack_size = stack_size;


### PR DESCRIPTION
On Fedora 42 aarch64 memory usage peaked at 8736403456 bytes

https://zsf.zulipchat.com/#narrow/channel/454360-compiler/topic/exceeding.20the.20declared.20upper.20bound/near/513471272