### PR TITLE
debug: disable fp-based frame unwinding when fp is omitted

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -932,6 +932,8 @@ pub const StackIterator = struct {
             }
         }
 
+        if (builtin.omit_frame_pointer) return null;
+
         const fp = if (comptime native_arch.isSPARC())
             // On SPARC the offset is positive. (!)
             math.add(usize, it.fp, fp_offset) catch return null


### PR DESCRIPTION
This has been causing non-deterministic timeouts on aarch64 CI.