### PR TITLE
Sema: Fix crash issue of writing to reinterpreted 0-sized array at co…

### DIFF
--- a/src/Sema/bitcast.zig
+++ b/src/Sema/bitcast.zig
@@ -155,6 +155,8 @@ fn bitCastSpliceInner(
 
     const abi_pad_bits, const host_pad_bits = if (host_bits > 0)
         .{ val_ty.abiSize(zcu) * 8 - host_bits, host_bits - val_ty.bitSize(zcu) }
+    else if (splice_val.toIntern() == .void_value and val_ty.abiSize(zcu) == 0)
+        .{ 0, 0 }
     else
         .{ val_ty.abiSize(zcu) * 8 - val_ty.bitSize(zcu), 0 };
 

--- a/src/Sema/bitcast.zig
+++ b/src/Sema/bitcast.zig
@@ -155,8 +155,6 @@ fn bitCastSpliceInner(
 
     const abi_pad_bits, const host_pad_bits = if (host_bits > 0)
         .{ val_ty.abiSize(zcu) * 8 - host_bits, host_bits - val_ty.bitSize(zcu) }
-    else if (splice_val.toIntern() == .void_value and val_ty.abiSize(zcu) == 0)
-        .{ 0, 0 }
     else
         .{ val_ty.abiSize(zcu) * 8 - val_ty.bitSize(zcu), 0 };
 

--- a/src/Sema/comptime_ptr_access.zig
+++ b/src/Sema/comptime_ptr_access.zig
@@ -855,8 +855,12 @@ fn prepareComptimePtrStore(
             => break, // terminal types (no sub-values)
             .optional => break, // this can only be a pointer-like optional so is terminal
             .array => {
+                const len = ip.indexToKey(cur_ty.toIntern()).array_type.len;
                 const elem_ty = cur_ty.childType(zcu);
                 const elem_size = try elem_ty.abiSizeSema(pt);
+                if (len == 0 or elem_size == 0) {
+                    break; // terminal array (0-sized array)
+                }
                 const elem_idx = cur_offset / elem_size;
                 const next_elem_off = elem_size * (elem_idx + 1);
                 if (cur_offset + need_bytes <= next_elem_off) {

--- a/src/Sema/comptime_ptr_access.zig
+++ b/src/Sema/comptime_ptr_access.zig
@@ -859,7 +859,7 @@ fn prepareComptimePtrStore(
                 const elem_ty = cur_ty.childType(zcu);
                 const elem_size = try elem_ty.abiSizeSema(pt);
                 if (len == 0 or elem_size == 0) {
-                    break; // terminal array (0-sized array)
+                    break; // break for 0-sized array
                 }
                 const elem_idx = cur_offset / elem_size;
                 const next_elem_off = elem_size * (elem_idx + 1);

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1638,14 +1638,11 @@ pub fn bitSizeInner(
             if (len == 0) return 0;
             const elem_ty = Type.fromInterned(array_type.child);
             const elem_abi_size = (try elem_ty.abiSizeInner(strat_lazy, zcu, tid)).scalar;
-            const elem_size = if (elem_abi_size > 0)
-                @max(
-                    (try elem_ty.abiAlignmentInner(strat_lazy, zcu, tid)).scalar.toByteUnits() orelse 0,
-                    elem_abi_size,
-                )
-            else
-                0;
-            if (elem_size == 0) return 0;
+            if (elem_abi_size == 0) return 0;
+            const elem_size = @max(
+                (try elem_ty.abiAlignmentInner(strat_lazy, zcu, tid)).scalar.toByteUnits() orelse 0,
+                elem_abi_size,
+            );
             const elem_bit_size = try elem_ty.bitSizeInner(strat, zcu, tid);
             return (len - 1) * 8 * elem_size + elem_bit_size;
         },

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1637,10 +1637,14 @@ pub fn bitSizeInner(
             const len = array_type.lenIncludingSentinel();
             if (len == 0) return 0;
             const elem_ty = Type.fromInterned(array_type.child);
-            const elem_size = @max(
-                (try elem_ty.abiAlignmentInner(strat_lazy, zcu, tid)).scalar.toByteUnits() orelse 0,
-                (try elem_ty.abiSizeInner(strat_lazy, zcu, tid)).scalar,
-            );
+            const elem_abi_size = (try elem_ty.abiSizeInner(strat_lazy, zcu, tid)).scalar;
+            const elem_size = if (elem_abi_size > 0)
+                @max(
+                    (try elem_ty.abiAlignmentInner(strat_lazy, zcu, tid)).scalar.toByteUnits() orelse 0,
+                    elem_abi_size,
+                )
+            else
+                0;
             if (elem_size == 0) return 0;
             const elem_bit_size = try elem_ty.bitSizeInner(strat, zcu, tid);
             return (len - 1) * 8 * elem_size + elem_bit_size;

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -1133,3 +1133,19 @@ test "initialize pointer to anyopaque with reference to empty array initializer"
     // We can't check the value, but it's zero-bit, so the type matching is good enough.
     comptime assert(@TypeOf(loaded) == @TypeOf(.{}));
 }
+
+test "reinterpreted 0-sized array at comptime" {
+    const S = struct {
+        fn writeReinterpreted(comptime Buffer: type) void {
+            var buffer: Buffer = undefined;
+            const pointer: *void = @ptrCast(&buffer);
+            pointer.* = {};
+        }
+    };
+    comptime {
+        S.writeReinterpreted([0]u8); //[0](positive-sized) crashes
+        S.writeReinterpreted([8]u0); //[positive](0-sized) crashes
+        S.writeReinterpreted([8]u8); //[positive](positive-sized) works
+        S.writeReinterpreted(u0); //(0-sized) works
+    }
+}

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -1143,10 +1143,10 @@ test "reinterpreted 0-sized array at comptime" {
         }
     };
     comptime {
-        S.writeReinterpreted([0]u8); //[0](positive-sized) crashes
-        S.writeReinterpreted([8]u0); //[positive](0-sized) crashes
-        S.writeReinterpreted([8]u8); //[positive](positive-sized) works
-        S.writeReinterpreted(u0); //(0-sized) works
+        S.writeReinterpreted([0]u8);
+        S.writeReinterpreted([8]u0);
+        S.writeReinterpreted([8]u8);
+        S.writeReinterpreted(u0);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/21202
Fixes https://github.com/ziglang/zig/issues/21508

Add more checks for 0-sized array in function prepareComptimePtrStore and bitCastSpliceInner.
The bytes occupied by arrays need to consider memory alignment, but zero-sized arrays do not need to consider memory alignment.