### PR TITLE
add standalone test for libfuzzer initialization

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -523,6 +523,7 @@ pub const getauxval = if (extern_getauxval) struct {
 }.getauxval else getauxvalImpl;
 
 fn getauxvalImpl(index: usize) callconv(.c) usize {
+    @disableInstrumentation();
     const auxv = elf_aux_maybe orelse return 0;
     var i: usize = 0;
     while (auxv[i].a_type != std.elf.AT_NULL) : (i += 1) {

--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -416,7 +416,7 @@ pub fn flushModule(
     }
 
     if (comp.config.any_fuzz) {
-        try positionals.append(try link.openObjectInput(diags, comp.fuzzer_lib.?.full_object_path));
+        try positionals.append(try link.openArchiveInput(diags, comp.fuzzer_lib.?.full_object_path, false, false));
     }
 
     if (comp.ubsan_rt_lib) |crt_file| {

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -108,6 +108,9 @@
         .libcxx = .{
             .path = "libcxx",
         },
+        .libfuzzer = .{
+            .path = "libfuzzer",
+        },
         .load_dynamic_library = .{
             .path = "load_dynamic_library",
         },

--- a/test/standalone/libfuzzer/build.zig
+++ b/test/standalone/libfuzzer/build.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    if (builtin.os.tag == .windows) return; // TODO: libfuzzer support for windows
+
+    const run_step = b.step("run", "Run executables");
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .fuzz = true,
+        }),
+    });
+
+    b.installArtifact(exe);
+    b.default_step = run_step;
+
+    const run_artifact = b.addRunArtifact(exe);
+    run_step.dependOn(&run_artifact.step);
+}

--- a/test/standalone/libfuzzer/main.zig
+++ b/test/standalone/libfuzzer/main.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+
+const FuzzerSlice = extern struct {
+    ptr: [*]const u8,
+    len: usize,
+
+    fn fromSlice(s: []const u8) FuzzerSlice {
+        return .{ .ptr = s.ptr, .len = s.len };
+    }
+};
+
+extern fn fuzzer_set_name(name_ptr: [*]const u8, name_len: usize) void;
+extern fn fuzzer_init(cache_dir: FuzzerSlice) void;
+extern fn fuzzer_init_corpus_elem(input_ptr: [*]const u8, input_len: usize) void;
+extern fn fuzzer_coverage_id() u64;
+
+pub fn main() !void {
+    fuzzer_init(FuzzerSlice.fromSlice(""));
+    fuzzer_init_corpus_elem("hello".ptr, "hello".len);
+    fuzzer_set_name("test".ptr, "test".len);
+    _ = fuzzer_coverage_id();
+}


### PR DESCRIPTION
Running this test without #23721 (fails on linux, see https://github.com/ziglang/zig/actions/runs/14738198828)
```
1/3 main.test_0...OK
2/3 main.test.equality...OK
3/3 main.test.arithmetic...OK
All 3 tests passed.
Segmentation fault at address 0x119d008
/home/ci/actions-runner4/_work/zig/zig/build-release/../lib/std/hash/wyhash.zig:127:66: 0x116512c in fuzzer_init (fuzzer)
            self.state[i] = mix(a ^ secret[i + 1], b ^ self.state[i]);
                                                                 ^
/home/ci/actions-runner4/_work/zig/zig/test/standalone/libfuzzer/main.zig:18:16: 0x1134d42 in main (main)
    fuzzer_init(FuzzerSlice.fromSlice(""));
               ^
/home/ci/actions-runner4/_work/zig/zig/build-release/../lib/std/start.zig:671:37: 0x1134cb0 in posixCallMainAndExit (main)
            const result = root.main() catch |err| {
                                    ^
/home/ci/actions-runner4/_work/zig/zig/build-release/../lib/std/start.zig:282:5: 0x113487d in _start (main)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x0 in ??? (???)
test
+- test-standalone
   +- standalone_test_cases
      +- standalone_test_cases.libfuzzer
         +- run main failure
error: the following command terminated unexpectedly:
/home/ci/actions-runner4/_work/zig/zig/zig-local-cache/o/5b68e5d3b92666118aa9d1c9ff6e3f39/main
```

After cherry picking #23721 everything passes.