### PR TITLE
std.Build.Step.Run: inherit build runner cwd

### DIFF
--- a/lib/std/Build/Step/Run.zig
+++ b/lib/std/Build/Step/Run.zig
@@ -1334,9 +1334,6 @@ fn spawnChildAndCollect(
     var child = std.process.Child.init(argv, arena);
     if (run.cwd) |lazy_cwd| {
         child.cwd = lazy_cwd.getPath2(b, &run.step);
-    } else {
-        child.cwd = b.build_root.path;
-        child.cwd_dir = b.build_root.handle;
     }
     child.env_map = run.env_map orelse &b.graph.env_map;
     child.request_resource_usage_statistics = true;

--- a/test/standalone/options/build.zig
+++ b/test/standalone/options/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) void {
     }) });
 
     const options = b.addOptions();
-    main.addOptions("build_options", options);
+    main.root_module.addOptions("build_options", options);
     options.addOption(bool, "bool_true", b.option(bool, "bool_true", "t").?);
     options.addOption(bool, "bool_false", b.option(bool, "bool_false", "f").?);
     options.addOption(u32, "int", b.option(u32, "int", "i").?);

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1657,16 +1657,23 @@ pub fn addCliTests(b: *std.Build) *Step {
     }
 
     {
-        // TODO this should move to become a CLI test rather than standalone
-        //    cases.addBuildFile("test/standalone/options/build.zig", .{
-        //        .extra_argv = &.{
-        //            "-Dbool_true",
-        //            "-Dbool_false=false",
-        //            "-Dint=1234",
-        //            "-De=two",
-        //            "-Dstring=hello",
-        //        },
-        //    });
+        const run_test = b.addSystemCommand(&.{
+            b.graph.zig_exe,
+            "build",
+            "test",
+            "-Dbool_true",
+            "-Dbool_false=false",
+            "-Dint=1234",
+            "-De=two",
+            "-Dstring=hello",
+        });
+        run_test.addArg("--build-file");
+        run_test.addFileArg(b.path("test/standalone/options/build.zig"));
+        run_test.addArg("--cache-dir");
+        run_test.addFileArg(.{ .cwd_relative = b.cache_root.join(b.allocator, &.{}) catch @panic("OOM") });
+        run_test.setName("test build options");
+
+        step.dependOn(&run_test.step);
     }
 
     return step;


### PR DESCRIPTION
Right now, if you override the build root with `--build-root`, then `Run` steps can fail to execute because of incorrect path handling in the compiler: `std.process.Child` gets a cwd-relative path, but also has its cwd set to the build root. The latter behavior is really weird; it doesn't match my expectations, nor does it match how we spawn child `zig` processes. So, this commit makes the child process inherit the build runner's cwd, as `LazyPath.getPath2` *expects* it to.

After investigating, this behavior dates all the way back to 2017; it was introduced in 4543413. So, there isn't any clear/documented reason for this; it should be safe to revert, since under the modern `LazyPath` system it is strictly a bug AFAICT.