### PR TITLE
zig init: simplify templating logic

### DIFF
--- a/lib/init/build.zig
+++ b/lib/init/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
     // to our consumers. We must give it a name because a Zig package can expose
     // multiple modules and consumers will need to be able to specify which
     // module they want to access.
-    const mod = b.addModule(".NAME", .{
+    const mod = b.addModule("_NAME", .{
         // The root source file is the "entry point" of this module. Users of
         // this module will only be able to access public declarations contained
         // in this file, which means that if you have declarations that you
@@ -59,7 +59,7 @@ pub fn build(b: *std.Build) void {
     // If neither case applies to you, feel free to delete the declaration you
     // don't need and to put everything under a single module.
     const exe = b.addExecutable(.{
-        .name = ".NAME",
+        .name = "_NAME",
         .root_module = b.createModule(.{
             // b.createModule defines a new module just like b.addModule but,
             // unlike b.addModule, it does not expose the module to consumers of
@@ -74,12 +74,12 @@ pub fn build(b: *std.Build) void {
             // List of modules available for import in source files part of the
             // root module.
             .imports = &.{
-                // Here ".NAME" is the name you will use in your source code to
-                // import this module (e.g. `@import(".NAME")`). The name is
+                // Here "_NAME" is the name you will use in your source code to
+                // import this module (e.g. `@import("_NAME")`). The name is
                 // repeated because you are allowed to rename your imports, which
                 // can be extremely useful in case of collisions (which can happen
                 // importing modules from different packages).
-                .{ .name = ".NAME", .module = mod },
+                .{ .name = "_NAME", .module = mod },
             },
         }),
     });

--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -6,7 +6,7 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = .LITNAME,
+    .name = ._NAME,
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.0.0",
@@ -25,7 +25,7 @@
     .fingerprint = .FINGERPRINT, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = ".ZIGVER",
+    .minimum_zig_version = "_ZIGVER",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/lib/init/src/main.zig
+++ b/lib/init/src/main.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
-const _LITNAME = @import(".NAME");
+const _NAME = @import(".NAME");
 
 pub fn main() !void {
     // Prints to stderr, ignoring potential errors.
     std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
-    try .NAME.advancedPrint();
+    try _NAME.bufferedPrint();
 }
 
 test "simple test" {

--- a/lib/init/src/root.zig
+++ b/lib/init/src/root.zig
@@ -1,11 +1,12 @@
 //! By convention, root.zig is the root source file when making a library.
 const std = @import("std");
 
-pub fn advancedPrint() !void {
+pub fn bufferedPrint() !void {
     // Stdout is for the actual output of your application, for example if you
     // are implementing gzip, then only the compressed bytes should be sent to
     // stdout, not any debugging messages.
     const stdout_file = std.io.getStdOut().writer();
+    // Buffering can improve performance significantly in print-heavy programs.
     var bw = std.io.bufferedWriter(stdout_file);
     const stdout = bw.writer();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -7290,34 +7290,27 @@ const Templates = struct {
                     new_line = false;
                 }
             }
+
             if (templates.strip and contents[i] == '\n') {
                 new_line = true;
-            } else if (contents[i] == '_') {
-                if (std.mem.startsWith(u8, contents[i..], "_LITNAME")) {
+            } else if (contents[i] == '_' or contents[i] == '.') {
+                // Both '_' and '.' are allowed because depending on the context
+                // one prefix will be valid, while the other might not.
+                if (std.mem.startsWith(u8, contents[i + 1 ..], "NAME")) {
                     try templates.buffer.appendSlice(root_name);
-                    i += "_LITNAME".len;
+                    i += "_NAME".len;
                     continue;
-                }
-            } else if (contents[i] == '.') {
-                if (std.mem.startsWith(u8, contents[i..], ".LITNAME")) {
-                    try templates.buffer.append('.');
-                    try templates.buffer.appendSlice(root_name);
-                    i += ".LITNAME".len;
-                    continue;
-                } else if (std.mem.startsWith(u8, contents[i..], ".NAME")) {
-                    try templates.buffer.appendSlice(root_name);
-                    i += ".NAME".len;
-                    continue;
-                } else if (std.mem.startsWith(u8, contents[i..], ".FINGERPRINT")) {
+                } else if (std.mem.startsWith(u8, contents[i + 1 ..], "FINGERPRINT")) {
                     try templates.buffer.writer().print("0x{x}", .{fingerprint.int()});
-                    i += ".FINGERPRINT".len;
+                    i += "_FINGERPRINT".len;
                     continue;
-                } else if (std.mem.startsWith(u8, contents[i..], ".ZIGVER")) {
+                } else if (std.mem.startsWith(u8, contents[i + 1 ..], "ZIGVER")) {
                     try templates.buffer.appendSlice(build_options.version);
-                    i += ".ZIGVER".len;
+                    i += "_ZIGVER".len;
                     continue;
                 }
             }
+
             try templates.buffer.append(contents[i]);
             i += 1;
         }


### PR DESCRIPTION
And also rename `advancedPrint` to `bufferedPrint` in the zig init templates.

These are left overs from my previous changes to zig init.

The new templating system removes LITNAME because the new restrictions on package names make it redundant with NAME, and the use of underscores for marking templated identifiers lets us template variable names while still keeping zig fmt happy.