### PR TITLE
link.Elf: add root directory of libraries to linker path

### DIFF
--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -1943,9 +1943,19 @@ fn linkWithLLD(self: *Elf, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: s
         // Positional arguments to the linker such as object files.
         var whole_archive = false;
 
+        var lib_directories = std.StringArrayHashMap(void).init(gpa);
+        defer lib_directories.deinit();
+
         for (self.base.comp.link_inputs) |link_input| switch (link_input) {
             .res => unreachable, // Windows-only
-            .dso => continue,
+            .dso => |dso| {
+                if (dso.path.root_dir.path) |root_dir| {
+                    const lib_dir = try lib_directories.getOrPut(root_dir);
+                    if (lib_dir.found_existing) continue;
+                    try argv.append("-L");
+                    try argv.append(root_dir);
+                }
+            },
             .object, .archive => |obj| {
                 if (obj.must_link and !whole_archive) {
                     try argv.append("-whole-archive");


### PR DESCRIPTION
fixes #23849

all the given dynamic shared objects will be linked with an absolute path however they may link to other dynamic shared objects which won't have an absolute path, for this we need to add the library path so that lld can resolve it

works as is and deduplicates the directories
can probably be optimized in some way and naming is subjective