### PR TITLE
Fix std.Progress panic

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -246,7 +246,7 @@ pub const Node = struct {
         }
         const index = n.index.unwrap() orelse return;
         const parent_ptr = parentByIndex(index);
-        if (parent_ptr.unwrap()) |parent_index| {
+        if (@atomicLoad(Parent, parent_ptr, .acquire).unwrap()) |parent_index| {
             _ = @atomicRmw(u32, &storageByIndex(parent_index).completed_count, .Add, 1, .monotonic);
             @atomicStore(Node.Parent, parent_ptr, .unused, .seq_cst);
 

--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -307,7 +307,8 @@ pub const Node = struct {
             @atomicStore(u8, &storage.name[name_len], 0, .monotonic);
 
         const parent_ptr = parentByIndex(free_index);
-        assert(parent_ptr.* == .unused);
+        const current_parent = @atomicLoad(Node.Parent, parent_ptr, .acquire);
+        assert(current_parent == .unused);
         @atomicStore(Node.Parent, parent_ptr, parent, .release);
 
         return .{ .index = free_index.toOptional() };


### PR DESCRIPTION
Fixes #21663

The main issue was an ABA problem in the maintenance of the freelist. This has been fixed by making `node_freelist_first` into a generational index.

Also in this MR are fixes for some other issues I encountered while investigating this.

<details><summary>An example program to reproduce the issue and confirm the fix.</summary>

Run like `repro 20 3` to reproduce the main issue. Run like `repro 200 3` to reproduce the issue behind commit "Fix maintenance of node_end_index when out of node storage memory".

```zig
const std = @import("std");
const Progress = std.Progress;
const Thread = std.Thread;

pub fn main() !void {
    var args = std.process.ArgIteratorPosix.init();
    if (args.count != 3) {
        std.debug.print("Usage: repro num_threads steps_per_node\n", .{});
        return;
    }
    _ = args.skip();
    const num_threads = try std.fmt.parseInt(usize, args.next().?, 10);
    if (num_threads > 200) {
        std.debug.print("max 200 threads\n", .{});
        return;
    }
    const steps_per_node = try std.fmt.parseInt(usize, args.next().?, 10);

    var root_progress = Progress.start(.{ .root_name = "root" });
    var threads: [200]Thread = undefined;
    for (0..num_threads) |i| {
        threads[i] = try Thread.spawn(.{}, spam, .{ &root_progress, i, steps_per_node });
    }
    for (0..num_threads) |i| {
        std.debug.print("joining {d}\n", .{i});
        threads[i].join();
    }
}

fn spam(root_progress: *Progress.Node, threadnum: usize, steps_per_node: usize) void {
    var name: [5]u8 = undefined;
    const name_len = std.fmt.formatIntBuf(name[0..name.len], threadnum, 10, .lower, .{ .width = 2 });
    while (true) {
        const node = root_progress.start(name[0..name_len], steps_per_node);
        for (0..steps_per_node) |_| {
            node.completeOne();
        }
        node.end();
    }
}
```

</details>