### PR TITLE
std.Build.Step.ConfigHeader: handle empty keys more permissively

### DIFF
--- a/test/standalone/cmakedefine/config.h.in
+++ b/test/standalone/cmakedefine/config.h.in
@@ -94,6 +94,9 @@
 // test10
 // @noval@@stringval@@trueval@@zeroval@
 
+// empty key, removed
+// ${}
+
 // no substition
 // ${noval}
 

--- a/test/standalone/cmakedefine/expected_config.h
+++ b/test/standalone/cmakedefine/expected_config.h
@@ -94,6 +94,9 @@
 // test10
 // test10
 
+// empty key, removed
+// 
+
 // no substition
 // 
 


### PR DESCRIPTION
${} is valid in cmake config headers and needs to be substituted instead of throwing an error

```cmake
cmake_minimum_required(VERSION 3.15)

project(test)

set("" "Empty Key")

message("Output: ${}")
```

```bash
$ cmake .
Ouput: Empty Key
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/tmp.xjaLJ6qVKc
```

There are still projects (e.g. [darktable](https://github.com/darktable-org/darktable/blob/457caec3198277bddac416b7a6d8181bfbd2ff06/src/config.cmake.h#L7)) with cmake config headers that include ${} in a comment that is not intended to be subsituted with anything else, I think that requiring the user to explicitly provide an empty key introduces unnecessary friction for a problem that isn't real, so this PR uses .undef as a fallback instead of erroring.

TL;DR
- make empty key not an error
- if empty key has no value default to undefined