### PR TITLE
langref: undefined _is_ materialized in all safe modes

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2295,7 +2295,7 @@ or
       {#code|test_aligned_struct_fields.zig#}
 
       <p>
-      Equating packed structs results in a comparison of the backing integer, 
+      Equating packed structs results in a comparison of the backing integer,
       and only works for the {#syntax#}=={#endsyntax#} and {#syntax#}!={#endsyntax#} {#link|Operators#}.
       </p>
       {#code|test_packed_struct_equality.zig#}

--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -777,7 +777,7 @@
       value. Using this value would be a bug. The value will be unused, or overwritten before being used."
       </p>
       <p>
-      In {#link|Debug#} mode, Zig writes {#syntax#}0xaa{#endsyntax#} bytes to undefined memory. This is to catch
+      In {#link|Debug#} and {#link|ReleaseSafe#} mode, Zig writes {#syntax#}0xaa{#endsyntax#} bytes to undefined memory. This is to catch
       bugs early, and to help detect use of undefined memory in a debugger. However, this behavior is only an
       implementation feature, not a language semantic, so it is not guaranteed to be observable to code.
       </p>


### PR DESCRIPTION
Context: 

* https://lobste.rs/s/oei5fj/jepsen_tigerbeetle_0_16_11#c_gkrsdf
* https://lobste.rs/s/oei5fj/jepsen_tigerbeetle_0_16_11#c_c8znsc

I am also not suprer happy about the clause that immediately follows. I
_believe_ what we want to say here is that, simultaneously:

* undefined is guaranteed to be matrerialized in in all safe modes.
  A Zig implementation that elides `ptr.* = undefined` in ReleaseSafe
  mode would be a non-conforming implementation.
* A Zig program that relies on undefined being materialized is buggy.

But I don't think it's the time to engage this level of language-lawering!