### PR TITLE
Use correcct symbol for the end of pc counters section on Linux

### DIFF
--- a/lib/fuzzer.zig
+++ b/lib/fuzzer.zig
@@ -477,7 +477,7 @@ export fn fuzzer_init(cache_dir_struct: Fuzzer.Slice) void {
     const end_symbol_prefix: []const u8 = if (ofmt == .macho)
         "\x01section$end$__DATA$__"
     else
-        "__end___";
+        "__stop___";
 
     const pc_counters_start_name = start_symbol_prefix ++ "sancov_cntrs";
     const pc_counters_start = @extern([*]u8, .{


### PR DESCRIPTION
This PR will fix linux fuzzer.
Currently it looks for the symbols `__end___sancov_cntrs ` but this weak symbol is not defined on linux, hence fuzzing on linux is broken right now as it resolves to 0
The correct symbol to look for is `__stop__sancov_cntrs`.

More details in my comment in https://github.com/ziglang/zig/pull/23621#issuecomment-2835484481