### PR TITLE
std.fmt.hex: support integer sizes that are not powers of two

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -602,7 +602,7 @@ pub fn shl(comptime T: type, a: T, shift_amt: anytype) T {
             if (abs_shift_amt >= @typeInfo(C).int.bits) return @splat(0);
             break :blk @as(@Vector(len, Log2Int(C)), @splat(@as(Log2Int(C), @intCast(abs_shift_amt))));
         } else {
-            if (abs_shift_amt >= @typeInfo(T).int.bits) return 0;
+            if (T != comptime_int and abs_shift_amt >= @typeInfo(T).int.bits) return 0;
             break :blk @as(Log2Int(T), @intCast(abs_shift_amt));
         }
     };
@@ -642,7 +642,7 @@ pub fn shr(comptime T: type, a: T, shift_amt: anytype) T {
             if (abs_shift_amt >= @typeInfo(C).int.bits) return @splat(0);
             break :blk @as(@Vector(len, Log2Int(C)), @splat(@as(Log2Int(C), @intCast(abs_shift_amt))));
         } else {
-            if (abs_shift_amt >= @typeInfo(T).int.bits) return 0;
+            if (T != comptime_int and abs_shift_amt >= @typeInfo(T).int.bits) return if (a < 0) -1 else 0;
             break :blk @as(Log2Int(T), @intCast(abs_shift_amt));
         }
     };
@@ -658,6 +658,8 @@ pub fn shr(comptime T: type, a: T, shift_amt: anytype) T {
 
 test shr {
     try testing.expect(shr(u8, 0b11111111, @as(usize, 3)) == 0b00011111);
+    try testing.expect(shr(i8, -1, @as(usize, 3)) == -1);
+    try testing.expect(shr(i8, -1, @as(usize, 9)) == -1);
     try testing.expect(shr(u8, 0b11111111, @as(usize, 8)) == 0);
     try testing.expect(shr(u8, 0b11111111, @as(usize, 9)) == 0);
     try testing.expect(shr(u8, 0b11111111, @as(isize, -2)) == 0b11111100);


### PR DESCRIPTION
Fixes https://github.com/ziglang/zig/issues/23799

This changes the return type, but I don't know of any targets where this is actually breaking change.