### PR TITLE
link: support static archives that are linker scripts

### DIFF
--- a/src/link/Elf/Object.zig
+++ b/src/link/Elf/Object.zig
@@ -20,8 +20,8 @@ atoms: std.ArrayListUnmanaged(Atom) = .empty,
 atoms_indexes: std.ArrayListUnmanaged(Atom.Index) = .empty,
 atoms_extra: std.ArrayListUnmanaged(u32) = .empty,
 
-comdat_groups: std.ArrayListUnmanaged(Elf.ComdatGroup) = .empty,
-comdat_group_data: std.ArrayListUnmanaged(u32) = .empty,
+groups: std.ArrayListUnmanaged(Elf.Group) = .empty,
+group_data: std.ArrayListUnmanaged(u32) = .empty,
 
 input_merge_sections: std.ArrayListUnmanaged(Merge.InputSection) = .empty,
 input_merge_sections_indexes: std.ArrayListUnmanaged(Merge.InputSection.Index) = .empty,
@@ -49,8 +49,8 @@ pub fn deinit(self: *Object, gpa: Allocator) void {
     self.atoms.deinit(gpa);
     self.atoms_indexes.deinit(gpa);
     self.atoms_extra.deinit(gpa);
-    self.comdat_groups.deinit(gpa);
-    self.comdat_group_data.deinit(gpa);
+    self.groups.deinit(gpa);
+    self.group_data.deinit(gpa);
     self.relocs.deinit(gpa);
     self.fdes.deinit(gpa);
     self.cies.deinit(gpa);
@@ -304,22 +304,22 @@ fn initAtoms(
                 }
                 const group_members = @as([*]align(1) const u32, @ptrCast(group_raw_data.ptr))[0..group_nmembers];
 
-                if (group_members[0] != elf.GRP_COMDAT) {
-                    return diags.failParse(path, "corrupt section group: unknown SHT_GROUP format", .{});
+                switch (group_members[0]) {
+                    0, elf.GRP_COMDAT => {
+                        const group_start: u32 = @intCast(self.group_data.items.len);
+                        try self.group_data.appendUnalignedSlice(gpa, group_members[1..]);
+
+                        self.group(try self.addGroup(gpa)).* = .{
+                            .signature_off = group_signature,
+                            .file_index = self.index,
+                            .shndx = shndx,
+                            .members_start = group_start,
+                            .members_len = @intCast(group_nmembers - 1),
+                            .is_comdat = group_members[0] == elf.GRP_COMDAT,
+                        };
+                    },
+                    else => return diags.failParse(path, "corrupt section group: unknown SHT_GROUP format", .{}),
                 }
-
-                const group_start: u32 = @intCast(self.comdat_group_data.items.len);
-                try self.comdat_group_data.appendUnalignedSlice(gpa, group_members[1..]);
-
-                const comdat_group_index = try self.addComdatGroup(gpa);
-                const comdat_group = self.comdatGroup(comdat_group_index);
-                comdat_group.* = .{
-                    .signature_off = group_signature,
-                    .file_index = self.index,
-                    .shndx = shndx,
-                    .members_start = group_start,
-                    .members_len = @intCast(group_nmembers - 1),
-                };
             },
 
             elf.SHT_SYMTAB_SHNDX => @panic("TODO SHT_SYMTAB_SHNDX"),
@@ -986,28 +986,28 @@ pub fn convertCommonSymbols(self: *Object, elf_file: *Elf) !void {
     }
 }
 
-pub fn resolveComdatGroups(self: *Object, elf_file: *Elf, table: anytype) !void {
-    for (self.comdat_groups.items, 0..) |*cg, cgi| {
-        const signature = cg.signature(elf_file);
+pub fn resolveGroups(self: *Object, elf_file: *Elf, table: anytype) !void {
+    for (self.groups.items, 0..) |*g, gi| {
+        const signature = g.signature(elf_file);
         const gop = try table.getOrPut(signature);
         if (!gop.found_existing) {
-            gop.value_ptr.* = .{ .index = @intCast(cgi), .file = self.index };
+            gop.value_ptr.* = .{ .index = @intCast(gi), .file = self.index };
             continue;
         }
-        const current = elf_file.comdatGroup(gop.value_ptr.*);
-        cg.alive = false;
+        const current = elf_file.group(gop.value_ptr.*);
+        g.alive = false;
         if (self.index < current.file_index) {
             current.alive = false;
-            cg.alive = true;
-            gop.value_ptr.* = .{ .index = @intCast(cgi), .file = self.index };
+            g.alive = true;
+            gop.value_ptr.* = .{ .index = @intCast(gi), .file = self.index };
         }
     }
 }
 
-pub fn markComdatGroupsDead(self: *Object, elf_file: *Elf) void {
-    for (self.comdat_groups.items) |cg| {
-        if (cg.alive) continue;
-        for (cg.comdatGroupMembers(elf_file)) |shndx| {
+pub fn markGroupsDead(self: *Object, elf_file: *Elf) void {
+    for (self.groups.items) |g| {
+        if (g.alive) continue;
+        for (g.members(elf_file)) |shndx| {
             const atom_index = self.atoms_indexes.items[shndx];
             if (self.atom(atom_index)) |atom_ptr| {
                 atom_ptr.alive = false;
@@ -1421,15 +1421,15 @@ fn inputMergeSection(self: *Object, index: Merge.InputSection.Index) ?*Merge.Inp
     return &self.input_merge_sections.items[index];
 }
 
-fn addComdatGroup(self: *Object, gpa: Allocator) !Elf.ComdatGroup.Index {
-    const index = @as(Elf.ComdatGroup.Index, @intCast(self.comdat_groups.items.len));
-    _ = try self.comdat_groups.addOne(gpa);
+fn addGroup(self: *Object, gpa: Allocator) !Elf.Group.Index {
+    const index: Elf.Group.Index = @intCast(self.groups.items.len);
+    _ = try self.groups.addOne(gpa);
     return index;
 }
 
-pub fn comdatGroup(self: *Object, index: Elf.ComdatGroup.Index) *Elf.ComdatGroup {
-    assert(index < self.comdat_groups.items.len);
-    return &self.comdat_groups.items[index];
+pub fn group(self: *Object, index: Elf.Group.Index) *Elf.Group {
+    assert(index < self.groups.items.len);
+    return &self.groups.items[index];
 }
 
 pub fn format(
@@ -1550,14 +1550,14 @@ fn formatFdes(
     }
 }
 
-pub fn fmtComdatGroups(self: *Object, elf_file: *Elf) std.fmt.Formatter(formatComdatGroups) {
+pub fn fmtGroups(self: *Object, elf_file: *Elf) std.fmt.Formatter(formatGroups) {
     return .{ .data = .{
         .object = self,
         .elf_file = elf_file,
     } };
 }
 
-fn formatComdatGroups(
+fn formatGroups(
     ctx: FormatContext,
     comptime unused_fmt_string: []const u8,
     options: std.fmt.FormatOptions,
@@ -1567,13 +1567,13 @@ fn formatComdatGroups(
     _ = options;
     const object = ctx.object;
     const elf_file = ctx.elf_file;
-    try writer.writeAll("  COMDAT groups\n");
-    for (object.comdat_groups.items, 0..) |cg, cg_index| {
-        try writer.print("    COMDAT({d})", .{cg_index});
-        if (!cg.alive) try writer.writeAll(" : [*]");
+    try writer.writeAll("  groups\n");
+    for (object.groups.items, 0..) |g, g_index| {
+        try writer.print("    {s}({d})", .{ if (g.is_comdat) "COMDAT" else "GROUP", g_index });
+        if (!g.alive) try writer.writeAll(" : [*]");
         try writer.writeByte('\n');
-        const cg_members = cg.comdatGroupMembers(elf_file);
-        for (cg_members) |shndx| {
+        const g_members = g.members(elf_file);
+        for (g_members) |shndx| {
             const atom_index = object.atoms_indexes.items[shndx];
             const atom_ptr = object.atom(atom_index) orelse continue;
             try writer.print("      atom({d}) : {s}\n", .{ atom_index, atom_ptr.name(elf_file) });

--- a/src/link/Elf/file.zig
+++ b/src/link/Elf/file.zig
@@ -198,10 +198,10 @@ pub const File = union(enum) {
         };
     }
 
-    pub fn comdatGroup(file: File, ind: Elf.ComdatGroup.Index) *Elf.ComdatGroup {
+    pub fn group(file: File, ind: Elf.Group.Index) *Elf.Group {
         return switch (file) {
             .linker_defined, .shared_object, .zig_object => unreachable,
-            .object => |x| x.comdatGroup(ind),
+            .object => |x| x.group(ind),
         };
     }
 

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -1484,33 +1484,33 @@ pub const VerneedSection = struct {
     }
 };
 
-pub const ComdatGroupSection = struct {
+pub const GroupSection = struct {
     shndx: u32,
     cg_ref: Elf.Ref,
 
-    fn comdatGroup(cgs: ComdatGroupSection, elf_file: *Elf) *Elf.ComdatGroup {
+    fn group(cgs: GroupSection, elf_file: *Elf) *Elf.Group {
         const cg_file = elf_file.file(cgs.cg_ref.file).?;
-        return cg_file.object.comdatGroup(cgs.cg_ref.index);
+        return cg_file.object.group(cgs.cg_ref.index);
     }
 
-    pub fn symbol(cgs: ComdatGroupSection, elf_file: *Elf) *Symbol {
-        const cg = cgs.comdatGroup(elf_file);
+    pub fn symbol(cgs: GroupSection, elf_file: *Elf) *Symbol {
+        const cg = cgs.group(elf_file);
         const object = cg.file(elf_file).object;
         const shdr = object.shdrs.items[cg.shndx];
         return &object.symbols.items[shdr.sh_info];
     }
 
-    pub fn size(cgs: ComdatGroupSection, elf_file: *Elf) usize {
-        const cg = cgs.comdatGroup(elf_file);
-        const members = cg.comdatGroupMembers(elf_file);
+    pub fn size(cgs: GroupSection, elf_file: *Elf) usize {
+        const cg = cgs.group(elf_file);
+        const members = cg.members(elf_file);
         return (members.len + 1) * @sizeOf(u32);
     }
 
-    pub fn write(cgs: ComdatGroupSection, elf_file: *Elf, writer: anytype) !void {
-        const cg = cgs.comdatGroup(elf_file);
+    pub fn write(cgs: GroupSection, elf_file: *Elf, writer: anytype) !void {
+        const cg = cgs.group(elf_file);
         const object = cg.file(elf_file).object;
-        const members = cg.comdatGroupMembers(elf_file);
-        try writer.writeInt(u32, elf.GRP_COMDAT, .little);
+        const members = cg.members(elf_file);
+        try writer.writeInt(u32, if (cg.is_comdat) elf.GRP_COMDAT else 0, .little);
         for (members) |shndx| {
             const shdr = object.shdrs.items[shndx];
             switch (shdr.sh_type) {


### PR DESCRIPTION
Note that `openLoadArchive` already has linker script support.

With this change I get a failure parsing a real archive in the self hosted elf linker, rather than the previous behavior of getting an error while trying to parse a pseudo archive that is actually a load script.

Also support non-comdat groups, whatever those are.