### PR TITLE
std (posix): support for `wait()` (any process termination)

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4393,9 +4393,7 @@ pub const WaitPidResult = struct {
     status: u32,
 };
 
-const Rc = if (builtin.link_libc)
-    c_int else
-    u32;
+const Rc = if (builtin.link_libc) c_int else u32;
 
 /// Use this version of the `waitpid` wrapper if you spawned your child process using explicit
 /// `fork` and `execve` method.
@@ -4424,7 +4422,8 @@ pub fn wait(flags: u32) ?WaitPidResult {
         const rc = system.waitpid(-1, &status, @intCast(flags));
         switch (errno(rc)) {
             .SUCCESS => return if (rc != 0)
-                .{ .pid = @intCast(rc), .status = @bitCast(status) } else
+                .{ .pid = @intCast(rc), .status = @bitCast(status) }
+            else
                 null,
             .INTR => continue,
             .CHILD => return null, // For WNOHANG, where waitpid() returns immediately if no process already terminated. Null without WNOHANG is impossible.

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4412,6 +4412,25 @@ pub fn waitpid(pid: pid_t, flags: u32) WaitPidResult {
     }
 }
 
+/// Waits for the termination of any child process. If WNOHANG is supplied as flag and no process
+/// was already terminated, returns null.
+pub fn wait(flags: u32) ?WaitPidResult {
+    var status: if (builtin.link_libc) c_int else u32 = undefined;
+    while (true) {
+        const rc = system.waitpid(-1, &status, @intCast(flags));
+        switch (errno(rc)) {
+            .SUCCESS => return .{
+                .pid = @intCast(rc),
+                .status = @bitCast(status),
+            },
+            .INTR => continue,
+            .CHILD => return null, // For WNOHANG, where waitpid() returns immediately if no process already terminated. Null without WNOHANG is impossible.
+            .INVAL => unreachable, // Invalid flags.
+            else => unreachable,
+        }
+    }
+}
+
 pub fn wait4(pid: pid_t, flags: u32, ru: ?*rusage) WaitPidResult {
     var status: if (builtin.link_libc) c_int else u32 = undefined;
     while (true) {

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4393,10 +4393,14 @@ pub const WaitPidResult = struct {
     status: u32,
 };
 
+const Rc = if (builtin.link_libc)
+    c_int else
+    u32;
+
 /// Use this version of the `waitpid` wrapper if you spawned your child process using explicit
 /// `fork` and `execve` method.
 pub fn waitpid(pid: pid_t, flags: u32) WaitPidResult {
-    var status: if (builtin.link_libc) c_int else u32 = undefined;
+    var status: Rc = undefined;
     while (true) {
         const rc = system.waitpid(pid, &status, @intCast(flags));
         switch (errno(rc)) {
@@ -4415,7 +4419,7 @@ pub fn waitpid(pid: pid_t, flags: u32) WaitPidResult {
 /// Waits for the termination of any child process. If WNOHANG is supplied as flag and no process
 /// was already terminated, returns null.
 pub fn wait(flags: u32) ?WaitPidResult {
-    var status: if (builtin.link_libc) c_int else u32 = undefined;
+    var status: Rc = undefined;
     while (true) {
         const rc = system.waitpid(-1, &status, @intCast(flags));
         switch (errno(rc)) {

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4423,10 +4423,9 @@ pub fn wait(flags: u32) ?WaitPidResult {
     while (true) {
         const rc = system.waitpid(-1, &status, @intCast(flags));
         switch (errno(rc)) {
-            .SUCCESS => return .{
-                .pid = @intCast(rc),
-                .status = @bitCast(status),
-            },
+            .SUCCESS => return if (rc != 0)
+                .{ .pid = @intCast(rc), .status = @bitCast(status) } else
+                null,
             .INTR => continue,
             .CHILD => return null, // For WNOHANG, where waitpid() returns immediately if no process already terminated. Null without WNOHANG is impossible.
             .INVAL => unreachable, // Invalid flags.

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1184,10 +1184,9 @@ test "wait waits for all terminated processes" {
     if (native_os == .wasi) return error.SkipZigTest;
     if (native_os == .windows) return error.SkipZigTest;
 
-    const flags = switch (builtin.os.tag) {
-        .linux => linux.W.NOHANG,
-        else => 0
-    };
+    const flags = if (@hasDecl(posix.W, "NOHANG"))
+        posix.W.NOHANG else
+        0;
 
     const pid1 = try posix.fork();
     if (pid1 == 0) posix.exit(0);

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1180,11 +1180,30 @@ test "POSIX file locking with fcntl" {
     }
 }
 
+test "waitpid waits for the designated process" {
+    if (native_os == .wasi) return error.SkipZigTest;
+    if (native_os == .windows) return error.SkipZigTest;
+
+    const pid1 = try posix.fork();
+    if (pid1 == 0) posix.exit(0);
+
+    try expect(posix.waitpid(pid1, 0).pid == pid1);
+
+    const pid2 = try posix.fork();
+    const pid3 = try posix.fork();
+    if (pid2 == 0) posix.exit(0);
+    if (pid3 == 0) posix.exit(0);
+
+    // out of order:
+    try expect(posix.waitpid(pid3, 0).pid == pid3);
+    try expect(posix.waitpid(pid2, 0).pid == pid2);
+}
+
 test "wait waits for all terminated processes" {
     if (native_os == .wasi) return error.SkipZigTest;
     if (native_os == .windows) return error.SkipZigTest;
 
-    const flags = if (@hasDecl(posix.W, "NOHANG"))
+    const nohang = if (@hasDecl(posix.W, "NOHANG"))
         posix.W.NOHANG else
         0;
 
@@ -1194,9 +1213,9 @@ test "wait waits for all terminated processes" {
     const pid2 = try posix.fork();
     if (pid2 == 0) posix.exit(0);
 
-    try expect(posix.wait(flags) != null);
-    try expect(posix.wait(flags) != null);
-    try expect(posix.wait(flags) == null);
+    try expect(posix.wait(0) != null);
+    try expect(posix.wait(0) != null);
+    try expect(posix.wait(nohang) == null);
 }
 
 test "rename smoke test" {

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1204,7 +1204,8 @@ test "wait waits for all terminated processes" {
     if (native_os == .windows) return error.SkipZigTest;
 
     const nohang = if (@hasDecl(posix.W, "NOHANG"))
-        posix.W.NOHANG else
+        posix.W.NOHANG
+    else
         0;
 
     const pid1 = try posix.fork();

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1180,6 +1180,26 @@ test "POSIX file locking with fcntl" {
     }
 }
 
+test "wait waits for all terminated processes" {
+    if (native_os == .wasi) return error.SkipZigTest;
+    if (native_os == .windows) return error.SkipZigTest;
+
+    const flags = switch (builtin.os.tag) {
+        .linux => linux.W.NOHANG,
+        else => 0
+    };
+
+    const pid1 = try posix.fork();
+    if (pid1 == 0) posix.exit(0);
+
+    const pid2 = try posix.fork();
+    if (pid2 == 0) posix.exit(0);
+
+    try expect(posix.wait(flags) != null);
+    try expect(posix.wait(flags) != null);
+    try expect(posix.wait(flags) == null);
+}
+
 test "rename smoke test" {
     if (native_os == .wasi) return error.SkipZigTest;
     if (native_os == .windows) return error.SkipZigTest;

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1202,6 +1202,7 @@ test "waitpid waits for the designated process" {
 test "wait waits for all terminated processes" {
     if (native_os == .wasi) return error.SkipZigTest;
     if (native_os == .windows) return error.SkipZigTest;
+    if ((builtin.cpu.arch == .riscv32 or builtin.cpu.arch.isLoongArch()) and builtin.os.tag == .linux and !builtin.link_libc) return error.SkipZigTest; // No `wait4` natively.
 
     const pid1 = try posix.fork();
     if (pid1 == 0) posix.exit(0);

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1203,11 +1203,6 @@ test "wait waits for all terminated processes" {
     if (native_os == .wasi) return error.SkipZigTest;
     if (native_os == .windows) return error.SkipZigTest;
 
-    const nohang = if (@hasDecl(posix.W, "NOHANG"))
-        posix.W.NOHANG
-    else
-        0;
-
     const pid1 = try posix.fork();
     if (pid1 == 0) posix.exit(0);
 
@@ -1216,7 +1211,10 @@ test "wait waits for all terminated processes" {
 
     try expect(posix.wait(0) != null);
     try expect(posix.wait(0) != null);
-    try expect(posix.wait(nohang) == null);
+
+    if (!@hasDecl(posix.W, "NOHANG"))
+        return error.SkipZigTest;
+    try expect(posix.wait(posix.W.NOHANG) == null);
 }
 
 test "rename smoke test" {


### PR DESCRIPTION
With the implementation of `std.posix.waitpid(pid:, flags:)`, the use of `-1` will crash as unreachable (due to errno of `CHILD`) if there's no terminated children instead of allowing it to be defined behaviour and return a pid of 0.

The documentation of the [`waitpid`](https://www.man7.org/linux/man-pages/man2/waitpid.2.html) syscall states:

```
       The waitpid() system call suspends execution of the calling thread
       until a child specified by pid argument has changed state.  By
       default, waitpid() waits only for terminated children, but this
       behavior is modifiable via the options argument, as described
       below.
```

For example, the nginx worker process `SIGCHLD` handler uses something like ([source](https://github.com/nginx/nginx/blob/6a134dfd4888fc3850d22294687cfb3940994c69/src/os/unix/ngx_process.c#L482-L487)):

```c
for ( ;; ) {
    pid = waitpid(-1, &status, WNOHANG);

    if (pid == 0) {
        return;
    }

    // ... rest omitted
}
```

The reasoning for using `wait(flags:)` as name is due to the documented behaviour of:

```
       The wait() system call suspends execution of the calling thread
       until one of its children terminates.  The call wait(&wstatus) is
       equivalent to:

           waitpid(-1, &wstatus, 0);
```

This change allow daemons/monitor processes to respawn their forks when they exit by querying all currently-terminated processes, and ignore/continue when there aren't any.

I'm currently using this PR's change for a company project, functioning correctly indicated by these logs (tested on both Linux and macOS, still need verification for other POSIX-compliant operating systems):

```bash
~/redacted-company/MultiMedia$ zig-out/bin/managedmultimedia foo bar --ifsf awd
start worker processes
MultiMedia: start worker process 29200
Event-Proxy: start worker process 29201
signal 20 received
Event-Proxy (29201): exited with status 0
MultiMedia (29200): exited with status 0
```

The usage within a `SIGCHLD` handler, for example:

```zig
while (std.posix.wait(flags)) |result|
    on_exit(result.pid, result.status);
```