### PR TITLE
Step-style support for compile_commands.json generation

### DIFF
--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -184,12 +184,12 @@ pub const CompileCommands = struct {
             try writer.writeAll("\n  {\n");
 
             try writer.writeAll("    \"directory\": \"");
-            try std.json.encodeJsonString(entry.working_directory, .{}, writer);
+            try std.json.encodeJsonStringChars(entry.working_directory, .{}, writer);
             try writer.writeAll("\",\n");
 
             try writer.writeAll("    \"file\": \"");
             const full_path = b.pathJoin(&.{ entry.working_directory, entry.relative_path });
-            try std.json.encodeJsonString(full_path, .{}, writer);
+            try std.json.encodeJsonStringChars(full_path, .{}, writer);
             try writer.writeAll("\",\n");
 
             try writer.writeAll("    \"command\": \"");
@@ -206,7 +206,7 @@ pub const CompileCommands = struct {
             try temp_writer.writeAll(" ");
             try temp_writer.writeAll(entry.relative_path);
 
-            try std.json.encodeJsonString(temp.items, .{}, writer);
+            try std.json.encodeJsonStringChars(temp.items, .{}, writer);
             try writer.writeAll("\"\n  }");
         }
 

--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1285,6 +1285,16 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                                 try zig_args.append(lang.internalIdentifier());
                             }
 
+                            if (b.compile_commands) |compdb| {
+                                const path = c_source_file.file.getPath3(mod.owner, step);
+                                try compdb.append(.{
+                                    .module = compile.root_module,
+                                    .working_directory = b.pathResolve(&.{path.root_dir.path orelse "."}),
+                                    .relative_path = path.sub_path,
+                                    .flags = c_source_file.flags,
+                                });
+                            }
+
                             try zig_args.append(c_source_file.file.getPath2(mod.owner, step));
 
                             if (c_source_file.language != null) {
@@ -1312,6 +1322,18 @@ fn getZigArgs(compile: *Compile, fuzz: bool) ![][]const u8 {
                             }
 
                             const root_path = c_source_files.root.getPath2(mod.owner, step);
+
+                            if (b.compile_commands) |compdb| {
+                                for (c_source_files.files) |file| {
+                                    try compdb.append(.{
+                                        .module = compile.root_module,
+                                        .working_directory = root_path,
+                                        .relative_path = file,
+                                        .flags = c_source_files.flags,
+                                    });
+                                }
+                            }
+
                             for (c_source_files.files) |file| {
                                 try zig_args.append(b.pathJoin(&.{ root_path, file }));
                             }


### PR DESCRIPTION
Compared to #22012 and #18391, this PR introduces a new `b.addCompileCommands` along with the corresponding Step implementation. I believe this approach is more flexible than using `-fcompdb / -fno-compdb`.

The only issue is that I made this thing look ugly, and I can't think of a better way to do it.

I've simply wrapped it into a Step — the original implementation comes from the two PRs I mentioned earlier.

```zig
const compile_commands = b.addCompileCommands(b.path("compile_commands.json"));

b.getInstallStep().dependOn(&compile_commands.step);
```