### PR TITLE
avoid being tricked that Build.zig is build.zig

### DIFF
--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -201,6 +201,9 @@
         .config_header = .{
             .path = "config_header",
         },
+        .case_insensitive = .{
+            .path = "case_insensitive",
+        },
     },
     .paths = .{
         "build.zig",

--- a/test/standalone/case_insensitive/build.zig
+++ b/test/standalone/case_insensitive/build.zig
@@ -1,0 +1,27 @@
+pub fn build(b: *std.Build) !void {
+    const run_zig_build = b.addSystemCommand(&[_][]const u8{
+        b.graph.zig_exe,
+        "build",
+        "printfoo",
+    });
+    run_zig_build.setCwd(b.path("capital"));
+    run_zig_build.expectStdOutEqual("Foo\n");
+    b.default_step.dependOn(&run_zig_build.step);
+
+    const printfoo = try b.allocator.create(std.Build.Step);
+    printfoo.* = std.Build.Step.init(.{
+        .id = .custom,
+        .name = "printfoo",
+        .owner = b,
+        .makeFn = printFoo,
+    });
+    b.step("printfoo", "").dependOn(printfoo);
+}
+
+fn printFoo(step: *std.Build.Step, options: std.Build.Step.MakeOptions) anyerror!void {
+    _ = step;
+    _ = options;
+    try std.io.getStdOut().writer().writeAll("Foo\n");
+}
+
+const std = @import("std");

--- a/test/standalone/case_insensitive/capital/Build.zig
+++ b/test/standalone/case_insensitive/capital/Build.zig
@@ -1,0 +1,3 @@
+comptime {
+    @compileError("Don't be tricked into thinking this is build.zig, it's Build.zig!");
+}


### PR DESCRIPTION
Updates `findBuildRoot` to skip `build.zig` entries if the case doesn't match. It does this by iterating over the parent directory and verifying that an entry with the same case exists.

fixes #23980

![image](https://github.com/user-attachments/assets/933090ec-a3b4-4e0e-8b9f-950a16018286)

