### PR TITLE
Rename `--glibc-runtimes` to `--libc-runtimes` and make it work with musl; add more targets to the module test matrix

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -241,8 +241,9 @@ pub fn main() !void {
                 // but it is handled by the parent process. The build runner
                 // only sees this flag.
                 graph.system_package_mode = true;
-            } else if (mem.eql(u8, arg, "--glibc-runtimes")) {
-                builder.glibc_runtimes_dir = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--libc-runtimes") or mem.eql(u8, arg, "--glibc-runtimes")) {
+                // --glibc-runtimes was the old name of the flag; kept for compatibility for now.
+                builder.libc_runtimes_dir = nextArgOrFatal(args, &arg_idx);
             } else if (mem.eql(u8, arg, "--verbose-link")) {
                 builder.verbose_link = true;
             } else if (mem.eql(u8, arg, "--verbose-air")) {
@@ -1279,9 +1280,10 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  -fqemu,     -fno-qemu        Integration with system-installed QEMU to execute
         \\                               foreign-architecture programs on Linux hosts
         \\                               (default: no)
-        \\  --glibc-runtimes [path]      Enhances QEMU integration by providing glibc built
-        \\                               for multiple foreign architectures, allowing
-        \\                               execution of non-native programs that link with glibc.
+        \\  --libc-runtimes [path]       Enhances QEMU integration by providing dynamic libc
+        \\                               (e.g. glibc or musl) built for multiple foreign
+        \\                               architectures, allowing execution of non-native
+        \\                               programs that link with libc.
         \\  -frosetta,  -fno-rosetta     Rely on Rosetta to execute x86_64 programs on
         \\                               ARM64 macOS hosts. (default: no)
         \\  -fwasmtime, -fno-wasmtime    Integration with system-installed wasmtime to

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -79,7 +79,8 @@ enable_wine: bool = false,
 /// this will be the directory $glibc-build-dir/install/glibcs
 /// Given the example of the aarch64 target, this is the directory
 /// that contains the path `aarch64-linux-gnu/lib/ld-linux-aarch64.so.1`.
-glibc_runtimes_dir: ?[]const u8 = null,
+/// Also works for dynamic musl.
+libc_runtimes_dir: ?[]const u8 = null,
 
 dep_prefix: []const u8 = "",
 
@@ -390,7 +391,7 @@ fn createChildOnly(
         .enable_rosetta = parent.enable_rosetta,
         .enable_wasmtime = parent.enable_wasmtime,
         .enable_wine = parent.enable_wine,
-        .glibc_runtimes_dir = parent.glibc_runtimes_dir,
+        .libc_runtimes_dir = parent.libc_runtimes_dir,
         .dep_prefix = parent.fmt("{s}{s}.", .{ parent.dep_prefix, dep_name }),
         .modules = .init(allocator),
         .named_writefiles = .init(allocator),

--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1026,11 +1026,11 @@ fn runCommand(
             }
 
             const root_target = exe.rootModuleTarget();
-            const need_cross_glibc = root_target.isGnuLibC() and
-                exe.is_linking_libc;
+            const need_cross_libc = exe.is_linking_libc and
+                (root_target.isGnuLibC() or (root_target.isMuslLibC() and exe.linkage == .dynamic));
             const other_target = exe.root_module.resolved_target.?.result;
             switch (std.zig.system.getExternalExecutor(b.graph.host.result, &other_target, .{
-                .qemu_fixes_dl = need_cross_glibc and b.glibc_runtimes_dir != null,
+                .qemu_fixes_dl = need_cross_libc and b.libc_runtimes_dir != null,
                 .link_libc = exe.is_linking_libc,
             })) {
                 .native, .rosetta => {
@@ -1047,31 +1047,29 @@ fn runCommand(
                 },
                 .qemu => |bin_name| {
                     if (b.enable_qemu) {
-                        const glibc_dir_arg = if (need_cross_glibc)
-                            b.glibc_runtimes_dir orelse
-                                return failForeign(run, "--glibc-runtimes", argv[0], exe)
-                        else
-                            null;
-
                         try interp_argv.append(bin_name);
 
-                        if (glibc_dir_arg) |dir| {
-                            try interp_argv.append("-L");
-                            try interp_argv.append(b.pathJoin(&.{
-                                dir,
-                                try std.zig.target.glibcRuntimeTriple(
-                                    b.allocator,
-                                    root_target.cpu.arch,
-                                    root_target.os.tag,
-                                    root_target.abi,
-                                ),
-                            }));
+                        if (need_cross_libc) {
+                            if (b.libc_runtimes_dir) |dir| {
+                                try interp_argv.append("-L");
+                                try interp_argv.append(b.pathJoin(&.{
+                                    dir,
+                                    try if (root_target.isGnuLibC()) std.zig.target.glibcRuntimeTriple(
+                                        b.allocator,
+                                        root_target.cpu.arch,
+                                        root_target.os.tag,
+                                        root_target.abi,
+                                    ) else if (root_target.isMuslLibC()) std.zig.target.muslRuntimeTriple(
+                                        b.allocator,
+                                        root_target.cpu.arch,
+                                        root_target.abi,
+                                    ) else unreachable,
+                                }));
+                            } else return failForeign(run, "--libc-runtimes", argv[0], exe);
                         }
 
                         try interp_argv.appendSlice(argv);
-                    } else {
-                        return failForeign(run, "-fqemu", argv[0], exe);
-                    }
+                    } else return failForeign(run, "-fqemu", argv[0], exe);
                 },
                 .darling => |bin_name| {
                     if (b.enable_darling) {

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -2471,6 +2471,8 @@ pub const DynamicLinker = struct {
                 .mips64,
                 .mips64el,
                 .powerpc,
+                .powerpc64,
+                .riscv32,
                 .riscv64,
                 .sparc,
                 .sparc64,

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -838,7 +838,6 @@ pub const Abi = enum {
             .aix => if (arch == .powerpc) .eabihf else .none,
             .haiku => switch (arch) {
                 .arm,
-                .thumb,
                 .powerpc,
                 => .eabihf,
                 else => .none,
@@ -877,22 +876,13 @@ pub const Abi = enum {
             },
             .freebsd => switch (arch) {
                 .arm,
-                .armeb,
-                .thumb,
-                .thumbeb,
                 .powerpc,
                 => .eabihf,
-                // Soft float tends to be more common for MIPS.
-                .mips,
-                .mipsel,
-                => .eabi,
                 else => .none,
             },
             .netbsd => switch (arch) {
                 .arm,
                 .armeb,
-                .thumb,
-                .thumbeb,
                 .powerpc,
                 => .eabihf,
                 // Soft float tends to be more common for MIPS.
@@ -903,7 +893,6 @@ pub const Abi = enum {
             },
             .openbsd => switch (arch) {
                 .arm,
-                .thumb,
                 => .eabi,
                 .powerpc,
                 => .eabihf,
@@ -2209,7 +2198,6 @@ pub const DynamicLinker = struct {
 
             .haiku => switch (cpu.arch) {
                 .arm,
-                .thumb,
                 .aarch64,
                 .m68k,
                 .powerpc,
@@ -2238,9 +2226,7 @@ pub const DynamicLinker = struct {
 
             .linux => if (abi.isAndroid())
                 switch (cpu.arch) {
-                    .arm,
-                    .thumb,
-                    => if (abi == .androideabi) init("/system/bin/linker") else none,
+                    .arm => if (abi == .androideabi) init("/system/bin/linker") else none,
 
                     .aarch64,
                     .riscv64,
@@ -2458,19 +2444,11 @@ pub const DynamicLinker = struct {
 
             .freebsd => switch (cpu.arch) {
                 .arm,
-                .armeb,
-                .thumb,
-                .thumbeb,
                 .aarch64,
-                .mips,
-                .mipsel,
-                .mips64,
-                .mips64el,
                 .powerpc,
                 .powerpc64,
                 .powerpc64le,
                 .riscv64,
-                .sparc64,
                 .x86,
                 .x86_64,
                 => initFmt("{s}/libexec/ld-elf.so.1", .{
@@ -2485,8 +2463,6 @@ pub const DynamicLinker = struct {
             .netbsd => switch (cpu.arch) {
                 .arm,
                 .armeb,
-                .thumb,
-                .thumbeb,
                 .aarch64,
                 .aarch64_be,
                 .m68k,
@@ -2506,7 +2482,6 @@ pub const DynamicLinker = struct {
 
             .openbsd => switch (cpu.arch) {
                 .arm,
-                .thumb,
                 .aarch64,
                 .mips64,
                 .mips64el,
@@ -2534,11 +2509,16 @@ pub const DynamicLinker = struct {
             },
 
             .illumos,
+            => switch (cpu.arch) {
+                .x86,
+                .x86_64,
+                => initFmt("/lib/{s}ld.so.1", .{if (ptrBitWidth_cpu_abi(cpu, .none) == 64) "64/" else ""}),
+                else => none,
+            },
+
             .solaris,
             => switch (cpu.arch) {
-                .sparc,
                 .sparc64,
-                .x86,
                 .x86_64,
                 => initFmt("/lib/{s}ld.so.1", .{if (ptrBitWidth_cpu_abi(cpu, .none) == 64) "64/" else ""}),
                 else => none,

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1394,6 +1394,7 @@ test "pwritev, preadv" {
 test "setEndPos" {
     // https://github.com/ziglang/zig/issues/20747 (open fd does not have write permission)
     if (native_os == .wasi and builtin.link_libc) return error.SkipZigTest;
+    if (builtin.cpu.arch.isMIPS64() and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23806
 
     var tmp = tmpDir(.{});
     defer tmp.cleanup();

--- a/lib/std/hash/xxhash.zig
+++ b/lib/std/hash/xxhash.zig
@@ -781,6 +781,7 @@ fn testExpect(comptime H: type, seed: anytype, input: []const u8, expected: u64)
 
 test "xxhash3" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.cpu.arch.isMIPS64() and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23807
 
     const H = XxHash3;
     // Non-Seeded Tests
@@ -814,6 +815,7 @@ test "xxhash3" {
 
 test "xxhash3 smhasher" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.cpu.arch.isMIPS64() and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23807
 
     const Test = struct {
         fn do() !void {
@@ -827,6 +829,7 @@ test "xxhash3 smhasher" {
 
 test "xxhash3 iterative api" {
     if (builtin.zig_backend == .stage2_x86_64) return error.SkipZigTest;
+    if (builtin.cpu.arch.isMIPS64() and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23807
 
     const Test = struct {
         fn do() !void {

--- a/lib/std/os/linux/test.zig
+++ b/lib/std/os/linux/test.zig
@@ -8,6 +8,8 @@ const expectEqual = std.testing.expectEqual;
 const fs = std.fs;
 
 test "fallocate" {
+    if (builtin.cpu.arch.isMIPS64() and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23809
+
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1377,6 +1377,8 @@ fn expectMode(dir: posix.fd_t, file: []const u8, mode: posix.mode_t) !void {
 }
 
 test "fchmodat smoke test" {
+    if (builtin.cpu.arch.isMIPS64() and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23808
+
     if (!std.fs.has_executable_bit) return error.SkipZigTest;
 
     var tmp = tmpDir(.{});

--- a/lib/std/zig/target.zig
+++ b/lib/std/zig/target.zig
@@ -131,6 +131,20 @@ pub fn glibcRuntimeTriple(
     };
 }
 
+/// Returns the subdirectory triple to be used to find the correct musl for the given `arch` and
+/// `abi` in an installation directory.
+///
+/// `abi` must be a musl ABI, i.e. `.isMusl()`.
+pub fn muslRuntimeTriple(
+    allocator: Allocator,
+    arch: std.Target.Cpu.Arch,
+    abi: std.Target.Abi,
+) Allocator.Error![]const u8 {
+    assert(abi.isMusl());
+
+    return std.Target.linuxTripleSimple(allocator, arch, .linux, abi);
+}
+
 pub fn osArchName(target: std.Target) [:0]const u8 {
     return switch (target.os.tag) {
         .linux => switch (target.cpu.arch) {

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -1204,6 +1204,7 @@ test "arrays and vectors with big integers" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_llvm and (builtin.abi == .gnuabin32 or builtin.abi == .muslabin32)) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/23805
 
     inline for (.{ u65528, u65529, u65535 }) |Int| {
         var a: [1]Int = undefined;

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -826,7 +826,33 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .mips64,
                 .os_tag = .linux,
+                .abi = .muslabin32,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64,
+                .os_tag = .linux,
+                .abi = .muslabin32,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64,
+                .os_tag = .linux,
                 .abi = .gnuabi64,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64,
+                .os_tag = .linux,
+                .abi = .gnuabin32,
             },
             .link_libc = true,
         },
@@ -860,7 +886,33 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .mips64el,
                 .os_tag = .linux,
+                .abi = .muslabin32,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64el,
+                .os_tag = .linux,
+                .abi = .muslabin32,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64el,
+                .os_tag = .linux,
                 .abi = .gnuabi64,
+            },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64el,
+                .os_tag = .linux,
+                .abi = .gnuabin32,
             },
             .link_libc = true,
         },

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -20,6 +20,7 @@ pub const StackTracesContext = @import("src/StackTrace.zig");
 pub const DebuggerContext = @import("src/Debugger.zig");
 
 const TestTarget = struct {
+    linkage: ?std.builtin.LinkMode = null,
     target: std.Target.Query = .{},
     optimize_mode: std.builtin.OptimizeMode = .Debug,
     link_libc: ?bool = null,
@@ -30,8 +31,9 @@ const TestTarget = struct {
     strip: ?bool = null,
     skip_modules: []const []const u8 = &.{},
 
-    // This is intended for targets that are known to be slow to compile, or require a newer LLVM
-    // version than is present on the CI machines, etc.
+    // This is intended for targets that, for any reason, shouldn't be run as part of a normal test
+    // invocation. This could be because of a slow backend, requiring a newer LLVM version, being
+    // too niche, etc.
     extra_target: bool = false,
 };
 
@@ -244,9 +246,28 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .x86_64,
                 .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
                 .abi = .muslx32,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .abi = .muslx32,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -273,6 +294,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        // https://github.com/ziglang/zig/issues/7935
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .x86,
+        //         .os_tag = .linux,
+        //         .abi = .musl,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     .extra_target = true,
+        // },
         .{
             .target = .{
                 .cpu_arch = .x86,
@@ -295,6 +327,15 @@ const test_targets = blk: {
                 .os_tag = .linux,
                 .abi = .musl,
             },
+            .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .aarch64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
             .link_libc = true,
         },
         .{
@@ -333,6 +374,16 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .aarch64_be,
                 .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .aarch64_be,
+                .os_tag = .linux,
                 .abi = .gnu,
             },
             .link_libc = true,
@@ -360,6 +411,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        // Crashes in weird ways when applying relocations.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .arm,
+        //         .os_tag = .linux,
+        //         .abi = .musleabi,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     .extra_target = true,
+        // },
         .{
             .target = .{
                 .cpu_arch = .arm,
@@ -368,6 +430,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        // Crashes in weird ways when applying relocations.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .arm,
+        //         .os_tag = .linux,
+        //         .abi = .musleabihf,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     .extra_target = true,
+        // },
         .{
             .target = .{
                 .cpu_arch = .arm,
@@ -407,6 +480,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        // Crashes in weird ways when applying relocations.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .armeb,
+        //         .os_tag = .linux,
+        //         .abi = .musleabi,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     .extra_target = true,
+        // },
         .{
             .target = .{
                 .cpu_arch = .armeb,
@@ -415,6 +499,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        // Crashes in weird ways when applying relocations.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .armeb,
+        //         .os_tag = .linux,
+        //         .abi = .musleabihf,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     .extra_target = true,
+        // },
         .{
             .target = .{
                 .cpu_arch = .armeb,
@@ -516,6 +611,19 @@ const test_targets = blk: {
             // https://github.com/llvm/llvm-project/pull/111217
             .skip_modules = &.{"std"},
         },
+        // Currently crashes in qemu-hexagon.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .hexagon,
+        //         .os_tag = .linux,
+        //         .abi = .musl,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     // https://github.com/llvm/llvm-project/pull/111217
+        //     .skip_modules = &.{"std"},
+        //     .extra_target = true,
+        // },
 
         .{
             .target = .{
@@ -533,6 +641,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
             .skip_modules = &.{"std"},
+        },
+        .{
+            .target = .{
+                .cpu_arch = .loongarch64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .skip_modules = &.{"std"},
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -570,9 +689,29 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .mips,
                 .os_tag = .linux,
+                .abi = .musleabi,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips,
+                .os_tag = .linux,
                 .abi = .musleabihf,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips,
+                .os_tag = .linux,
+                .abi = .musleabihf,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -617,9 +756,29 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .mipsel,
                 .os_tag = .linux,
+                .abi = .musleabi,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mipsel,
+                .os_tag = .linux,
                 .abi = .musleabihf,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mipsel,
+                .os_tag = .linux,
+                .abi = .musleabihf,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -657,6 +816,16 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .mips64,
                 .os_tag = .linux,
+                .abi = .muslabi64,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64,
+                .os_tag = .linux,
                 .abi = .gnuabi64,
             },
             .link_libc = true,
@@ -676,6 +845,16 @@ const test_targets = blk: {
                 .abi = .muslabi64,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .mips64el,
+                .os_tag = .linux,
+                .abi = .muslabi64,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -712,9 +891,33 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .powerpc,
                 .os_tag = .linux,
+                .abi = .musleabi,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            // https://github.com/ziglang/zig/issues/2256
+            .skip_modules = &.{"std"},
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .powerpc,
+                .os_tag = .linux,
                 .abi = .musleabihf,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .powerpc,
+                .os_tag = .linux,
+                .abi = .musleabihf,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            // https://github.com/ziglang/zig/issues/2256
+            .skip_modules = &.{"std"},
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -751,6 +954,16 @@ const test_targets = blk: {
                 .abi = .musl,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .powerpc64,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
         },
         // Requires ELFv1 linker support.
         // .{
@@ -775,6 +988,16 @@ const test_targets = blk: {
                 .abi = .musl,
             },
             .link_libc = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .powerpc64le,
+                .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
         },
         .{
             .target = .{
@@ -818,6 +1041,16 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .riscv32,
                 .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .riscv32,
+                .os_tag = .linux,
                 .abi = .gnu,
             },
             .link_libc = true,
@@ -856,6 +1089,16 @@ const test_targets = blk: {
             .target = .{
                 .cpu_arch = .riscv64,
                 .os_tag = .linux,
+                .abi = .musl,
+            },
+            .linkage = .dynamic,
+            .link_libc = true,
+            .extra_target = true,
+        },
+        .{
+            .target = .{
+                .cpu_arch = .riscv64,
+                .os_tag = .linux,
                 .abi = .gnu,
             },
             .link_libc = true,
@@ -885,6 +1128,17 @@ const test_targets = blk: {
             },
             .link_libc = true,
         },
+        // Currently hangs in qemu-s390x.
+        // .{
+        //     .target = .{
+        //         .cpu_arch = .s390x,
+        //         .os_tag = .linux,
+        //         .abi = .musl,
+        //     },
+        //     .linkage = .dynamic,
+        //     .link_libc = true,
+        //     .extra_target = true,
+        // },
         .{
             .target = .{
                 .cpu_arch = .s390x,
@@ -1518,6 +1772,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             .use_lld = test_target.use_lld,
             .zig_lib_dir = b.path("lib"),
         });
+        these_tests.linkage = test_target.linkage;
         if (options.no_builtin) these_tests.no_builtin = true;
         if (options.build_options) |build_options| {
             these_tests.root_module.addOptions("build_options", build_options);
@@ -1532,11 +1787,14 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         else
             "";
         const use_lld = if (test_target.use_lld == false) "-no-lld" else "";
+        const linkage_name = if (test_target.linkage) |linkage| switch (linkage) {
+            inline else => |t| "-" ++ @tagName(t),
+        } else "";
         const use_pic = if (test_target.pic == true) "-pic" else "";
 
         for (options.include_paths) |include_path| these_tests.addIncludePath(b.path(include_path));
 
-        const qualified_name = b.fmt("{s}-{s}-{s}-{s}{s}{s}{s}{s}{s}", .{
+        const qualified_name = b.fmt("{s}-{s}-{s}-{s}{s}{s}{s}{s}{s}{s}", .{
             options.name,
             triple_txt,
             model_txt,
@@ -1545,6 +1803,7 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
             single_threaded_suffix,
             backend_suffix,
             use_lld,
+            linkage_name,
             use_pic,
         });
 


### PR DESCRIPTION
* `--glibc-runtimes` is now called `--libc-runtimes` as it now also works for dynamic musl. (`--glibc-runtimes` is still accepted for compatibility, but it won't show up in `--help`.) I've written a wiki page with copy-pastable scripts for building glibc and musl for (almost) all supported targets: https://github.com/ziglang/zig/wiki/Building-multiple-libcs-for-testing
* Dynamically-linked variants of all musl targets have been added to the module test matrix. Some are commented out because they're crashing/hanging, however. Most are gated by `-Dtest-extra-targets` mainly because we only have so much CI time to work with. `x86_64-linux-musl` and `aarch64-linux-musl` are not gated because they're the most common platforms that dynamic musl will be used on, so we'll want to have some bare minimum coverage of those.
* MIPS N32 targets have been added to the test matrix as well. The dynamic musl variants are gated by `-Dtest-extra-targets`.