### PR TITLE
compiler: reference trace fixes

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -750,7 +750,7 @@ fn runStepNames(
     if (run.prominent_compile_errors and total_compile_errors > 0) {
         for (step_stack.keys()) |s| {
             if (s.result_error_bundle.errorMessageCount() > 0) {
-                s.result_error_bundle.renderToStdErr(.{ .ttyconf = ttyconf, .include_reference_trace = (b.reference_trace orelse 0) > 0 });
+                s.result_error_bundle.renderToStdErr(.{ .ttyconf = ttyconf });
             }
         }
 
@@ -1129,11 +1129,7 @@ fn workerMakeOneStep(
         defer std.debug.unlockStdErr();
 
         const gpa = b.allocator;
-        const options: std.zig.ErrorBundle.RenderOptions = .{
-            .ttyconf = run.ttyconf,
-            .include_reference_trace = (b.reference_trace orelse 0) > 0,
-        };
-        printErrorMessages(gpa, s, options, run.stderr, run.prominent_compile_errors) catch {};
+        printErrorMessages(gpa, s, .{ .ttyconf = run.ttyconf }, run.stderr, run.prominent_compile_errors) catch {};
     }
 
     handle_result: {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -448,6 +448,21 @@ pub const Block = struct {
         func: InternPool.Index,
         comptime_result: Air.Inst.Ref,
         merges: Merges,
+        /// Populated lazily by `refFrame`.
+        ref_frame: Zcu.InlineReferenceFrame.Index.Optional = .none,
+
+        fn refFrame(inlining: *Inlining, zcu: *Zcu) Allocator.Error!Zcu.InlineReferenceFrame.Index {
+            if (inlining.ref_frame == .none) {
+                inlining.ref_frame = (try zcu.addInlineReferenceFrame(.{
+                    .callee = inlining.func,
+                    .call_src = inlining.call_src,
+                    .parent = if (inlining.call_block.inlining) |parent_inlining| p: {
+                        break :p (try parent_inlining.refFrame(zcu)).toOptional();
+                    } else .none,
+                })).toOptional();
+            }
+            return inlining.ref_frame.unwrap().?;
+        }
     };
 
     pub const Merges = struct {
@@ -4287,7 +4302,7 @@ fn zirResolveInferredAlloc(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Com
             if (zcu.intern_pool.isFuncBody(val)) {
                 const ty = Type.fromInterned(zcu.intern_pool.typeOf(val));
                 if (try ty.fnHasRuntimeBitsSema(pt)) {
-                    try sema.addReferenceEntry(src, AnalUnit.wrap(.{ .func = val }));
+                    try sema.addReferenceEntry(block, src, AnalUnit.wrap(.{ .func = val }));
                     try zcu.ensureFuncBodyAnalysisQueued(val);
                 }
             }
@@ -6615,7 +6630,7 @@ pub fn analyzeExport(
     if (options.linkage == .internal)
         return;
 
-    try sema.ensureNavResolved(src, orig_nav_index, .fully);
+    try sema.ensureNavResolved(block, src, orig_nav_index, .fully);
 
     const exported_nav_index = switch (ip.indexToKey(ip.getNav(orig_nav_index).status.fully_resolved.val)) {
         .variable => |v| v.owner_nav,
@@ -6644,7 +6659,7 @@ pub fn analyzeExport(
         return sema.fail(block, src, "export target cannot be extern", .{});
     }
 
-    try sema.maybeQueueFuncBodyAnalysis(src, exported_nav_index);
+    try sema.maybeQueueFuncBodyAnalysis(block, src, exported_nav_index);
 
     try sema.exports.append(gpa, .{
         .opts = options,
@@ -6892,7 +6907,7 @@ fn zirDeclRef(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air
         .no_embedded_nulls,
     );
     const nav_index = try sema.lookupIdentifier(block, src, decl_name);
-    return sema.analyzeNavRef(src, nav_index);
+    return sema.analyzeNavRef(block, src, nav_index);
 }
 
 fn zirDeclVal(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
@@ -6988,7 +7003,7 @@ fn lookupInNamespace(
                 }
 
                 for (usingnamespaces.items) |sub_ns_nav| {
-                    try sema.ensureNavResolved(src, sub_ns_nav, .fully);
+                    try sema.ensureNavResolved(block, src, sub_ns_nav, .fully);
                     const sub_ns_ty = Type.fromInterned(ip.getNav(sub_ns_nav).status.fully_resolved.val);
                     const sub_ns = zcu.namespacePtr(sub_ns_ty.getNamespaceIndex(zcu));
                     try checked_namespaces.put(gpa, sub_ns, {});
@@ -7720,8 +7735,8 @@ fn analyzeCall(
     var generic_inlining: Block.Inlining = if (func_ty_info.is_generic) .{
         .call_block = block,
         .call_src = call_src,
+        .func = func_val.?.toIntern(),
         .has_comptime_args = false, // unused by error reporting
-        .func = .none, // unused by error reporting
         .comptime_result = .none, // unused by error reporting
         .merges = undefined, // unused because we'll never `return`
     } else undefined;
@@ -7999,7 +8014,7 @@ fn analyzeCall(
         ref_func: {
             const runtime_func_val = try sema.resolveValue(runtime_func) orelse break :ref_func;
             if (!ip.isFuncBody(runtime_func_val.toIntern())) break :ref_func;
-            try sema.addReferenceEntry(call_src, .wrap(.{ .func = runtime_func_val.toIntern() }));
+            try sema.addReferenceEntry(block, call_src, .wrap(.{ .func = runtime_func_val.toIntern() }));
             try zcu.ensureFuncBodyAnalysisQueued(runtime_func_val.toIntern());
         }
 
@@ -17254,7 +17269,7 @@ fn zirClosureGet(sema: *Sema, block: *Block, extended: Zir.Inst.Extended.InstDat
         .@"comptime" => |index| return Air.internedToRef(index),
         .runtime => |index| index,
         .nav_val => |nav| return sema.analyzeNavVal(block, src, nav),
-        .nav_ref => |nav| return sema.analyzeNavRef(src, nav),
+        .nav_ref => |nav| return sema.analyzeNavRef(block, src, nav),
     };
 
     // The comptime case is handled already above. Runtime case below.
@@ -18407,7 +18422,7 @@ fn typeInfoNamespaceDecls(
         if (zcu.analysis_in_progress.contains(.wrap(.{ .nav_val = nav }))) {
             continue;
         }
-        try sema.ensureNavResolved(src, nav, .fully);
+        try sema.ensureNavResolved(block, src, nav, .fully);
         const namespace_ty = Type.fromInterned(ip.getNav(nav).status.fully_resolved.val);
         try sema.typeInfoNamespaceDecls(block, src, namespace_ty.getNamespaceIndex(zcu).toOptional(), declaration_ty, decl_vals, seen_namespaces);
     }
@@ -27932,7 +27947,7 @@ fn namespaceLookupRef(
     decl_name: InternPool.NullTerminatedString,
 ) CompileError!?Air.Inst.Ref {
     const nav = try sema.namespaceLookup(block, src, namespace, decl_name) orelse return null;
-    return try sema.analyzeNavRef(src, nav);
+    return try sema.analyzeNavRef(block, src, nav);
 }
 
 fn namespaceLookupVal(
@@ -29095,7 +29110,7 @@ fn coerceExtra(
                     .@"extern" => |e| e.owner_nav,
                     else => unreachable,
                 };
-                const inst_as_ptr = try sema.analyzeNavRef(inst_src, fn_nav);
+                const inst_as_ptr = try sema.analyzeNavRef(block, inst_src, fn_nav);
                 return sema.coerce(block, dest_ty, inst_as_ptr, inst_src);
             }
 
@@ -30748,7 +30763,7 @@ fn coerceVarArgParam(
         .@"fn" => fn_ptr: {
             const fn_val = try sema.resolveConstDefinedValue(block, LazySrcLoc.unneeded, inst, undefined);
             const fn_nav = zcu.funcInfo(fn_val.toIntern()).owner_nav;
-            break :fn_ptr try sema.analyzeNavRef(inst_src, fn_nav);
+            break :fn_ptr try sema.analyzeNavRef(block, inst_src, fn_nav);
         },
         .array => return sema.fail(block, inst_src, "arrays must be passed by reference to variadic function", .{}),
         .float => float: {
@@ -31758,12 +31773,13 @@ fn analyzeNavVal(
     src: LazySrcLoc,
     nav_index: InternPool.Nav.Index,
 ) CompileError!Air.Inst.Ref {
-    const ref = try sema.analyzeNavRefInner(src, nav_index, false);
+    const ref = try sema.analyzeNavRefInner(block, src, nav_index, false);
     return sema.analyzeLoad(block, src, ref, src);
 }
 
 fn addReferenceEntry(
     sema: *Sema,
+    opt_block: ?*Block,
     src: LazySrcLoc,
     referenced_unit: AnalUnit,
 ) !void {
@@ -31771,10 +31787,12 @@ fn addReferenceEntry(
     if (!zcu.comp.incremental and zcu.comp.reference_trace == 0) return;
     const gop = try sema.references.getOrPut(sema.gpa, referenced_unit);
     if (gop.found_existing) return;
-    // TODO: we need to figure out how to model inline calls here.
-    // They aren't references in the analysis sense, but ought to show up in the reference trace!
-    // Would representing inline calls in the reference table cause excessive memory usage?
-    try zcu.addUnitReference(sema.owner, referenced_unit, src);
+    try zcu.addUnitReference(sema.owner, referenced_unit, src, inline_frame: {
+        const block = opt_block orelse break :inline_frame .none;
+        const inlining = block.inlining orelse break :inline_frame .none;
+        const frame = try inlining.refFrame(zcu);
+        break :inline_frame frame.toOptional();
+    });
 }
 
 pub fn addTypeReferenceEntry(
@@ -31793,7 +31811,7 @@ fn ensureMemoizedStateResolved(sema: *Sema, src: LazySrcLoc, stage: InternPool.M
     const pt = sema.pt;
 
     const unit: AnalUnit = .wrap(.{ .memoized_state = stage });
-    try sema.addReferenceEntry(src, unit);
+    try sema.addReferenceEntry(null, src, unit);
     try sema.declareDependency(.{ .memoized_state = stage });
 
     if (pt.zcu.analysis_in_progress.contains(unit)) {
@@ -31802,7 +31820,7 @@ fn ensureMemoizedStateResolved(sema: *Sema, src: LazySrcLoc, stage: InternPool.M
     try pt.ensureMemoizedStateUpToDate(stage);
 }
 
-pub fn ensureNavResolved(sema: *Sema, src: LazySrcLoc, nav_index: InternPool.Nav.Index, kind: enum { type, fully }) CompileError!void {
+pub fn ensureNavResolved(sema: *Sema, block: *Block, src: LazySrcLoc, nav_index: InternPool.Nav.Index, kind: enum { type, fully }) CompileError!void {
     const pt = sema.pt;
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
@@ -31825,7 +31843,7 @@ pub fn ensureNavResolved(sema: *Sema, src: LazySrcLoc, nav_index: InternPool.Nav
         .type => .{ .nav_ty = nav_index },
         .fully => .{ .nav_val = nav_index },
     });
-    try sema.addReferenceEntry(src, anal_unit);
+    try sema.addReferenceEntry(block, src, anal_unit);
 
     if (zcu.analysis_in_progress.contains(anal_unit)) {
         return sema.failWithOwnedErrorMsg(null, try sema.errMsg(.{
@@ -31855,25 +31873,25 @@ fn optRefValue(sema: *Sema, opt_val: ?Value) !Value {
     } }));
 }
 
-fn analyzeNavRef(sema: *Sema, src: LazySrcLoc, nav_index: InternPool.Nav.Index) CompileError!Air.Inst.Ref {
-    return sema.analyzeNavRefInner(src, nav_index, true);
+fn analyzeNavRef(sema: *Sema, block: *Block, src: LazySrcLoc, nav_index: InternPool.Nav.Index) CompileError!Air.Inst.Ref {
+    return sema.analyzeNavRefInner(block, src, nav_index, true);
 }
 
 /// Analyze a reference to the `Nav` at the given index. Ensures the underlying `Nav` is analyzed.
 /// If this pointer will be used directly, `is_ref` must be `true`.
 /// If this pointer will be immediately loaded (i.e. a `decl_val` instruction), `is_ref` must be `false`.
-fn analyzeNavRefInner(sema: *Sema, src: LazySrcLoc, orig_nav_index: InternPool.Nav.Index, is_ref: bool) CompileError!Air.Inst.Ref {
+fn analyzeNavRefInner(sema: *Sema, block: *Block, src: LazySrcLoc, orig_nav_index: InternPool.Nav.Index, is_ref: bool) CompileError!Air.Inst.Ref {
     const pt = sema.pt;
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
 
-    try sema.ensureNavResolved(src, orig_nav_index, if (is_ref) .type else .fully);
+    try sema.ensureNavResolved(block, src, orig_nav_index, if (is_ref) .type else .fully);
 
     const nav_index = nav: {
         if (ip.getNav(orig_nav_index).isExternOrFn(ip)) {
             // Getting a pointer to this `Nav` might mean we actually get a pointer to something else!
             // We need to resolve the value to know for sure.
-            if (is_ref) try sema.ensureNavResolved(src, orig_nav_index, .fully);
+            if (is_ref) try sema.ensureNavResolved(block, src, orig_nav_index, .fully);
             switch (ip.indexToKey(ip.getNav(orig_nav_index).status.fully_resolved.val)) {
                 .func => |f| break :nav f.owner_nav,
                 .@"extern" => |e| break :nav e.owner_nav,
@@ -31897,7 +31915,7 @@ fn analyzeNavRefInner(sema: *Sema, src: LazySrcLoc, orig_nav_index: InternPool.N
         },
     });
     if (is_ref) {
-        try sema.maybeQueueFuncBodyAnalysis(src, nav_index);
+        try sema.maybeQueueFuncBodyAnalysis(block, src, nav_index);
     }
     return Air.internedToRef((try pt.intern(.{ .ptr = .{
         .ty = ptr_ty.toIntern(),
@@ -31906,7 +31924,7 @@ fn analyzeNavRefInner(sema: *Sema, src: LazySrcLoc, orig_nav_index: InternPool.N
     } })));
 }
 
-fn maybeQueueFuncBodyAnalysis(sema: *Sema, src: LazySrcLoc, nav_index: InternPool.Nav.Index) !void {
+fn maybeQueueFuncBodyAnalysis(sema: *Sema, block: *Block, src: LazySrcLoc, nav_index: InternPool.Nav.Index) !void {
     const pt = sema.pt;
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
@@ -31914,16 +31932,16 @@ fn maybeQueueFuncBodyAnalysis(sema: *Sema, src: LazySrcLoc, nav_index: InternPoo
     // To avoid forcing too much resolution, let's first resolve the type, and check if it's a function.
     // If it is, we can resolve the *value*, and queue analysis as needed.
 
-    try sema.ensureNavResolved(src, nav_index, .type);
+    try sema.ensureNavResolved(block, src, nav_index, .type);
     const nav_ty: Type = .fromInterned(ip.getNav(nav_index).typeOf(ip));
     if (nav_ty.zigTypeTag(zcu) != .@"fn") return;
     if (!try nav_ty.fnHasRuntimeBitsSema(pt)) return;
 
-    try sema.ensureNavResolved(src, nav_index, .fully);
+    try sema.ensureNavResolved(block, src, nav_index, .fully);
     const nav_val = zcu.navValue(nav_index);
     if (!ip.isFuncBody(nav_val.toIntern())) return;
 
-    try sema.addReferenceEntry(src, AnalUnit.wrap(.{ .func = nav_val.toIntern() }));
+    try sema.addReferenceEntry(block, src, AnalUnit.wrap(.{ .func = nav_val.toIntern() }));
     try zcu.ensureFuncBodyAnalysisQueued(nav_val.toIntern());
 }
 
@@ -31939,8 +31957,8 @@ fn analyzeRef(
 
     if (try sema.resolveValue(operand)) |val| {
         switch (zcu.intern_pool.indexToKey(val.toIntern())) {
-            .@"extern" => |e| return sema.analyzeNavRef(src, e.owner_nav),
-            .func => |f| return sema.analyzeNavRef(src, f.owner_nav),
+            .@"extern" => |e| return sema.analyzeNavRef(block, src, e.owner_nav),
+            .func => |f| return sema.analyzeNavRef(block, src, f.owner_nav),
             else => return uavRef(sema, val.toIntern()),
         }
     }
@@ -35504,7 +35522,7 @@ fn resolveInferredErrorSet(
         }
         // In this case we are dealing with the actual InferredErrorSet object that
         // corresponds to the function, not one created to track an inline/comptime call.
-        try sema.addReferenceEntry(src, AnalUnit.wrap(.{ .func = func_index }));
+        try sema.addReferenceEntry(block, src, AnalUnit.wrap(.{ .func = func_index }));
         try pt.ensureFuncBodyUpToDate(func_index);
     }
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -191,7 +191,6 @@ const LowerZon = @import("Sema/LowerZon.zig");
 const arith = @import("Sema/arith.zig");
 
 pub const default_branch_quota = 1000;
-pub const default_reference_trace_len = 2;
 
 pub const InferredErrorSet = struct {
     /// The function body from which this error set originates.
@@ -2580,7 +2579,7 @@ pub fn failWithOwnedErrorMsg(sema: *Sema, block: ?*Block, err_msg: *Zcu.ErrorMsg
     if (build_options.enable_debug_extensions and zcu.comp.debug_compile_errors) {
         var wip_errors: std.zig.ErrorBundle.Wip = undefined;
         wip_errors.init(gpa) catch @panic("out of memory");
-        Compilation.addModuleErrorMsg(zcu, &wip_errors, err_msg.*) catch @panic("out of memory");
+        Compilation.addModuleErrorMsg(zcu, &wip_errors, err_msg.*, false) catch @panic("out of memory");
         std.debug.print("compile error during Sema:\n", .{});
         var error_bundle = wip_errors.toOwnedBundle("") catch @panic("out of memory");
         error_bundle.renderToStdErr(.{ .ttyconf = .no_color });
@@ -2600,10 +2599,7 @@ pub fn failWithOwnedErrorMsg(sema: *Sema, block: ?*Block, err_msg: *Zcu.ErrorMsg
         }
     }
 
-    const use_ref_trace = if (zcu.comp.reference_trace) |n| n > 0 else zcu.failed_analysis.count() == 0;
-    if (use_ref_trace) {
-        err_msg.reference_trace_root = sema.owner.toOptional();
-    }
+    err_msg.reference_trace_root = sema.owner.toOptional();
 
     const gop = try zcu.failed_analysis.getOrPut(gpa, sema.owner);
     if (gop.found_existing) {

--- a/src/Sema/comptime_ptr_access.zig
+++ b/src/Sema/comptime_ptr_access.zig
@@ -228,7 +228,7 @@ fn loadComptimePtrInner(
 
     const base_val: MutableValue = switch (ptr.base_addr) {
         .nav => |nav| val: {
-            try sema.ensureNavResolved(src, nav, .fully);
+            try sema.ensureNavResolved(block, src, nav, .fully);
             const val = ip.getNav(nav).status.fully_resolved.val;
             switch (ip.indexToKey(val)) {
                 .variable => return .runtime_load,

--- a/test/cases/compile_errors/add_overflow_in_function_evaluation.zig
+++ b/test/cases/compile_errors/add_overflow_in_function_evaluation.zig
@@ -8,8 +8,6 @@ export fn entry() usize {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :3:14: error: overflow of integer type 'u16' with value '65540'
-// :1:14: note: called from here
+// :1:14: note: called at comptime here

--- a/test/cases/compile_errors/closure_get_depends_on_failed_decl.zig
+++ b/test/cases/compile_errors/closure_get_depends_on_failed_decl.zig
@@ -18,9 +18,7 @@ pub export fn entry() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :11:5: error: expected 0 argument(s), found 1
 // :1:12: note: function declared here
-// :17:19: note: called from here
+// :17:19: note: called inline here

--- a/test/cases/compile_errors/compile_time_division_by_zero.zig
+++ b/test/cases/compile_errors/compile_time_division_by_zero.zig
@@ -10,4 +10,4 @@ export fn entry() usize {
 // error
 //
 // :3:16: error: division by zero here causes illegal behavior
-// :1:14: note: called from here
+// :1:14: note: called at comptime here

--- a/test/cases/compile_errors/comptime_try_non_error.zig
+++ b/test/cases/compile_errors/comptime_try_non_error.zig
@@ -11,8 +11,6 @@ pub fn bar() u8 {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :6:12: error: expected error union type, found 'u8'
-// :2:8: note: called from here
+// :2:8: note: called at comptime here

--- a/test/cases/compile_errors/comptime_var_referenced_by_type.zig
+++ b/test/cases/compile_errors/comptime_var_referenced_by_type.zig
@@ -22,4 +22,4 @@ comptime {
 //
 // :7:16: error: captured value contains reference to comptime var
 // :16:30: note: 'wrapper.ptr' points to comptime var declared here
-// :17:29: note: called from here
+// :17:29: note: called at comptime here

--- a/test/cases/compile_errors/constant_inside_comptime_function_has_compile_error.zig
+++ b/test/cases/compile_errors/constant_inside_comptime_function_has_compile_error.zig
@@ -15,9 +15,8 @@ export fn entry() void {
 }
 
 // error
-// target=native
 //
 // :4:5: error: unreachable code
 // :4:25: note: control flow is diverted here
 // :4:25: error: aoeu
-// :1:36: note: called from here
+// :1:36: note: called at comptime here

--- a/test/cases/compile_errors/error_in_comptime_call_in_container_level_initializer.zig
+++ b/test/cases/compile_errors/error_in_comptime_call_in_container_level_initializer.zig
@@ -15,8 +15,6 @@ pub export fn entry() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :9:48: error: caught unexpected error 'InvalidVersion'
 // :?:?: note: error returned here
@@ -24,4 +22,4 @@ pub export fn entry() void {
 // :?:?: note: error returned here
 // :?:?: note: error returned here
 // :?:?: note: error returned here
-// :12:37: note: called from here
+// :12:37: note: called at comptime here

--- a/test/cases/compile_errors/generic_function_instantiation_inherits_parent_branch_quota.zig
+++ b/test/cases/compile_errors/generic_function_instantiation_inherits_parent_branch_quota.zig
@@ -25,5 +25,5 @@ fn Type(comptime n: usize) type {
 //
 // :21:16: error: evaluation exceeded 1001 backwards branches
 // :21:16: note: use @setEvalBranchQuota() to raise the branch limit from 1001
-// :16:34: note: called from here
-// :8:15: note: called from here
+// :16:34: note: called at comptime here
+// :8:15: note: generic function instantiated here

--- a/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
+++ b/test/cases/compile_errors/generic_instantiation_failure_in_generic_function_return_type.zig
@@ -36,8 +36,6 @@ pub fn is(comptime id: std.builtin.TypeId) TraitFn {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :8:48: error: expected type 'type', found 'bool'
-// :5:21: note: called from here
+// :5:21: note: generic function instantiated here

--- a/test/cases/compile_errors/missing_main_fn_in_executable.zig
+++ b/test/cases/compile_errors/missing_main_fn_in_executable.zig
@@ -1,9 +1,8 @@
 // error
-// backend=stage2
 // target=x86_64-linux
 // output_mode=Exe
 //
 // : error: root source file struct 'tmp' has no member named 'main'
 // : note: struct declared here
-// : note: called from here
-// : note: called from here
+// : note: called inline here
+// : note: called inline here

--- a/test/cases/compile_errors/missing_struct_field_in_fn_called_at_comptime.zig
+++ b/test/cases/compile_errors/missing_struct_field_in_fn_called_at_comptime.zig
@@ -10,9 +10,7 @@ comptime {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :5:17: error: missing struct field: b
 // :1:11: note: struct declared here
-// :9:15: note: called from here
+// :9:15: note: called at comptime here

--- a/test/cases/compile_errors/mul_overflow_in_function_evaluation.zig
+++ b/test/cases/compile_errors/mul_overflow_in_function_evaluation.zig
@@ -8,8 +8,6 @@ export fn entry() usize {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :3:14: error: overflow of integer type 'u16' with value '1800000'
-// :1:14: note: called from here
+// :1:14: note: called at comptime here

--- a/test/cases/compile_errors/negation_overflow_in_function_evaluation.zig
+++ b/test/cases/compile_errors/negation_overflow_in_function_evaluation.zig
@@ -8,8 +8,6 @@ export fn entry() usize {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :3:12: error: overflow of integer type 'i8' with value '128'
-// :1:14: note: called from here
+// :1:14: note: called at comptime here

--- a/test/cases/compile_errors/non-comptime-parameter-used-as-array-size.zig
+++ b/test/cases/compile_errors/non-comptime-parameter-used-as-array-size.zig
@@ -11,4 +11,4 @@ fn makeLlamas(count: usize) [count]u8 {}
 //
 // :8:30: error: unable to resolve comptime value
 // :8:30: note: array length must be comptime-known
-// :2:31: note: called from here
+// :2:31: note: generic function instantiated here

--- a/test/cases/compile_errors/private_main_fn.zig
+++ b/test/cases/compile_errors/private_main_fn.zig
@@ -1,11 +1,10 @@
 fn main() void {}
 
 // error
-// backend=stage2
 // target=x86_64-linux
 // output_mode=Exe
 //
 // : error: 'main' is not marked 'pub'
 // :1:1: note: declared here
-// : note: called from here
-// : note: called from here
+// : note: called inline here
+// : note: called inline here

--- a/test/cases/compile_errors/recursive_inline_fn.zig
+++ b/test/cases/compile_errors/recursive_inline_fn.zig
@@ -31,8 +31,8 @@ pub export fn entry2() void {
 // error
 //
 // :5:27: error: inline call is recursive
-// :12:12: note: called from here
+// :12:12: note: called inline here
 // :24:10: error: inline call is recursive
-// :20:10: note: called from here
-// :16:11: note: called from here
-// :28:10: note: called from here
+// :20:10: note: called inline here
+// :16:11: note: called inline here
+// :28:10: note: called inline here

--- a/test/cases/compile_errors/referring_to_a_struct_that_is_invalid.zig
+++ b/test/cases/compile_errors/referring_to_a_struct_that_is_invalid.zig
@@ -11,8 +11,6 @@ fn assert(ok: bool) void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :10:14: error: reached unreachable code
-// :6:20: note: called from here
+// :6:20: note: called at comptime here

--- a/test/cases/compile_errors/ret_coercion_error_in_generic_fn_called_from_non_fn_scope.zig
+++ b/test/cases/compile_errors/ret_coercion_error_in_generic_fn_called_from_non_fn_scope.zig
@@ -6,9 +6,7 @@ comptime {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :2:12: error: expected type 'fn () void', found 'type'
 // :1:10: note: function return type declared here
-// :5:12: note: called from here
+// :5:12: note: called at comptime here

--- a/test/cases/compile_errors/runtime_operation_in_comptime_scope.zig
+++ b/test/cases/compile_errors/runtime_operation_in_comptime_scope.zig
@@ -30,7 +30,7 @@ var rt: u32 = undefined;
 // :10:12: note: call to function with comptime-only return type 'type' is evaluated at comptime
 // :13:10: note: return type declared here
 // :10:12: note: types are not available at runtime
-// :2:8: note: called from here
+// :2:8: note: called inline here
 // :19:8: error: unable to evaluate comptime expression
 // :19:5: note: operation is runtime due to this operand
 // :6:8: note: called at comptime from here

--- a/test/cases/compile_errors/sema_src_used_after_inline_call.zig
+++ b/test/cases/compile_errors/sema_src_used_after_inline_call.zig
@@ -18,9 +18,7 @@ export fn entry() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :13:30: error: expected type 'u32', found 'i32'
 // :13:30: note: unsigned 32-bit int cannot represent all possible signed 32-bit values
-// :17:33: note: called from here
+// :17:33: note: called inline here

--- a/test/cases/compile_errors/stack_usage_in_naked_function.zig
+++ b/test/cases/compile_errors/stack_usage_in_naked_function.zig
@@ -36,10 +36,9 @@ export fn d() callconv(.naked) noreturn {
 }
 
 // error
-// backend=stage2
 //
 // :2:5: error: local variable in naked function
 // :10:5: error: local variable in naked function
 // :23:5: error: local variable in naked function
 // :30:13: error: local variable in naked function
-// :35:12: note: called from here
+// :35:12: note: called inline here

--- a/test/cases/compile_errors/store_to_comptime_var_through_call.zig
+++ b/test/cases/compile_errors/store_to_comptime_var_through_call.zig
@@ -12,4 +12,4 @@ fn incr(x: *comptime_int) void {
 //
 // :8:9: error: store to comptime variable depends on runtime condition
 // :3:9: note: runtime condition here
-// :4:22: note: called from here
+// :4:22: note: called at comptime here

--- a/test/cases/compile_errors/sub_overflow_in_function_evaluation.zig
+++ b/test/cases/compile_errors/sub_overflow_in_function_evaluation.zig
@@ -8,8 +8,6 @@ export fn entry() usize {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :3:14: error: overflow of integer type 'u16' with value '-10'
-// :1:14: note: called from here
+// :1:14: note: called at comptime here

--- a/test/cases/compile_errors/unreachable_executed_at_comptime.zig
+++ b/test/cases/compile_errors/unreachable_executed_at_comptime.zig
@@ -9,8 +9,6 @@ export fn entry() void {
 }
 
 // error
-// backend=stage2
-// target=native
 //
 // :4:9: error: reached unreachable code
-// :8:21: note: called from here
+// :8:21: note: called at comptime here


### PR DESCRIPTION
* Ensure we always show the first (and only the first) reference trace when `-freference-trace` is not passed
  * Previously, an *arbitrary* error had the trace, because we added it to the first error Sema hit but later sorted the errors
  * The old logic also did not support incremental compilation, where there might be unused entries in `failed_analysis`
* Include inline calls in the reference trace
  * Inline calls "above" the current `AnalUnit` still appear as notes, but inline calls "below" the current `AnalUnit` now appear in the reference trace
  * This makes it easier to track the full chain of references, particularly when comptime calls are involved since they often nest deeply
  * These frames appear in the reference trace with `[inlined]` appended to the function name
* Improve "called from here" notes
  * It's unclear to the user why these are special (rather than just being in the reference trace); it's because the calls are inline (ish), so comptime values can propagate through them
  * The wording is now either "called at comptime here", "called inline here", or "generic function instantiated here"
* Don't incorrectly omit the one default-enabled reference trace when using `zig build`

Some of the following issues were actually already fixed on master, but I've confirmed they're all working.

At some point we should definitely add a way to test reference traces in test case manifests so I can actually add tests for all of this, but that shouldn't block these fixes.

Resolves: #17103
Resolves: #19116
Resolves: #22845
Resolves: #23415