### PR TITLE
zig fmt: canonicalize nested cast builtin order

### DIFF
--- a/lib/build-web/fuzz.zig
+++ b/lib/build-web/fuzz.zig
@@ -256,7 +256,7 @@ fn updateStats() error{OutOfMemory}!void {
 
     if (recent_coverage_update.items.len == 0) return;
 
-    const hdr: *abi.fuzz.CoverageUpdateHeader = @alignCast(@ptrCast(
+    const hdr: *abi.fuzz.CoverageUpdateHeader = @ptrCast(@alignCast(
         recent_coverage_update.items[0..@sizeOf(abi.fuzz.CoverageUpdateHeader)],
     ));
 

--- a/lib/compiler_rt/memcpy.zig
+++ b/lib/compiler_rt/memcpy.zig
@@ -110,7 +110,7 @@ inline fn copyForwards(
     const d = dest + alignment_offset;
     const s = src + alignment_offset;
 
-    copyBlocksAlignedSource(@ptrCast(d), @alignCast(@ptrCast(s)), n);
+    copyBlocksAlignedSource(@ptrCast(d), @ptrCast(@alignCast(s)), n);
 
     // copy last `@sizeOf(Element)` bytes unconditionally, since block copy
     // methods only copy a multiple of `@sizeOf(Element)` bytes.

--- a/lib/compiler_rt/memmove.zig
+++ b/lib/compiler_rt/memmove.zig
@@ -157,7 +157,7 @@ inline fn copyForwards(
     const d = dest + alignment_offset;
     const s = src + alignment_offset;
 
-    copyBlocksAlignedSource(@ptrCast(d), @alignCast(@ptrCast(s)), n);
+    copyBlocksAlignedSource(@ptrCast(d), @ptrCast(@alignCast(s)), n);
 
     // copy last `copy_size` bytes unconditionally, since block copy
     // methods only copy a multiple of `copy_size` bytes.

--- a/lib/std/Io.zig
+++ b/lib/std/Io.zig
@@ -304,7 +304,7 @@ pub fn GenericReader(
         const Self = @This();
 
         fn typeErasedReadFn(context: *const anyopaque, buffer: []u8) anyerror!usize {
-            const ptr: *const Context = @alignCast(@ptrCast(context));
+            const ptr: *const Context = @ptrCast(@alignCast(context));
             return readFn(ptr.*, buffer);
         }
 
@@ -397,7 +397,7 @@ pub fn GenericWriter(
         }
 
         fn typeErasedWriteFn(context: *const anyopaque, bytes: []const u8) anyerror!usize {
-            const ptr: *const Context = @alignCast(@ptrCast(context));
+            const ptr: *const Context = @ptrCast(@alignCast(context));
             return writeFn(ptr.*, bytes);
         }
 

--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -1698,7 +1698,7 @@ pub fn adaptToOldInterface(r: *Reader) std.Io.AnyReader {
 }
 
 fn derpRead(context: *const anyopaque, buffer: []u8) anyerror!usize {
-    const r: *Reader = @constCast(@alignCast(@ptrCast(context)));
+    const r: *Reader = @ptrCast(@alignCast(@constCast(context)));
     return r.readSliceShort(buffer);
 }
 

--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -2086,7 +2086,7 @@ const IndexHeader = struct {
     /// Returns the attached array of indexes.  I must match the type
     /// returned by capacityIndexType.
     fn indexes(header: *IndexHeader, comptime I: type) []Index(I) {
-        const start_ptr: [*]Index(I) = @alignCast(@ptrCast(@as([*]u8, @ptrCast(header)) + @sizeOf(IndexHeader)));
+        const start_ptr: [*]Index(I) = @ptrCast(@alignCast(@as([*]u8, @ptrCast(header)) + @sizeOf(IndexHeader)));
         return start_ptr[0..header.length()];
     }
 
@@ -2122,7 +2122,7 @@ const IndexHeader = struct {
         const nbytes = @sizeOf(IndexHeader) + index_size * len;
         const bytes = try gpa.alignedAlloc(u8, .of(IndexHeader), nbytes);
         @memset(bytes[@sizeOf(IndexHeader)..], 0xff);
-        const result: *IndexHeader = @alignCast(@ptrCast(bytes.ptr));
+        const result: *IndexHeader = @ptrCast(@alignCast(bytes.ptr));
         result.* = .{
             .bit_index = new_bit_index,
         };

--- a/lib/std/crypto/codecs/asn1/der/Encoder.zig
+++ b/lib/std/crypto/codecs/asn1/der/Encoder.zig
@@ -37,7 +37,7 @@ fn anyTag(self: *Encoder, tag_: Tag, val: anytype) !void {
                 // > The encoding of a set value or sequence value shall not include an encoding for any
                 // > component value which is equal to its default value.
                 const is_default = if (f.is_comptime) false else if (f.default_value_ptr) |v| brk: {
-                    const default_val: *const f.type = @alignCast(@ptrCast(v));
+                    const default_val: *const f.type = @ptrCast(@alignCast(v));
                     break :brk std.mem.eql(u8, std.mem.asBytes(default_val), std.mem.asBytes(&field_val));
                 } else false;
 

--- a/lib/std/crypto/timing_safe.zig
+++ b/lib/std/crypto/timing_safe.zig
@@ -147,7 +147,7 @@ fn markSecret(ptr: anytype, comptime action: enum { classify, declassify }) void
             @compileError("A pointer value is always assumed leak information via side channels");
         },
         else => {
-            const mem8: *const [@sizeOf(@TypeOf(ptr.*))]u8 = @constCast(@ptrCast(ptr));
+            const mem8: *const [@sizeOf(@TypeOf(ptr.*))]u8 = @ptrCast(@constCast(ptr));
             if (action == .classify) {
                 std.valgrind.memcheck.makeMemUndefined(mem8);
             } else {

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -569,7 +569,7 @@ pub fn assertReadable(slice: []const volatile u8) void {
 /// Invokes detectable illegal behavior when the provided array is not aligned
 /// to the provided amount.
 pub fn assertAligned(ptr: anytype, comptime alignment: std.mem.Alignment) void {
-    const aligned_ptr: *align(alignment.toByteUnits()) anyopaque = @alignCast(@ptrCast(ptr));
+    const aligned_ptr: *align(alignment.toByteUnits()) anyopaque = @ptrCast(@alignCast(ptr));
     _ = aligned_ptr;
 }
 

--- a/lib/std/debug/SelfInfo.zig
+++ b/lib/std/debug/SelfInfo.zig
@@ -836,7 +836,7 @@ pub const WindowsModule = struct {
 
         pub fn deinit(self: @This()) void {
             const process_handle = windows.GetCurrentProcess();
-            assert(windows.ntdll.NtUnmapViewOfSection(process_handle, @constCast(@ptrCast(self.section_view.ptr))) == .SUCCESS);
+            assert(windows.ntdll.NtUnmapViewOfSection(process_handle, @ptrCast(@constCast(self.section_view.ptr))) == .SUCCESS);
             windows.CloseHandle(self.section_handle);
             self.file.close();
         }

--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1511,7 +1511,7 @@ pub fn HashMapUnmanaged(
 
             const total_size = std.mem.alignForward(usize, vals_end, max_align);
 
-            const slice = @as([*]align(max_align) u8, @alignCast(@ptrCast(self.header())))[0..total_size];
+            const slice = @as([*]align(max_align) u8, @ptrCast(@alignCast(self.header())))[0..total_size];
             allocator.free(slice);
 
             self.metadata = null;

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -151,7 +151,7 @@ const CAllocator = struct {
     };
 
     fn getHeader(ptr: [*]u8) *[*]u8 {
-        return @alignCast(@ptrCast(ptr - @sizeOf(usize)));
+        return @ptrCast(@alignCast(ptr - @sizeOf(usize)));
     }
 
     fn alignedAlloc(len: usize, alignment: Alignment) ?[*]u8 {

--- a/lib/std/heap/SmpAllocator.zig
+++ b/lib/std/heap/SmpAllocator.zig
@@ -205,7 +205,7 @@ fn free(context: *anyopaque, memory: []u8, alignment: mem.Alignment, ra: usize) 
         return PageAllocator.unmap(@alignCast(memory));
     }
 
-    const node: *usize = @alignCast(@ptrCast(memory.ptr));
+    const node: *usize = @ptrCast(@alignCast(memory.ptr));
 
     const t = Thread.lock();
     defer t.unlock();

--- a/lib/std/heap/debug_allocator.zig
+++ b/lib/std/heap/debug_allocator.zig
@@ -291,7 +291,7 @@ pub fn DebugAllocator(comptime config: Config) type {
 
             fn usedBits(bucket: *BucketHeader, index: usize) *usize {
                 const ptr: [*]u8 = @ptrCast(bucket);
-                const bits: [*]usize = @alignCast(@ptrCast(ptr + @sizeOf(BucketHeader)));
+                const bits: [*]usize = @ptrCast(@alignCast(ptr + @sizeOf(BucketHeader)));
                 return &bits[index];
             }
 

--- a/lib/std/http/Server.zig
+++ b/lib/std/http/Server.zig
@@ -624,7 +624,7 @@ pub const Request = struct {
     };
 
     fn read_cl(context: *const anyopaque, buffer: []u8) ReadError!usize {
-        const request: *Request = @constCast(@alignCast(@ptrCast(context)));
+        const request: *Request = @ptrCast(@alignCast(@constCast(context)));
         const s = request.server;
 
         const remaining_content_length = &request.reader_state.remaining_content_length;
@@ -652,7 +652,7 @@ pub const Request = struct {
     }
 
     fn read_chunked(context: *const anyopaque, buffer: []u8) ReadError!usize {
-        const request: *Request = @constCast(@alignCast(@ptrCast(context)));
+        const request: *Request = @ptrCast(@alignCast(@constCast(context)));
         const s = request.server;
 
         const cp = &request.reader_state.chunk_parser;
@@ -894,7 +894,7 @@ pub const Response = struct {
     }
 
     fn write_cl(context: *const anyopaque, bytes: []const u8) WriteError!usize {
-        const r: *Response = @constCast(@alignCast(@ptrCast(context)));
+        const r: *Response = @ptrCast(@alignCast(@constCast(context)));
 
         var trash: u64 = std.math.maxInt(u64);
         const len = switch (r.transfer_encoding) {
@@ -944,7 +944,7 @@ pub const Response = struct {
     }
 
     fn write_chunked(context: *const anyopaque, bytes: []const u8) WriteError!usize {
-        const r: *Response = @constCast(@alignCast(@ptrCast(context)));
+        const r: *Response = @ptrCast(@alignCast(@constCast(context)));
         assert(r.transfer_encoding == .chunked);
 
         if (r.elide_body)

--- a/lib/std/os/uefi/tables.zig
+++ b/lib/std/os/uefi/tables.zig
@@ -154,7 +154,7 @@ pub const MemoryMapSlice = struct {
 
     pub fn getUnchecked(self: MemoryMapSlice, index: usize) *MemoryDescriptor {
         const offset: usize = index * self.info.descriptor_size;
-        return @alignCast(@ptrCast(self.ptr[offset..]));
+        return @ptrCast(@alignCast(self.ptr[offset..]));
     }
 };
 

--- a/lib/std/os/uefi/tables/runtime_services.zig
+++ b/lib/std/os/uefi/tables/runtime_services.zig
@@ -353,7 +353,7 @@ pub const RuntimeServices = extern struct {
             reset_type,
             reset_status,
             if (data) |d| d.len else 0,
-            if (data) |d| @alignCast(@ptrCast(d.ptr)) else null,
+            if (data) |d| @ptrCast(@alignCast(d.ptr)) else null,
         );
     }
 

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -202,7 +202,7 @@ pub fn CreatePipe(rd: *HANDLE, wr: *HANDLE, sattr: *const SECURITY_ATTRIBUTES) C
         const name = UNICODE_STRING{
             .Length = len,
             .MaximumLength = len,
-            .Buffer = @constCast(@ptrCast(str)),
+            .Buffer = @ptrCast(@constCast(str)),
         };
         const attrs = OBJECT_ATTRIBUTES{
             .ObjectName = @constCast(&name),

--- a/lib/std/pie.zig
+++ b/lib/std/pie.zig
@@ -259,7 +259,7 @@ pub fn relocate(phdrs: []const elf.Phdr) void {
 
     const rel = sorted_dynv[elf.DT_REL];
     if (rel != 0) {
-        const rels: []const elf.Rel = @alignCast(@ptrCast(
+        const rels: []const elf.Rel = @ptrCast(@alignCast(
             @as([*]align(@alignOf(elf.Rel)) const u8, @ptrFromInt(base_addr + rel))[0..sorted_dynv[elf.DT_RELSZ]],
         ));
         for (rels) |r| {
@@ -270,7 +270,7 @@ pub fn relocate(phdrs: []const elf.Phdr) void {
 
     const rela = sorted_dynv[elf.DT_RELA];
     if (rela != 0) {
-        const relas: []const elf.Rela = @alignCast(@ptrCast(
+        const relas: []const elf.Rela = @ptrCast(@alignCast(
             @as([*]align(@alignOf(elf.Rela)) const u8, @ptrFromInt(base_addr + rela))[0..sorted_dynv[elf.DT_RELASZ]],
         ));
         for (relas) |r| {

--- a/lib/std/zig/c_translation.zig
+++ b/lib/std/zig/c_translation.zig
@@ -71,7 +71,7 @@ fn castInt(comptime DestType: type, target: anytype) DestType {
 }
 
 fn castPtr(comptime DestType: type, target: anytype) DestType {
-    return @constCast(@volatileCast(@alignCast(@ptrCast(target))));
+    return @ptrCast(@alignCast(@constCast(@volatileCast(target))));
 }
 
 fn castToPtr(comptime DestType: type, comptime SourceType: type, target: anytype) DestType {

--- a/lib/ubsan_rt.zig
+++ b/lib/ubsan_rt.zig
@@ -58,8 +58,8 @@ const Value = extern struct {
         }
 
         return switch (size) {
-            64 => @as(*const u64, @alignCast(@ptrCast(value.handle))).*,
-            128 => @as(*const u128, @alignCast(@ptrCast(value.handle))).*,
+            64 => @as(*const u64, @ptrCast(@alignCast(value.handle))).*,
+            128 => @as(*const u128, @ptrCast(@alignCast(value.handle))).*,
             else => @trap(),
         };
     }
@@ -74,8 +74,8 @@ const Value = extern struct {
             return (handle << extra_bits) >> extra_bits;
         }
         return switch (size) {
-            64 => @as(*const i64, @alignCast(@ptrCast(value.handle))).*,
-            128 => @as(*const i128, @alignCast(@ptrCast(value.handle))).*,
+            64 => @as(*const i64, @ptrCast(@alignCast(value.handle))).*,
+            128 => @as(*const i128, @ptrCast(@alignCast(value.handle))).*,
             else => @trap(),
         };
     }
@@ -92,9 +92,9 @@ const Value = extern struct {
             }, @bitCast(@intFromPtr(value.handle)));
         }
         return @floatCast(switch (size) {
-            64 => @as(*const f64, @alignCast(@ptrCast(value.handle))).*,
-            80 => @as(*const f80, @alignCast(@ptrCast(value.handle))).*,
-            128 => @as(*const f128, @alignCast(@ptrCast(value.handle))).*,
+            64 => @as(*const f64, @ptrCast(@alignCast(value.handle))).*,
+            80 => @as(*const f80, @ptrCast(@alignCast(value.handle))).*,
+            128 => @as(*const f128, @ptrCast(@alignCast(value.handle))).*,
             else => @trap(),
         });
     }

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -1365,7 +1365,7 @@ const Local = struct {
                 capacity: u32,
             };
             fn header(list: ListSelf) *Header {
-                return @alignCast(@ptrCast(list.bytes - bytes_offset));
+                return @ptrCast(@alignCast(list.bytes - bytes_offset));
             }
             pub fn view(list: ListSelf) View {
                 const capacity = list.header().capacity;
@@ -1574,7 +1574,7 @@ const Shard = struct {
                 }
             };
             fn header(map: @This()) *Header {
-                return @alignCast(@ptrCast(@as([*]u8, @ptrCast(map.entries)) - entries_offset));
+                return @ptrCast(@alignCast(@as([*]u8, @ptrCast(map.entries)) - entries_offset));
             }
 
             const Entry = extern struct {

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -898,7 +898,7 @@ const Resource = union(enum) {
     }
 
     fn read(context: *const anyopaque, buffer: []u8) anyerror!usize {
-        const resource: *Resource = @constCast(@ptrCast(@alignCast(context)));
+        const resource: *Resource = @ptrCast(@alignCast(@constCast(context)));
         switch (resource.*) {
             .file => |*f| return f.read(buffer),
             .http_request => |*r| return r.read(buffer),

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -4008,11 +4008,11 @@ fn transCreateCompoundAssign(
 }
 
 fn removeCVQualifiers(c: *Context, dst_type_node: Node, expr: Node) Error!Node {
-    const const_casted = try Tag.const_cast.create(c.arena, expr);
-    const volatile_casted = try Tag.volatile_cast.create(c.arena, const_casted);
+    const volatile_casted = try Tag.volatile_cast.create(c.arena, expr);
+    const const_casted = try Tag.const_cast.create(c.arena, volatile_casted);
     return Tag.as.create(c.arena, .{
         .lhs = dst_type_node,
-        .rhs = try Tag.ptr_cast.create(c.arena, volatile_casted),
+        .rhs = try Tag.ptr_cast.create(c.arena, const_casted),
     });
 }
 

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -1091,7 +1091,7 @@ test "initialize pointer to anyopaque with reference to empty array initializer"
     const ptr: *const anyopaque = &.{};
     // The above acts like an untyped initializer, since the `.{}` has no result type.
     // So, `ptr` points in memory to an empty tuple (`@TypeOf(.{})`).
-    const casted: *const @TypeOf(.{}) = @alignCast(@ptrCast(ptr));
+    const casted: *const @TypeOf(.{}) = @ptrCast(@alignCast(ptr));
     const loaded = casted.*;
     // `val` should be a `@TypeOf(.{})`, as expected.
     // We can't check the value, but it's zero-bit, so the type matching is good enough.

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -477,7 +477,7 @@ fn GenericIntApplier(
         }
 
         fn typeErasedApplyFn(context: *const anyopaque, arg: u32) void {
-            const ptr: *const Context = @alignCast(@ptrCast(context));
+            const ptr: *const Context = @ptrCast(@alignCast(context));
             applyFn(ptr.*, arg);
         }
     };

--- a/test/behavior/extern.zig
+++ b/test/behavior/extern.zig
@@ -8,7 +8,7 @@ test "anyopaque extern symbol" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     const a = @extern(*anyopaque, .{ .name = "a_mystery_symbol" });
-    const b: *i32 = @alignCast(@ptrCast(a));
+    const b: *i32 = @ptrCast(@alignCast(a));
     try expect(b.* == 1234);
 }
 

--- a/test/cases/compile_errors/nested_ptr_cast_bad_operand.zig
+++ b/test/cases/compile_errors/nested_ptr_cast_bad_operand.zig
@@ -6,7 +6,7 @@ export fn b() void {
     _ = @constCast(@volatileCast(123));
 }
 export fn c() void {
-    const x: ?*f32 = @constCast(@ptrCast(@addrSpaceCast(@volatileCast(p))));
+    const x: ?*f32 = @ptrCast(@addrSpaceCast(@constCast(@volatileCast(p))));
     _ = x;
 }
 

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3234,12 +3234,12 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\pub export fn bar(arg_a: [*c]const c_int) void {
         \\    var a = arg_a;
         \\    _ = &a;
-        \\    foo(@as([*c]c_int, @ptrCast(@volatileCast(@constCast(a)))));
+        \\    foo(@as([*c]c_int, @ptrCast(@constCast(@volatileCast(a)))));
         \\}
         \\pub export fn baz(arg_a: [*c]volatile c_int) void {
         \\    var a = arg_a;
         \\    _ = &a;
-        \\    foo(@as([*c]c_int, @ptrCast(@volatileCast(@constCast(a)))));
+        \\    foo(@as([*c]c_int, @ptrCast(@constCast(@volatileCast(a)))));
         \\}
     });
 


### PR DESCRIPTION
Closes #24106

Searches for surrounding tokens tagged with `.builtin` when a `.builtin_...` node whose main token ends in `"Cast"` is encountered and picks which one to render first according to the field order in `CastKind`. In case of a redundant casting operation (e.g. `@ptrCast(@volatileCast(@ptrCast(...)))`) no reordering is done for the entire nested chain.

The canonical ordering is the one proposed by mlugg:
```zig
@ptrCast(@alignCast(@addrSpaceCast(@constCast(@volatileCast(something)))))
```
It can be changed by simply rearranging the fields of `CastKind` (and adjusting the rendering order in `translate_c.removeCVQualifiers` for `@constCast()`/`@volatileCast()` and related tests).

The first commit is the actual implementation,the second commit is the new ordering applied to affected source files.