### PR TITLE
chore(std.mem): Rename `trimLeft` and `trimRight` to `trimStart` and `trimEnd`

### DIFF
--- a/lib/compiler/resinator/compile.zig
+++ b/lib/compiler/resinator/compile.zig
@@ -3274,7 +3274,7 @@ pub const StringTable = struct {
                     // Note: This is only the case for STRINGTABLE strings
                     const trimmed = trimToDoubleNUL(u16, utf16_string);
                     // We also want to trim any trailing NUL characters
-                    break :trim std.mem.trimRight(u16, trimmed, &[_]u16{0});
+                    break :trim std.mem.trimEnd(u16, trimmed, &[_]u16{0});
                 };
 
                 // String literals are limited to maxInt(u15) codepoints, so these UTF-16 encoded

--- a/lib/docs/wasm/markdown/Parser.zig
+++ b/lib/docs/wasm/markdown/Parser.zig
@@ -140,7 +140,7 @@ const Block = struct {
     /// (e.g. for a blockquote, this would be everything except the leading
     /// `>`). If unsuccessful, returns null.
     fn match(b: Block, line: []const u8) ?[]const u8 {
-        const unindented = mem.trimLeft(u8, line, " \t");
+        const unindented = mem.trimStart(u8, line, " \t");
         const indent = line.len - unindented.len;
         return switch (b.tag) {
             .list => line,
@@ -156,7 +156,7 @@ const Block = struct {
             .table_row => null,
             .heading => null,
             .code_block => code_block: {
-                const trimmed = mem.trimRight(u8, unindented, " \t");
+                const trimmed = mem.trimEnd(u8, unindented, " \t");
                 if (mem.indexOfNone(u8, trimmed, "`") != null or trimmed.len != b.data.code_block.fence_len) {
                     const effective_indent = @min(indent, b.data.code_block.indent);
                     break :code_block line[effective_indent..];
@@ -225,7 +225,7 @@ pub fn feedLine(p: *Parser, line: []const u8) Allocator.Error!void {
         p.pending_blocks.items.len > 0 and
         p.pending_blocks.getLast().tag == .paragraph)
     {
-        try p.addScratchStringLine(mem.trimLeft(u8, rest_line, " \t"));
+        try p.addScratchStringLine(mem.trimStart(u8, rest_line, " \t"));
         return;
     }
 
@@ -261,7 +261,7 @@ pub fn feedLine(p: *Parser, line: []const u8) Allocator.Error!void {
         last_pending_block.canAccept()
     else
         .blocks;
-    const rest_line_trimmed = mem.trimLeft(u8, rest_line, " \t");
+    const rest_line_trimmed = mem.trimStart(u8, rest_line, " \t");
     switch (can_accept) {
         .blocks => {
             // If we're inside a list item and the rest of the line is blank, it
@@ -500,7 +500,7 @@ fn appendBlockStart(p: *Parser, block_start: BlockStart) !void {
 }
 
 fn startBlock(p: *Parser, line: []const u8) !?BlockStart {
-    const unindented = mem.trimLeft(u8, line, " \t");
+    const unindented = mem.trimStart(u8, line, " \t");
     const indent = line.len - unindented.len;
     if (isThematicBreak(line)) {
         // Thematic breaks take precedence over list items.

--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -364,7 +364,7 @@ pub fn init(stream: anytype, options: Options) InitError(@TypeOf(stream))!Client
                         };
                         P.AEAD.decrypt(cleartext, ciphertext, auth_tag, record_header, nonce, pv.server_handshake_key) catch
                             return error.TlsBadRecordMac;
-                        cleartext_fragment_end += std.mem.trimRight(u8, cleartext, "\x00").len;
+                        cleartext_fragment_end += std.mem.trimEnd(u8, cleartext, "\x00").len;
                     },
                 }
                 read_seq += 1;
@@ -1353,7 +1353,7 @@ pub fn readvAdvanced(c: *Client, stream: anytype, iovecs: []const std.posix.iove
                     const cleartext = cleartext_buf[0..ciphertext.len];
                     P.AEAD.decrypt(cleartext, ciphertext, auth_tag, ad, nonce, pv.server_key) catch
                         return error.TlsBadRecordMac;
-                    const msg = mem.trimRight(u8, cleartext, "\x00");
+                    const msg = mem.trimEnd(u8, cleartext, "\x00");
                     break :cleartext .{ msg[0 .. msg.len - 1], @enumFromInt(msg[msg.len - 1]) };
                 },
                 .tls_1_2 => {

--- a/lib/std/elf.zig
+++ b/lib/std/elf.zig
@@ -2330,12 +2330,12 @@ pub const ar_hdr = extern struct {
     ar_fmag: [2]u8,
 
     pub fn date(self: ar_hdr) std.fmt.ParseIntError!u64 {
-        const value = mem.trimRight(u8, &self.ar_date, &[_]u8{0x20});
+        const value = mem.trimEnd(u8, &self.ar_date, &[_]u8{0x20});
         return std.fmt.parseInt(u64, value, 10);
     }
 
     pub fn size(self: ar_hdr) std.fmt.ParseIntError!u32 {
-        const value = mem.trimRight(u8, &self.ar_size, &[_]u8{0x20});
+        const value = mem.trimEnd(u8, &self.ar_size, &[_]u8{0x20});
         return std.fmt.parseInt(u32, value, 10);
     }
 
@@ -2369,7 +2369,7 @@ pub const ar_hdr = extern struct {
     pub fn nameOffset(self: ar_hdr) std.fmt.ParseIntError!?u32 {
         const value = &self.ar_name;
         if (value[0] != '/') return null;
-        const trimmed = mem.trimRight(u8, value, &[_]u8{0x20});
+        const trimmed = mem.trimEnd(u8, value, &[_]u8{0x20});
         return try std.fmt.parseInt(u32, trimmed[1..], 10);
     }
 };

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1162,7 +1162,7 @@ pub fn formatFloatHexadecimal(
 
     try writer.writeAll("0x");
     try writer.writeByte(buf[0]);
-    const trimmed = mem.trimRight(u8, buf[1..], "0");
+    const trimmed = mem.trimEnd(u8, buf[1..], "0");
     if (options.precision) |precision| {
         if (precision > 0) try writer.writeAll(".");
     } else if (trimmed.len > 0) {

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -473,7 +473,7 @@ pub const Response = struct {
         };
         if (first_line[8] != ' ') return error.HttpHeadersInvalid;
         const status: http.Status = @enumFromInt(parseInt3(first_line[9..12]));
-        const reason = mem.trimLeft(u8, first_line[12..], " ");
+        const reason = mem.trimStart(u8, first_line[12..], " ");
 
         res.version = version;
         res.status = status;

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1198,18 +1198,32 @@ pub fn allEqual(comptime T: type, slice: []const T, scalar: T) bool {
 }
 
 /// Remove a set of values from the beginning of a slice.
-pub fn trimLeft(comptime T: type, slice: []const T, values_to_strip: []const T) []const T {
+pub fn trimStart(comptime T: type, slice: []const T, values_to_strip: []const T) []const T {
     var begin: usize = 0;
     while (begin < slice.len and indexOfScalar(T, values_to_strip, slice[begin]) != null) : (begin += 1) {}
     return slice[begin..];
 }
 
+test trimStart {
+    try testing.expectEqualSlices(u8, "foo\n ", trimStart(u8, " foo\n ", " \n"));
+}
+
+/// Deprecated: use `trimStart` instead.
+pub const trimLeft = trimStart;
+
 /// Remove a set of values from the end of a slice.
-pub fn trimRight(comptime T: type, slice: []const T, values_to_strip: []const T) []const T {
+pub fn trimEnd(comptime T: type, slice: []const T, values_to_strip: []const T) []const T {
     var end: usize = slice.len;
     while (end > 0 and indexOfScalar(T, values_to_strip, slice[end - 1]) != null) : (end -= 1) {}
     return slice[0..end];
 }
+
+test trimEnd {
+    try testing.expectEqualSlices(u8, " foo", trimEnd(u8, " foo\n ", " \n"));
+}
+
+/// Deprecated: use `trimEnd` instead.
+pub const trimRight = trimEnd;
 
 /// Remove a set of values from the beginning and end of a slice.
 pub fn trim(comptime T: type, slice: []const T, values_to_strip: []const T) []const T {
@@ -1221,8 +1235,8 @@ pub fn trim(comptime T: type, slice: []const T, values_to_strip: []const T) []co
 }
 
 test trim {
-    try testing.expectEqualSlices(u8, "foo\n ", trimLeft(u8, " foo\n ", " \n"));
-    try testing.expectEqualSlices(u8, " foo", trimRight(u8, " foo\n ", " \n"));
+    try testing.expectEqualSlices(u8, "foo\n ", trimStart(u8, " foo\n ", " \n"));
+    try testing.expectEqualSlices(u8, " foo", trimEnd(u8, " foo\n ", " \n"));
     try testing.expectEqualSlices(u8, "foo", trim(u8, " foo\n ", " \n"));
     try testing.expectEqualSlices(u8, "foo", trim(u8, "foo", " \n"));
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1235,8 +1235,6 @@ pub fn trim(comptime T: type, slice: []const T, values_to_strip: []const T) []co
 }
 
 test trim {
-    try testing.expectEqualSlices(u8, "foo\n ", trimStart(u8, " foo\n ", " \n"));
-    try testing.expectEqualSlices(u8, " foo", trimEnd(u8, " foo\n ", " \n"));
     try testing.expectEqualSlices(u8, "foo", trim(u8, " foo\n ", " \n"));
     try testing.expectEqualSlices(u8, "foo", trim(u8, "foo", " \n"));
 }

--- a/lib/std/tar.zig
+++ b/lib/std/tar.zig
@@ -250,8 +250,8 @@ const Header = struct {
         const raw = header.bytes[start..][0..len];
         // Zero-filled octal number in ASCII. Each numeric field of width w
         // contains w minus 1 digits, and a null
-        const ltrimmed = std.mem.trimLeft(u8, raw, "0 ");
-        const rtrimmed = std.mem.trimRight(u8, ltrimmed, " \x00");
+        const ltrimmed = std.mem.trimStart(u8, raw, "0 ");
+        const rtrimmed = std.mem.trimEnd(u8, ltrimmed, " \x00");
         if (rtrimmed.len == 0) return 0;
         return std.fmt.parseInt(u64, rtrimmed, 8) catch return error.TarHeader;
     }

--- a/lib/std/zig/LibCInstallation.zig
+++ b/lib/std/zig/LibCInstallation.zig
@@ -317,7 +317,7 @@ fn findNativeIncludeDirPosix(self: *LibCInstallation, args: FindNativeOptions) F
     while (path_i < search_paths.items.len) : (path_i += 1) {
         // search in reverse order
         const search_path_untrimmed = search_paths.items[search_paths.items.len - path_i - 1];
-        const search_path = std.mem.trimLeft(u8, search_path_untrimmed, " ");
+        const search_path = std.mem.trimStart(u8, search_path_untrimmed, " ");
         var search_dir = fs.cwd().openDir(search_path, .{}) catch |err| switch (err) {
             error.FileNotFound,
             error.NotDir,

--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -1849,7 +1849,7 @@ fn parseTypeExpr(p: *Parse) Error!?Node.Index {
                 var sentinel: ?Node.Index = null;
                 if (p.eatToken(.identifier)) |ident| {
                     const ident_slice = p.source[p.tokenStart(ident)..p.tokenStart(ident + 1)];
-                    if (!std.mem.eql(u8, std.mem.trimRight(u8, ident_slice, &std.ascii.whitespace), "c")) {
+                    if (!std.mem.eql(u8, std.mem.trimEnd(u8, ident_slice, &std.ascii.whitespace), "c")) {
                         p.tok_i -= 1;
                     }
                 } else if (p.eatToken(.colon)) |_| {

--- a/lib/std/zig/render.zig
+++ b/lib/std/zig/render.zig
@@ -2955,7 +2955,7 @@ fn renderComments(r: *Render, start: usize, end: usize) Error!bool {
         const newline = if (newline_index) |i| comment_start + i else null;
 
         const untrimmed_comment = tree.source[comment_start .. newline orelse tree.source.len];
-        const trimmed_comment = mem.trimRight(u8, untrimmed_comment, &std.ascii.whitespace);
+        const trimmed_comment = mem.trimEnd(u8, untrimmed_comment, &std.ascii.whitespace);
 
         // Don't leave any whitespace at the start of the file
         if (index != 0) {
@@ -2976,7 +2976,7 @@ fn renderComments(r: *Render, start: usize, end: usize) Error!bool {
 
         index = 1 + (newline orelse end - 1);
 
-        const comment_content = mem.trimLeft(u8, trimmed_comment["//".len..], &std.ascii.whitespace);
+        const comment_content = mem.trimStart(u8, trimmed_comment["//".len..], &std.ascii.whitespace);
         if (ais.disabled_offset != null and mem.eql(u8, comment_content, "zig fmt: on")) {
             // Write the source for which formatting was disabled directly
             // to the underlying writer, fixing up invalid whitespace.
@@ -3103,7 +3103,7 @@ fn tokenSliceForRender(tree: Ast, token_index: Ast.TokenIndex) []const u8 {
     var ret = tree.tokenSlice(token_index);
     switch (tree.tokenTag(token_index)) {
         .container_doc_comment, .doc_comment => {
-            ret = mem.trimRight(u8, ret, &std.ascii.whitespace);
+            ret = mem.trimEnd(u8, ret, &std.ascii.whitespace);
         },
         else => {},
     }

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1182,13 +1182,13 @@ fn detectAbiAndDynamicLinker(
                 // We detected shebang, now parse entire line.
 
                 // Trim leading "#!", spaces and tabs.
-                const trimmed_line = mem.trimLeft(u8, content[2..], &.{ ' ', '\t' });
+                const trimmed_line = mem.trimStart(u8, content[2..], &.{ ' ', '\t' });
 
                 // This line can have:
                 // * Interpreter path only,
                 // * Interpreter path and arguments, all separated by space, tab or NUL character.
                 // And optionally newline at the end.
-                const path_maybe_args = mem.trimRight(u8, trimmed_line, "\n");
+                const path_maybe_args = mem.trimEnd(u8, trimmed_line, "\n");
 
                 // Separate path and args.
                 const path_end = mem.indexOfAny(u8, path_maybe_args, &.{ ' ', '\t', 0 }) orelse path_maybe_args.len;

--- a/lib/std/zig/system/darwin.zig
+++ b/lib/std/zig/system/darwin.zig
@@ -59,7 +59,7 @@ pub fn getSdk(allocator: Allocator, target: Target) ?[]const u8 {
         .Exited => |code| if (code != 0) return null,
         else => return null,
     }
-    return allocator.dupe(u8, mem.trimRight(u8, result.stdout, "\r\n")) catch null;
+    return allocator.dupe(u8, mem.trimEnd(u8, result.stdout, "\r\n")) catch null;
 }
 
 test {

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -362,8 +362,8 @@ fn CpuinfoParser(comptime impl: anytype) type {
             while (true) {
                 const line = (try reader.readUntilDelimiterOrEof(&line_buf, '\n')) orelse break;
                 const colon_pos = mem.indexOfScalar(u8, line, ':') orelse continue;
-                const key = mem.trimRight(u8, line[0..colon_pos], " \t");
-                const value = mem.trimLeft(u8, line[colon_pos + 1 ..], " \t");
+                const key = mem.trimEnd(u8, line[0..colon_pos], " \t");
+                const value = mem.trimStart(u8, line[colon_pos + 1 ..], " \t");
 
                 if (!try obj.line_hook(key, value))
                     break;

--- a/src/link.zig
+++ b/src/link.zig
@@ -192,7 +192,7 @@ pub const Diags = struct {
                 current_err.?.* = .{ .msg = duped_msg };
             } else if (current_err != null) {
                 const context_prefix = ">>> ";
-                var trimmed = mem.trimRight(u8, line, &std.ascii.whitespace);
+                var trimmed = mem.trimEnd(u8, line, &std.ascii.whitespace);
                 if (mem.startsWith(u8, trimmed, context_prefix)) {
                     trimmed = trimmed[context_prefix.len..];
                 }

--- a/src/link/MachO/Archive.zig
+++ b/src/link/MachO/Archive.zig
@@ -159,12 +159,12 @@ pub const ar_hdr = extern struct {
     ar_fmag: [2]u8,
 
     fn date(self: ar_hdr) !u64 {
-        const value = mem.trimRight(u8, &self.ar_date, &[_]u8{@as(u8, 0x20)});
+        const value = mem.trimEnd(u8, &self.ar_date, &[_]u8{@as(u8, 0x20)});
         return std.fmt.parseInt(u64, value, 10);
     }
 
     fn size(self: ar_hdr) !u32 {
-        const value = mem.trimRight(u8, &self.ar_size, &[_]u8{@as(u8, 0x20)});
+        const value = mem.trimEnd(u8, &self.ar_size, &[_]u8{@as(u8, 0x20)});
         return std.fmt.parseInt(u32, value, 10);
     }
 
@@ -178,7 +178,7 @@ pub const ar_hdr = extern struct {
     fn nameLength(self: ar_hdr) !?u32 {
         const value = &self.ar_name;
         if (!mem.startsWith(u8, value, "#1/")) return null;
-        const trimmed = mem.trimRight(u8, self.ar_name["#1/".len..], &[_]u8{0x20});
+        const trimmed = mem.trimEnd(u8, self.ar_name["#1/".len..], &[_]u8{0x20});
         return try std.fmt.parseInt(u32, trimmed, 10);
     }
 };

--- a/src/link/Wasm/Archive.zig
+++ b/src/link/Wasm/Archive.zig
@@ -64,7 +64,7 @@ const Header = extern struct {
     }
 
     fn getValue(raw: []const u8) []const u8 {
-        return mem.trimRight(u8, raw, &[_]u8{@as(u8, 0x20)});
+        return mem.trimEnd(u8, raw, &[_]u8{@as(u8, 0x20)});
     }
 };
 
@@ -162,7 +162,7 @@ pub fn parseObject(
         .index => |index| n: {
             const long_file_names = file_contents[archive.long_file_names.off..][0..archive.long_file_names.len];
             const name = mem.sliceTo(long_file_names[index..], 0x0a);
-            break :n mem.trimRight(u8, name, "/");
+            break :n mem.trimEnd(u8, name, "/");
         },
     };
 

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -828,7 +828,7 @@ const TestManifest = struct {
 
         fn next(self: *TrailingIterator) ?[]const u8 {
             const next_inner = self.inner.next() orelse return null;
-            return if (next_inner.len == 2) "" else std.mem.trimRight(u8, next_inner[3..], " \t");
+            return if (next_inner.len == 2) "" else std.mem.trimEnd(u8, next_inner[3..], " \t");
         }
     };
 

--- a/test/standalone/simple/guess_number/main.zig
+++ b/test/standalone/simple/guess_number/main.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
             try stdout.print("Input too long.\n", .{});
             continue;
         }
-        const line = std.mem.trimRight(u8, line_buf[0..amt], "\r\n");
+        const line = std.mem.trimEnd(u8, line_buf[0..amt], "\r\n");
 
         const guess = fmt.parseUnsigned(u8, line, 10) catch {
             try stdout.print("Invalid number.\n", .{});

--- a/tools/docgen.zig
+++ b/tools/docgen.zig
@@ -943,10 +943,10 @@ fn printShell(out: anytype, shell_content: []const u8, escape: bool) !void {
     var cmd_cont: bool = false;
     var iter = std.mem.splitScalar(u8, trimmed_shell_content, '\n');
     while (iter.next()) |orig_line| {
-        const line = mem.trimRight(u8, orig_line, " \r");
+        const line = mem.trimEnd(u8, orig_line, " \r");
         if (!cmd_cont and line.len > 1 and mem.eql(u8, line[0..2], "$ ") and line[line.len - 1] != '\\') {
             try out.writeAll("$ <kbd>");
-            const s = std.mem.trimLeft(u8, line[1..], " ");
+            const s = std.mem.trimStart(u8, line[1..], " ");
             if (escape) {
                 try writeEscaped(out, s);
             } else {
@@ -955,7 +955,7 @@ fn printShell(out: anytype, shell_content: []const u8, escape: bool) !void {
             try out.writeAll("</kbd>" ++ "\n");
         } else if (!cmd_cont and line.len > 1 and mem.eql(u8, line[0..2], "$ ") and line[line.len - 1] == '\\') {
             try out.writeAll("$ <kbd>");
-            const s = std.mem.trimLeft(u8, line[1..], " ");
+            const s = std.mem.trimStart(u8, line[1..], " ");
             if (escape) {
                 try writeEscaped(out, s);
             } else {

--- a/tools/doctest.zig
+++ b/tools/doctest.zig
@@ -1109,10 +1109,10 @@ fn printShell(out: anytype, shell_content: []const u8, escape: bool) !void {
     var cmd_cont: bool = false;
     var iter = std.mem.splitScalar(u8, trimmed_shell_content, '\n');
     while (iter.next()) |orig_line| {
-        const line = mem.trimRight(u8, orig_line, " \r");
+        const line = mem.trimEnd(u8, orig_line, " \r");
         if (!cmd_cont and line.len > 1 and mem.eql(u8, line[0..2], "$ ") and line[line.len - 1] != '\\') {
             try out.writeAll("$ <kbd>");
-            const s = std.mem.trimLeft(u8, line[1..], " ");
+            const s = std.mem.trimStart(u8, line[1..], " ");
             if (escape) {
                 try writeEscaped(out, s);
             } else {
@@ -1121,7 +1121,7 @@ fn printShell(out: anytype, shell_content: []const u8, escape: bool) !void {
             try out.writeAll("</kbd>" ++ "\n");
         } else if (!cmd_cont and line.len > 1 and mem.eql(u8, line[0..2], "$ ") and line[line.len - 1] == '\\') {
             try out.writeAll("$ <kbd>");
-            const s = std.mem.trimLeft(u8, line[1..], " ");
+            const s = std.mem.trimStart(u8, line[1..], " ");
             if (escape) {
                 try writeEscaped(out, s);
             } else {

--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -670,7 +670,7 @@ const Case = struct {
             if (std.mem.startsWith(u8, line, "#")) {
                 var line_it = std.mem.splitScalar(u8, line, '=');
                 const key = line_it.first()[1..];
-                const val = std.mem.trimRight(u8, line_it.rest(), "\r"); // windows moment
+                const val = std.mem.trimEnd(u8, line_it.rest(), "\r"); // windows moment
                 if (val.len == 0) {
                     fatal("line {d}: missing value", .{line_n});
                 } else if (std.mem.eql(u8, key, "target")) {
@@ -720,7 +720,7 @@ const Case = struct {
 
                     while (true) {
                         const next_line_raw = it.peek() orelse fatal("line {d}: unexpected EOF", .{line_n});
-                        const next_line = std.mem.trimRight(u8, next_line_raw, "\r");
+                        const next_line = std.mem.trimEnd(u8, next_line_raw, "\r");
                         if (std.mem.startsWith(u8, next_line, "#")) break;
 
                         _ = it.next();
@@ -759,7 +759,7 @@ const Case = struct {
                         if (!std.mem.startsWith(u8, next_line, "#")) break;
                         var new_line_it = std.mem.splitScalar(u8, next_line, '=');
                         const new_key = new_line_it.first()[1..];
-                        const new_val = std.mem.trimRight(u8, new_line_it.rest(), "\r");
+                        const new_val = std.mem.trimEnd(u8, new_line_it.rest(), "\r");
                         if (new_val.len == 0) break;
                         if (!std.mem.eql(u8, new_key, "expect_error")) break;
 
@@ -774,7 +774,7 @@ const Case = struct {
                         if (!std.mem.startsWith(u8, next_line, "#")) break;
                         var new_line_it = std.mem.splitScalar(u8, next_line, '=');
                         const new_key = new_line_it.first()[1..];
-                        const new_val = std.mem.trimRight(u8, new_line_it.rest(), "\r");
+                        const new_val = std.mem.trimEnd(u8, new_line_it.rest(), "\r");
                         if (new_val.len == 0) break;
                         if (!std.mem.eql(u8, new_key, "expect_compile_log")) break;
 


### PR DESCRIPTION
Rename `trimLeft` to `trimStart`, and `trimRight` to `trimEnd`. `trimLeft` and `trimRight` functions remain as deprecated aliases for these new names.

Due to this change, these functions will do exactly what their names suggest in right-to-left scripts, just like in left-to-right scripts and non-string slices.

The new function names I suggested are inspired by JavaScript,[^1][^2] C#,[^3][^4] and Rust.[^5][^6]

Closes #23664

[^1]: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart>
[^2]: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd>
[^3]: <https://learn.microsoft.com/en-us/dotnet/api/system.string.trimstart>
[^4]: <https://learn.microsoft.com/en-us/dotnet/api/system.string.trimend>
[^5]: <https://doc.rust-lang.org/std/primitive.str.html#method.trim_start>
[^6]: <https://doc.rust-lang.org/std/primitive.str.html#method.trim_end>