### PR TITLE
std.Build.Step.ConfigHeader: handle undefined keys and values correctly

### DIFF
--- a/test/standalone/cmakedefine/config.h.in
+++ b/test/standalone/cmakedefine/config.h.in
@@ -46,13 +46,16 @@
 
 // @ substition
 
-// no substition
+// // undefined key, removed
+// @undefvalue@
+
+// no value, removed
 // @noval@
 
-// no substition
+// no value, removed
 // @noval@@noval@
 
-// no substition
+// no value, removed
 // @noval@.@noval@
 
 // 1
@@ -94,13 +97,16 @@
 // test10
 // @noval@@stringval@@trueval@@zeroval@
 
-// no substition
+// undefined key, removed
+// ${undefvalue}
+
+// no value, removed
 // ${noval}
 
-// no substition
+// no value, removed
 // ${noval}${noval}
 
-// no substition
+// no value, removed
 // ${noval}.${noval}
 
 // 1

--- a/test/standalone/cmakedefine/expected_config.h
+++ b/test/standalone/cmakedefine/expected_config.h
@@ -46,13 +46,16 @@
 
 // @ substition
 
-// no substition
+// // undefined key, removed
 // 
 
-// no substition
+// no value, removed
 // 
 
-// no substition
+// no value, removed
+// 
+
+// no value, removed
 // .
 
 // 1
@@ -94,13 +97,16 @@
 // test10
 // test10
 
-// no substition
+// undefined key, removed
 // 
 
-// no substition
+// no value, removed
 // 
 
-// no substition
+// no value, removed
+// 
+
+// no value, removed
 // .
 
 // 1


### PR DESCRIPTION
We intend to mimic the behavior of cmake which means we need to handle undefined keys and values the same

Zulip thread where I brought this up
https://zsf.zulipchat.com/#narrow/channel/454371-std/topic/ConfigHeader.20strictness/near/520861756

Here is a repo that where the output of cmake and zig is compared https://github.com/Jan200101/cmakedefine-test

on master running `zig_diff.sh` erors out while with this PR it outputs a matching file (minus header comment)

the cmakedefine standalone test was also modified to include a CMakeLists build solution to generate the expected headers and to test for undefined keys.