### PR TITLE
std: remove `std.crypto.Certificate.Parsed.pubKeySigAlgo` method

### DIFF
--- a/lib/std/crypto/Certificate.zig
+++ b/lib/std/crypto/Certificate.zig
@@ -223,10 +223,6 @@ pub const Parsed = struct {
         return p.slice(p.pub_key_slice);
     }
 
-    pub fn pubKeySigAlgo(p: Parsed) []const u8 {
-        return p.slice(p.pub_key_signature_algorithm_slice);
-    }
-
     pub fn message(p: Parsed) []const u8 {
         return p.slice(p.message_slice);
     }


### PR DESCRIPTION
Contributes to #20505 

Reasons for the removal:
- The method is not used anywhere.
- Similar fields like `signature_algorithm` do not have methods that return their byte array representations.
- Using this method causes compiler error currently, so this is not a breaking change.