### PR TITLE
Revert "mingw: Link to ucrtbased.dll instead of API set DLLs in Debug mode."

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2352,12 +2352,8 @@ pub fn create(gpa: Allocator, arena: Allocator, options: CreateOptions) !*Compil
                     comp.remaining_prelink_tasks += 2;
 
                     // When linking mingw-w64 there are some import libs we always need.
-                    const always_link_libs: []const []const u8 = switch (comp.root_mod.optimize_mode) {
-                        .Debug => &mingw.always_link_libs_debug,
-                        .ReleaseSafe, .ReleaseFast, .ReleaseSmall => &mingw.always_link_libs_release,
-                    };
-                    try comp.windows_libs.ensureUnusedCapacity(gpa, always_link_libs.len);
-                    for (always_link_libs) |name| comp.windows_libs.putAssumeCapacity(name, {});
+                    try comp.windows_libs.ensureUnusedCapacity(gpa, mingw.always_link_libs.len);
+                    for (mingw.always_link_libs) |name| comp.windows_libs.putAssumeCapacity(name, {});
                 } else {
                     return error.LibCUnavailable;
                 }

--- a/src/libs/mingw.zig
+++ b/src/libs/mingw.zig
@@ -1011,21 +1011,7 @@ const mingw32_winpthreads_src = [_][]const u8{
     "winpthreads" ++ path.sep_str ++ "thread.c",
 };
 
-const always_link_libs = [_][]const u8{
-    "advapi32",
-    "kernel32",
-    "ntdll",
-    "shell32",
-    "user32",
-};
-
-// In Debug mode, we link against `ucrtbased.dll` instead of the API set DLLs so that we can get
-// access to functions like `_CrtDbgReport`.
-pub const always_link_libs_debug = [_][]const u8{
-    "ucrtbased",
-} ++ always_link_libs;
-
-pub const always_link_libs_release = [_][]const u8{
+pub const always_link_libs = [_][]const u8{
     "api-ms-win-crt-conio-l1-1-0",
     "api-ms-win-crt-convert-l1-1-0",
     "api-ms-win-crt-environment-l1-1-0",
@@ -1041,4 +1027,9 @@ pub const always_link_libs_release = [_][]const u8{
     "api-ms-win-crt-string-l1-1-0",
     "api-ms-win-crt-time-l1-1-0",
     "api-ms-win-crt-utility-l1-1-0",
-} ++ always_link_libs;
+    "advapi32",
+    "kernel32",
+    "ntdll",
+    "shell32",
+    "user32",
+};


### PR DESCRIPTION
This reverts commit 4641e9556d1343e95e4676e2f1e3024173db9962.

See discussion on #24052.