### PR TITLE
std.math.big: Implementation of assembly version of some functions and division improvement

### DIFF
--- a/lib/compiler/aro/aro/Value.zig
+++ b/lib/compiler/aro/aro/Value.zig
@@ -695,7 +695,7 @@ pub fn div(res: *Value, lhs: Value, rhs: Value, ty: Type, comp: *Compilation) !b
         );
         defer comp.gpa.free(limbs_buffer);
 
-        result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer);
+        result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer, null);
 
         res.* = try intern(comp, .{ .int = .{ .big_int = result_q.toConst() } });
         return !result_q.toConst().fitsInTwosComp(ty.signedness(comp), bits);
@@ -748,7 +748,7 @@ pub fn rem(lhs: Value, rhs: Value, ty: Type, comp: *Compilation) !Value {
     );
     defer comp.gpa.free(limbs_buffer);
 
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer, null);
     return intern(comp, .{ .int = .{ .big_int = result_r.toConst() } });
 }
 

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -4186,6 +4186,7 @@ fn lldiv1(q: []Limb, a: []Limb, b: Limb) void {
         assert(q.len >= calcDivQLenExact(a, &.{b}));
         // b must be normalized
         assert(@clz(b) == 0);
+        assert(!slicesOverlap(q, a));
     }
 
     const n = a.len;

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -17,6 +17,10 @@ const Endian = std.builtin.Endian;
 const Signedness = std.builtin.Signedness;
 const native_endian = builtin.cpu.arch.endian();
 
+// value based only on a few tests, could probably be adjusted
+// it may also depend on the cpu
+const recursive_division_threshold = 100;
+
 /// Returns the number of limbs needed to store `scalar`, which must be a
 /// primitive integer value.
 /// Note: A comptime-known upper bound of this value that may be used
@@ -796,7 +800,7 @@ pub const Mutable = struct {
 
         @memset(rma.limbs[0..req_limbs], 0);
 
-        llmulacc(.add, allocator, rma.limbs, a_limbs, b_limbs);
+        llmulacc(.add, allocator, rma.limbs[0..req_limbs], a_limbs, b_limbs);
         rma.normalize(@min(req_limbs, a.limbs.len + b.limbs.len));
         rma.positive = (a.positive == b.positive);
         rma.truncate(rma.toConst(), signedness, bit_count);
@@ -979,18 +983,12 @@ pub const Mutable = struct {
     /// The upper bound for q limb count is given by `a.limbs`.
     ///
     /// `limbs_buffer` is used for temporary storage. The amount required is given by `calcDivLimbsBufferLen`.
-    pub fn divFloor(
-        q: *Mutable,
-        r: *Mutable,
-        a: Const,
-        b: Const,
-        limbs_buffer: []Limb,
-    ) void {
+    pub fn divFloor(q: *Mutable, r: *Mutable, a: Const, b: Const, limbs_buffer: []Limb, opt_allocator: ?Allocator) void {
         const sep = a.limbs.len + 2;
         const x = a.toMutable(limbs_buffer[0..sep]);
         const y = b.toMutable(limbs_buffer[sep..]);
 
-        div(q, r, x, y);
+        div(q, r, x, y, opt_allocator);
 
         // Note, `div` performs truncating division, which satisfies
         // @divTrunc(a, b) * b + @rem(a, b) = a
@@ -1106,18 +1104,12 @@ pub const Mutable = struct {
     /// The upper bound for q limb count is given by `a.limbs.len`.
     ///
     /// `limbs_buffer` is used for temporary storage. The amount required is given by `calcDivLimbsBufferLen`.
-    pub fn divTrunc(
-        q: *Mutable,
-        r: *Mutable,
-        a: Const,
-        b: Const,
-        limbs_buffer: []Limb,
-    ) void {
+    pub fn divTrunc(q: *Mutable, r: *Mutable, a: Const, b: Const, limbs_buffer: []Limb, opt_allocator: ?Allocator) void {
         const sep = a.limbs.len + 2;
         const x = a.toMutable(limbs_buffer[0..sep]);
         const y = b.toMutable(limbs_buffer[sep..]);
 
-        div(q, r, x, y);
+        div(q, r, x, y, opt_allocator);
     }
 
     /// r = a << shift, in other words, r = a * 2^shift
@@ -1441,7 +1433,8 @@ pub const Mutable = struct {
         };
 
         while (true) {
-            t.divFloor(&rem, a, s.toConst(), limbs_buffer[buf_index..]);
+            // TODO: pass an allocator or remove the need for it in the division
+            t.divFloor(&rem, a, s.toConst(), limbs_buffer[buf_index..], null);
             t.add(t.toConst(), s.toConst());
             u.shiftRight(t.toConst(), 1);
 
@@ -1566,7 +1559,7 @@ pub const Mutable = struct {
     // Truncates by default.
     // Requires no aliasing between all variables
     // a must have the capacity to store a one limb shift
-    fn div(q: *Mutable, r: *Mutable, a: Mutable, b: Mutable) void {
+    fn div(q: *Mutable, r: *Mutable, a: Mutable, b: Mutable, opt_allocator: ?Allocator) void {
         if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
             assert(!b.eqlZero()); // division by zero
             assert(q != r); // illegal aliasing
@@ -1621,7 +1614,20 @@ pub const Mutable = struct {
             a_limbs[1] = result.r[0];
             a_limbs[0] = result.r[1];
         } else {
-            basecaseDivRem(q.limbs, a_limbs, b_limbs);
+            // Currently, an allocator is required to use karatsuba.
+            // Recursive division is only faster than the basecase division thanks to better
+            // multiplication algorithms. Without them, it is worse due to overhead, so we just
+            // default to the basecase
+            if (opt_allocator) |allocator| {
+                // if `B.limbs.len` < `recursive_division_threshold`, the recursiveDivRem calls from unbalancedDivision
+                // will always immediatly default to basecaseDivRem, so just using the basecase is faster
+                if (b_limbs.len < recursive_division_threshold)
+                    basecaseDivRem(q.limbs, a_limbs, b_limbs)
+                else
+                    unbalancedDivision(q.limbs, a_limbs, b_limbs, allocator);
+            } else {
+                basecaseDivRem(q.limbs, a_limbs, b_limbs);
+            }
         }
 
         // we have r < b, so there is at most b.len() limbs
@@ -2195,7 +2201,8 @@ pub const Const = struct {
             while (q.len >= 2) {
                 // Passing an allocator here would not be helpful since this division is destroying
                 // information, not creating it. [TODO citation needed]
-                q.divTrunc(&r, q.toConst(), b, rest_of_the_limbs_buf);
+                // passing an allocator is not useful since b is one limb, so it will use lldiv1
+                q.divTrunc(&r, q.toConst(), b, rest_of_the_limbs_buf, null);
 
                 var r_word = r.limbs[0];
                 var i: usize = 0;
@@ -2903,7 +2910,7 @@ pub const Managed = struct {
         var mr = r.toMutable();
         const limbs_buffer = try q.allocator.alloc(Limb, calcDivLimbsBufferLen(a.len(), b.len()));
         defer q.allocator.free(limbs_buffer);
-        mq.divFloor(&mr, a.toConst(), b.toConst(), limbs_buffer);
+        mq.divFloor(&mr, a.toConst(), b.toConst(), limbs_buffer, q.allocator);
         q.setMetadata(mq.positive, mq.len);
         r.setMetadata(mr.positive, mr.len);
     }
@@ -2920,7 +2927,7 @@ pub const Managed = struct {
         var mr = r.toMutable();
         const limbs_buffer = try q.allocator.alloc(Limb, calcDivLimbsBufferLen(a.len(), b.len()));
         defer q.allocator.free(limbs_buffer);
-        mq.divTrunc(&mr, a.toConst(), b.toConst(), limbs_buffer);
+        mq.divTrunc(&mr, a.toConst(), b.toConst(), limbs_buffer, q.allocator);
         q.setMetadata(mq.positive, mq.len);
         r.setMetadata(mr.positive, mr.len);
     }
@@ -3129,7 +3136,8 @@ const AccOp = enum {
 /// r = r (op) a * b
 /// r MUST NOT alias any of a or b.
 ///
-/// The result is computed modulo `r.len`. When `r.len >= a.len + b.len`, no overflow occurs.
+/// Returns whether the operation overflowed
+/// The result is computed modulo `r.len`.
 fn llmulacc(comptime op: AccOp, opt_allocator: ?Allocator, r: []Limb, a: []const Limb, b: []const Limb) void {
     assert(r.len >= a.len);
     assert(r.len >= b.len);
@@ -3747,8 +3755,9 @@ pub fn llcmp(a: []const Limb, b: []const Limb) math.Order {
 }
 
 /// r = r (op) y * xi
-/// The result is computed modulo `r.len`. When `r.len >= a.len + b.len`, no overflow occurs.
-fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb) void {
+/// returns whether the operation overflowed
+/// The result is computed modulo `r.len`.
+pub fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb) void {
     assert(r.len >= a.len);
     assert(a.len >= b.len);
 
@@ -3759,8 +3768,11 @@ fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb)
 }
 
 /// r = r (op) y * xi
-/// The result is computed modulo `r.len`.
 /// Returns whether the operation overflowed.
+/// If y.len > acc.len, it assumes some of the remaining limbs are non-zero and always overflows
+//
+// usually, if y.len > acc.len, the caller wants a modular operation, and therefore does not care
+// about the overflow anyway
 fn llmulLimb(comptime op: AccOp, acc: []Limb, y: []const Limb, xi: Limb) bool {
     assert(!slicesOverlap(acc, y) or @intFromPtr(acc.ptr) <= @intFromPtr(y.ptr));
 
@@ -3787,7 +3799,7 @@ fn llmulLimb(comptime op: AccOp, acc: []Limb, y: []const Limb, xi: Limb) bool {
         if (carry != 0 and acc.len > y.len)
             carry = @intFromBool(llaccum(op, acc[y.len..], &.{carry}));
 
-        return carry != 0;
+        return carry != 0 or y.len > acc.len;
     }
 
     return llmulLimbGeneric(op, acc, y, xi);
@@ -3933,6 +3945,143 @@ fn lladd(r: []Limb, a: []const Limb, b: []const Limb) void {
     r[a.len] = lladdcarry(r, a, b);
 }
 
+/// Algorithm UnbalancedDivision from "Modern Computer Arithmetic" by Richard P. Brent and Paul Zimmermann
+///
+/// `q` = `a` / `b` rem `r`
+///
+/// Normalization and unnormalization steps are handled by the caller.
+/// `r` is written in `a[0..b.len]` (`a[b.len..]` is NOT zeroed out).
+/// The most significant limbs of `a` (input) can be zeroes.
+///
+/// requires:
+/// - `b.len` >= 2
+/// - `a.len` >= 3
+/// - `a.len` >= `b.len`
+/// - `b` must be normalized (most significant bit of `b[b.len - 1]` must be set)
+/// - `q.len >= calcDivQLenExact(a, b)` (the quotient must be able to fit in `q`)
+///   a valid bound for q can be obtained more cheaply using `calcDivQLen`
+/// - no overlap between q, a and b
+fn unbalancedDivision(q: []Limb, a: []Limb, b: []const Limb, allocator: std.mem.Allocator) void {
+    if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
+        assert(!slicesOverlap(q, a));
+        assert(!slicesOverlap(q, b));
+        assert(!slicesOverlap(a, b));
+        assert(b.len >= 2);
+        assert(a.len >= 3);
+        assert(a.len >= b.len);
+        assert(q.len >= calcDivQLenExact(a, b));
+        // b must be normalized
+        assert(@clz(b[b.len - 1]) == 0);
+    }
+    const n = b.len;
+    var m = a.len - b.len;
+
+    // We slightly deviate from the paper, by allowing `m <= n`, and, instead of doing a division after
+    // the loop, we do it before, in case the quotient takes up m - n + 1 Limbs.
+    // For the next loops, the quotient is always guaranteed to fit in n Limbs.
+    //
+    // `q.len` may be only m limbs instead of m + 1 if the caller know the result will fit
+    // (which has already been asserted).
+    const k = m % n;
+    recursiveDivRem(q[m - k .. @min(m + 1, q.len)], a[m - k .. m + n], b, allocator);
+    m -= k;
+
+    while (m > 0) {
+        // At each loop, we divide <r, a[m - n .. m]> by `b`, with r = a[m .. m + n],
+        // the remainder from the previous loop. This is effectively a 2 word by 1 word division,
+        // except each word is n Limbs long. The process is analogous to `lldiv1`.
+        //
+        // The quotient is guaranteed to fit in `n` Limbs since r < b (from the previous iteration).
+        recursiveDivRem(q[m - n .. m], a[m - n .. m + n], b, allocator);
+        m -= n;
+    }
+}
+
+/// Algorithm RecursiveDivRem from "Modern Computer Arithmetic" by Richard P. Brent and Paul Zimmermann
+///
+/// `q` = `a` / `b` rem `r`
+///
+/// Normalization and unnormalization steps are handled by the caller.
+/// `r` is written in `a[0..b.len]` (`a[b.len..]` is NOT zeroed out).
+/// The most significant limbs of `a` (input) can be zeroes.
+///
+/// requires:
+/// - `b.len` >= 2
+/// - `a.len` >= 3
+/// - `a.len` >= `b.len` and 2 * `b.len` >= `a.len`
+/// - `b` must be normalized (most significant bit of `b[b.len - 1]` must be set)
+/// - `q.len >= calcDivQLenExact(a, b)` (the quotient must be able to fit in `q`)
+///   a valid bound for q can be obtained more cheaply using `calcDivQLen`
+/// - no overlap between q, a and b
+fn recursiveDivRem(q: []Limb, a: []Limb, b: []const Limb, allocator: std.mem.Allocator) void {
+    if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
+        assert(!slicesOverlap(q, a));
+        assert(!slicesOverlap(q, b));
+        assert(!slicesOverlap(a, b));
+        assert(b.len >= 2);
+        assert(a.len >= 3);
+        assert(a.len >= b.len);
+        // n >= m
+        assert(2 * b.len >= a.len);
+        assert(q.len >= std.math.big.int.calcDivQLenExact(a, b));
+        // b must be normalized
+        assert(@clz(b[b.len - 1]) == 0);
+        assert(recursive_division_threshold > 2);
+    }
+
+    const n = b.len;
+    const m = a.len - n;
+
+    if (m < recursive_division_threshold) return basecaseDivRem(q, a, b);
+
+    const k = m / 2;
+
+    const b0 = b[0..k];
+    const b1 = b[k..];
+    const q1 = q[k..@min(q.len, m + 1)];
+    const q0 = q[0..k];
+
+    // It is possible to reduce the probability of `a_is_negative`
+    // by adding a Limb to a[2*k..] and b[k..]. In practice, I did not
+    // see any meaningful speed difference
+    recursiveDivRem(q1, a[2 * k ..], b1, allocator);
+
+    // Step 4:
+    // - A mod B^2k is just a[0..2*k], which is left untouched after the recursive call
+    // - R1 B^2k is already written into a[2*k..] by the recursive call
+    // we only need to subtract Q1 B0 B^k
+
+    // we have i <= m + 1 + k = a.len - n + k + 1
+    // and k + 1 < m <= n since m >= recursive_division_threshold > 2
+    // therefore k + 1 - n < 0, so i < a.len
+    const i = q1.len + b0.len + k;
+    // We detect an underflow by using the next limb after the subtraction.
+    // If it is not 0, then a carry cannot propagate, since we
+    // subtract either 0 or 1 from this limb.
+    // If it is a 0, a carry propagates if it becomes a maxInt(Limb).
+    var can_underflow = a[i] == 0;
+    llmulacc(.sub, allocator, a[k .. i + 1], q1, b0);
+    var a_is_negative = can_underflow and a[i] == maxInt(Limb);
+
+    while (a_is_negative) {
+        _ = llaccum(.sub, q1, &.{1});
+        a_is_negative = !llaccum(.add, a[k .. i + 1], b);
+    }
+
+    recursiveDivRem(q0, a[k..][0..n], b1, allocator);
+
+    // Step 7.
+    // same as above
+    can_underflow = a[2 * k] == 0;
+    llmulacc(.sub, allocator, a[0 .. 2 * k + 1], q0, b0);
+    a_is_negative = can_underflow and a[2 * k] == maxInt(Limb);
+
+    while (a_is_negative) {
+        _ = llaccum(.sub, q0, &.{1});
+        a_is_negative = !llaccum(.add, a[0 .. 2 * k + 1], b);
+    }
+}
+
 /// Algorithm BasecaseDivRem from "Modern Computer Arithmetic" by Richard P. Brent and Paul Zimmermann
 /// modified to use Algorithm 5 from "Improved division by invariant integers"
 /// by Niels Möller and Torbjörn Granlund
@@ -3961,6 +4110,7 @@ fn basecaseDivRem(q: []Limb, a: []Limb, b: []const Limb) void {
         assert(b.len >= 2);
         assert(a.len >= 3);
         assert(q.len >= calcDivQLenExact(a, b));
+        assert(a.len >= b.len);
         // b must be normalized
         assert(@clz(b[b.len - 1]) == 0);
     }

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1970,7 +1970,7 @@ pub const Const = struct {
         for (self.limbs[0..self.limbs.len]) |limb| {
             std.debug.print("{x} ", .{limb});
         }
-        std.debug.print("len={} positive={}\n", .{ self.len, self.positive });
+        std.debug.print("len={} positive={}\n", .{ self.limbs.len, self.positive });
     }
 
     pub fn abs(self: Const) Const {

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1617,8 +1617,9 @@ pub const Mutable = struct {
             const result = div3by2(0, a_limbs[1], a_limbs[0], b.limbs[1], b.limbs[0], reciprocal);
 
             q.limbs[0] = result.q;
-            a_limbs[0] = result.r[0];
-            a_limbs[1] = result.r[1];
+            // result.r[0] is the high part of r and result.r[1] its low part
+            a_limbs[1] = result.r[0];
+            a_limbs[0] = result.r[1];
         } else {
             basecaseDivRem(q.limbs, a_limbs, b_limbs);
         }

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -3667,3 +3667,64 @@ test "ctz" {
     try testing.expectEqual(0, limb_max_squared.ctz(@bitSizeOf(Limb) * 2));
     try testing.expectEqual(0, limb_max_squared.ctz(@bitSizeOf(Limb) * 2 + 1));
 }
+
+test "divFloor random (positive)" {
+    // This test assumes multiplication is correct
+    var rand = std.Random.DefaultPrng.init(testing.random_seed);
+
+    // must be large enough to trigger advanced division algorithm
+    const max_limb_count = 1000;
+
+    for (0..500) |_| {
+        var a = blk: {
+            const len = 2 + rand.next() % max_limb_count;
+            const bytes = try testing.allocator.alignedAlloc(u8, .of(Limb), @intCast(len * @sizeOf(Limb)));
+            rand.fill(bytes);
+
+            var retry_limit: u8 = 5;
+            while (std.mem.allEqual(u8, bytes, 0) and retry_limit > 0) : (retry_limit -= 1)
+                rand.fill(bytes);
+
+            if (retry_limit == 0)
+                @panic("Failed to fill limbs with non zero values");
+
+            const limbs = std.mem.bytesAsSlice(Limb, bytes);
+            var num = Managed{ .allocator = testing.allocator, .limbs = limbs, .metadata = limbs.len };
+            num.normalize(num.len());
+            break :blk num;
+        };
+        defer a.deinit();
+
+        var b = blk: {
+            const len = 2 + rand.next() % a.len();
+            const bytes = try testing.allocator.alignedAlloc(u8, .of(Limb), @intCast(len * @sizeOf(Limb)));
+            rand.fill(bytes);
+
+            var retry_limit: u8 = 5;
+            while (std.mem.allEqual(u8, bytes, 0) and retry_limit > 0) : (retry_limit -= 1)
+                rand.fill(bytes);
+
+            if (retry_limit == 0)
+                @panic("Failed to fill limbs with non zero values");
+
+            const limbs = std.mem.bytesAsSlice(Limb, bytes);
+            var num = Managed{ .allocator = testing.allocator, .limbs = limbs, .metadata = limbs.len };
+            num.normalize(num.len());
+            break :blk num;
+        };
+        defer b.deinit();
+
+        var q = try Managed.init(testing.allocator);
+        defer q.deinit();
+
+        var r = try Managed.init(testing.allocator);
+        defer r.deinit();
+
+        try q.divFloor(&r, &a, &b);
+
+        try q.mul(&q, &b);
+        try q.add(&q, &r);
+
+        try testing.expect(q.eql(a));
+    }
+}

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -34,7 +34,7 @@ pub var log_level = std.log.Level.warn;
 // Disable printing in tests for simple backends.
 pub const backend_can_print = !(builtin.zig_backend == .stage2_spirv64 or builtin.zig_backend == .stage2_riscv64);
 
-fn print(comptime fmt: []const u8, args: anytype) void {
+pub fn print(comptime fmt: []const u8, args: anytype) void {
     if (@inComptime()) {
         @compileError(std.fmt.comptimePrint(fmt, args));
     } else if (backend_can_print) {

--- a/src/Sema/arith.zig
+++ b/src/Sema/arith.zig
@@ -1290,7 +1290,7 @@ fn intDivTruncInner(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     if (ty.toIntern() != .comptime_int_type) {
         const info = ty.intInfo(zcu);
         if (!result_q.toConst().fitsInTwosComp(info.signedness, info.bits)) {
@@ -1324,7 +1324,7 @@ fn intDivExact(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !union(enum) {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     if (!result_r.toConst().eqlZero()) {
         return .remainder;
     }
@@ -1370,7 +1370,7 @@ fn intDivFloorInner(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     if (ty.toIntern() != .comptime_int_type) {
         const info = ty.intInfo(zcu);
         if (!result_q.toConst().fitsInTwosComp(info.signedness, info.bits)) {
@@ -1400,7 +1400,7 @@ fn intMod(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     return pt.intValue_big(ty, result_r.toConst());
 }
 fn intRem(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
@@ -1424,7 +1424,7 @@ fn intRem(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     return pt.intValue_big(ty, result_r.toConst());
 }
 

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -1905,7 +1905,7 @@ pub fn intModScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: 
     );
     var result_q = BigIntMutable{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r = BigIntMutable{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buffer);
+    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buffer, null);
     return pt.intValue_big(ty, result_r.toConst());
 }
 


### PR DESCRIPTION
A bigger pull request this time.

What this PR does:
- add x86_64 assembly implementations for `llaccum` and `llmulLimb` (for both `.add` and `.sub`), with a special case for `ReleaseSmall`. There are also versions of `llmulLimb` for the `.add` operation if the `adx` cpu feature is supported (needed for `adox` and `adcx` instructions)
- add generic versions of `llaccum` and `llmulLimb` for other architectures, with slight edits from the previous function to have a better codegen (for `llmulLimb`)
- add tests for `llaccum` and `llmulLimb`
- change the algorithm (overall very similar) for the division, and prepare the function for future implementations of better algorithms for larger numbers (coming soonish, hopefully). There is also a special case when the divisor fits in one `Limb`

I hope the addition of assembly version of these functions will be accepted, as I am not sure about the stance on assembly implementations in the std for functions that can be written without.
The current way I handle the assembly is suboptimal, and adding assembly for other architectures or other cpu features is cumbersome. It would probably be better to have a separate file for each architecture whenever these versions are added.
Also, my implementations (at least for `llmulLimb`) can still be improved.

### Speed comparison on my machine:
Based on some quick tests for various size of randomly generated arrays of `Limb` (from 500 to 10000):
- the new `llaccum` is ~5.5 times faster than the previous one for addition and ~4.3 times faster for subtraction
- the new `llmulLimb` is ~2.5 times faster than the previous one (with adx) while it is ~2.2 times faster for both addition (without adx) and subtraction.

The new generic version of `llmulLimb` is faster than the previous one but slower than the assembly one (between 30 to 60% slower depending on the operation and whether `adx` is supported)
I did not manage to get better codegen for `llaccum`, which is partly why I resorted to assembly.

### The division part
*note: a "2n by n division" mean a division of a bigint with 2n limbs by a bigint of n limbs. Likewise, a "n by 1 division" mean a division of a bigint with n limbs by a bigint of 1 limb.
Also, "gmp (basecase division only)" is a gmp version where I only enabled the base algorithm. Once numbers get large enough, gmp switches to better division algorithms, so it is not a fair comparison, though I left default gmp in the graphs as a reference.*


Division performance for 2n by n division is only improved by the new `llmulLimb` (leading to the same curve on the graph). The new division is ~2.2 times faster than the previous one, while being about 34% slower than gmp (basecase division only). Based on a few tests, this is due to gmp's better implementation of `llmulLimb` (which makes sense, since the algorithm used is otherwise near identical).

For n by 1 division, however, the new implementation is vastly superior, as it is ~6 times faster than the previous one, and about 32% slower than gmp. I got very similar graphs for n by 2 and n by 3 divisions (and haven't benched beyond). I don't know why the previous algorithm underperforms that much in these cases. Also, I haven't benched the now removed `lldiv0p5`, but the new implementation now doesn't care about half limbs and is probably faster.

![graph](https://github.com/user-attachments/assets/b8cc535c-532e-4196-8893-7e7ccf959b0f)

Benching script [here](https://gist.github.com/samy-00007/de46f5f87cd27edaba95176807358c7f).