### PR TITLE
std.os: handle ENOENT for fcntl on macos

### DIFF
--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -121,6 +121,7 @@ pub fn getFdPath(fd: std.posix.fd_t, out_buffer: *[max_path_bytes]u8) std.posix.
                 .SUCCESS => {},
                 .BADF => return error.FileNotFound,
                 .NOSPC => return error.NameTooLong,
+                .NOENT => return error.FileNotFound,
                 // TODO man pages for fcntl on macOS don't really tell you what
                 // errno values to expect when command is F.GETPATH...
                 else => |err| return posix.unexpectedErrno(err),


### PR DESCRIPTION
observed in the wild