### PR TITLE
build: pass zig lib dir as directory instead of as string

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1392,7 +1392,14 @@ fn generateLangRef(b: *std.Build) std.Build.LazyPath {
             // in a temporary directory
             "--cache-root", b.cache_root.path orelse ".",
         });
-        cmd.addArgs(&.{ "--zig-lib-dir", b.fmt("{}", .{b.graph.zig_lib_directory}) });
+        if (b.graph.zig_lib_directory.path) |zig_lib_dir| {
+            cmd.addArgs(&.{"--zig-lib-dir"});
+            if (fs.path.isAbsolute(zig_lib_dir)) {
+                cmd.addArgs(&.{zig_lib_dir});
+            } else {
+                cmd.addDirectoryArg(b.path(zig_lib_dir));
+            }
+        }
         cmd.addArgs(&.{"-i"});
         cmd.addFileArg(b.path(b.fmt("doc/langref/{s}", .{entry.name})));
 


### PR DESCRIPTION
I can't build langref on 0.14.0 or master because a relative path is passed to doctest and doctest is ran in a temporary directory.

alex pointed me to #23122, but that is a more radical solution to the problem, this PR is more modest by checking if `graph.zig_lib_directory.path` is set and then passing it via `addDirectoryArg`.

tested by running `zig build docs`

https://zsf.zulipchat.com/#narrow/channel/454360-compiler/topic/unable.20to.20open.20zig.20lib.20directory.20when.20building.20docs/with/513624116