### PR TITLE
update `zig env` to respect `ZIG_LIB_DIR` and support wasi

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -360,7 +360,12 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
         dev.check(.env_command);
         verifyLibcxxCorrectlyLinked();
         var stdout_writer = fs.File.stdout().writer(&stdout_buffer);
-        try @import("print_env.zig").cmdEnv(arena, &stdout_writer.interface);
+        try @import("print_env.zig").cmdEnv(
+            arena,
+            &stdout_writer.interface,
+            args,
+            if (native_os == .wasi) wasi_preopens,
+        );
         return stdout_writer.interface.flush();
     } else if (mem.eql(u8, cmd, "reduce")) {
         return jitCmd(gpa, arena, cmd_args, .{


### PR DESCRIPTION
The `zig env` command does not respect the `ZIG_LIB_DIR` environment variable which seems to be unintentional as the similar `ZIG_GLOBAL_CACHE_DIR` variable is being handled as expected. 

With the recent addition of `Compilation.Directories`, I also went ahead and made `zig env` runnable on wasi to make some progress on #20665. Here is how the output `wasmtime run --dir=lib::/lib --dir=cache::/cache build/stage4-wasi/bin/zig.wasm env` looks like:

```json
{
 "zig_exe": "zig.wasm",
 "lib_dir": "/lib",
 "std_dir": "/lib/std",
 "global_cache_dir": "/cache",
 "version": "0.15.0-dev.650+4f3b59f70",
 "target": "wasm32-wasi.0.1...0.2.2-musl",
 "env": {
  "ZIG_GLOBAL_CACHE_DIR": null,
  "ZIG_LOCAL_CACHE_DIR": null,
  "ZIG_LIB_DIR": null,
  "ZIG_LIBC": null,
  "ZIG_BUILD_RUNNER": null,
  "ZIG_VERBOSE_LINK": null,
  "ZIG_VERBOSE_CC": null,
  "ZIG_BTRFS_WORKAROUND": null,
  "ZIG_DEBUG_CMD": null,
  "CC": null,
  "NO_COLOR": null,
  "CLICOLOR_FORCE": null,
  "XDG_CACHE_HOME": null,
  "HOME": null
 }
}
```

To test these changes on `wasm32-wasi`, I had to edit `src/dev.zig` to only enable the `.env_command` feature.