### PR TITLE
std.fmt.parseFloat: fix hex-float negative inf

### DIFF
--- a/lib/std/fmt/parse_float.zig
+++ b/lib/std/fmt/parse_float.zig
@@ -159,6 +159,9 @@ test "hex.special" {
     try testing.expect(math.isPositiveInf(try parseFloat(f32, "iNf")));
     try testing.expect(math.isPositiveInf(try parseFloat(f32, "+Inf")));
     try testing.expect(math.isNegativeInf(try parseFloat(f32, "-iNf")));
+
+    try testing.expect(math.isPositiveInf(try parseFloat(f32, "0x9999p9999")));
+    try testing.expect(math.isNegativeInf(try parseFloat(f32, "-0x9999p9999")));
 }
 
 test "hex.zero" {

--- a/lib/std/fmt/parse_float/convert_hex.zig
+++ b/lib/std/fmt/parse_float/convert_hex.zig
@@ -78,7 +78,7 @@ pub fn convertHex(comptime T: type, n_: Number(T)) T {
 
     // Infinity and range error
     if (n.exponent > max_exp) {
-        return math.inf(T);
+        return if (n.negative) -math.inf(T) else math.inf(T);
     }
 
     var bits = n.mantissa & ((1 << mantissa_bits) - 1);


### PR DESCRIPTION
Closes #24111.