### PR TITLE
`ci`: Skip building non-native tests on `aarch64-linux`.

### DIFF
--- a/ci/aarch64-linux-debug.sh
+++ b/ci/aarch64-linux-debug.sh
@@ -52,6 +52,7 @@ ninja install
 stage3-debug/bin/zig build test docs \
   --maxrss 24696061952 \
   -Dstatic-llvm \
+  -Dskip-non-native \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \

--- a/ci/aarch64-linux-release.sh
+++ b/ci/aarch64-linux-release.sh
@@ -52,6 +52,7 @@ ninja install
 stage3-release/bin/zig build test docs \
   --maxrss 24696061952 \
   -Dstatic-llvm \
+  -Dskip-non-native \
   -Dtarget=native-native-musl \
   --search-prefix "$PREFIX" \
   --zig-lib-dir "$PWD/../lib" \


### PR DESCRIPTION
Because we don't pass `-fqemu` and `-fwasmtime` on `aarch64-linux`, we're just spending a bunch of time compiling all these module tests only to not even run them. `x86_64-linux` already covers both compiling and running them.

Hopefully resolves the CI timeouts we've been seeing.