### PR TITLE
compiler: test runner: fix tests never fails on crippled architectures

### DIFF
--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -309,7 +309,7 @@ pub fn mainSimple() anyerror!void {
                 stderr.writeAll("... ") catch {};
                 stderr.writeAll("PASS\n") catch {};
             }
-        } else |err| if (enable_print) {
+        } else |err| {
             if (enable_print) {
                 stderr.writeAll(test_fn.name) catch {};
                 stderr.writeAll("... ") catch {};

--- a/lib/compiler/test_runner.zig
+++ b/lib/compiler/test_runner.zig
@@ -292,6 +292,7 @@ pub fn mainSimple() anyerror!void {
     };
     // is the backend capable of using std.fmt.format to print a summary at the end?
     const print_summary = switch (builtin.zig_backend) {
+        .stage2_riscv64 => true,
         else => false,
     };
 

--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -409,6 +409,7 @@ test "struct field explicit alignment" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest; // flaky
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = struct {
         const Node = struct {
@@ -532,6 +533,7 @@ test "alignment of zero-bit types is respected" {
     if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = struct { arr: [0]usize = .{} };
 

--- a/test/behavior/atomics.zig
+++ b/test/behavior/atomics.zig
@@ -153,6 +153,7 @@ test "atomic load and rmw with enum" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const Value = enum(u8) { a, b, c };
     var x = Value.a;
@@ -188,6 +189,7 @@ test "atomicrmw with floats" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     try testAtomicRmwFloat();
     try comptime testAtomicRmwFloat();

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -477,6 +477,7 @@ test "@bitCast of packed struct of bools all true" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const P = packed struct {
         b0: bool,

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1793,6 +1793,7 @@ test "peer type resolution: array and vector with same child type" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     var arr: [2]u32 = .{ 0, 1 };
     var vec: @Vector(2, u32) = .{ 2, 3 };
@@ -1931,6 +1932,7 @@ test "peer type resolution: vector and optional vector" {
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     var a: ?@Vector(3, u32) = .{ 0, 1, 2 };
     var b: @Vector(3, u32) = .{ 3, 4, 5 };

--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -35,6 +35,7 @@ test "coerce i8 to i32 and @intCast back" {
 }
 
 test "coerce non byte-sized integers accross 32bits boundary" {
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
     {
         var v: u21 = 6417;
         _ = &v;
@@ -166,6 +167,7 @@ const Piece = packed struct {
 test "load non byte-sized optional value" {
     // Originally reported at https://github.com/ziglang/zig/issues/14200
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     // note: this bug is triggered by the == operator, expectEqual will hide it
     const opt: ?Piece = try Piece.charToPiece('p');
@@ -181,6 +183,7 @@ test "load non byte-sized optional value" {
 test "load non byte-sized value in struct" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.cpu.arch.endian() != .little) return error.SkipZigTest; // packed struct TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     // note: this bug is triggered by the == operator, expectEqual will hide it
     // using ptrCast not to depend on unitialised memory state

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1121,6 +1121,7 @@ test "bit field access with enum fields" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     var data = bit_field_1;
     try expect(getA(&data) == A.Two);

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1087,6 +1087,7 @@ test "result location initialization of error union with OPV payload" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = struct {
         x: u0,

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -412,6 +412,7 @@ test "generic struct as parameter type" {
 
 test "slice as parameter type" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = struct {
         fn internComptimeString(comptime str: []const u8) *const []const u8 {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -66,7 +66,7 @@ test "@clz" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
-
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
     try testClz();
     try comptime testClz();
 }
@@ -870,6 +870,7 @@ test "@addWithOverflow" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     try testAddWithOverflow(u8, 250, 100, 94, 1);
     try testAddWithOverflow(u8, 100, 150, 250, 0);
@@ -931,6 +932,7 @@ test "@addWithOverflow > 64 bits" {
 test "small int addition" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     var x: u2 = 0;
     try expect(x == 0);
@@ -958,6 +960,7 @@ fn testMulWithOverflow(comptime T: type, a: T, b: T, mul: T, bit: u1) !void {
 test "basic @mulWithOverflow" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     try testMulWithOverflow(u8, 86, 3, 2, 1);
     try testMulWithOverflow(u8, 85, 3, 255, 0);

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -641,6 +641,7 @@ test "result location initialization of optional with OPV payload" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = struct {
         x: u0,

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -429,6 +429,7 @@ test "nested packed struct field pointers" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_c) return error.SkipZigTest; // ubsan unaligned pointer access
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
     if (native_endian != .little) return error.SkipZigTest; // Byte aligned packed struct field pointers have not been implemented yet
 
     const S2 = packed struct {
@@ -953,6 +954,7 @@ test "pointer to container level packed struct field" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = packed struct(u32) {
         test_bit: bool,
@@ -997,6 +999,7 @@ test "bitcast back and forth" {
 test "field access of packed struct smaller than its abi size inside struct initialized with rls" {
     // Originally reported at https://github.com/ziglang/zig/issues/14200
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = struct {
         ps: packed struct { x: i2, y: i2 },
@@ -1146,6 +1149,7 @@ test "assignment to non-byte-aligned field in packed struct" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const Frame = packed struct {
         num: u20,
@@ -1360,6 +1364,7 @@ test "byte-aligned packed relocation" {
 
 test "packed struct store of comparison result" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S1 = packed struct {
         val1: u3,

--- a/test/behavior/packed-union.zig
+++ b/test/behavior/packed-union.zig
@@ -8,6 +8,7 @@ test "flags in packed union" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     try testFlagsInPackedUnion();
     try comptime testFlagsInPackedUnion();
@@ -50,6 +51,7 @@ test "flags in packed union at offset" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     try testFlagsInPackedUnionAtOffset();
     try comptime testFlagsInPackedUnionAtOffset();

--- a/test/behavior/popcount.zig
+++ b/test/behavior/popcount.zig
@@ -8,6 +8,7 @@ test "@popCount integers" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     try comptime testPopCountIntegers();
     try testPopCountIntegers();

--- a/test/behavior/src.zig
+++ b/test/behavior/src.zig
@@ -40,6 +40,8 @@ test "@src used as a comptime parameter" {
 }
 
 test "@src in tuple passed to anytype function" {
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
+
     const S = struct {
         fn Foo(a: anytype) u32 {
             return a[0].line;

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -424,6 +424,7 @@ test "packed struct 24bits" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.cpu.arch.isArm()) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     comptime {
         std.debug.assert(@sizeOf(Foo24Bits) == @sizeOf(u24));
@@ -526,6 +527,7 @@ test "implicit cast packed struct field to const ptr" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const LevelUpMove = packed struct {
         move_id: u9,
@@ -590,6 +592,7 @@ test "bit field access" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     var data = bit_field_1;
     try expect(getA(&data) == 1);
@@ -713,6 +716,7 @@ test "pointer to packed struct member in a stack variable" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S = packed struct {
         a: u2,
@@ -1525,6 +1529,7 @@ test "optional generic function label struct field" {
 test "struct fields get automatically reordered" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const S1 = struct {
         a: u32,

--- a/test/behavior/threadlocal.zig
+++ b/test/behavior/threadlocal.zig
@@ -9,6 +9,7 @@ test "thread local variable" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_x86_64 and builtin.target.ofmt == .coff) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     if (builtin.zig_backend == .stage2_x86_64 and builtin.os.tag == .macos) {
         // Fails due to register hazards.

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -1841,6 +1841,7 @@ test "reinterpret packed union" {
 
 test "reinterpret packed union inside packed struct" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
 
     const U = packed union {
         a: u7,


### PR DESCRIPTION
Previously tests for stage2 RISC-V 64 backend are never failing. This PR fixes it and skips all currently failing rv64 behavior tests.