### PR TITLE
Sema: check min/max operand types

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -25140,6 +25140,7 @@ fn analyzeMinMax(
         } else {
             for (operands[1..], operand_srcs[1..]) |operand, operand_src| {
                 const operand_ty = sema.typeOf(operand);
+                try sema.checkNumericType(block, operand_src, operand_ty);
                 if (operand_ty.zigTypeTag(zcu) == .vector) {
                     return sema.failWithOwnedErrorMsg(block, msg: {
                         const msg = try sema.errMsg(operand_srcs[0], "expected vector, found '{}'", .{first_operand_ty.fmt(pt)});


### PR DESCRIPTION
We weren't checking the types of operands after the first, and then later we were assuming they were all numeric.

Closes #24060.