### PR TITLE
`wasi-libc`: Fix paths to `psignal.c` and `strsignal.c`.

### DIFF
--- a/src/wasi_libc.zig
+++ b/src/wasi_libc.zig
@@ -1252,6 +1252,6 @@ const emulated_signal_bottom_half_src_files = &[_][]const u8{
 };
 
 const emulated_signal_top_half_src_files = &[_][]const u8{
-    "wasi/libc-top-half/musl/src/signal/psignal.c",
-    "wasi/libc-top-half/musl/src/string/strsignal.c",
+    "musl/src/signal/psignal.c",
+    "musl/src/string/strsignal.c",
 };


### PR DESCRIPTION
Closes #23709.