### PR TITLE
Compilation: write CACHEDIR.TAG

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1415,6 +1415,7 @@ pub const MiscTask = enum {
     analyze_mod,
     docs_copy,
     docs_wasm,
+    cachedir_tag,
 
     @"musl crt1.o",
     @"musl rcrt1.o",
@@ -4601,6 +4602,8 @@ fn performAllTheWork(
     comp.link_prog_node.increaseEstimatedTotalItems(comp.link_task_queue.queued_prelink.items.len);
     comp.link_task_queue.start(comp);
 
+    comp.thread_pool.spawnWg(&work_queue_wait_group, workerTagCacheDirs, .{comp});
+
     if (comp.emit_docs != null) {
         dev.check(.docs_emit);
         comp.thread_pool.spawnWg(&work_queue_wait_group, workerDocsCopy, .{comp});
@@ -5491,6 +5494,29 @@ fn workerDocsWasmFallible(comp: *Compilation, prog_node: std.Progress.Node) SubU
         });
         return error.AlreadyReported;
     };
+}
+
+fn workerTagCacheDirs(comp: *Compilation) void {
+    for (&[_]Cache.Directory{ comp.dirs.global_cache, comp.dirs.local_cache }) |dir| {
+        tagCacheDir(dir.handle) catch |err| {
+            return comp.lockAndSetMiscFailure(
+                .cachedir_tag,
+                "unable to create CACHEDIR.TAG file in '{f}': {s}",
+                .{ dir, @errorName(err) },
+            );
+        };
+    }
+}
+
+fn tagCacheDir(dir: fs.Dir) !void {
+    const file = try dir.createFile("CACHEDIR.TAG", .{});
+    defer file.close();
+    try file.writeAll(
+        \\Signature: 8a477f597d28d172789f06886806bc55
+        \\# This file is a cache directory tag created by Zig.
+        \\# For information about cache directory tags, see: http://www.brynosaurus.com/cachedir/
+        \\
+    );
 }
 
 fn workerUpdateFile(

--- a/stage1/panic.h
+++ b/stage1/panic.h
@@ -4,9 +4,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static void panic(const char *reason) {
-    fprintf(stderr, "%s\n", reason);
-    abort();
-}
+#define panic(REASON) do { \
+    fprintf(stderr, "%s:%d: %s\n", __func__, __LINE__, REASON); \
+    abort(); \
+} while (0)
 
 #endif /* PANIC_H */

--- a/stage1/wasi.c
+++ b/stage1/wasi.c
@@ -876,7 +876,6 @@ uint32_t wasi_snapshot_preview1_path_open(uint32_t fd, uint32_t dirflags, uint32
     FILE *stream;
     if (directory) stream = NULL;
     else {
-      if (lookup_errno == wasi_errno_success) panic("unimplemented");
       const enum wasi_errno open_errno = FileDescriptor_open(de, oflags, fs_rights_base, fdflags, &stream);
       if (open_errno != wasi_errno_success) {
         if (lookup_errno == wasi_errno_noent) {


### PR DESCRIPTION
This was previously attempted in #14875 but it was asked to make the file creation an asynchronous task like the others in `performAllTheWork`.
For context, see #8210. In my case it's motivated by the fact that my little project's `.zig-cache` is already 40+GB (I haven't checked why) and I'd like the [backup utility](https://restic.net/) to avoid backing up the intermediate artifacts. In #8210 it was also asked to tag `zig-out` but from a quick glance this might not be as simple because that's also the install prefix but also doesn't appear as large.