### PR TITLE
`std.Target`: Remove `Abi.gnuilp32`.

### DIFF
--- a/lib/compiler/aro/aro/target.zig
+++ b/lib/compiler/aro/aro/target.zig
@@ -687,7 +687,6 @@ pub fn toLLVMTriple(target: std.Target, buf: []u8) []const u8 {
         .gnuf32 => "gnuf32",
         .gnusf => "gnusf",
         .gnux32 => "gnux32",
-        .gnuilp32 => "gnu_ilp32",
         .code16 => "code16",
         .eabi => "eabi",
         .eabihf => "eabihf",

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -763,7 +763,6 @@ pub const Abi = enum {
     gnuf32,
     gnusf,
     gnux32,
-    gnuilp32,
     code16,
     eabi,
     eabihf,
@@ -938,7 +937,6 @@ pub const Abi = enum {
             .gnuf32,
             .gnusf,
             .gnux32,
-            .gnuilp32,
             => true,
             else => false,
         };
@@ -2205,14 +2203,7 @@ pub const DynamicLinker = struct {
             .hurd => switch (cpu.arch) {
                 .aarch64,
                 .aarch64_be,
-                => |arch| initFmt("/lib/ld-{s}{s}.so.1", .{
-                    @tagName(arch),
-                    switch (abi) {
-                        .gnu => "",
-                        .gnuilp32 => "_ilp32",
-                        else => return none,
-                    },
-                }),
+                => |arch| if (abi == .gnu) initFmt("/lib/ld-{s}.so.1", .{@tagName(arch)}) else none,
 
                 .x86 => if (abi == .gnu) init("/lib/ld.so.1") else none,
                 .x86_64 => initFmt("/lib/ld-{s}.so.1", .{switch (abi) {
@@ -2344,14 +2335,7 @@ pub const DynamicLinker = struct {
 
                     .aarch64,
                     .aarch64_be,
-                    => |arch| initFmt("/lib/ld-linux-{s}{s}.so.1", .{
-                        @tagName(arch),
-                        switch (abi) {
-                            .gnu => "",
-                            .gnuilp32 => "_ilp32",
-                            else => return none,
-                        },
-                    }),
+                    => |arch| if (abi == .gnu) initFmt("/lib/ld-linux-{s}.so.1", .{@tagName(arch)}) else none,
 
                     // TODO: `-be` architecture support.
                     .csky => initFmt("/lib/ld-linux-cskyv2{s}.so.1", .{switch (abi) {
@@ -2585,7 +2569,7 @@ pub fn standardDynamicLinkerPath(target: Target) DynamicLinker {
 
 pub fn ptrBitWidth_cpu_abi(cpu: Cpu, abi: Abi) u16 {
     switch (abi) {
-        .gnux32, .muslx32, .gnuabin32, .muslabin32, .gnuilp32, .ilp32 => return 32,
+        .gnux32, .muslx32, .gnuabin32, .muslabin32, .ilp32 => return 32,
         .gnuabi64, .muslabi64 => return 64,
         else => {},
     }
@@ -2979,7 +2963,7 @@ pub fn cTypeBitSize(target: Target, c_type: CType) u16 {
                 .long, .ulong => return 32,
                 .longlong, .ulonglong, .double => return 64,
                 .longdouble => switch (target.abi) {
-                    .gnu, .gnuilp32, .ilp32, .cygnus => return 80,
+                    .gnu, .ilp32, .cygnus => return 80,
                     else => return 64,
                 },
             },
@@ -2993,7 +2977,7 @@ pub fn cTypeBitSize(target: Target, c_type: CType) u16 {
                 },
                 .longlong, .ulonglong, .double => return 64,
                 .longdouble => switch (target.abi) {
-                    .gnu, .gnuilp32, .ilp32, .cygnus => return 80,
+                    .gnu, .ilp32, .cygnus => return 80,
                     else => return 64,
                 },
             },
@@ -3091,7 +3075,7 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
             .windows, .uefi => switch (c_type) {
                 .longlong, .ulonglong, .double => return 8,
                 .longdouble => switch (target.abi) {
-                    .gnu, .gnuilp32, .ilp32, .cygnus => return 4,
+                    .gnu, .ilp32, .cygnus => return 4,
                     else => return 8,
                 },
                 else => {},
@@ -3192,7 +3176,7 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
             },
             .windows, .uefi => switch (c_type) {
                 .longdouble => switch (target.abi) {
-                    .gnu, .gnuilp32, .ilp32, .cygnus => return 4,
+                    .gnu, .ilp32, .cygnus => return 4,
                     else => return 8,
                 },
                 else => {},

--- a/lib/std/zig/LibCDirs.zig
+++ b/lib/std/zig/LibCDirs.zig
@@ -229,7 +229,6 @@ fn libCGenericName(target: std.Target) [:0]const u8 {
         .gnuf32,
         .gnusf,
         .gnux32,
-        .gnuilp32,
         => return "glibc",
         .musl,
         .muslabin32,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -259,7 +259,6 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .gnuf32 => "gnuf32",
         .gnusf => "gnusf",
         .gnux32 => "gnux32",
-        .gnuilp32 => "gnu_ilp32",
         .code16 => "code16",
         .eabi => "eabi",
         .eabihf => "eabihf",


### PR DESCRIPTION
* This has not seen meaningful development for about a decade.
* The Linux kernel port was never upstreamed.
* The glibc port was never upstreamed.
* GCC 15.1 recently deprecated support it.

It may still make sense to support an ILP32 ABI on AArch64 more broadly (which we already have the `Abi.ilp32` tag for), but, to the extent that it even existed in any "official" sense, the *GNU* ILP32 ABI is certainly dead.