### PR TITLE
x86_64: fix broken unit test for register IDs

### DIFF
--- a/src/arch/x86_64/bits.zig
+++ b/src/arch/x86_64/bits.zig
@@ -680,7 +680,7 @@ test "Register id - different classes" {
     try expect(Register.xmm0.id() != Register.mm0.id());
     try expect(Register.mm0.id() != Register.st0.id());
 
-    try expect(Register.es.id() == 0b110000);
+    try expect(Register.es.id() == 0b1000000);
 }
 
 test "Register enc - different classes" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -37,6 +37,7 @@ const dev = @import("dev.zig");
 
 test {
     _ = Package;
+    _ = @import("arch/x86_64/Mir.zig");
 }
 
 const thread_stack_size = 50 << 20;


### PR DESCRIPTION
Fixes: 7a2963efabfe ("x86_64: add avx512 registers")
