### PR TITLE
test: Enable some working vector tests

### DIFF
--- a/test/behavior/abs.zig
+++ b/test/behavior/abs.zig
@@ -343,11 +343,6 @@ test "@abs float vectors" {
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
 
-    // https://github.com/ziglang/zig/issues/12827
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.os.tag == .macos and
-        builtin.target.cpu.arch == .x86_64) return error.SkipZigTest;
-
     @setEvalBranchQuota(2000);
     try comptime testAbsFloatVectors(f16, 1);
     try testAbsFloatVectors(f16, 1);

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -357,13 +357,6 @@ test "vector @splat" {
     if (builtin.zig_backend == .stage2_spirv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt != .elf and builtin.target.ofmt != .macho) return error.SkipZigTest;
 
-    if (builtin.zig_backend == .stage2_llvm and
-        builtin.os.tag == .macos)
-    {
-        // LLVM 15 regression: https://github.com/ziglang/zig/issues/12827
-        return error.SkipZigTest;
-    }
-
     const S = struct {
         fn testForT(comptime N: comptime_int, v: anytype) !void {
             const T = @TypeOf(v);


### PR DESCRIPTION
As mentioned in #24131, these tests seem to be working fine, so we can enable them again unless I am missing something. 