### PR TITLE
build.zig: handle tarball with "." as root module

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -546,7 +546,8 @@ fn runResource(
         // directory.
         f.computed_hash = try computeHash(f, pkg_path, filter);
 
-        break :blk if (unpack_result.root_dir.len > 0)
+        const dot_root_dir = unpack_result.root_dir.len == 1 and unpack_result.root_dir[0] == '.';
+        break :blk if (unpack_result.root_dir.len > 0 and !dot_root_dir)
             try fs.path.join(arena, &.{ tmp_dir_sub_path, unpack_result.root_dir })
         else
             tmp_dir_sub_path;


### PR DESCRIPTION
The issue has been reported under https://github.com/ziglang/zig/issues/23152 and [#23187](https://github.com/ziglang/zig/issues/23187)

I've also face the issue while working on https://github.com/zml/zml/pull/262
Note that the issue trigger just by adding a `.tar.gz` in your `build.zig.zon` that has a `./myfile.txt` inside and running `zig build --fetch`.

I've modified a bit the fetch rule to strip root dir equal to "." 