### PR TITLE
fix a typo in langref

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -6605,7 +6605,7 @@ const builtin = @import("builtin");
       {#header_open|Special Root Declarations#}
       <p>
       Because the root module's root source file is always accessible using
-      {#syntax#}@import("root"){#endsyntax#}, is is sometimes used by libraries &mdash; including the Zig Standard
+      {#syntax#}@import("root"){#endsyntax#}, it is sometimes used by libraries &mdash; including the Zig Standard
       Library &mdash; as a place for the program to expose some "global" information to that library. The Zig
       Standard Library will look for several declarations in this file.
       </p>


### PR DESCRIPTION
there is a typo in langref, ", is is" should be ", it is"

<img width="812" alt="截屏2025-06-17 14 32 27" src="https://github.com/user-attachments/assets/deffebf6-d428-48a3-b656-b5a11e19a057" />
