### PR TITLE
Compilation: don't warn about failure to delete missing C depfile

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5174,11 +5174,13 @@ fn updateCObject(comp: *Compilation, c_object: *CObject, c_obj_prog_node: std.Pr
         }
 
         // Just to save disk space, we delete the files that are never needed again.
-        defer if (out_diag_path) |diag_file_path| zig_cache_tmp_dir.deleteFile(std.fs.path.basename(diag_file_path)) catch |err| {
-            log.warn("failed to delete '{s}': {s}", .{ diag_file_path, @errorName(err) });
+        defer if (out_diag_path) |diag_file_path| zig_cache_tmp_dir.deleteFile(std.fs.path.basename(diag_file_path)) catch |err| switch (err) {
+            error.FileNotFound => {}, // the file wasn't created due to an error we reported
+            else => log.warn("failed to delete '{s}': {s}", .{ diag_file_path, @errorName(err) }),
         };
-        defer if (out_dep_path) |dep_file_path| zig_cache_tmp_dir.deleteFile(std.fs.path.basename(dep_file_path)) catch |err| {
-            log.warn("failed to delete '{s}': {s}", .{ dep_file_path, @errorName(err) });
+        defer if (out_dep_path) |dep_file_path| zig_cache_tmp_dir.deleteFile(std.fs.path.basename(dep_file_path)) catch |err| switch (err) {
+            error.FileNotFound => {}, // the file wasn't created due to an error we reported
+            else => log.warn("failed to delete '{s}': {s}", .{ dep_file_path, @errorName(err) }),
         };
         if (std.process.can_spawn) {
             var child = std.process.Child.init(argv.items, arena);


### PR DESCRIPTION
If clang encountered bad imports, the depfile will not be generated. It doesn't make sense to warn the user in this case. In fact, `FileNotFound` is never worth warning about here; it just means that the file we were deleting to save space isn't there in the first place! If the missing file actually affected the compilation (e.g. another process raced to delete it for some reason) we would already error in the normal code path which reads these files, so we can safely omit the warning in the `FileNotFound` case always, only warning when the file might still exist.

To see what this fixes, create the following file...

```c
#include <nonexist>
```

...and run `zig build-obj` on it. Before this commit, you will get a redundant warning; after this commit, that warning is gone.