### PR TITLE
compiler: Don't link `ucrtbased.dll` when targeting `*-windows-msvc` in Debug mode

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5904,8 +5904,7 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
         // them being defined matches the behavior of how MSVC calls rc.exe which is the more
         // relevant behavior in this case.
         switch (rc_src.owner.optimize_mode) {
-            .Debug => try argv.append("-D_DEBUG"),
-            .ReleaseSafe => {},
+            .Debug, .ReleaseSafe => {},
             .ReleaseFast, .ReleaseSmall => try argv.append("-DNDEBUG"),
         }
         try argv.appendSlice(rc_src.extra_flags);
@@ -6260,10 +6259,7 @@ pub fn addCCArgs(
         // LLVM IR files don't support these flags.
         if (ext != .ll and ext != .bc) {
             switch (mod.optimize_mode) {
-                .Debug => {
-                    // windows c runtime requires -D_DEBUG if using debug libraries
-                    try argv.append("-D_DEBUG");
-                },
+                .Debug => {},
                 .ReleaseSafe => {
                     try argv.append("-D_FORTIFY_SOURCE=2");
                 },

--- a/src/link/Coff.zig
+++ b/src/link/Coff.zig
@@ -2113,21 +2113,17 @@ fn linkWithLLD(coff: *Coff, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: 
 
                         try argv.append(try comp.crtFileAsString(arena, "libmingw32.lib"));
                     } else {
-                        const lib_str = switch (comp.config.link_mode) {
-                            .dynamic => "",
-                            .static => "lib",
-                        };
-                        const d_str = switch (optimize_mode) {
-                            .Debug => "d",
-                            else => "",
-                        };
-                        switch (comp.config.link_mode) {
-                            .static => try argv.append(try allocPrint(arena, "libcmt{s}.lib", .{d_str})),
-                            .dynamic => try argv.append(try allocPrint(arena, "msvcrt{s}.lib", .{d_str})),
-                        }
+                        try argv.append(switch (comp.config.link_mode) {
+                            .static => "libcmt.lib",
+                            .dynamic => "msvcrt.lib",
+                        });
 
-                        try argv.append(try allocPrint(arena, "{s}vcruntime{s}.lib", .{ lib_str, d_str }));
-                        try argv.append(try allocPrint(arena, "{s}ucrt{s}.lib", .{ lib_str, d_str }));
+                        const lib_str = switch (comp.config.link_mode) {
+                            .static => "lib",
+                            .dynamic => "",
+                        };
+                        try argv.append(try allocPrint(arena, "{s}vcruntime.lib", .{lib_str}));
+                        try argv.append(try allocPrint(arena, "{s}ucrt.lib", .{lib_str}));
 
                         //Visual C++ 2015 Conformance Changes
                         //https://msdn.microsoft.com/en-us/library/bb531344.aspx


### PR DESCRIPTION
Linking it by default means that we produce binaries that, effectively, only run on systems which have the Windows SDK installed because `ucrtbased.dll` is not redistributable, and the Windows SDK is what actually installs `ucrtbased.dll` into `%SYSTEM32%`. The resulting binaries also can't run under Wine because Wine does not provide `ucrtbased.dll`.

It is also inconsistent with our behavior for `*-windows-gnu` where we always link `ucrtbase.dll`. See #23983, #24019, and #24053 for more details.

So just use `ucrtbase.dll` regardless of mode. With this change, we can also drop the implicit definition of the `_DEBUG` macro in `zig cc`, which has in some cases been problematic for users.

Users who want to opt into the old behavior can do so, both for `*-windows-msvc` and `*-windows-gnu`, by explicitly passing `-lucrtbased` and `-D_DEBUG`. We might consider adding a more ergonomic flag like `-fdebug-crt` to the `zig build-*` family of commands in the future.

Closes #24052.