### PR TITLE
std.Build: resolved generated paths are cwd-relative

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2443,12 +2443,12 @@ pub const GeneratedFile = struct {
     /// The step that generates the file
     step: *Step,
 
-    /// The path to the generated file. Must be either absolute or relative to the build root.
+    /// The path to the generated file. Must be either absolute or relative to the build runner cwd.
     /// This value must be set in the `fn make()` of the `step` and must not be `null` afterwards.
     path: ?[]const u8 = null,
 
     pub fn getPath(gen: GeneratedFile) []const u8 {
-        return gen.step.owner.pathFromRoot(gen.path orelse std.debug.panic(
+        return gen.step.owner.pathFromCwd(gen.path orelse std.debug.panic(
             "getPath() was called on a GeneratedFile that wasn't built yet. Is there a missing Step dependency on step '{s}'?",
             .{gen.step.name},
         ));


### PR DESCRIPTION
The doc comment here agreed with the implementation, but not with *any* `Step` which populates a `GeneratedFile`, where they are treated as cwd-relative. This is the obvious correct choice, because these paths usually come from joining onto a cache root, and those are cwd-relative if not absolute.

This was a pre-existing bug, but #23836 caused it to trigger more often, because the compiler now commonly passes the local cache directory to the build runner process as a relative path where it was previously an absolute path.

Resolves: #23954