### PR TITLE
`ci`: Revert `aarch64-linux` timeout to GitHub's default 6 hours.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
       - name: Build and Test
         run: sh ci/x86_64-linux-release.sh
   aarch64-linux-debug:
-    timeout-minutes: 540
     runs-on: [self-hosted, Linux, aarch64]
     steps:
       - name: Checkout
@@ -37,7 +36,6 @@ jobs:
       - name: Build and Test
         run: sh ci/aarch64-linux-debug.sh
   aarch64-linux-release:
-    timeout-minutes: 540
     runs-on: [self-hosted, Linux, aarch64]
     steps:
       - name: Checkout


### PR DESCRIPTION
We don't seem to be getting non-deterministic hangs since 4f3b59f, and e28b402 cut the run times significantly on top of that. Runs now seem to take around 1-2 hours, so the default timeout should be plenty.