### PR TITLE
std.Build: propagate added (system) library paths from dependencies

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1171,6 +1171,11 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                     }
                 }
 
+                // Inherit dependencies on library paths
+                for (mod.lib_paths.items) |path| {
+                    try zig_args.appendSlice(&.{ "-L", path.getPath2(mod.owner, step) });
+                }
+
                 // Inherit dependencies on system libraries and static libraries.
                 for (mod.link_objects.items) |link_object| {
                     switch (link_object) {


### PR DESCRIPTION
System libraries are already propagated in the same manner; it makes sense to additionally propagate the directories in which they are specified to be found (addLibraryPath).

Resolves the issue described at https://github.com/ziglang/zig/pull/23936#issuecomment-3288543092