### PR TITLE
Revert "Work around stage1 not yet returning null-terminated `@typeInfo` strings"

### DIFF
--- a/lib/std/enums.zig
+++ b/lib/std/enums.zig
@@ -17,7 +17,7 @@ pub fn EnumFieldStruct(comptime E: type, comptime Data: type, comptime field_def
     var struct_fields: [@typeInfo(E).@"enum".fields.len]std.builtin.Type.StructField = undefined;
     for (&struct_fields, @typeInfo(E).@"enum".fields) |*struct_field, enum_field| {
         struct_field.* = .{
-            .name = enum_field.name ++ "",
+            .name = enum_field.name,
             .type = Data,
             .default_value_ptr = if (field_default) |d| @as(?*const anyopaque, @ptrCast(&d)) else null,
             .is_comptime = false,

--- a/lib/std/io.zig
+++ b/lib/std/io.zig
@@ -803,7 +803,7 @@ pub fn PollFiles(comptime StreamEnum: type) type {
     var struct_fields: [enum_fields.len]std.builtin.Type.StructField = undefined;
     for (&struct_fields, enum_fields) |*struct_field, enum_field| {
         struct_field.* = .{
-            .name = enum_field.name ++ "",
+            .name = enum_field.name,
             .type = fs.File,
             .default_value_ptr = null,
             .is_comptime = false,

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -537,7 +537,7 @@ pub fn FieldEnum(comptime T: type) type {
     var decls = [_]std.builtin.Type.Declaration{};
     inline for (field_infos, 0..) |field, i| {
         enumFields[i] = .{
-            .name = field.name ++ "",
+            .name = field.name,
             .value = i,
         };
     }
@@ -609,7 +609,7 @@ pub fn DeclEnum(comptime T: type) type {
     var enumDecls: [fieldInfos.len]std.builtin.Type.EnumField = undefined;
     var decls = [_]std.builtin.Type.Declaration{};
     inline for (fieldInfos, 0..) |field, i| {
-        enumDecls[i] = .{ .name = field.name ++ "", .value = i };
+        enumDecls[i] = .{ .name = field.name, .value = i };
     }
     return @Type(.{
         .@"enum" = .{


### PR DESCRIPTION
This was a temporary workaround intended to be removed after zig1.wasm was updated.

I saw someone about to cargo cult this now useless `++ ""` into their own code, so I think we should finally revert it.

This reverts commit c8fa767f083e610840cef688b709783c5ad66acc.