### PR TITLE
compiler: Set libc++ ABI version to 2 for Emscripten.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -259,8 +259,6 @@ crt_files: std.StringHashMapUnmanaged(CrtFile) = .empty,
 /// Null means only show snippet on first error.
 reference_trace: ?u32 = null,
 
-libcxx_abi_version: libcxx.AbiVersion = libcxx.AbiVersion.default,
-
 /// This mutex guards all `Compilation` mutable state.
 /// Disabled in single-threaded mode because the thread pool spawns in the same thread.
 mutex: if (builtin.single_threaded) struct {
@@ -1171,7 +1169,6 @@ pub const CreateOptions = struct {
     force_load_objc: bool = false,
     /// Whether local symbols should be discarded from the symbol table.
     discard_local_symbols: bool = false,
-    libcxx_abi_version: libcxx.AbiVersion = libcxx.AbiVersion.default,
     /// (Windows) PDB source path prefix to instruct the linker how to resolve relative
     /// paths when consolidating CodeView streams into a single PDB file.
     pdb_source_path: ?[]const u8 = null,
@@ -1555,7 +1552,6 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
             .debug_compiler_runtime_libs = options.debug_compiler_runtime_libs,
             .debug_compile_errors = options.debug_compile_errors,
             .incremental = options.incremental,
-            .libcxx_abi_version = options.libcxx_abi_version,
             .root_name = root_name,
             .sysroot = sysroot,
             .windows_libs = windows_libs,

--- a/src/libcxx.zig
+++ b/src/libcxx.zig
@@ -8,13 +8,6 @@ const build_options = @import("build_options");
 const trace = @import("tracy.zig").trace;
 const Module = @import("Package/Module.zig");
 
-pub const AbiVersion = enum(u2) {
-    @"1" = 1,
-    @"2" = 2,
-
-    pub const default: AbiVersion = .@"1";
-};
-
 const libcxxabi_files = [_][]const u8{
     "src/abort_message.cpp",
     "src/cxa_aux_runtime.cpp",
@@ -535,11 +528,12 @@ pub fn addCxxArgs(
     const target = comp.getTarget();
     const optimize_mode = comp.compilerRtOptMode();
 
+    const abi_version: u2 = if (target.os.tag == .emscripten) 2 else 1;
     try cflags.append(try std.fmt.allocPrint(arena, "-D_LIBCPP_ABI_VERSION={d}", .{
-        @intFromEnum(comp.libcxx_abi_version),
+        abi_version,
     }));
     try cflags.append(try std.fmt.allocPrint(arena, "-D_LIBCPP_ABI_NAMESPACE=__{d}", .{
-        @intFromEnum(comp.libcxx_abi_version),
+        abi_version,
     }));
     try cflags.append(try std.fmt.allocPrint(arena, "-D_LIBCPP_HAS_{s}THREADS", .{
         if (!comp.config.any_non_single_threaded) "NO_" else "",


### PR DESCRIPTION
It remains 1 everywhere else.

Also remove some code that allowed setting the libc++ ABI version on the `Compilation` since there are no current plans to actually expose this in the CLI.