### PR TITLE
Module: name builtin module root directory correctly

### DIFF
--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -430,7 +430,7 @@ pub fn createLimited(gpa: Allocator, options: LimitedOptions) Allocator.Error!*P
 
 /// Does not ensure that the module's root directory exists on-disk; see `Builtin.updateFileOnDisk` for that task.
 pub fn createBuiltin(arena: Allocator, opts: Builtin, dirs: Compilation.Directories) Allocator.Error!*Module {
-    const sub_path = "b" ++ Cache.binToHex(opts.hash());
+    const sub_path = "b" ++ std.fs.path.sep_str ++ Cache.binToHex(opts.hash());
     const new = try arena.create(Module);
     new.* = .{
         .root = try .fromRoot(arena, dirs, .global_cache, sub_path),


### PR DESCRIPTION
37a9a4e accidentally turned paths `b/[hash]/` into `b[hash]/` in the global cache. This doesn't technically break anything, but it pollutes the global cache directory. Sorry about that one!