### PR TITLE
Package: support and extract `jar` files like `zip` files

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -908,6 +908,7 @@ const FileType = enum {
         if (ascii.endsWithIgnoreCase(file_path, ".tzst")) return .@"tar.zst";
         if (ascii.endsWithIgnoreCase(file_path, ".tar.zst")) return .@"tar.zst";
         if (ascii.endsWithIgnoreCase(file_path, ".zip")) return .zip;
+        if (ascii.endsWithIgnoreCase(file_path, ".jar")) return .zip;
         return null;
     }
 
@@ -1128,6 +1129,9 @@ fn unpackResource(
                 break :ft .@"tar.zst";
 
             if (ascii.eqlIgnoreCase(mime_type, "application/zip"))
+                break :ft .zip;
+
+            if (ascii.eqlIgnoreCase(mime_type, "application/java-archive"))
                 break :ft .zip;
 
             if (!ascii.eqlIgnoreCase(mime_type, "application/octet-stream") and


### PR DESCRIPTION
### What this PR does ?

This PR make the `zig fetch` command but also the zig package system handle `jar` like `zip`

### A tiny story on why I make this PR

In one of my personal project, I used zig to make a cross platform audio player engine where FFmpeg was linked to my zig executable as a shared library.

Since the zig build system and package manager are so powerful, I'm able to directly fetch from the Internet my prebuild binaries of FFmpeg in my zig build so I could link them and install them along my executable.

Everything was fine for IOS, MacOS and even windows since I could download `zip` and `tar` but for my Android build the library was shared with `jar` file since some others android project could directly find the `include` and `lib` directories.

However when I try to fetch my `jar` file to extract manually the `include` and `lib` directories from github I got this error :
```
error: unsupported Content-Disposition header value: 'attachment; filename=default-arm64-v8a.jar' for Content-Type=application/octet-stream
```

I understand jar file are more than zip file but I still think `zig` should be able to understand them like regular `zip`. (If I take a `jar` and use `unzip` on it it's just works)

Maybe I'm wrong and also this is the first time I contribute here but I didn't see anyone discuss about that and since it was simple to add the `mime-type` and the file extension recognition as `zip`

I still hope you will find this PR interesting ^^