### PR TITLE
Fix connectUnix and allow passing connections to fetch()

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1406,7 +1406,7 @@ pub fn connectUnix(client: *Client, path: []const u8) ConnectUnixError!*Connecti
 
     const conn = try client.allocator.create(Connection);
     errdefer client.allocator.destroy(conn);
-    
+
     const stream = try std.net.connectUnixSocket(path);
     errdefer stream.close();
 
@@ -1707,6 +1707,9 @@ pub const FetchOptions = struct {
     raw_uri: bool = false,
     keep_alive: bool = true,
 
+    /// Must be an already acquired connection.
+    connection: ?*Connection = null,
+
     /// Standard headers that have default, but overridable, behavior.
     headers: Request.Headers = .{},
     /// These headers are kept including when following a redirect to a
@@ -1756,6 +1759,7 @@ pub fn fetch(client: *Client, options: FetchOptions) !FetchResult {
         .extra_headers = options.extra_headers,
         .privileged_headers = options.privileged_headers,
         .keep_alive = options.keep_alive,
+        .connection = options.connection,
     });
     defer req.deinit();
 

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1404,26 +1404,27 @@ pub fn connectUnix(client: *Client, path: []const u8) ConnectUnixError!*Connecti
     })) |node|
         return node;
 
-    const conn = try client.allocator.create(ConnectionPool.Node);
+    const conn = try client.allocator.create(Connection);
     errdefer client.allocator.destroy(conn);
-    conn.* = .{ .data = undefined };
-
+    
     const stream = try std.net.connectUnixSocket(path);
     errdefer stream.close();
 
-    conn.data = .{
+    conn.* = .{
         .stream = stream,
         .tls_client = undefined,
         .protocol = .plain,
 
         .host = try client.allocator.dupe(u8, path),
         .port = 0,
+
+        .pool_node = .{},
     };
-    errdefer client.allocator.free(conn.data.host);
+    errdefer client.allocator.free(conn.host);
 
     client.connection_pool.addUsed(conn);
 
-    return &conn.data;
+    return conn;
 }
 
 /// Connect to `tunnel_host:tunnel_port` using the specified proxy with HTTP


### PR DESCRIPTION
`connectUnix()` was broken by the changes to how we manage the connection pool that were made when length tracking was removed from `std.DoublyLinkedList`. If a developer attempted to use it currently, it would fail to compile due to it relying on incorrect types.

In addition, it was previously impossible to use the `client.fetch()` API to work with unix sockets. If a developer wanted to make a request on a socket, they were required to use the low-level request API via `client.open()`. This lead to code like the following:

```zig
fn createContainerRequest(
    allocator: Allocator,
    client: *http.Client,
    socket: []const u8,
) ![]u8 {
    var arena = ArenaAllocator.init(allocator);
    defer arena.deinit();

    const aa = arena.allocator();

    const uri = try std.Uri.parse("http://localhost/v1.49/containers/create");

    // SNIPPED:  const payload = ...
    const json = try std.json.stringifyAlloc(aa, payload, .{});

    const conn = try client.connectUnix(socket);

    var header_buffer = std.mem.zeroes([2048]u8);
    var req = try client.open(.POST, uri, .{
        .connection = conn,
        .server_header_buffer = &header_buffer,
        .headers = .{ .content_type = .{ .override = "application/json" } },
    });
    defer req.deinit();

    req.transfer_encoding = .{ .content_length = json.len };

    try req.send();
    try req.writeAll(json);
    try req.finish();
    try req.wait();

    var reader = req.reader();
    const res = try reader.readAllAlloc(aa, 4096);

    if (req.response.status.class() != .success) {
        std.debug.print("Error: {s}\n", .{res});
        return error.CreationFailed;
    }

    const container_res = try std.json.parseFromSliceLeaky(struct { Id: []u8 }, aa, res, .{
        .ignore_unknown_fields = true,
    });
    return try allocator.dupe(u8, container_res.Id);
}
```

If we allow developers to use the fetch API, the function body can be greatly simplified:

```zig
    var arena = ArenaAllocator.init(allocator);
    defer arena.deinit();

    const aa = arena.allocator();

    // SNIPPED: const payload = ...
    const json = try std.json.stringifyAlloc(aa, payload, .{});

    const conn = try client.connectUnix(socket);
    var data = std.ArrayList(u8).init(aa);

    const res = try client.fetch(.{
        .method = .POST,
        .connection = conn,
        .location = .{ .url = "http://localhost/v1.49/containers/create" },
        .headers = .{ .content_type = .{ .override = "application/json" } },
        .payload = json,
        .response_storage = .{
            .dynamic = &data,
        },
    });

    if (res.status.class() != .success) {
        std.debug.print("Error: {s}\n", .{data.items});
        return error.CreationFailed;
    }

    const container_res = try std.json.parseFromSliceLeaky(struct { Id: []u8 }, aa, data.items, .{
        .ignore_unknown_fields = true,
    });
    return try allocator.dupe(u8, container_res.Id);
```