### PR TITLE
Module: omit frame pointer in ReleaseFast

### DIFF
--- a/lib/std/Build/Module.zig
+++ b/lib/std/Build/Module.zig
@@ -265,7 +265,7 @@ pub const CreateOptions = struct {
     /// Position Independent Code
     pic: ?bool = null,
     red_zone: ?bool = null,
-    /// Whether to omit the stack frame pointer. Frees up a register and makes it
+    /// Whether to omit the stack frame pointer. Frees up a register but makes it
     /// more difficult to obtain stack traces. Has target-dependent effects.
     omit_frame_pointer: ?bool = null,
     error_tracing: ?bool = null,


### PR DESCRIPTION
Because it frees up a register it can have performance implications on the program and because we're optimizing for speed and not debugging, I think it's a no-brainer to make this true.
In general, I expect performance with this change to be strictly better or unchanged, both at the cost of it being more difficult to obtain a stack trace but that's not the goal of ReleaseFast.

How can performance be possibly worse if you have an additional register unless the code generator's register allocator has some bug where that somehow makes it perform worse? Can't really imagine that.

Wanted to include some kind of benchmark here but from the benchmarking I was able to do on the compiler, there doesn't seem to be a difference for `zig ast-check` with or without the frame pointer (anything beyond `-Ddev=ast_gen` takes too long to build with ReleaseFast...)