### PR TITLE
compiler: Rework PIE option logic.

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -6169,6 +6169,9 @@ pub fn addCCArgs(
     }
 
     if (target_util.supports_fpic(target)) {
+        // PIE needs to go before PIC because Clang interprets `-fno-PIE` to imply `-fno-PIC`, which
+        // we don't necessarily want.
+        try argv.append(if (comp.config.pie) "-fPIE" else "-fno-PIE");
         try argv.append(if (mod.pic) "-fPIC" else "-fno-PIC");
     }
 

--- a/src/Compilation/Config.zig
+++ b/src/Compilation/Config.zig
@@ -135,6 +135,7 @@ pub const ResolveError = error{
     LibCppRequiresLibC,
     LibUnwindRequiresLibC,
     TargetCannotDynamicLink,
+    TargetCannotStaticLinkExecutables,
     LibCRequiresDynamicLinking,
     SharedLibrariesRequireDynamicLinking,
     ExportMemoryAndDynamicIncompatible,
@@ -359,6 +360,10 @@ pub fn resolve(options: Options) ResolveError!Config {
         if (target_util.cannotDynamicLink(target)) {
             if (options.link_mode == .dynamic) return error.TargetCannotDynamicLink;
             break :b .static;
+        }
+        if (target.os.tag == .fuchsia and options.output_mode == .Exe) {
+            if (options.link_mode == .static) return error.TargetCannotStaticLinkExecutables;
+            break :b .dynamic;
         }
         if (explicitly_exe_or_dyn_lib and link_libc and
             (target_util.osRequiresLibC(target) or

--- a/src/main.zig
+++ b/src/main.zig
@@ -4118,6 +4118,7 @@ fn createModule(
             error.LibCppRequiresLibC => fatal("libc++ requires linking libc", .{}),
             error.LibUnwindRequiresLibC => fatal("libunwind requires linking libc", .{}),
             error.TargetCannotDynamicLink => fatal("dynamic linking unavailable on the specified target", .{}),
+            error.TargetCannotStaticLinkExecutables => fatal("static linking of executables unavailable on the specified target", .{}),
             error.LibCRequiresDynamicLinking => fatal("libc of the specified target requires dynamic linking", .{}),
             error.SharedLibrariesRequireDynamicLinking => fatal("using shared libraries requires dynamic linking", .{}),
             error.ExportMemoryAndDynamicIncompatible => fatal("exporting memory is incompatible with dynamic linking", .{}),

--- a/src/target.zig
+++ b/src/target.zig
@@ -60,7 +60,12 @@ pub fn picLevel(target: std.Target) u32 {
 /// This is not whether the target supports Position Independent Code, but whether the -fPIC
 /// C compiler argument is valid to Clang.
 pub fn supports_fpic(target: std.Target) bool {
-    return target.os.tag != .windows and target.os.tag != .uefi;
+    return switch (target.os.tag) {
+        .windows,
+        .uefi,
+        => target.abi == .gnu or target.abi == .cygnus,
+        else => true,
+    };
 }
 
 pub fn alwaysSingleThreaded(target: std.Target) bool {

--- a/src/target.zig
+++ b/src/target.zig
@@ -43,10 +43,6 @@ pub fn libCxxNeedsLibUnwind(target: std.Target) bool {
     };
 }
 
-pub fn requiresPIE(target: std.Target) bool {
-    return target.abi.isAndroid() or target.os.tag.isDarwin() or target.os.tag == .openbsd;
-}
-
 /// This function returns whether non-pic code is completely invalid on the given target.
 pub fn requiresPIC(target: std.Target, linking_libc: bool) bool {
     return target.abi.isAndroid() or


### PR DESCRIPTION
To my knowledge, the only platform that actually *requires* PIE is Android, and that is *only* when building a dynamically-linked executable. Fuchsia, OpenBSD, and macOS all strongly encourage using PIE by default, but it isn't technically required. So for the latter platforms, we enable it by default but don't enforce it.

Also, importantly, if we're building an object file or a static library, and the user hasn't explicitly told us whether to build PIE or non-PIE code (and the target doesn't require PIE), we should *not* default to PIE. Doing so produces code that cannot be linked into non-PIE output. In other words, building an object file or a static library as PIE is an optimization only to be done when the user knows that it'll end up in a PIE executable in the end.

Closes #21837.