### PR TITLE
std: fix compile errors in `std.crypto.ecc`

### DIFF
--- a/lib/std/crypto/pcurves/p256.zig
+++ b/lib/std/crypto/pcurves/p256.zig
@@ -471,6 +471,10 @@ pub const AffineCoordinates = struct {
     /// Identity element in affine coordinates.
     pub const identityElement = AffineCoordinates{ .x = P256.identityElement.x, .y = P256.identityElement.y };
 
+    pub fn neg(p: AffineCoordinates) AffineCoordinates {
+        return .{ .x = p.x, .y = p.y.neg() };
+    }
+
     fn cMov(p: *AffineCoordinates, a: AffineCoordinates, c: u1) void {
         p.x.cMov(a.x, c);
         p.y.cMov(a.y, c);

--- a/lib/std/crypto/pcurves/p384.zig
+++ b/lib/std/crypto/pcurves/p384.zig
@@ -471,6 +471,10 @@ pub const AffineCoordinates = struct {
     /// Identity element in affine coordinates.
     pub const identityElement = AffineCoordinates{ .x = P384.identityElement.x, .y = P384.identityElement.y };
 
+    pub fn neg(p: AffineCoordinates) AffineCoordinates {
+        return .{ .x = p.x, .y = p.y.neg() };
+    }
+
     fn cMov(p: *AffineCoordinates, a: AffineCoordinates, c: u1) void {
         p.x.cMov(a.x, c);
         p.y.cMov(a.y, c);

--- a/lib/std/crypto/pcurves/secp256k1.zig
+++ b/lib/std/crypto/pcurves/secp256k1.zig
@@ -549,6 +549,10 @@ pub const AffineCoordinates = struct {
     /// Identity element in affine coordinates.
     pub const identityElement = AffineCoordinates{ .x = Secp256k1.identityElement.x, .y = Secp256k1.identityElement.y };
 
+    pub fn neg(p: AffineCoordinates) AffineCoordinates {
+        return .{ .x = p.x, .y = p.y.neg() };
+    }
+
     fn cMov(p: *AffineCoordinates, a: AffineCoordinates, c: u1) void {
         p.x.cMov(a.x, c);
         p.y.cMov(a.y, c);


### PR DESCRIPTION
Implemented `neg()` method for `AffineCoordinates` struct of p256, p384 and secp256k1 curves.

Rust implementation reference: https://docs.rs/primeorder/0.13.6/src/primeorder/affine.rs.html#433

Contributes to #20505.