### PR TITLE
valgrind: Add `riscv64-linux` support.

### DIFF
--- a/lib/std/valgrind.zig
+++ b/lib/std/valgrind.zig
@@ -66,6 +66,20 @@ pub fn doClientRequest(default: usize, request: usize, a1: usize, a2: usize, a3:
               [_] "{r3}" (default),
             : "cc", "memory"
         ),
+        .riscv64 => asm volatile (
+            \\ .option push
+            \\ .option norvc
+            \\ srli zero, zero, 3
+            \\ srli zero, zero, 13
+            \\ srli zero, zero, 51
+            \\ srli zero, zero, 61
+            \\ or   a0,   a0,   a0
+            \\ .option pop
+            : [_] "={a3}" (-> usize),
+            : [_] "{a4}" (args),
+              [_] "{a3}" (default),
+            : "cc", "memory"
+        ),
         .s390x => asm volatile (
             \\ lr %%r15, %%r15
             \\ lr %%r1,  %%r1

--- a/src/Package/Module.zig
+++ b/src/Package/Module.zig
@@ -113,8 +113,10 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
         break :b options.global.root_strip;
     };
 
+    const zig_backend = target_util.zigBackend(target, options.global.use_llvm);
+
     const valgrind = b: {
-        if (!target_util.hasValgrindSupport(target)) {
+        if (!target_util.hasValgrindSupport(target, zig_backend)) {
             if (options.inherited.valgrind == true)
                 return error.ValgrindUnsupportedOnTarget;
             break :b false;
@@ -124,8 +126,6 @@ pub fn create(arena: Allocator, options: CreateOptions) !*Package.Module {
         if (strip) break :b false;
         break :b optimize_mode == .Debug;
     };
-
-    const zig_backend = target_util.zigBackend(target, options.global.use_llvm);
 
     const single_threaded = b: {
         if (target_util.alwaysSingleThreaded(target)) {

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -11604,7 +11604,7 @@ pub const FuncGen = struct {
         const pt = o.pt;
         const zcu = pt.zcu;
         const target = zcu.getTarget();
-        if (!target_util.hasValgrindSupport(target)) return default_value;
+        if (!target_util.hasValgrindSupport(target, .stage2_llvm)) return default_value;
 
         const llvm_usize = try o.lowerType(Type.usize);
         const usize_alignment = Type.usize.abiAlignment(zcu).toLlvm();
@@ -11677,6 +11677,19 @@ pub const FuncGen = struct {
                 \\ or     1, 1, 1
                 ,
                 .constraints = "={r3},{r4},{r3},~{cc},~{memory}",
+            },
+            .riscv64 => .{
+                .template =
+                \\ .option push
+                \\ .option norvc
+                \\ srli zero, zero, 3
+                \\ srli zero, zero, 13
+                \\ srli zero, zero, 51
+                \\ srli zero, zero, 61
+                \\ or   a0,   a0,   a0
+                \\ .option pop
+                ,
+                .constraints = "={a3},{a4},{a3},~{cc},~{memory}",
             },
             .s390x => .{
                 .template =

--- a/src/target.zig
+++ b/src/target.zig
@@ -84,7 +84,7 @@ pub fn defaultSingleThreaded(target: std.Target) bool {
     return false;
 }
 
-pub fn hasValgrindSupport(target: std.Target) bool {
+pub fn hasValgrindSupport(target: std.Target, backend: std.builtin.CompilerBackend) bool {
     // We can't currently output the necessary Valgrind client request assembly when using the C
     // backend and compiling with an MSVC-like compiler.
     const ofmt_c_msvc = (target.abi == .msvc or target.abi == .itanium) and target.ofmt == .c;
@@ -103,7 +103,11 @@ pub fn hasValgrindSupport(target: std.Target) bool {
             else => false,
         },
         .powerpc, .powerpcle, .powerpc64, .powerpc64le => switch (target.os.tag) {
-            .linux => true,
+            .linux => backend != .stage2_powerpc, // Insufficient inline assembly support in self-hosted.
+            else => false,
+        },
+        .riscv64 => switch (target.os.tag) {
+            .linux => backend != .stage2_riscv64, // Insufficient inline assembly support in self-hosted.
             else => false,
         },
         .s390x => switch (target.os.tag) {


### PR DESCRIPTION
This appeared in Valgrind 3.25.0.