### PR TITLE
windows: msvc: avoid depending on ucrtbased.dll by statically linking to ucrt in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,16 @@ if(ZIG_STATIC_ZSTD)
     list(APPEND LLVM_LIBRARIES "${ZSTD}")
 endif()
 
+if (MSVC)
+    if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+        if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+            # avoid linking to the debug versions of ucrt by default
+            # as they are not redistributable.
+            set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+        endif()
+    endif()
+endif ()
+
 if(ZIG_STATIC_CURSES)
     list(REMOVE_ITEM LLVM_LIBRARIES "-lcurses")
     find_library(CURSES NAMES libcurses.a libncurses.a NAMES_PER_DIR


### PR DESCRIPTION
In debug builds, this change updates all cmake targets to statically link to the "Universal C Runtime Library" (ucrt) by default. This adds about 1 to 2 megabytes but also removes th runtime dependency on `ucrtbased.dll`, which is only available on machines that have installed the Windows SDK (and added the ucrtbased.dll parent directory to the system `PATH` environment variable).