### PR TITLE
ci: Bump `x86_64-linux` timeout from 8 hours to 9 hours.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 jobs:
   x86_64-linux-debug:
-    timeout-minutes: 480
+    timeout-minutes: 540
     runs-on: [self-hosted, Linux, x86_64]
     steps:
       - name: Checkout
@@ -21,7 +21,7 @@ jobs:
       - name: Build and Test
         run: sh ci/x86_64-linux-debug.sh
   x86_64-linux-release:
-    timeout-minutes: 480
+    timeout-minutes: 540
     runs-on: [self-hosted, Linux, x86_64]
     steps:
       - name: Checkout


### PR DESCRIPTION
The addition of FreeBSD and NetBSD targets to the test matrix in #24013 seems to be causing timeouts under load. We might need to exclude some of those from CI, but start by bumping the timeout so we can get a sense of how much more time is actually needed.