### PR TITLE
std.mem: Leverage simd usage in `containsAtLeastScalar`

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1668,15 +1668,14 @@ test containsAtLeast {
 pub fn containsAtLeastScalar(comptime T: type, haystack: []const T, expected_count: usize, needle: T) bool {
     if (expected_count == 0) return true;
 
+    var i: usize = 0;
     var found: usize = 0;
 
-    for (haystack) |item| {
-        if (item == needle) {
-            found += 1;
-            if (found == expected_count) return true;
-        }
+    while (indexOfScalarPos(T, haystack, i, needle)) |idx| {
+        i = idx + 1;
+        found += 1;
+        if (found == expected_count) return true;
     }
-
     return false;
 }
 


### PR DESCRIPTION
I've noticed that `containsAtLeastScalar` doesn't use vectorization and relies solely on compiler optimizations (which aren't perfect and even almost disabled in Debug; In 14.0 the old function took 4.5s of user space now it takes 2.5s but SIMD version is still only 0.5s in userspace)

Eventually I found that rewrite I did is exactly what `containsAtLeast` does except excessive branching which thanks to modern cpus branch prediction is eliminated so it is even possible to turn `containsAtLeastScalar` to a wrapper around `containsAtLeast` look at #23890 

Small downsides:
1. it adds `600B` to `13KB` binary if compiled with `-Doptimize=ReleaseSmall`
2. `zig2` created with `./bootstrap` actually prefers linear version. But it shouldn't matter?

## Benchmarks

First of all tbh I couldn't compile zig by myself... So I just downloaded latest zig from the site and just edited files in the `lib/std`. It seems that zig just compiles std as part of user program and can be even fully removed replaced "on fly" but I am not sure that the way I did it doesn't affect the final results...

Also I've just thought I tested it only on `u8` and big array of 3G so not sure about other cases...

CPU: `Intel(R) Core(TM) i3-6006U CPU @ 2.00GHz`
FIle size: `3G` (to create a lot of work)
Benchmark command: `hyperfine -w 2 -r 10 ./zig-out/bin/foo`
Code used for benchmarks:
```
const std = @import("std");
const mem = std.mem;

pub fn main() !void {
    const file = try std.fs.cwd().openFile("data/file.bin", .{ .mode = .read_only });
    const buffer = try file.readToEndAlloc(std.heap.page_allocator, 1 << 48);
    // std.debug.print("{any}", .{mem.containsAtLeast(u8, buffer, 1 << 32, &[1]u8{0xbb})});
    std.debug.print("{any}", .{mem.containsAtLeastScalar(u8, buffer, 1 << 32, 0xbb)});
}
```

####  -Doptimize=ReleaseFast -Dcpu=x86_64_v3 | containsAtLeast
```
Benchmark 1: ./zig-out/bin/foo
  Time (mean ± σ):      2.780 s ±  0.015 s    [User: 0.576 s, System: 2.186 s]
  Range (min … max):    2.756 s …  2.807 s    10 runs
```

####  -Doptimize=ReleaseFast -Dcpu=x86_64_v3 | `OLD` containsAtLeastScalar
```
Benchmark 1: ./zig-out/bin/foo
  Time (mean ± σ):      4.803 s ±  0.041 s    [User: 2.585 s, System: 2.190 s]
  Range (min … max):    4.765 s …  4.894 s    10 runs
```

####  -Doptimize=ReleaseFast -Dcpu=x86_64_v3 | `NEW` containsAtLeastScalar
```
Benchmark 1: ./zig-out/bin/foo
  Time (mean ± σ):      2.784 s ±  0.021 s    [User: 0.571 s, System: 2.194 s]
  Range (min … max):    2.757 s …  2.824 s    10 runs
```
