### PR TITLE
std.zig.LibCDirs: fix wasi-libc support

### DIFF
--- a/lib/std/zig/LibCDirs.zig
+++ b/lib/std/zig/LibCDirs.zig
@@ -168,7 +168,7 @@ pub fn detectFromBuilding(
 
     const generic_name = libCGenericName(target);
     // Some architecture families are handled by the same set of headers.
-    const arch_name = if (target.isMuslLibC())
+    const arch_name = if (target.isMuslLibC() or target.isWasiLibC())
         std.zig.target.muslArchNameHeaders(target.cpu.arch)
     else if (target.isFreeBSDLibC())
         std.zig.target.freebsdArchNameHeaders(target.cpu.arch)


### PR DESCRIPTION
https://github.com/ziglang/zig/commit/01390cc533b471c5a8ad13b8b1380a508b630fef mistakenly omitted wasi-libc, which has led to the incorrect use of `libc/include/wasm32-wasi-musl` instead of `libc/include/wasm-wasi-musl`.