### PR TITLE
`std.Target`: Remove `Os.Tag.elfiamcu`.

### DIFF
--- a/lib/compiler/aro/aro/Driver/GCCDetector.zig
+++ b/lib/compiler/aro/aro/Driver/GCCDetector.zig
@@ -284,15 +284,11 @@ fn collectLibDirsAndTriples(
         },
         .x86 => {
             lib_dirs.appendSliceAssumeCapacity(&X86LibDirs);
-            // MCU toolchain is 32 bit only and its triple alias is TargetTriple
-            // itself, which will be appended below.
-            if (target.os.tag != .elfiamcu) {
-                triple_aliases.appendSliceAssumeCapacity(&X86Triples);
-                biarch_libdirs.appendSliceAssumeCapacity(&X86_64LibDirs);
-                biarch_triple_aliases.appendSliceAssumeCapacity(&X86_64Triples);
-                biarch_libdirs.appendSliceAssumeCapacity(&X32LibDirs);
-                biarch_triple_aliases.appendSliceAssumeCapacity(&X32Triples);
-            }
+            triple_aliases.appendSliceAssumeCapacity(&X86Triples);
+            biarch_libdirs.appendSliceAssumeCapacity(&X86_64LibDirs);
+            biarch_triple_aliases.appendSliceAssumeCapacity(&X86_64Triples);
+            biarch_libdirs.appendSliceAssumeCapacity(&X32LibDirs);
+            biarch_triple_aliases.appendSliceAssumeCapacity(&X32Triples);
         },
         .loongarch64 => {
             lib_dirs.appendSliceAssumeCapacity(&LoongArch64LibDirs);
@@ -511,7 +507,7 @@ fn findBiarchMultilibs(
 
     const multilib_filter = Multilib.Filter{
         .base = path,
-        .file = if (target.os.tag == .elfiamcu) "libgcc.a" else "crtbegin.o",
+        .file = "crtbegin.o",
     };
 
     const Want = enum {

--- a/lib/compiler/aro/aro/Toolchain.zig
+++ b/lib/compiler/aro/aro/Toolchain.zig
@@ -83,9 +83,7 @@ pub fn discover(tc: *Toolchain) !void {
 
     const target = tc.getTarget();
     tc.inner = switch (target.os.tag) {
-        .elfiamcu,
-        .linux,
-        => if (target.cpu.arch == .hexagon)
+        .linux => if (target.cpu.arch == .hexagon)
             .{ .unknown = {} } // TODO
         else if (target.cpu.arch.isMIPS())
             .{ .unknown = {} } // TODO
@@ -418,7 +416,6 @@ fn addUnwindLibrary(tc: *const Toolchain, argv: *std.ArrayList([]const u8)) !voi
     const unw = try tc.getUnwindLibKind();
     const target = tc.getTarget();
     if ((target.abi.isAndroid() and unw == .libgcc) or
-        target.os.tag == .elfiamcu or
         target.ofmt == .wasm or
         target_util.isWindowsMSVCEnvironment(target) or
         unw == .none) return;

--- a/lib/compiler/aro/aro/target.zig
+++ b/lib/compiler/aro/aro/target.zig
@@ -412,7 +412,7 @@ pub fn defaultFpEvalMethod(target: std.Target) LangOpts.FPEvalMethod {
 /// Value of the `-m` flag for `ld` for this target
 pub fn ldEmulationOption(target: std.Target, arm_endianness: ?std.builtin.Endian) ?[]const u8 {
     return switch (target.cpu.arch) {
-        .x86 => if (target.os.tag == .elfiamcu) "elf_iamcu" else "elf_i386",
+        .x86 => "elf_i386",
         .arm,
         .armeb,
         .thumb,
@@ -642,7 +642,6 @@ pub fn toLLVMTriple(target: std.Target, buf: []u8) []const u8 {
         .amdhsa => "amdhsa",
         .ps4 => "ps4",
         .ps5 => "ps5",
-        .elfiamcu => "elfiamcu",
         .mesa3d => "mesa3d",
         .contiki => "contiki",
         .amdpal => "amdpal",

--- a/lib/compiler/aro/aro/toolchains/Linux.zig
+++ b/lib/compiler/aro/aro/toolchains/Linux.zig
@@ -170,7 +170,6 @@ pub fn buildLinkerArgs(self: *const Linux, tc: *const Toolchain, argv: *std.Arra
     const is_static_pie = try self.getStaticPIE(d);
     const is_static = self.getStatic(d);
     const is_android = target.abi.isAndroid();
-    const is_iamcu = target.os.tag == .elfiamcu;
     const is_ve = target.cpu.arch == .ve;
     const has_crt_begin_end_files = target.abi != .none; // TODO: clang checks for MIPS vendor
 
@@ -225,7 +224,7 @@ pub fn buildLinkerArgs(self: *const Linux, tc: *const Toolchain, argv: *std.Arra
     try argv.appendSlice(&.{ "-o", d.output_name orelse "a.out" });
 
     if (!d.nostdlib and !d.nostartfiles and !d.relocatable) {
-        if (!is_android and !is_iamcu) {
+        if (!is_android) {
             if (!d.shared) {
                 const crt1 = if (is_pie)
                     "Scrt1.o"
@@ -241,9 +240,7 @@ pub fn buildLinkerArgs(self: *const Linux, tc: *const Toolchain, argv: *std.Arra
             try argv.appendSlice(&.{ "-z", "max-page-size=0x4000000" });
         }
 
-        if (is_iamcu) {
-            try argv.append(try tc.getFilePath("crt0.o"));
-        } else if (has_crt_begin_end_files) {
+        if (has_crt_begin_end_files) {
             var path: []const u8 = "";
             if (tc.getRuntimeLibKind() == .compiler_rt and !is_android) {
                 const crt_begin = try tc.getCompilerRt("crtbegin", .object);
@@ -285,19 +282,13 @@ pub fn buildLinkerArgs(self: *const Linux, tc: *const Toolchain, argv: *std.Arra
             if (!d.nolibc) {
                 try argv.append("-lc");
             }
-            if (is_iamcu) {
-                try argv.append("-lgloss");
-            }
             if (is_static or is_static_pie) {
                 try argv.append("--end-group");
             } else {
                 try tc.addRuntimeLibs(argv);
             }
-            if (is_iamcu) {
-                try argv.appendSlice(&.{ "--as-needed", "-lsoftfp", "--no-as-needed" });
-            }
         }
-        if (!d.nostartfiles and !is_iamcu) {
+        if (!d.nostartfiles) {
             if (has_crt_begin_end_files) {
                 var path: []const u8 = "";
                 if (tc.getRuntimeLibKind() == .compiler_rt and !is_android) {

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -20,7 +20,6 @@ pub const Os = struct {
         other,
 
         contiki,
-        elfiamcu,
         fuchsia,
         hermit,
 
@@ -155,8 +154,6 @@ pub const Os = struct {
             return switch (tag) {
                 .freestanding,
                 .other,
-
-                .elfiamcu,
 
                 .haiku,
                 .plan9,
@@ -399,8 +396,6 @@ pub const Os = struct {
             return switch (tag) {
                 .freestanding,
                 .other,
-
-                .elfiamcu,
 
                 .haiku,
                 .plan9,
@@ -708,7 +703,6 @@ pub const Os = struct {
             .amdhsa,
             .ps4,
             .ps5,
-            .elfiamcu,
             .mesa3d,
             .contiki,
             .amdpal,
@@ -902,7 +896,6 @@ pub const Abi = enum {
             .wasi, .emscripten => .musl,
 
             .contiki,
-            .elfiamcu,
             .fuchsia,
             .hermit,
             .plan9,
@@ -1075,7 +1068,7 @@ pub fn toElfMachine(target: Target) std.elf.EM {
         .sparc => if (Target.sparc.featureSetHas(target.cpu.features, .v9)) .SPARC32PLUS else .SPARC,
         .sparc64 => .SPARCV9,
         .ve => .VE,
-        .x86 => if (target.os.tag == .elfiamcu) .IAMCU else .@"386",
+        .x86 => .@"386",
         .x86_64 => .X86_64,
         .xcore => .XCORE,
         .xtensa => .XTENSA,
@@ -2136,7 +2129,6 @@ pub const DynamicLinker = struct {
             .other,
 
             .contiki,
-            .elfiamcu,
             .hermit,
 
             .aix,
@@ -2545,7 +2537,6 @@ pub const DynamicLinker = struct {
             .other,
 
             .contiki,
-            .elfiamcu,
             .hermit,
 
             .aix,
@@ -2685,7 +2676,7 @@ pub fn stackAlignment(target: Target) u16 {
         .riscv64,
         => if (!Target.riscv.featureSetHas(target.cpu.features, .e)) return 16,
         .x86 => if (target.os.tag != .windows and target.os.tag != .uefi) return 16,
-        .x86_64 => return if (target.os.tag == .elfiamcu) 4 else 16,
+        .x86_64 => return 16,
         else => {},
     }
 
@@ -2846,7 +2837,6 @@ pub fn cTypeBitSize(target: Target, c_type: CType) u16 {
             },
         },
 
-        .elfiamcu,
         .fuchsia,
         .hermit,
 
@@ -2913,10 +2903,7 @@ pub fn cTypeBitSize(target: Target, c_type: CType) u16 {
                 .longdouble => switch (target.cpu.arch) {
                     .x86 => switch (target.abi) {
                         .android => return 64,
-                        else => switch (target.os.tag) {
-                            .elfiamcu => return 64,
-                            else => return 80,
-                        },
+                        else => return 80,
                     },
 
                     .powerpc,
@@ -3084,10 +3071,6 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
     switch (target.cpu.arch) {
         .avr => return 1,
         .x86 => switch (target.os.tag) {
-            .elfiamcu => switch (c_type) {
-                .longlong, .ulonglong, .double => return 4,
-                else => {},
-            },
             .windows, .uefi => switch (c_type) {
                 .longlong, .ulonglong, .double => return 8,
                 .longdouble => switch (target.abi) {
@@ -3186,10 +3169,6 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
         },
         .avr => return 1,
         .x86 => switch (target.os.tag) {
-            .elfiamcu => switch (c_type) {
-                .longlong, .ulonglong, .double, .longdouble => return 4,
-                else => {},
-            },
             .windows, .uefi => switch (c_type) {
                 .longdouble => switch (target.abi) {
                     .gnu, .gnuilp32, .ilp32, .cygnus => return 4,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -208,7 +208,6 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .opencl => "unknown", // https://llvm.org/docs/SPIRVUsage.html#target-triples
         .ps4 => "ps4",
         .ps5 => "ps5",
-        .elfiamcu => "elfiamcu",
         .mesa3d => "mesa3d",
         .amdpal => "amdpal",
         .hermit => "hermit",
@@ -403,36 +402,32 @@ pub fn dataLayout(target: std.Target) []const u8 {
             "E-m:l-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
         else
             "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64",
-        .x86 => switch (target.os.tag) {
-            .elfiamcu => "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:32-f64:32-f128:32-n8:16:32-a:0:32-S32",
-            .windows => switch (target.abi) {
-                .cygnus => "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32",
-                .gnu => if (target.ofmt == .coff)
-                    "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32"
-                else
-                    "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32",
-                else => blk: {
-                    const msvc = switch (target.abi) {
-                        .none, .msvc => true,
-                        else => false,
-                    };
-
-                    break :blk if (target.ofmt == .coff)
-                        if (msvc)
-                            "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32-a:0:32-S32"
-                        else
-                            "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32"
-                    else if (msvc)
-                        "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32-a:0:32-S32"
-                    else
-                        "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32";
-                },
-            },
-            else => if (target.ofmt == .macho)
-                "e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128"
+        .x86 => if (target.os.tag == .windows) switch (target.abi) {
+            .cygnus => "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32",
+            .gnu => if (target.ofmt == .coff)
+                "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32"
             else
-                "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
-        },
+                "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32",
+            else => blk: {
+                const msvc = switch (target.abi) {
+                    .none, .msvc => true,
+                    else => false,
+                };
+
+                break :blk if (target.ofmt == .coff)
+                    if (msvc)
+                        "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32-a:0:32-S32"
+                    else
+                        "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32"
+                else if (msvc)
+                    "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32-a:0:32-S32"
+                else
+                    "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32";
+            },
+        } else if (target.ofmt == .macho)
+            "e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128"
+        else
+            "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
         .x86_64 => if (target.os.tag.isDarwin() or target.ofmt == .macho)
             "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
         else switch (target.abi) {

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -4174,7 +4174,6 @@ fn getLDMOption(target: std.Target) ?[]const u8 {
         .s390x => "elf64_s390",
         .sparc64 => "elf64_sparc",
         .x86 => switch (target.os.tag) {
-            .elfiamcu => "elf_iamcu",
             .freebsd => "elf_i386_fbsd",
             else => "elf_i386",
         },

--- a/test/llvm_targets.zig
+++ b/test/llvm_targets.zig
@@ -312,7 +312,6 @@ const targets = [_]std.Target.Query{
     .{ .cpu_arch = .wasm64, .os_tag = .wasi, .abi = .musl },
     .{ .cpu_arch = .wasm64, .os_tag = .wasi, .abi = .none },
 
-    .{ .cpu_arch = .x86, .os_tag = .elfiamcu, .abi = .none },
     .{ .cpu_arch = .x86, .os_tag = .freebsd, .abi = .none },
     .{ .cpu_arch = .x86, .os_tag = .freestanding, .abi = .none },
     .{ .cpu_arch = .x86, .os_tag = .haiku, .abi = .none },


### PR DESCRIPTION
The last Intel Quark MCU was released in 2015. Quark was announced to be EOL in 2019, and stopped shipping entirely in 2022.

The OS tag was only meaningful for Intel's weird fork of Linux 3.8.7 with a special ABI that differs from the regular i386 System V ABI; beyond that, the CPU itself is just a plain old P54C (i586). We of course keep support for the CPU itself, just not Intel's Linux fork (which is unmaintained, and thus will never be supported by us due to being so old).