### PR TITLE
inline assembly: enable GCC's `%=` syntax

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -7453,6 +7453,10 @@ pub const FuncGen = struct {
                         name_start = i + 1;
                         state = .input;
                     },
+                    '=' => {
+                        try rendered_template.appendSlice("${:uid}");
+                        state = .start;
+                    },
                     else => {
                         try rendered_template.append('%');
                         try rendered_template.append(byte);


### PR DESCRIPTION
GCC uses the `%=` syntax to generate a unique number for each `asm` statement (see [on gcc's docs](https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Special-format-strings)). LLVM uses `${:uid}` to do the same.

This PR adds the syntax, since it is not currently possible to use `%=` or `${:uid}` in zig's inline assembly. Also, it is currently impossible to use `${:comment}` or `${:private}` described [here on llvm's docs](https://releases.llvm.org/10.0.0/docs/LangRef.html#inline-assembler-expressions), and this PR does **not** change that.

I am unsure if this change requires tests, and how to even test it.