### PR TITLE
pwhash: Simplify strHash/strVerify APIs

### DIFF
--- a/lib/std/crypto/bcrypt.zig
+++ b/lib/std/crypto/bcrypt.zig
@@ -748,8 +748,6 @@ const CryptFormatHasher = struct {
 
 /// Options for hashing a password.
 pub const HashOptions = struct {
-    /// For `bcrypt`, that can be left to `null`.
-    allocator: ?mem.Allocator = null,
     /// Internal bcrypt parameters.
     params: Params,
     /// Encoding to use for the output of the hash function.
@@ -776,8 +774,6 @@ pub fn strHash(
 
 /// Options for hash verification.
 pub const VerifyOptions = struct {
-    /// For `bcrypt`, that can be left to `null`.
-    allocator: ?mem.Allocator = null,
     /// Whether to silently truncate the password to 72 bytes, or pre-hash the password when it is longer.
     silently_truncate_password: bool,
 };

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -407,23 +407,22 @@ const pwhashes = [_]CryptoPwhash{
 };
 
 fn benchmarkBcryptPwhash(
-    _: mem.Allocator,
+    allocator: mem.Allocator,
     comptime count: comptime_int,
 ) !f64 {
     const password = "testpass" ** 2;
     const opts = crypto.pwhash.bcrypt.HashOptions{
         .params = bcrypt_params,
         .encoding = .phc,
+        .strhash_max_bytes = 256,
     };
-    var buf: [256]u8 = undefined;
 
     var timer = try Timer.start();
     const start = timer.lap();
     {
         var i: usize = 0;
         while (i < count) : (i += 1) {
-            _ = try crypto.pwhash.bcrypt.strHash(password, opts, &buf);
-            mem.doNotOptimizeAway(&buf);
+            _ = try crypto.pwhash.bcrypt.strHash(allocator, password, opts);
         }
     }
     const end = timer.read();
@@ -442,16 +441,15 @@ fn benchmarkScryptPwhash(
     const opts = crypto.pwhash.scrypt.HashOptions{
         .params = crypto.pwhash.scrypt.Params.interactive,
         .encoding = .phc,
+        .strhash_max_bytes = 256,
     };
-    var buf: [256]u8 = undefined;
 
     var timer = try Timer.start();
     const start = timer.lap();
     {
         var i: usize = 0;
         while (i < count) : (i += 1) {
-            _ = try crypto.pwhash.scrypt.strHash(allocator, password, opts, &buf);
-            mem.doNotOptimizeAway(&buf);
+            _ = try crypto.pwhash.scrypt.strHash(allocator, password, opts);
         }
     }
     const end = timer.read();
@@ -469,16 +467,15 @@ fn benchmarkArgon2Pwhash(
     const password = "testpass" ** 2;
     const opts = crypto.pwhash.argon2.HashOptions{
         .params = crypto.pwhash.argon2.Params.interactive_2id,
+        .strhash_max_bytes = 256,
     };
-    var buf: [256]u8 = undefined;
 
     var timer = try Timer.start();
     const start = timer.lap();
     {
         var i: usize = 0;
         while (i < count) : (i += 1) {
-            _ = try crypto.pwhash.argon2.strHash(allocator, password, opts, &buf);
-            mem.doNotOptimizeAway(&buf);
+            _ = try crypto.pwhash.argon2.strHash(allocator, password, opts);
         }
     }
     const end = timer.read();


### PR DESCRIPTION
These APIs were "generic" in a way that obfuscated their intended use (e.g. using runtime errors for invalid parameters), and made use of a combination of output parameters and a return value that's lead to confusion in multiple projects.

This PR aims to simplify the APIs such that each one accurately communicates intent and is harder to misuse.

See https://github.com/ziglang/zig/issues/23994 for context and rationale