### PR TITLE
Fix implementation of std.os.linux.accept on x86

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2042,7 +2042,7 @@ pub fn socketpair(domain: i32, socket_type: i32, protocol: i32, fd: *[2]i32) usi
 
 pub fn accept(fd: i32, noalias addr: ?*sockaddr, noalias len: ?*socklen_t) usize {
     if (native_arch == .x86) {
-        return socketcall(SC.accept, &[4]usize{ fd, addr, len, 0 });
+        return socketcall(SC.accept, &[4]usize{ @as(usize, @bitCast(@as(isize, fd))), @intFromPtr(addr), @intFromPtr(len), 0 });
     }
     return accept4(fd, addr, len, 0);
 }


### PR DESCRIPTION
As an aside, the [man page](https://man7.org/linux/man-pages/man2/socketcall.2.html) for `socketcall` seems to suggest that its use should be phased out in favour of more specific syscalls. Additionally, [comments](https://github.com/torvalds/linux/blob/9c69f88849045499e8ad114e5e13dbb3c85f4443/include/linux/syscalls.h#L1169-L1170) in the kernel source code explicitly label `socketcall` as "obsolete" See [these](https://git.musl-libc.org/cgit/musl/log/?qt=grep&q=socketcall) commits for an example of this approach being taken in musl. It does seem to complicate the implementations a bit. As you can see in musl, they have code to handle falling back to the `socketcall` approach when the new syscalls are unavailable. However, as Zig only supports Linux versions >= 5.10, most if not all of these "new" syscalls should be guaranteed to be available.