### PR TITLE
compiler: fix ZIR hash not including compiler version

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -352,12 +352,17 @@ pub const Path = struct {
         gpa.free(p.sub_path);
     }
 
-    /// The returned digest is relocatable across any compiler process using the same lib and cache
+    /// The added data is relocatable across any compiler process using the same lib and cache
     /// directories; it does not depend on cwd.
-    pub fn digest(p: Path) Cache.BinDigest {
-        var h = Cache.hasher_init;
+    pub fn addToHasher(p: Path, h: *Cache.Hasher) void {
         h.update(&.{@intFromEnum(p.root)});
         h.update(p.sub_path);
+    }
+
+    /// Small convenience wrapper around `addToHasher`.
+    pub fn digest(p: Path) Cache.BinDigest {
+        var h = Cache.hasher_init;
+        p.addToHasher(&h);
         return h.finalResult();
     }
 

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -4239,13 +4239,6 @@ pub fn setFileRootType(zcu: *Zcu, file_index: File.Index, root_type: InternPool.
     files.view().items(.root_type)[file_index_unwrapped.index] = root_type;
 }
 
-pub fn filePathDigest(zcu: *const Zcu, file_index: File.Index) Cache.BinDigest {
-    const ip = &zcu.intern_pool;
-    const file_index_unwrapped = file_index.unwrap(ip);
-    const files = ip.getLocalShared(file_index_unwrapped.tid).files.acquire();
-    return files.view().items(.bin_digest)[file_index_unwrapped.index];
-}
-
 pub fn navSrcLoc(zcu: *const Zcu, nav_index: InternPool.Nav.Index) LazySrcLoc {
     const ip = &zcu.intern_pool;
     return .{

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -101,7 +101,15 @@ pub fn updateFile(
         .global_cache, .zig_lib => false,
     };
 
-    const hex_digest = Cache.binToHex(file.path.digest());
+    const hex_digest: Cache.HexDigest = d: {
+        var h: Cache.HashHelper = .{};
+        // As well as the file path, we also include the compiler version in case of backwards-incompatible ZIR changes.
+        file.path.addToHasher(&h.hasher);
+        h.addBytes(build_options.version);
+        h.add(builtin.zig_backend);
+        break :d h.final();
+    };
+
     const cache_directory = if (want_local_cache) zcu.local_zir_cache else zcu.global_zir_cache;
     const zir_dir = cache_directory.handle;
 


### PR DESCRIPTION
This was an unintentional regression in 23c8175 which meant that backwards-incompatible ZIR changes would have caused compiler crashes if old caches were present.