### PR TITLE
std.fmt.format: add "D" specifier: decimal with custom thousands separator

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -63,7 +63,7 @@ pub const FormatOptions = struct {
 ///   - for slices of u8, print the entire slice as a string without zero-termination
 /// - `e`: output floating point value in scientific notation
 /// - `d`: output numeric value in decimal notation
-/// - `D`: output numeric value in decimal notation with thousands separator charactor defaulting to comma. Use D[seperator] to use custom separator, example: D_
+/// - `D`: output numeric value in decimal notation with thousands separator defaulting to comma. Use D[seperator] to use custom separator, example: D_
 /// - `b`: output integer value in binary notation
 /// - `o`: output integer value in octal notation
 /// - `c`: output integer as an ASCII character. Integer type must have 8 bits at max.

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -63,7 +63,7 @@ pub const FormatOptions = struct {
 ///   - for slices of u8, print the entire slice as a string without zero-termination
 /// - `e`: output floating point value in scientific notation
 /// - `d`: output numeric value in decimal notation
-/// - `D`: output numeric value in decimal notation with thousands separator defaulting to comma. Use D[seperator] to use custom separator, example: D_
+/// - `D`: output numeric value in decimal notation with thousands separator defaulting to underscore. Use D[seperator] to use custom separator, example: {D,}
 /// - `b`: output integer value in binary notation
 /// - `o`: output integer value in octal notation
 /// - `c`: output integer as an ASCII character. Integer type must have 8 bits at max.
@@ -754,7 +754,7 @@ pub fn formatIntValue(
     } else if (comptime fmt[0] == 'D') {
         var o = options;
         if (fmt.len > 2) @compileError("thousands seperator should be 1 character, got " ++ fmt[1..]);
-        o.thousands_sep = if (fmt.len == 2) fmt[1] else ',';
+        o.thousands_sep = if (fmt.len == 2) fmt[1] else '_';
         return formatInt(int_value, base, case, o, writer);
     } else if (comptime std.mem.eql(u8, fmt, "c")) {
         if (@typeInfo(@TypeOf(int_value)).int.bits <= 8) {
@@ -810,7 +810,7 @@ fn formatFloatValue(
         };
         return formatBuf(s, options, writer);
     } else if (comptime std.mem.eql(u8, fmt[0..1], "D")) {
-        const s = formatFloat(&buf, value, .{ .mode = .decimal, .precision = options.precision, .thousands_sep = if (fmt.len > 1) fmt[2] else ',' }) catch |err| switch (err) {
+        const s = formatFloat(&buf, value, .{ .mode = .decimal, .precision = options.precision, .thousands_sep = if (fmt.len > 1) fmt[2] else '_' }) catch |err| switch (err) {
             error.BufferTooSmall => "(float)",
         };
         return formatBuf(s, options, writer);
@@ -3036,16 +3036,16 @@ test "parser specifier" {
 }
 
 test "thousands seperator" {
-    try expectFmt("1,234,567", "{D}", .{1234567});
-    try expectFmt("12,345,678", "{D}", .{12345678});
-    try expectFmt("123,456,789", "{D}", .{123456789});
-    try expectFmt("1,234,567,890", "{D}", .{1234567890});
+    try expectFmt("1_234_567", "{D}", .{1234567});
+    try expectFmt("12_345_678", "{D}", .{12345678});
+    try expectFmt("123_456_789", "{D}", .{123456789});
+    try expectFmt("1_234_567_890", "{D}", .{1234567890});
 
-    try expectFmt(" 1,234,567", "{D:10}", .{1234567});
-    try expectFmt(" 1,234,567.9", "{D:12.1}", .{1234567.89});
+    try expectFmt(" 1_234_567", "{D:10}", .{1234567});
+    try expectFmt(" 1_234_567.9", "{D:12.1}", .{1234567.89});
 
-    try expectFmt("1_234_567", "{D_}", .{1234567});
+    try expectFmt("1,234,567", "{D,}", .{1234567});
     try expectFmt("1.234.567", "{D.}", .{1234567});
 
-    try expectFmt(" 1_234_567", "{D_:10}", .{1234567});
+    try expectFmt(" 1,234,567", "{D,:10}", .{1234567});
 }

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -63,7 +63,7 @@ pub const FormatOptions = struct {
 ///   - for slices of u8, print the entire slice as a string without zero-termination
 /// - `e`: output floating point value in scientific notation
 /// - `d`: output numeric value in decimal notation
-/// - `D`: output numeric value in decimal notation with thousands separator defaulting to underscore. Use D[seperator] to use custom separator, example: {D,}
+/// - `D`: output numeric value in decimal notation with thousands separator defaulting to underscore. Use D[seperator] for custom separator, example: {D,}
 /// - `b`: output integer value in binary notation
 /// - `o`: output integer value in octal notation
 /// - `c`: output integer as an ASCII character. Integer type must have 8 bits at max.

--- a/lib/std/fmt/format_float.zig
+++ b/lib/std/fmt/format_float.zig
@@ -116,7 +116,7 @@ fn writeDecimal(buf: []u8, value: anytype, count_: usize, thousands_sep: ?u8) vo
 
     while (i < count) : (i += 1) {
         if (thousands_sep != null and i % 4 == 3) {
-            buf[count - i - 1] = ',';
+            buf[count - i - 1] = '_';
             i += 1;
         }
         const c: u8 = @intCast(value.* % 10);
@@ -1710,7 +1710,7 @@ test "format float to decimal with zero precision" {
 fn checkThousandsSep(value: f64, expected: []const u8) !void {
     var buf: [100]u8 = undefined;
     const options: FormatOptions = .{
-        .thousands_sep = ',',
+        .thousands_sep = '_',
         .mode = .decimal,
     };
     const str = try formatFloat(&buf, value, options);
@@ -1718,14 +1718,14 @@ fn checkThousandsSep(value: f64, expected: []const u8) !void {
 }
 
 test "format float with thousands seperator" {
-    try checkThousandsSep(123456, "123,456");
-    try checkThousandsSep(1234567, "1,234,567");
-    try checkThousandsSep(12345678, "12,345,678");
-    try checkThousandsSep(123456789, "123,456,789");
-    try checkThousandsSep(123456789.123, "123,456,789.123");
-    try checkThousandsSep(12345678.9123, "12,345,678.9123");
-    try checkThousandsSep(1234567.89123, "1,234,567.89123");
-    try checkThousandsSep(123456.789123, "123,456.789123");
+    try checkThousandsSep(123456, "123_456");
+    try checkThousandsSep(1234567, "1_234_567");
+    try checkThousandsSep(12345678, "12_345_678");
+    try checkThousandsSep(123456789, "123_456_789");
+    try checkThousandsSep(123456789.123, "123_456_789.123");
+    try checkThousandsSep(12345678.9123, "12_345_678.9123");
+    try checkThousandsSep(1234567.89123, "1_234_567.89123");
+    try checkThousandsSep(123456.789123, "123_456.789123");
     try checkThousandsSep(0.123456789, "0.123456789");
     try checkThousandsSep(0.12345678, "0.12345678");
     try checkThousandsSep(0.1234567, "0.1234567");


### PR DESCRIPTION
Thousands separator defaults to underscore:

```zig
std.debug.print("{D}", .{123456789});
// 123_456_789

std.debug.print("{D}", .{1234567.89});
// 1_234_567.89
```

Use D[separator] for custom separator, example: `"{D,}"`

```zig
std.debug.print("{D,}", .{123456789});
// 123,456,789

std.debug.print("{D.}", .{123456789});
// 123.456.789

std.debug.print("{D }", .{123456789});
// 123 456 789
```
