### PR TITLE
std.fs.Dir: Reduce stack usage of realpathW

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -1349,13 +1349,11 @@ pub fn realpathW(self: Dir, pathname: []const u16, out_buffer: []u8) RealPathErr
 
     var wide_buf: [w.PATH_MAX_WIDE]u16 = undefined;
     const wide_slice = try w.GetFinalPathNameByHandle(h_file, .{}, &wide_buf);
-    var big_out_buf: [fs.max_path_bytes]u8 = undefined;
-    const end_index = std.unicode.wtf16LeToWtf8(&big_out_buf, wide_slice);
-    if (end_index > out_buffer.len)
+    const len = std.unicode.calcWtf8Len(wide_slice);
+    if (len > out_buffer.len)
         return error.NameTooLong;
-    const result = out_buffer[0..end_index];
-    @memcpy(result, big_out_buf[0..end_index]);
-    return result;
+    const end_index = std.unicode.wtf16LeToWtf8(out_buffer, wide_slice);
+    return out_buffer[0..end_index];
 }
 
 pub const RealPathAllocError = RealPathError || Allocator.Error;


### PR DESCRIPTION
This reduces the stack usage by 96 KB by calculating the WTF-8 length and then checking the `out_buffer` length rather than converting into an intermediate buffer on the stack. This is one step towards fixing #23643.