### PR TITLE
build_runner: add option to clear console when watching

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -1312,6 +1312,7 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\    needed                     (Default) Lazy dependencies are fetched as needed
         \\    all                        Lazy dependencies are always fetched
         \\  --watch                      Continuously rebuild when source files are modified
+        \\  --watch-clear                Clear screen before each rebuild
         \\  --fuzz                       Continuously search for unit test failures
         \\  --debounce <ms>              Delay before rebuilding after changed file detected
         \\     -fincremental             Enable incremental compilation

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -110,6 +110,7 @@ pub fn main() !void {
     var steps_menu = false;
     var output_tmp_nonce: ?[16]u8 = null;
     var watch = false;
+    var withClear = false;
     var fuzz = false;
     var debounce_interval_ms: u16 = 50;
     var listen_port: u16 = 0;
@@ -266,6 +267,8 @@ pub fn main() !void {
                 prominent_compile_errors = true;
             } else if (mem.eql(u8, arg, "--watch")) {
                 watch = true;
+            } else if (mem.eql(u8, arg, "--with-clear")) {
+                withClear = true;
             } else if (mem.eql(u8, arg, "--fuzz")) {
                 fuzz = true;
             } else if (mem.eql(u8, arg, "-fincremental")) {
@@ -484,6 +487,10 @@ pub fn main() !void {
         var debounce_timeout: Watch.Timeout = .none;
         while (true) switch (try w.wait(gpa, debounce_timeout)) {
             .timeout => {
+                if (withClear) {
+                    try std.io.getStdOut().writeAll("\x1B[2J\x1B[H");
+                }
+
                 debouncing_node.end();
                 markFailedStepsDirty(gpa, run.step_stack.keys());
                 continue :rebuild;

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -110,7 +110,7 @@ pub fn main() !void {
     var steps_menu = false;
     var output_tmp_nonce: ?[16]u8 = null;
     var watch = false;
-    var withClear = false;
+    var watch_clear = false;
     var fuzz = false;
     var debounce_interval_ms: u16 = 50;
     var listen_port: u16 = 0;
@@ -267,8 +267,8 @@ pub fn main() !void {
                 prominent_compile_errors = true;
             } else if (mem.eql(u8, arg, "--watch")) {
                 watch = true;
-            } else if (mem.eql(u8, arg, "--with-clear")) {
-                withClear = true;
+            } else if (mem.eql(u8, arg, "--watch-clear")) {
+                watch_clear = true;
             } else if (mem.eql(u8, arg, "--fuzz")) {
                 fuzz = true;
             } else if (mem.eql(u8, arg, "-fincremental")) {
@@ -487,7 +487,7 @@ pub fn main() !void {
         var debounce_timeout: Watch.Timeout = .none;
         while (true) switch (try w.wait(gpa, debounce_timeout)) {
             .timeout => {
-                if (withClear) {
+                if (watch_clear) {
                     try std.io.getStdOut().writeAll("\x1B[2J\x1B[H");
                 }
 

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -267,8 +267,19 @@ pub fn main() !void {
                 prominent_compile_errors = true;
             } else if (mem.eql(u8, arg, "--watch")) {
                 watch = true;
-            } else if (mem.eql(u8, arg, "--watch-clear")) {
-                watch_clear = true;
+            } else if (mem.startsWith(u8, arg, "--watch=")) {
+                watch = true;
+                const text = arg["--watch=".len..];
+                const option = std.meta.stringToEnum(std.Build.Watch.Options, text) orelse {
+                    fatalWithHint("expected [clear] in '{s}', found '{s}'", .{
+                        arg, text,
+                    });
+                };
+                switch (option) {
+                    .clear => {
+                        watch_clear = true;
+                    },
+                }
             } else if (mem.eql(u8, arg, "--fuzz")) {
                 fuzz = true;
             } else if (mem.eql(u8, arg, "-fincremental")) {
@@ -1311,8 +1322,8 @@ fn usage(b: *std.Build, out_stream: anytype) !void {
         \\  --fetch[=mode]               Fetch dependency tree (optionally choose laziness) and exit
         \\    needed                     (Default) Lazy dependencies are fetched as needed
         \\    all                        Lazy dependencies are always fetched
-        \\  --watch                      Continuously rebuild when source files are modified
-        \\  --watch-clear                Clear screen before each rebuild
+        \\  --watch[=option]             Continuously rebuild when source files are modified
+        \\    clear                      Clear screen before each rebuild. (default: no clear)
         \\  --fuzz                       Continuously search for unit test failures
         \\  --debounce <ms>              Delay before rebuilding after changed file detected
         \\     -fincremental             Enable incremental compilation

--- a/lib/std/Build/Watch.zig
+++ b/lib/std/Build/Watch.zig
@@ -12,6 +12,10 @@ generation: Generation,
 
 pub const have_impl = Os != void;
 
+pub const Options = enum {
+    clear,
+};
+
 /// Key is the directory to watch which contains one or more files we are
 /// interested in noticing changes to.
 ///


### PR DESCRIPTION
As described in #23472.

Running `zig build` with `-fincremental` and `--watch` it's a bit hard to identify what's the up-to-date error state.

This PR allows you to opt-in having the screen cleared on debounce timeout.