### PR TITLE
`std.Target`: Add `Cpu.Arch.or1k` and basic target info.

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -1079,6 +1079,7 @@ pub fn toElfMachine(target: Target) std.elf.EM {
         .m68k => .@"68K",
         .mips, .mips64, .mipsel, .mips64el => .MIPS,
         .msp430 => .MSP430,
+        .or1k => .OR1K,
         .powerpc, .powerpcle => .PPC,
         .powerpc64, .powerpc64le => .PPC64,
         .propeller => .PROPELLER,
@@ -1133,6 +1134,7 @@ pub fn toCoffMachine(target: Target) std.coff.MachineType {
         .mips64,
         .mips64el,
         .msp430,
+        .or1k,
         .nvptx,
         .nvptx64,
         .powerpc,
@@ -1357,6 +1359,7 @@ pub const Cpu = struct {
         mips64,
         mips64el,
         msp430,
+        or1k,
         nvptx,
         nvptx64,
         powerpc,
@@ -1565,6 +1568,7 @@ pub const Cpu = struct {
                 .m68k,
                 .mips,
                 .mips64,
+                .or1k,
                 .powerpc,
                 .powerpc64,
                 .thumbeb,
@@ -1815,6 +1819,9 @@ pub const Cpu = struct {
                 .msp430_eabi,
                 => &.{.msp430},
 
+                .or1k_sysv,
+                => &.{.or1k},
+
                 .propeller_sysv,
                 => &.{.propeller},
 
@@ -1911,6 +1918,7 @@ pub const Cpu = struct {
                 .xtensa => &xtensa.cpu.generic,
 
                 .kalimba,
+                .or1k,
                 => &S.generic_model,
             };
         }
@@ -2598,6 +2606,7 @@ pub fn ptrBitWidth_cpu_abi(cpu: Cpu, abi: Abi) u16 {
         .m68k,
         .mips,
         .mipsel,
+        .or1k,
         .powerpc,
         .powerpcle,
         .riscv32,
@@ -3114,6 +3123,7 @@ pub fn cTypeAlignment(target: Target, c_type: CType) u16 {
             .csky,
             .x86,
             .xcore,
+            .or1k,
             .kalimba,
             .xtensa,
             .propeller,
@@ -3204,6 +3214,7 @@ pub fn cTypePreferredAlignment(target: Target, c_type: CType) u16 {
 
             .csky,
             .xcore,
+            .or1k,
             .kalimba,
             .xtensa,
             .propeller,
@@ -3276,6 +3287,7 @@ pub fn cMaxIntAlignment(target: std.Target) u16 {
         .hexagon,
         .mips,
         .mipsel,
+        .or1k,
         .powerpc,
         .powerpcle,
         .riscv32,
@@ -3372,6 +3384,7 @@ pub fn cCallingConvention(target: Target) ?std.builtin.CallingConvention {
         else
             .{ .m68k_sysv = .{} },
         .msp430 => .{ .msp430_eabi = .{} },
+        .or1k => .{ .or1k_sysv = .{} },
         .propeller => .{ .propeller_sysv = .{} },
         .s390x => .{ .s390x_sysv = .{} },
         .ve => .{ .ve_sysv = .{} },

--- a/lib/std/builtin.zig
+++ b/lib/std/builtin.zig
@@ -370,6 +370,9 @@ pub const CallingConvention = union(enum(u8)) {
     /// The standard `msp430` calling convention.
     msp430_eabi: CommonOptions,
 
+    /// The standard `or1k` calling convention.
+    or1k_sysv: CommonOptions,
+
     /// The standard `propeller` calling convention.
     propeller_sysv: CommonOptions,
 

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -3687,6 +3687,7 @@ pub fn atomicPtrAlignment(
         .mips,
         .mipsel,
         .nvptx,
+        .or1k,
         .powerpc,
         .powerpcle,
         .riscv32,

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -98,6 +98,7 @@ pub fn targetTriple(allocator: Allocator, target: std.Target) ![]const u8 {
         .ve => "ve",
 
         .kalimba,
+        .or1k,
         .propeller,
         => unreachable, // Gated by hasLlvmSupport().
     };
@@ -454,6 +455,7 @@ pub fn dataLayout(target: std.Target) []const u8 {
         .xtensa => "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32",
 
         .kalimba,
+        .or1k,
         .propeller,
         => unreachable, // Gated by hasLlvmSupport().
     };
@@ -11559,6 +11561,7 @@ fn toLlvmCallConvTag(cc_tag: std.builtin.CallingConvention.Tag, target: std.Targ
         .m68k_sysv,
         .m68k_gnu,
         .msp430_eabi,
+        .or1k_sysv,
         .propeller_sysv,
         .s390x_sysv,
         .s390x_sysv_vx,
@@ -12758,6 +12761,7 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
 
         // LLVM does does not have a backend for these.
         .kalimba,
+        .or1k,
         .propeller,
         => unreachable,
     }

--- a/src/target.zig
+++ b/src/target.zig
@@ -195,6 +195,7 @@ pub fn hasLlvmSupport(target: std.Target, ofmt: std.Target.ObjectFormat) bool {
 
         // No LLVM backend exists.
         .kalimba,
+        .or1k,
         .propeller,
         => false,
     };

--- a/test/cases/compile_errors/@import_zon_bad_type.zig
+++ b/test/cases/compile_errors/@import_zon_bad_type.zig
@@ -117,9 +117,9 @@ export fn testMutablePointer() void {
 // tmp.zig:37:38: note: imported here
 // neg_inf.zon:1:1: error: expected type '?u8'
 // tmp.zig:57:28: note: imported here
-// neg_inf.zon:1:1: error: expected type 'tmp.testNonExhaustiveEnum__enum_491'
+// neg_inf.zon:1:1: error: expected type 'tmp.testNonExhaustiveEnum__enum_492'
 // tmp.zig:62:39: note: imported here
-// neg_inf.zon:1:1: error: expected type 'tmp.testUntaggedUnion__union_493'
+// neg_inf.zon:1:1: error: expected type 'tmp.testUntaggedUnion__union_494'
 // tmp.zig:67:44: note: imported here
-// neg_inf.zon:1:1: error: expected type 'tmp.testTaggedUnionVoid__union_496'
+// neg_inf.zon:1:1: error: expected type 'tmp.testTaggedUnionVoid__union_497'
 // tmp.zig:72:50: note: imported here

--- a/test/cases/compile_errors/anytype_param_requires_comptime.zig
+++ b/test/cases/compile_errors/anytype_param_requires_comptime.zig
@@ -15,6 +15,6 @@ pub export fn entry() void {
 // error
 //
 // :7:25: error: unable to resolve comptime value
-// :7:25: note: initializer of comptime-only struct 'tmp.S.foo__anon_465.C' must be comptime-known
+// :7:25: note: initializer of comptime-only struct 'tmp.S.foo__anon_466.C' must be comptime-known
 // :4:16: note: struct requires comptime because of this field
 // :4:16: note: types are not available at runtime

--- a/test/cases/compile_errors/bogus_method_call_on_slice.zig
+++ b/test/cases/compile_errors/bogus_method_call_on_slice.zig
@@ -16,5 +16,5 @@ pub export fn entry2() void {
 //
 // :3:6: error: no field or member function named 'copy' in '[]const u8'
 // :9:8: error: no field or member function named 'bar' in '@TypeOf(.{})'
-// :12:18: error: no field or member function named 'bar' in 'tmp.entry2__struct_469'
+// :12:18: error: no field or member function named 'bar' in 'tmp.entry2__struct_470'
 // :12:6: note: struct declared here

--- a/test/cases/compile_errors/coerce_anon_struct.zig
+++ b/test/cases/compile_errors/coerce_anon_struct.zig
@@ -6,6 +6,6 @@ export fn foo() void {
 
 // error
 //
-// :4:16: error: expected type 'tmp.T', found 'tmp.foo__struct_458'
+// :4:16: error: expected type 'tmp.T', found 'tmp.foo__struct_459'
 // :3:16: note: struct declared here
 // :1:11: note: struct declared here

--- a/test/cases/compile_errors/redundant_try.zig
+++ b/test/cases/compile_errors/redundant_try.zig
@@ -44,9 +44,9 @@ comptime {
 //
 // :5:23: error: expected error union type, found 'comptime_int'
 // :10:23: error: expected error union type, found '@TypeOf(.{})'
-// :15:23: error: expected error union type, found 'tmp.test2__struct_495'
+// :15:23: error: expected error union type, found 'tmp.test2__struct_496'
 // :15:23: note: struct declared here
-// :20:27: error: expected error union type, found 'tmp.test3__struct_497'
+// :20:27: error: expected error union type, found 'tmp.test3__struct_498'
 // :20:27: note: struct declared here
 // :25:23: error: expected error union type, found 'struct { comptime *const [5:0]u8 = "hello" }'
 // :31:13: error: expected error union type, found 'u32'


### PR DESCRIPTION
No CPU features for now; I'll do those separately as part of a larger branch I'm working on.

FYI @tensorush (https://github.com/ziglang/zig/issues/23560#issuecomment-2845589283)