### PR TITLE
`libcxx`: Fix locale-related compilation errors on NetBSD.

### DIFF
--- a/lib/libcxx/include/__locale_dir/locale_base_api.h
+++ b/lib/libcxx/include/__locale_dir/locale_base_api.h
@@ -115,6 +115,8 @@
 #  include <__locale_dir/support/apple.h>
 #elif defined(__FreeBSD__)
 #  include <__locale_dir/support/freebsd.h>
+#elif defined(__NetBSD__)
+#  include <__locale_dir/support/netbsd.h>
 #elif defined(_LIBCPP_MSVCRT_LIKE)
 #  include <__locale_dir/support/windows.h>
 #elif defined(__Fuchsia__)

--- a/lib/libcxx/include/__locale_dir/support/bsd_like.h
+++ b/lib/libcxx/include/__locale_dir/support/bsd_like.h
@@ -24,8 +24,6 @@
 #  include <wctype.h>
 #endif
 
-#include <xlocale.h>
-
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif

--- a/lib/libcxx/include/__locale_dir/support/freebsd.h
+++ b/lib/libcxx/include/__locale_dir/support/freebsd.h
@@ -15,6 +15,8 @@
 #  pragma GCC system_header
 #endif
 
+#include <xlocale.h>
+
 #include <__locale_dir/support/bsd_like.h>
 
 #endif // _LIBCPP___LOCALE_DIR_SUPPORT_FREEBSD_H

--- a/lib/libcxx/include/__locale_dir/support/netbsd.h
+++ b/lib/libcxx/include/__locale_dir/support/netbsd.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _LIBCPP___LOCALE_DIR_SUPPORT_APPLE_H
-#define _LIBCPP___LOCALE_DIR_SUPPORT_APPLE_H
+#ifndef _LIBCPP___LOCALE_DIR_SUPPORT_NETBSD_H
+#define _LIBCPP___LOCALE_DIR_SUPPORT_NETBSD_H
 
 #include <__config>
 
@@ -15,8 +15,6 @@
 #  pragma GCC system_header
 #endif
 
-#include <xlocale.h>
-
 #include <__locale_dir/support/bsd_like.h>
 
-#endif // _LIBCPP___LOCALE_DIR_SUPPORT_APPLE_H
+#endif // _LIBCPP___LOCALE_DIR_SUPPORT_NETBSD_H


### PR DESCRIPTION
llvm/llvm-project#143055