### PR TITLE
std.mem: adapt SIMD code from indexOfScalar for other scalar functions

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1241,6 +1241,133 @@ test trim {
     try testing.expectEqualSlices(u8, "foo", trim(u8, "foo", " \n"));
 }
 
+const ScalarSimdOp = enum {
+    index,
+    last_index,
+    count,
+    contains_at_least,
+
+    const ContainsAtLeast = struct {
+        found: usize,
+        needed: usize,
+    };
+
+    fn Arg(op: ScalarSimdOp) type {
+        return switch (op) {
+            .index, .last_index => void,
+            .count => *usize,
+            .contains_at_least => *ContainsAtLeast,
+        };
+    }
+
+    fn Ret(op: ScalarSimdOp) type {
+        return switch (op) {
+            .index => usize,
+            .last_index => usize,
+            .count => void,
+            .contains_at_least => bool,
+        };
+    }
+};
+
+inline fn scalarSimdOp(
+    comptime T: type,
+    slice: []const T,
+    value: T,
+    i: *usize,
+    comptime op: ScalarSimdOp,
+    arg: op.Arg(),
+) ?op.Ret() {
+    if (!backend_supports_vectors) return null;
+    if (@inComptime()) return null;
+    if (@typeInfo(T) != .int and @typeInfo(T) != .float) return null;
+    if (!std.math.isPowerOfTwo(@bitSizeOf(T))) return null;
+    const block_len = std.simd.suggestVectorLength(T) orelse return null;
+
+    // Potentially a runtime check.
+    if (std.debug.inValgrind()) return null; // https://github.com/ziglang/zig/issues/17717
+
+    // For Intel Nehalem (2009) and AMD Bulldozer (2012) or later, unaligned loads on aligned data result
+    // in the same execution as aligned loads. We ignore older arch's here and don't bother pre-aligning.
+    //
+    // Use `std.simd.suggestVectorLength(T)` to get the same alignment as used in this function
+    // however this usually isn't necessary unless your arch has a performance penalty due to this.
+    //
+    // This may differ for other arch's. Arm for example costs a cycle when loading across a cache
+    // line so explicit alignment prologues may be worth exploration.
+
+    const Block = @Vector(block_len, T);
+    if (op == .last_index) {
+        const block_even = slice.len -| (slice.len % (block_len * 2));
+        while (i.* != block_even) {
+            i.* -= 1;
+            if (slice[i.*] == value) return i.*;
+        }
+
+        const mask: Block = @splat(value);
+        while (i.* != 0) {
+            inline for (0..2) |_| {
+                i.* -= block_len;
+                const block: Block = slice[i.*..][0..block_len].*;
+                const matches = block == mask;
+
+                if (std.simd.lastTrue(matches)) |found| return i.* + found;
+            }
+        }
+        return null;
+    }
+
+    // Unrolling here is ~10% improvement. We can then do one bounds check every 2 blocks
+    // instead of one which adds up.
+    if (i.* + 2 * block_len < slice.len) {
+        const mask: Block = @splat(value);
+        while (true) {
+            inline for (0..2) |_| {
+                const block: Block = slice[i.*..][0..block_len].*;
+                const matches = block == mask;
+
+                switch (op) {
+                    .count => arg.* += std.simd.countTrues(matches),
+                    .contains_at_least => {
+                        arg.found += std.simd.countTrues(matches);
+                        if (arg.found >= arg.needed) return true;
+                    },
+                    .index => if (std.simd.firstTrue(matches)) |found| return i.* + found,
+                    .last_index => unreachable,
+                }
+                i.* += block_len;
+            }
+            if (i.* + 2 * block_len >= slice.len) break;
+        }
+    }
+
+    // {block_len, block_len / 2} check
+    inline for (0..2) |j| {
+        const block_x_len = block_len / (1 << j);
+        comptime if (block_x_len < 4) break;
+
+        const BlockX = @Vector(block_x_len, T);
+        if (i.* + block_x_len < slice.len) {
+            const mask: BlockX = @splat(value);
+            const block: BlockX = slice[i.*..][0..block_x_len].*;
+            const matches = block == mask;
+
+            switch (op) {
+                .count => arg.* += std.simd.countTrues(matches),
+                .contains_at_least => {
+                    arg.found += std.simd.countTrues(matches);
+                    if (arg.found >= arg.needed) return true;
+                },
+                .index => if (std.simd.firstTrue(matches)) |found| return i.* + found,
+                .last_index => unreachable,
+            }
+            i.* += block_x_len;
+        }
+    }
+
+    return null;
+}
+
 /// Linear search for the index of a scalar value inside a slice.
 pub fn indexOfScalar(comptime T: type, slice: []const T, value: T) ?usize {
     return indexOfScalarPos(T, slice, 0, value);
@@ -1249,6 +1376,8 @@ pub fn indexOfScalar(comptime T: type, slice: []const T, value: T) ?usize {
 /// Linear search for the last index of a scalar value inside a slice.
 pub fn lastIndexOfScalar(comptime T: type, slice: []const T, value: T) ?usize {
     var i: usize = slice.len;
+    if (scalarSimdOp(T, slice, value, &i, .last_index, {})) |index| return index;
+
     while (i != 0) {
         i -= 1;
         if (slice[i] == value) return i;
@@ -1260,57 +1389,7 @@ pub fn indexOfScalarPos(comptime T: type, slice: []const T, start_index: usize, 
     if (start_index >= slice.len) return null;
 
     var i: usize = start_index;
-    if (backend_supports_vectors and
-        !std.debug.inValgrind() and // https://github.com/ziglang/zig/issues/17717
-        !@inComptime() and
-        (@typeInfo(T) == .int or @typeInfo(T) == .float) and std.math.isPowerOfTwo(@bitSizeOf(T)))
-    {
-        if (std.simd.suggestVectorLength(T)) |block_len| {
-            // For Intel Nehalem (2009) and AMD Bulldozer (2012) or later, unaligned loads on aligned data result
-            // in the same execution as aligned loads. We ignore older arch's here and don't bother pre-aligning.
-            //
-            // Use `std.simd.suggestVectorLength(T)` to get the same alignment as used in this function
-            // however this usually isn't necessary unless your arch has a performance penalty due to this.
-            //
-            // This may differ for other arch's. Arm for example costs a cycle when loading across a cache
-            // line so explicit alignment prologues may be worth exploration.
-
-            // Unrolling here is ~10% improvement. We can then do one bounds check every 2 blocks
-            // instead of one which adds up.
-            const Block = @Vector(block_len, T);
-            if (i + 2 * block_len < slice.len) {
-                const mask: Block = @splat(value);
-                while (true) {
-                    inline for (0..2) |_| {
-                        const block: Block = slice[i..][0..block_len].*;
-                        const matches = block == mask;
-                        if (@reduce(.Or, matches)) {
-                            return i + std.simd.firstTrue(matches).?;
-                        }
-                        i += block_len;
-                    }
-                    if (i + 2 * block_len >= slice.len) break;
-                }
-            }
-
-            // {block_len, block_len / 2} check
-            inline for (0..2) |j| {
-                const block_x_len = block_len / (1 << j);
-                comptime if (block_x_len < 4) break;
-
-                const BlockX = @Vector(block_x_len, T);
-                if (i + block_x_len < slice.len) {
-                    const mask: BlockX = @splat(value);
-                    const block: BlockX = slice[i..][0..block_x_len].*;
-                    const matches = block == mask;
-                    if (@reduce(.Or, matches)) {
-                        return i + std.simd.firstTrue(matches).?;
-                    }
-                    i += block_x_len;
-                }
-            }
-        }
-    }
+    if (scalarSimdOp(T, slice, value, &i, .index, {})) |index| return index;
 
     for (slice[i..], i..) |c, j| {
         if (c == value) return j;
@@ -1486,7 +1565,11 @@ fn boyerMooreHorspoolPreprocess(pattern: []const u8, table: *[256]usize) void {
 /// `lastIndexOfLinear` on small inputs.
 pub fn lastIndexOf(comptime T: type, haystack: []const T, needle: []const T) ?usize {
     if (needle.len > haystack.len) return null;
-    if (needle.len == 0) return haystack.len;
+    if (needle.len < 2) {
+        if (needle.len == 0) return haystack.len;
+        // lastIndexOfScalar is significantly faster than lastIndexOfLinear
+        return lastIndexOfScalar(T, haystack, needle[0]);
+    }
 
     if (!std.meta.hasUniqueRepresentation(T) or haystack.len < 52 or needle.len <= 4)
         return lastIndexOfLinear(T, haystack, needle);
@@ -1601,6 +1684,10 @@ test "indexOfPos empty needle" {
 /// does not count overlapping needles
 pub fn count(comptime T: type, haystack: []const T, needle: []const T) usize {
     assert(needle.len > 0);
+    if (needle.len == 1) {
+        return countScalar(T, haystack, needle[0]);
+    }
+
     var i: usize = 0;
     var found: usize = 0;
 
@@ -1626,6 +1713,29 @@ test count {
     try testing.expect(count(u8, "owowowu", "owowu") == 1);
 }
 
+/// Returns the number of needles inside the haystack
+//
+/// See also: `count`
+pub fn countScalar(comptime T: type, haystack: []const T, needle: T) usize {
+    var i: usize = 0;
+    var found: usize = 0;
+
+    _ = scalarSimdOp(T, haystack, needle, &i, .count, &found);
+
+    for (haystack[i..]) |c| {
+        if (c == needle) found += 1;
+    }
+
+    return found;
+}
+
+test countScalar {
+    try testing.expect(countScalar(u8, "", 'a') == 0);
+    try testing.expect(countScalar(u8, "a", 'a') == 1);
+    try testing.expect(countScalar(u8, "aa", 'a') == 2);
+    try testing.expect(countScalar(u8, "abbbabba", 'a') == 3);
+}
+
 /// Returns true if the haystack contains expected_count or more needles
 /// needle.len must be > 0
 /// does not count overlapping needles
@@ -1634,6 +1744,9 @@ test count {
 pub fn containsAtLeast(comptime T: type, haystack: []const T, expected_count: usize, needle: []const T) bool {
     assert(needle.len > 0);
     if (expected_count == 0) return true;
+    if (expected_count == 1) {
+        return containsAtLeastScalar(T, haystack, expected_count, needle[0]);
+    }
 
     var i: usize = 0;
     var found: usize = 0;
@@ -1668,12 +1781,20 @@ test containsAtLeast {
 pub fn containsAtLeastScalar(comptime T: type, haystack: []const T, expected_count: usize, needle: T) bool {
     if (expected_count == 0) return true;
 
-    var found: usize = 0;
+    var i: usize = 0;
+    var ctx: ScalarSimdOp.ContainsAtLeast = .{
+        .found = 0,
+        .needed = expected_count,
+    };
+    if (scalarSimdOp(T, haystack, needle, &i, .contains_at_least, &ctx)) |found_enough| {
+        std.mem.assert(found_enough);
+        return true;
+    }
 
-    for (haystack) |item| {
+    for (haystack[i..]) |item| {
         if (item == needle) {
-            found += 1;
-            if (found == expected_count) return true;
+            ctx.found += 1;
+            if (ctx.found == expected_count) return true;
         }
     }
 


### PR DESCRIPTION
Continued from #23889

All benchmarks compiled in `ReleaseFast` on `-target x86_64-linux-gnu` `-mcpu=haswell`.

```
echo 1 > data.bin
head -c 1G /dev/zero >> data.bin
echo 2 >> data.bin

head -c 1G /dev/urandom > data.bin
```

```zig
const std = @import("std");
pub fn main() !void {
    const file = try std.fs.cwd().openFile("data.bin", .{ .mode = .read_only });
    const buffer = try file.readToEndAlloc(std.heap.page_allocator, 1 << 48);

    for (0..20) |_| {
        std.mem.doNotOptimizeAway(std.mem.indexOfScalar(u8, buffer, '2'));

        // std.mem.doNotOptimizeAway(std.mem.containsAtLeastScalar(u8, buffer, 1 << 32, 0));

        // std.mem.doNotOptimizeAway(std.mem.count(u8, buffer, "\x00"));
        // std.mem.doNotOptimizeAway(std.mem.countScalar(u8, buffer, 0));

        // std.mem.doNotOptimizeAway(std.mem.lastIndexOfScalar(u8, buffer, '1'));
        // std.mem.doNotOptimizeAway(std.mem.lastIndexOf(u8, buffer, "1"));
    }
}
```


`indexOfScalar`:
```sh-session
$ hyperfine -w 2 -r 10 ./index-old ./index-new
Benchmark 1: ./index-old
  Time (mean ± σ):      1.914 s ±  0.031 s    [User: 1.551 s, System: 0.339 s]
  Range (min … max):    1.863 s …  1.970 s    10 runs
 
Benchmark 2: ./index-new
  Time (mean ± σ):      1.900 s ±  0.025 s    [User: 1.538 s, System: 0.338 s]
  Range (min … max):    1.876 s …  1.950 s    10 runs
 
Summary
  ./index-new ran
    1.01 ± 0.02 times faster than ./index-old
```

`containsAtLeastScalar`:
```sh-session
$ hyperfine -w 2 -r 10 ./contains-old ./contains-new
Benchmark 1: ./contains-old
  Time (mean ± σ):     17.224 s ±  0.050 s    [User: 16.916 s, System: 0.231 s]
  Range (min … max):   17.164 s … 17.321 s    10 runs
 
Benchmark 2: ./contains-new
  Time (mean ± σ):      1.826 s ±  0.018 s    [User: 1.584 s, System: 0.227 s]
  Range (min … max):    1.808 s …  1.853 s    10 runs
 
Summary
  ./contains-new ran
    9.43 ± 0.10 times faster than ./contains-old
```


`count`/`countScalar`:
```sh-session
$ hyperfine -w 2 -r 10 ./count-old ./count-new
Benchmark 1: ./count-old
 ⠸ Performing warmup runs         ██████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ ETA 00:03:35
^C
$ hyperfine -w 2 -r 10 ./count-new
Benchmark 1: ./count-new
  Time (mean ± σ):      1.775 s ±  0.016 s    [User: 1.533 s, System: 0.225 s]
  Range (min … max):    1.755 s …  1.806 s    10 runs
```

`lastIndexOf`/`lastIndexOfScalar`:
```sh-session
$ hyperfine -w 2 -r 10 ./last-index-scalar-old ./last-index-old ./last-index-new
Benchmark 1: ./last-index-scalar-old
  Time (mean ± σ):      8.408 s ±  0.038 s    [User: 8.119 s, System: 0.231 s]
  Range (min … max):    8.354 s …  8.477 s    10 runs
 
Benchmark 2: ./last-index-old
  Time (mean ± σ):     10.867 s ±  0.036 s    [User: 10.583 s, System: 0.226 s]
  Range (min … max):   10.817 s … 10.918 s    10 runs
 
Benchmark 3: ./last-index-new
  Time (mean ± σ):      1.696 s ±  0.013 s    [User: 1.452 s, System: 0.227 s]
  Range (min … max):    1.680 s …  1.716 s    10 runs
 
Summary
  ./last-index-new ran
    4.96 ± 0.04 times faster than ./last-index-scalar-old
    6.41 ± 0.05 times faster than ./last-index-old
```