### PR TITLE
`std.posix`: unlock nonblocking `connect()` use case

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4274,6 +4274,7 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
         const rc = windows.ws2_32.connect(sock, sock_addr, @intCast(len));
         if (rc == 0) return;
         switch (windows.ws2_32.WSAGetLastError()) {
+            .WSAEISCONN => return,
             .WSAEADDRINUSE => return error.AddressInUse,
             .WSAEADDRNOTAVAIL => return error.AddressNotAvailable,
             .WSAECONNREFUSED => return error.ConnectionRefused,
@@ -4284,9 +4285,9 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
             => return error.NetworkUnreachable,
             .WSAEFAULT => unreachable,
             .WSAEINVAL => unreachable,
-            .WSAEISCONN => unreachable,
             .WSAENOTSOCK => unreachable,
             .WSAEWOULDBLOCK => return error.WouldBlock,
+            .WSAEALREADY => return error.ConnectionPending,
             .WSAEACCES => unreachable,
             .WSAENOBUFS => return error.SystemResources,
             .WSAEAFNOSUPPORT => return error.AddressFamilyNotSupported,
@@ -4298,6 +4299,7 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
     while (true) {
         switch (errno(system.connect(sock, sock_addr, len))) {
             .SUCCESS => return,
+            .ISCONN => return,
             .ACCES => return error.AccessDenied,
             .PERM => return error.PermissionDenied,
             .ADDRINUSE => return error.AddressInUse,
@@ -4310,7 +4312,6 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
             .CONNRESET => return error.ConnectionResetByPeer,
             .FAULT => unreachable, // The socket structure address is outside the user's address space.
             .INTR => continue,
-            .ISCONN => unreachable, // The socket is already connected.
             .HOSTUNREACH => return error.NetworkUnreachable,
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.


### PR DESCRIPTION
Match Windows `WSAEALREADY` with Linux `EALREADY`
return gracefully when socket reports it is connected

for easy reference the [msdn page](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect) and the [man page](https://man7.org/linux/man-pages/man2/connect.2.html).

The msdn page also says that `WSAEINVAL` should be handled the same due to ambiguities. The `WSAConnect` api doesn't mention the same in the documentation. Is that a reason to change to `WSAConnect`?