### PR TITLE
compiler: Allow linking native glibc statically

### DIFF
--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -352,7 +352,7 @@ pub fn resolve(options: Options) ResolveError!Config {
             break :b .static;
         }
         if (explicitly_exe_or_dyn_lib and link_libc and
-            (target.isGnuLibC() or target_util.osRequiresLibC(target)))
+            (target_util.osRequiresLibC(target) or (target.isGnuLibC() and !options.resolved_target.is_native_abi)))
         {
             if (options.link_mode == .static) return error.LibCRequiresDynamicLinking;
             break :b .dynamic;
@@ -367,11 +367,11 @@ pub fn resolve(options: Options) ResolveError!Config {
 
         if (options.link_mode) |link_mode| break :b link_mode;
 
-        if (explicitly_exe_or_dyn_lib and link_libc and
-            options.resolved_target.is_native_abi and target.abi.isMusl())
+        if (explicitly_exe_or_dyn_lib and link_libc and options.resolved_target.is_native_abi and
+            (target.isGnuLibC() or target.isMuslLibC()))
         {
             // If targeting the system's native ABI and the system's libc is
-            // musl, link dynamically by default.
+            // glibc or musl, link dynamically by default.
             break :b .dynamic;
         }
 

--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -313,7 +313,7 @@ pub fn resolve(options: Options) ResolveError!Config {
     };
 
     const link_libunwind = b: {
-        if (link_libcpp and target_util.libcNeedsLibUnwind(target)) {
+        if (link_libcpp and target_util.libCxxNeedsLibUnwind(target)) {
             if (options.link_libunwind == false) return error.LibCppRequiresLibUnwind;
             break :b true;
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -4206,6 +4206,7 @@ fn createModule(
             error.LldCannotIncrementallyLink => fatal("self-hosted backends do not support linking with LLD", .{}),
             error.LtoRequiresLld => fatal("LTO requires using LLD", .{}),
             error.SanitizeThreadRequiresLibCpp => fatal("thread sanitization is (for now) implemented in C++, so it requires linking libc++", .{}),
+            error.LibCRequiresLibUnwind => fatal("libc of the specified target requires linking libunwind", .{}),
             error.LibCppRequiresLibUnwind => fatal("libc++ requires linking libunwind", .{}),
             error.OsRequiresLibC => fatal("the target OS requires using libc as the stable syscall interface", .{}),
             error.LibCppRequiresLibC => fatal("libc++ requires linking libc", .{}),

--- a/src/target.zig
+++ b/src/target.zig
@@ -23,7 +23,7 @@ pub fn osRequiresLibC(target: std.Target) bool {
     return target.os.requiresLibC();
 }
 
-pub fn libcNeedsLibUnwind(target: std.Target) bool {
+pub fn libCxxNeedsLibUnwind(target: std.Target) bool {
     return switch (target.os.tag) {
         .macos,
         .ios,

--- a/src/target.zig
+++ b/src/target.zig
@@ -23,6 +23,10 @@ pub fn osRequiresLibC(target: std.Target) bool {
     return target.os.requiresLibC();
 }
 
+pub fn libCNeedsLibUnwind(target: std.Target, link_mode: std.builtin.LinkMode) bool {
+    return target.isGnuLibC() and link_mode == .static;
+}
+
 pub fn libCxxNeedsLibUnwind(target: std.Target) bool {
     return switch (target.os.tag) {
         .macos,


### PR DESCRIPTION
This is generally ill-advised, but can be useful in some niche situations where the caveats don't apply. It might also be useful when providing a `libc.txt` that points to Eyra.

FYI @polarathene