### PR TITLE
Some `sparc64-linux` stuff

### DIFF
--- a/lib/compiler_rt/sqrt.zig
+++ b/lib/compiler_rt/sqrt.zig
@@ -13,6 +13,8 @@ comptime {
     @export(&__sqrtx, .{ .name = "__sqrtx", .linkage = common.linkage, .visibility = common.visibility });
     if (common.want_ppc_abi) {
         @export(&sqrtq, .{ .name = "sqrtf128", .linkage = common.linkage, .visibility = common.visibility });
+    } else if (common.want_sparc_abi) {
+        @export(&_Qp_sqrt, .{ .name = "_Qp_sqrt", .linkage = common.linkage, .visibility = common.visibility });
     }
     @export(&sqrtq, .{ .name = "sqrtq", .linkage = common.linkage, .visibility = common.visibility });
     @export(&sqrtl, .{ .name = "sqrtl", .linkage = common.linkage, .visibility = common.visibility });
@@ -240,6 +242,10 @@ pub fn __sqrtx(x: f80) callconv(.c) f80 {
 pub fn sqrtq(x: f128) callconv(.c) f128 {
     // TODO: more correct implementation
     return sqrt(@floatCast(x));
+}
+
+fn _Qp_sqrt(c: *f128, a: *f128) callconv(.c) void {
+    c.* = sqrt(@floatCast(a.*));
 }
 
 pub fn sqrtl(x: c_longdouble) callconv(.c) c_longdouble {

--- a/lib/std/os/linux/sparc64.zig
+++ b/lib/std/os/linux/sparc64.zig
@@ -304,6 +304,7 @@ pub const msghdr_const = extern struct {
 
 pub const off_t = i64;
 pub const ino_t = u64;
+pub const time_t = isize;
 pub const mode_t = u32;
 pub const dev_t = usize;
 pub const nlink_t = u32;

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -106,6 +106,7 @@ test "simple variadic function" {
     }
     if (builtin.cpu.arch == .x86_64 and builtin.os.tag == .windows) return error.SkipZigTest; // TODO
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
+    if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
 
     const S = struct {
         fn simple(...) callconv(.c) c_int {
@@ -200,6 +201,7 @@ test "variadic functions" {
     }
     if (builtin.cpu.arch == .x86_64 and builtin.os.tag == .windows) return error.SkipZigTest; // TODO
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
+    if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
 
     const S = struct {
         fn printf(list_ptr: *std.ArrayList(u8), format: [*:0]const u8, ...) callconv(.c) void {
@@ -245,6 +247,7 @@ test "copy VaList" {
     }
     if (builtin.cpu.arch == .x86_64 and builtin.os.tag == .windows) return error.SkipZigTest; // TODO
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
+    if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
 
     const S = struct {
         fn add(count: c_int, ...) callconv(.c) c_int {
@@ -282,6 +285,7 @@ test "unused VaList arg" {
         return error.SkipZigTest; // TODO
     }
     if (builtin.cpu.arch == .s390x and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21350
+    if (builtin.cpu.arch.isSPARC() and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23718
 
     const S = struct {
         fn thirdArg(dummy: c_int, ...) callconv(.c) c_int {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -765,6 +765,7 @@ test "vector reduce operation" {
     if (builtin.zig_backend == .stage2_c and builtin.cpu.arch.isArm()) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.cpu.arch.isMIPS64()) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21091
+    if (builtin.cpu.arch.isSPARC()) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23719
 
     const S = struct {
         fn testReduce(comptime op: std.builtin.ReduceOp, x: anytype, expected: anytype) !void {


### PR DESCRIPTION
`test-std` crashes QEMU with an internal error, but all other module tests pass for `sparc64-linux-none`. Note that this requires LLD changes that I'll be upstreaming soon; SPARC won't be part of the test matrix until LLVM 21 at least.