### PR TITLE
windows: Delete obsolete environment variable kernel32 wrappers and bindings

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1905,32 +1905,6 @@ pub fn SetFileCompletionNotificationModes(handle: HANDLE, flags: UCHAR) !void {
     }
 }
 
-pub const GetEnvironmentStringsError = error{OutOfMemory};
-
-pub fn GetEnvironmentStringsW() GetEnvironmentStringsError![*:0]u16 {
-    return kernel32.GetEnvironmentStringsW() orelse return error.OutOfMemory;
-}
-
-pub fn FreeEnvironmentStringsW(penv: [*:0]u16) void {
-    assert(kernel32.FreeEnvironmentStringsW(penv) != 0);
-}
-
-pub const GetEnvironmentVariableError = error{
-    EnvironmentVariableNotFound,
-    Unexpected,
-};
-
-pub fn GetEnvironmentVariableW(lpName: LPWSTR, lpBuffer: [*]u16, nSize: DWORD) GetEnvironmentVariableError!DWORD {
-    const rc = kernel32.GetEnvironmentVariableW(lpName, lpBuffer, nSize);
-    if (rc == 0) {
-        switch (GetLastError()) {
-            .ENVVAR_NOT_FOUND => return error.EnvironmentVariableNotFound,
-            else => |err| return unexpectedError(err),
-        }
-    }
-    return rc;
-}
-
 pub const CreateProcessError = error{
     FileNotFound,
     AccessDenied,

--- a/lib/std/os/windows/kernel32.zig
+++ b/lib/std/os/windows/kernel32.zig
@@ -340,21 +340,6 @@ pub extern "kernel32" fn GetExitCodeProcess(
 // TODO: Already a wrapper for this, see `windows.GetCurrentProcess`.
 pub extern "kernel32" fn GetCurrentProcess() callconv(.winapi) HANDLE;
 
-// TODO: memcpy peb().ProcessParameters.Environment, mem.span(0). Requires locking the PEB.
-pub extern "kernel32" fn GetEnvironmentStringsW() callconv(.winapi) ?LPWSTR;
-
-// TODO: RtlFreeHeap on the output of GetEnvironmentStringsW.
-pub extern "kernel32" fn FreeEnvironmentStringsW(
-    penv: LPWSTR,
-) callconv(.winapi) BOOL;
-
-// TODO: Wrapper around RtlQueryEnvironmentVariable.
-pub extern "kernel32" fn GetEnvironmentVariableW(
-    lpName: ?LPCWSTR,
-    lpBuffer: ?[*]WCHAR,
-    nSize: DWORD,
-) callconv(.winapi) DWORD;
-
 // TODO: Wrapper around RtlSetEnvironmentVar.
 pub extern "kernel32" fn SetEnvironmentVariableW(
     lpName: LPCWSTR,


### PR DESCRIPTION
These functions have been unused for a long time (since cfffb9c5e96eeeae43cd724e2d02ec8c2b7714e0; the PEB is used for this stuff now), and the GetEnvironmentVariableW wrapper's parameter types don't make much sense to boot.

Contributes towards:
- https://github.com/ziglang/zig/issues/4426
- https://github.com/ziglang/zig/issues/1840