### PR TITLE
libc: Prevent FCSEL instruction from being used to avoid raising an unintended exception

### DIFF
--- a/lib/compiler_rt/sin.zig
+++ b/lib/compiler_rt/sin.zig
@@ -49,7 +49,13 @@ pub fn sinf(x: f32) callconv(.c) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x!=0 and underflow if subnormal
-            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) {
+                if (ix < 0x00800000) {
+                    mem.doNotOptimizeAway(x / 0x1p120);
+                } else {
+                    mem.doNotOptimizeAway(x + 0x1p120);
+                }
+            }
             return x;
         }
         return trig.__sindf(x);
@@ -98,7 +104,13 @@ pub fn sin(x: f64) callconv(.c) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e500000) { // |x| < 2**-26
             // raise inexact if x != 0 and underflow if subnormal
-            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) {
+                if (ix < 0x00100000) {
+                    mem.doNotOptimizeAway(x / 0x1p120);
+                } else {
+                    mem.doNotOptimizeAway(x + 0x1p120);
+                }
+            }
             return x;
         }
         return trig.__sin(x, 0.0, 0);

--- a/lib/compiler_rt/sincos.zig
+++ b/lib/compiler_rt/sincos.zig
@@ -46,7 +46,13 @@ pub fn sincosf(x: f32, r_sin: *f32, r_cos: *f32) callconv(.c) void {
         // |x| < 2**-12
         if (ix < 0x39800000) {
             // raise inexact if x!=0 and underflow if subnormal
-            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) {
+                if (ix < 0x00100000) {
+                    mem.doNotOptimizeAway(x / 0x1p120);
+                } else {
+                    mem.doNotOptimizeAway(x + 0x1p120);
+                }
+            }
             r_sin.* = x;
             r_cos.* = 1.0;
             return;
@@ -134,7 +140,13 @@ pub fn sincos(x: f64, r_sin: *f64, r_cos: *f64) callconv(.c) void {
         // if |x| < 2**-27 * sqrt(2)
         if (ix < 0x3e46a09e) {
             // raise inexact if x != 0 and underflow if subnormal
-            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) {
+                if (ix < 0x00100000) {
+                    mem.doNotOptimizeAway(x / 0x1p120);
+                } else {
+                    mem.doNotOptimizeAway(x + 0x1p120);
+                }
+            }
             r_sin.* = x;
             r_cos.* = 1.0;
             return;

--- a/lib/compiler_rt/tan.zig
+++ b/lib/compiler_rt/tan.zig
@@ -51,7 +51,13 @@ pub fn tanf(x: f32) callconv(.c) f32 {
     if (ix <= 0x3f490fda) { // |x| ~<= pi/4
         if (ix < 0x39800000) { // |x| < 2**-12
             // raise inexact if x!=0 and underflow if subnormal
-            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00800000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) {
+                if (ix < 0x00800000) {
+                    mem.doNotOptimizeAway(x / 0x1p120);
+                } else {
+                    mem.doNotOptimizeAway(x + 0x1p120);
+                }
+            }
             return x;
         }
         return kernel.__tandf(x, false);
@@ -89,7 +95,13 @@ pub fn tan(x: f64) callconv(.c) f64 {
     if (ix <= 0x3fe921fb) {
         if (ix < 0x3e400000) { // |x| < 2**-27
             // raise inexact if x!=0 and underflow if subnormal
-            if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
+            if (common.want_float_exceptions) {
+                if (ix < 0x00100000) {
+                    mem.doNotOptimizeAway(x / 0x1p120);
+                } else {
+                    mem.doNotOptimizeAway(x + 0x1p120);
+                }
+            }
             return x;
         }
         return kernel.__tan(x, 0.0, false);


### PR DESCRIPTION
closes #24184

According to the comment, this line of the current `sin` function evaluates `x + 0x1p120` and raises an `INEXACT` exception if `x` is not zero.
It also evaluates `x / 0x1p120` and raises an `UNDERFLOW` exception if `x` is a non-normalized number.
```zig
// raise inexact if x != 0 and underflow if subnormal
if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
```

This is the disassembly results of the `sin` function test built in #24184.
```sh
$ llvm-objdump -S -l -d ./zig-out/bin/sin
[omitted]
; /workspaces/zig/lib/compiler_rt/sin.zig:101
;             if (common.want_float_exceptions) mem.doNotOptimizeAway(if (ix < 0x00100000) x / 0x1p120 else x + 0x1p120);
 1075300: f144011f     	cmp	x8, #0x100, lsl #12     // =0x100000
 1075304: 9e670121     	fmov	d1, x9
 1075308: 9e670142     	fmov	d2, x10
 107530c: 910023e8     	add	x8, sp, #0x8
 1075310: 1e610801     	fmul	d1, d0, d1
 1075314: 1e622802     	fadd	d2, d0, d2
 1075318: 1e623c21     	fcsel	d1, d1, d2, lo
[omitted]
```
`FCSEL` instruction selects one of the two registers according to the condition and copies its value.
The `FCSEL` instruction is preceded by the `FMUL` and `FADD` instructions, indicating that both `x / 0x1p120` and `x + 0x1p120` are evaluated.
It selects one or the other based on the result of `ix < 0x00100000`, but if a floating point exception occurs in the calculation of the one not selected, the exception is reflected in the final result.
In other words, it is effective in reducing branching, but both the `FMUL` and `FADD` instructions can have the side effect of raising a floating point exception, which may cause an exception that the programmer does not intend.

To prevent `FCSEL` instruction from being used here, this PR splits `doNotOptimizeAway` in two.
This change adds a branch instruction, but since this code path only passes if `x` is very small (`|x| < 2^-26` in `sin`), I believe this change is acceptable.

In fact, after this PR, unintended exceptions no longer occur.
```sh
$ ./zig-out/bin/sin
$
```

Several other functions are similarly changed to prevent from raising unintended exceptions.
- sin
- sinf
- sincos
- sincosf
- tan
- tanf