### PR TITLE
translate-c: fix applying struct alignment to first field

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -977,8 +977,8 @@ fn transRecordDecl(c: *Context, scope: *Scope, record_decl: *const clang.RecordD
                 else => |e| return e,
             };
 
-            const alignment = if (flexible_field != null and field_decl.getFieldIndex() == 0)
-                @as(c_uint, @intCast(record_alignment))
+            const alignment: ?c_uint = if (flexible_field == null and field_decl.getFieldIndex() == 0)
+                @intCast(record_alignment)
             else
                 ClangAlignment.forField(c, field_decl, record_def).zigAlignment();
 

--- a/test/cases/translate_c/aligned_struct.c
+++ b/test/cases/translate_c/aligned_struct.c
@@ -1,0 +1,12 @@
+struct __attribute__((aligned(16))) foo {
+    int bar;
+    int baz;
+};
+
+// translate-c
+// c_frontend=aro,clang
+//
+// pub const struct_foo = extern struct {
+//     bar: c_int align(16) = @import("std").mem.zeroes(c_int),
+//     baz: c_int = @import("std").mem.zeroes(c_int),
+// };


### PR DESCRIPTION
fixes ziglang/translate-c#53, fixes ziglang/translate-c#69