### PR TITLE
make error messages prettier

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -323,7 +323,7 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
         .asterisk_after_ptr_deref => {
             // Note that the token will point at the `.*` but ideally the source
             // location would point to the `*` after the `.*`.
-            return stream.writeAll("'.*' cannot be followed by '*'. Are you missing a space?");
+            return stream.writeAll("'.*' cannot be followed by '*'; are you missing a space?");
         },
         .chained_comparison_operators => {
             return stream.writeAll("comparison operators cannot be chained");
@@ -526,7 +526,7 @@ pub fn renderError(tree: Ast, parse_error: Error, stream: anytype) !void {
             return stream.writeAll("expected field initializer");
         },
         .mismatched_binary_op_whitespace => {
-            return stream.print("binary operator `{s}` has whitespace on one side, but not the other.", .{tree.tokenTag(parse_error.token).lexeme().?});
+            return stream.print("binary operator '{s}' has whitespace on one side, but not the other", .{tree.tokenTag(parse_error.token).lexeme().?});
         },
         .invalid_ampersand_ampersand => {
             return stream.writeAll("ambiguous use of '&&'; use 'and' for logical AND, or change whitespace to ' & &' for bitwise AND");

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -4299,12 +4299,12 @@ fn fnDeclInner(
                             &[_]u32{
                                 try astgen.errNoteNode(
                                     type_expr,
-                                    "if this is a name, annotate its type '{s}: T'",
+                                    "if this is a name, annotate its type: '{s}: T'",
                                     .{identifier_str},
                                 ),
                                 try astgen.errNoteNode(
                                     type_expr,
-                                    "if this is a type, give it a name '<name>: {s}'",
+                                    "if this is a type, give it a name: 'name: {s}'",
                                     .{identifier_str},
                                 ),
                             },

--- a/test/cases/compile_errors/Issue_6823_dont_allow_._to_be_followed_by_.zig
+++ b/test/cases/compile_errors/Issue_6823_dont_allow_._to_be_followed_by_.zig
@@ -7,4 +7,4 @@ fn foo() void {
 // backend=stage2
 // target=native
 //
-// :2:28: error: '.*' cannot be followed by '*'. Are you missing a space?
+// :2:28: error: '.*' cannot be followed by '*'; are you missing a space?

--- a/test/cases/compile_errors/missing_parameter_name.zig
+++ b/test/cases/compile_errors/missing_parameter_name.zig
@@ -15,5 +15,5 @@ fn f1(x) u64 {
 // :1:7: error: missing parameter name
 // :4:7: error: missing parameter name
 // :7:7: error: missing parameter name or type
-// :7:7: note: if this is a name, annotate its type 'x: T'
-// :7:7: note: if this is a type, give it a name '<name>: x'
+// :7:7: note: if this is a name, annotate its type: 'x: T'
+// :7:7: note: if this is a type, give it a name: 'name: x'


### PR DESCRIPTION
1. Error messages never contain periods or grave accents. Get rid of the periods and use apostrophes instead in probably the only two error messages that had them.
2. Change T to Type. It looks like something taken from languages like Rust that by convention use single letters for type parameter names. Zig doesn't need that.