### PR TITLE
std (posix): lower `getpid` and `getppid` into `std.posix`

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -4412,6 +4412,18 @@ pub fn waitpid(pid: pid_t, flags: u32) WaitPidResult {
     }
 }
 
+pub fn getpid() pid_t {
+    if (@hasDecl(system, "getpid"))
+        return system.getpid();
+    @compileError("getpid() not yet implemented for target system");
+}
+
+pub fn getppid() pid_t {
+    if (@hasDecl(system, "getppid"))
+        return system.getppid();
+    @compileError("getppid() not yet implemented for target system");
+}
+
 pub fn wait4(pid: pid_t, flags: u32, ru: ?*rusage) WaitPidResult {
     var status: if (builtin.link_libc) c_int else u32 = undefined;
     while (true) {

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1180,6 +1180,27 @@ test "POSIX file locking with fcntl" {
     }
 }
 
+test "posix getpid" {
+    if (!@hasDecl(posix.system, "getpid"))
+        return error.SkipZigTest;
+
+    try expect(posix.getpid() != 0);
+}
+
+test "posix getppid" {
+    if (!@hasDecl(posix.system, "getppid"))
+        return error.SkipZigTest;
+
+    const parent = posix.getpid();
+    const child = try posix.fork();
+    if (child == 0)
+        posix.exit(if (parent == posix.getppid()) 0 else 1);
+
+    const result = posix.waitpid(child, 0);
+    try expect(result.pid != 0);
+    try expect(result.status == 0);
+}
+
 test "rename smoke test" {
     if (native_os == .wasi) return error.SkipZigTest;
     if (native_os == .windows) return error.SkipZigTest;


### PR DESCRIPTION
Simply puts `getpid()` and `getppid()` into `std.posix` by making use of `posix.system` if available. Removes a tiny bit of boilerplate when making cross-Darwin-Linux platform stuff by not referencing `std.c` or `std.os.linux` directly.

Also adds a proper test for `getppid()`. Kind of depends on `fork()` and `waitpid()` but I'm not sure what the policy of inter-dependent tests are.