### PR TITLE
bail when failing to parse `error`

### DIFF
--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -2774,9 +2774,9 @@ fn parsePrimaryTypeExpr(p: *Parse) !?Node.Index {
             else => {
                 const main_token = p.nextToken();
                 const period = p.eatToken(.period);
-                if (period == null) try p.warnExpected(.period);
+                if (period == null) return p.failExpected(.period);
                 const identifier = p.eatToken(.identifier);
-                if (identifier == null) try p.warnExpected(.identifier);
+                if (identifier == null) return p.failExpected(.identifier);
                 return try p.addNode(.{
                     .tag = .error_value,
                     .main_token = main_token,

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -6280,7 +6280,6 @@ test "recovery: invalid global error set access" {
         \\}
     , &[_]Error{
         .expected_token,
-        .expected_token,
     });
 }
 


### PR DESCRIPTION
this could cause usages of `error_value` to go past the end of the token list due to the assumption that `main_token + 2` existed