### PR TITLE
std.math.big.int: Improvements to `toString` and `setString` speed

### DIFF
--- a/lib/compiler/aro/aro/Value.zig
+++ b/lib/compiler/aro/aro/Value.zig
@@ -695,7 +695,7 @@ pub fn div(res: *Value, lhs: Value, rhs: Value, ty: Type, comp: *Compilation) !b
         );
         defer comp.gpa.free(limbs_buffer);
 
-        result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer);
+        result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer, null);
 
         res.* = try intern(comp, .{ .int = .{ .big_int = result_q.toConst() } });
         return !result_q.toConst().fitsInTwosComp(ty.signedness(comp), bits);
@@ -748,7 +748,7 @@ pub fn rem(lhs: Value, rhs: Value, ty: Type, comp: *Compilation) !Value {
     );
     defer comp.gpa.free(limbs_buffer);
 
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buffer, null);
     return intern(comp, .{ .int = .{ .big_int = result_r.toConst() } });
 }
 

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -4186,6 +4186,7 @@ fn lldiv1(q: []Limb, a: []Limb, b: Limb) void {
         assert(q.len >= calcDivQLenExact(a, &.{b}));
         // b must be normalized
         assert(@clz(b) == 0);
+        assert(!slicesOverlap(q, a));
     }
 
     const n = a.len;

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -17,6 +17,10 @@ const Endian = std.builtin.Endian;
 const Signedness = std.builtin.Signedness;
 const native_endian = builtin.cpu.arch.endian();
 
+// value based only on a few tests, could probably be adjusted
+// it may also depend on the cpu
+const recursive_division_threshold = 100;
+
 /// Returns the number of limbs needed to store `scalar`, which must be a
 /// primitive integer value.
 /// Note: A comptime-known upper bound of this value that may be used
@@ -796,7 +800,7 @@ pub const Mutable = struct {
 
         @memset(rma.limbs[0..req_limbs], 0);
 
-        llmulacc(.add, allocator, rma.limbs, a_limbs, b_limbs);
+        llmulacc(.add, allocator, rma.limbs[0..req_limbs], a_limbs, b_limbs);
         rma.normalize(@min(req_limbs, a.limbs.len + b.limbs.len));
         rma.positive = (a.positive == b.positive);
         rma.truncate(rma.toConst(), signedness, bit_count);
@@ -979,18 +983,12 @@ pub const Mutable = struct {
     /// The upper bound for q limb count is given by `a.limbs`.
     ///
     /// `limbs_buffer` is used for temporary storage. The amount required is given by `calcDivLimbsBufferLen`.
-    pub fn divFloor(
-        q: *Mutable,
-        r: *Mutable,
-        a: Const,
-        b: Const,
-        limbs_buffer: []Limb,
-    ) void {
+    pub fn divFloor(q: *Mutable, r: *Mutable, a: Const, b: Const, limbs_buffer: []Limb, opt_allocator: ?Allocator) void {
         const sep = a.limbs.len + 2;
         const x = a.toMutable(limbs_buffer[0..sep]);
         const y = b.toMutable(limbs_buffer[sep..]);
 
-        div(q, r, x, y);
+        div(q, r, x, y, opt_allocator);
 
         // Note, `div` performs truncating division, which satisfies
         // @divTrunc(a, b) * b + @rem(a, b) = a
@@ -1106,18 +1104,12 @@ pub const Mutable = struct {
     /// The upper bound for q limb count is given by `a.limbs.len`.
     ///
     /// `limbs_buffer` is used for temporary storage. The amount required is given by `calcDivLimbsBufferLen`.
-    pub fn divTrunc(
-        q: *Mutable,
-        r: *Mutable,
-        a: Const,
-        b: Const,
-        limbs_buffer: []Limb,
-    ) void {
+    pub fn divTrunc(q: *Mutable, r: *Mutable, a: Const, b: Const, limbs_buffer: []Limb, opt_allocator: ?Allocator) void {
         const sep = a.limbs.len + 2;
         const x = a.toMutable(limbs_buffer[0..sep]);
         const y = b.toMutable(limbs_buffer[sep..]);
 
-        div(q, r, x, y);
+        div(q, r, x, y, opt_allocator);
     }
 
     /// r = a << shift, in other words, r = a * 2^shift
@@ -1441,7 +1433,8 @@ pub const Mutable = struct {
         };
 
         while (true) {
-            t.divFloor(&rem, a, s.toConst(), limbs_buffer[buf_index..]);
+            // TODO: pass an allocator or remove the need for it in the division
+            t.divFloor(&rem, a, s.toConst(), limbs_buffer[buf_index..], null);
             t.add(t.toConst(), s.toConst());
             u.shiftRight(t.toConst(), 1);
 
@@ -1566,7 +1559,7 @@ pub const Mutable = struct {
     // Truncates by default.
     // Requires no aliasing between all variables
     // a must have the capacity to store a one limb shift
-    fn div(q: *Mutable, r: *Mutable, a: Mutable, b: Mutable) void {
+    fn div(q: *Mutable, r: *Mutable, a: Mutable, b: Mutable, opt_allocator: ?Allocator) void {
         if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
             assert(!b.eqlZero()); // division by zero
             assert(q != r); // illegal aliasing
@@ -1621,7 +1614,20 @@ pub const Mutable = struct {
             a_limbs[1] = result.r[0];
             a_limbs[0] = result.r[1];
         } else {
-            basecaseDivRem(q.limbs, a_limbs, b_limbs);
+            // Currently, an allocator is required to use karatsuba.
+            // Recursive division is only faster than the basecase division thanks to better
+            // multiplication algorithms. Without them, it is worse due to overhead, so we just
+            // default to the basecase
+            if (opt_allocator) |allocator| {
+                // if `B.limbs.len` < `recursive_division_threshold`, the recursiveDivRem calls from unbalancedDivision
+                // will always immediatly default to basecaseDivRem, so just using the basecase is faster
+                if (b_limbs.len < recursive_division_threshold)
+                    basecaseDivRem(q.limbs, a_limbs, b_limbs)
+                else
+                    unbalancedDivision(q.limbs, a_limbs, b_limbs, allocator);
+            } else {
+                basecaseDivRem(q.limbs, a_limbs, b_limbs);
+            }
         }
 
         // we have r < b, so there is at most b.len() limbs
@@ -2195,7 +2201,8 @@ pub const Const = struct {
             while (q.len >= 2) {
                 // Passing an allocator here would not be helpful since this division is destroying
                 // information, not creating it. [TODO citation needed]
-                q.divTrunc(&r, q.toConst(), b, rest_of_the_limbs_buf);
+                // passing an allocator is not useful since b is one limb, so it will use lldiv1
+                q.divTrunc(&r, q.toConst(), b, rest_of_the_limbs_buf, null);
 
                 var r_word = r.limbs[0];
                 var i: usize = 0;
@@ -2903,7 +2910,7 @@ pub const Managed = struct {
         var mr = r.toMutable();
         const limbs_buffer = try q.allocator.alloc(Limb, calcDivLimbsBufferLen(a.len(), b.len()));
         defer q.allocator.free(limbs_buffer);
-        mq.divFloor(&mr, a.toConst(), b.toConst(), limbs_buffer);
+        mq.divFloor(&mr, a.toConst(), b.toConst(), limbs_buffer, q.allocator);
         q.setMetadata(mq.positive, mq.len);
         r.setMetadata(mr.positive, mr.len);
     }
@@ -2920,7 +2927,7 @@ pub const Managed = struct {
         var mr = r.toMutable();
         const limbs_buffer = try q.allocator.alloc(Limb, calcDivLimbsBufferLen(a.len(), b.len()));
         defer q.allocator.free(limbs_buffer);
-        mq.divTrunc(&mr, a.toConst(), b.toConst(), limbs_buffer);
+        mq.divTrunc(&mr, a.toConst(), b.toConst(), limbs_buffer, q.allocator);
         q.setMetadata(mq.positive, mq.len);
         r.setMetadata(mr.positive, mr.len);
     }
@@ -3129,7 +3136,8 @@ const AccOp = enum {
 /// r = r (op) a * b
 /// r MUST NOT alias any of a or b.
 ///
-/// The result is computed modulo `r.len`. When `r.len >= a.len + b.len`, no overflow occurs.
+/// Returns whether the operation overflowed
+/// The result is computed modulo `r.len`.
 fn llmulacc(comptime op: AccOp, opt_allocator: ?Allocator, r: []Limb, a: []const Limb, b: []const Limb) void {
     assert(r.len >= a.len);
     assert(r.len >= b.len);
@@ -3747,8 +3755,9 @@ pub fn llcmp(a: []const Limb, b: []const Limb) math.Order {
 }
 
 /// r = r (op) y * xi
-/// The result is computed modulo `r.len`. When `r.len >= a.len + b.len`, no overflow occurs.
-fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb) void {
+/// returns whether the operation overflowed
+/// The result is computed modulo `r.len`.
+pub fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb) void {
     assert(r.len >= a.len);
     assert(a.len >= b.len);
 
@@ -3759,8 +3768,11 @@ fn llmulaccLong(comptime op: AccOp, r: []Limb, a: []const Limb, b: []const Limb)
 }
 
 /// r = r (op) y * xi
-/// The result is computed modulo `r.len`.
 /// Returns whether the operation overflowed.
+/// If y.len > acc.len, it assumes some of the remaining limbs are non-zero and always overflows
+//
+// usually, if y.len > acc.len, the caller wants a modular operation, and therefore does not care
+// about the overflow anyway
 fn llmulLimb(comptime op: AccOp, acc: []Limb, y: []const Limb, xi: Limb) bool {
     assert(!slicesOverlap(acc, y) or @intFromPtr(acc.ptr) <= @intFromPtr(y.ptr));
 
@@ -3787,7 +3799,7 @@ fn llmulLimb(comptime op: AccOp, acc: []Limb, y: []const Limb, xi: Limb) bool {
         if (carry != 0 and acc.len > y.len)
             carry = @intFromBool(llaccum(op, acc[y.len..], &.{carry}));
 
-        return carry != 0;
+        return carry != 0 or y.len > acc.len;
     }
 
     return llmulLimbGeneric(op, acc, y, xi);
@@ -3933,6 +3945,143 @@ fn lladd(r: []Limb, a: []const Limb, b: []const Limb) void {
     r[a.len] = lladdcarry(r, a, b);
 }
 
+/// Algorithm UnbalancedDivision from "Modern Computer Arithmetic" by Richard P. Brent and Paul Zimmermann
+///
+/// `q` = `a` / `b` rem `r`
+///
+/// Normalization and unnormalization steps are handled by the caller.
+/// `r` is written in `a[0..b.len]` (`a[b.len..]` is NOT zeroed out).
+/// The most significant limbs of `a` (input) can be zeroes.
+///
+/// requires:
+/// - `b.len` >= 2
+/// - `a.len` >= 3
+/// - `a.len` >= `b.len`
+/// - `b` must be normalized (most significant bit of `b[b.len - 1]` must be set)
+/// - `q.len >= calcDivQLenExact(a, b)` (the quotient must be able to fit in `q`)
+///   a valid bound for q can be obtained more cheaply using `calcDivQLen`
+/// - no overlap between q, a and b
+fn unbalancedDivision(q: []Limb, a: []Limb, b: []const Limb, allocator: std.mem.Allocator) void {
+    if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
+        assert(!slicesOverlap(q, a));
+        assert(!slicesOverlap(q, b));
+        assert(!slicesOverlap(a, b));
+        assert(b.len >= 2);
+        assert(a.len >= 3);
+        assert(a.len >= b.len);
+        assert(q.len >= calcDivQLenExact(a, b));
+        // b must be normalized
+        assert(@clz(b[b.len - 1]) == 0);
+    }
+    const n = b.len;
+    var m = a.len - b.len;
+
+    // We slightly deviate from the paper, by allowing `m <= n`, and, instead of doing a division after
+    // the loop, we do it before, in case the quotient takes up m - n + 1 Limbs.
+    // For the next loops, the quotient is always guaranteed to fit in n Limbs.
+    //
+    // `q.len` may be only m limbs instead of m + 1 if the caller know the result will fit
+    // (which has already been asserted).
+    const k = m % n;
+    recursiveDivRem(q[m - k .. @min(m + 1, q.len)], a[m - k .. m + n], b, allocator);
+    m -= k;
+
+    while (m > 0) {
+        // At each loop, we divide <r, a[m - n .. m]> by `b`, with r = a[m .. m + n],
+        // the remainder from the previous loop. This is effectively a 2 word by 1 word division,
+        // except each word is n Limbs long. The process is analogous to `lldiv1`.
+        //
+        // The quotient is guaranteed to fit in `n` Limbs since r < b (from the previous iteration).
+        recursiveDivRem(q[m - n .. m], a[m - n .. m + n], b, allocator);
+        m -= n;
+    }
+}
+
+/// Algorithm RecursiveDivRem from "Modern Computer Arithmetic" by Richard P. Brent and Paul Zimmermann
+///
+/// `q` = `a` / `b` rem `r`
+///
+/// Normalization and unnormalization steps are handled by the caller.
+/// `r` is written in `a[0..b.len]` (`a[b.len..]` is NOT zeroed out).
+/// The most significant limbs of `a` (input) can be zeroes.
+///
+/// requires:
+/// - `b.len` >= 2
+/// - `a.len` >= 3
+/// - `a.len` >= `b.len` and 2 * `b.len` >= `a.len`
+/// - `b` must be normalized (most significant bit of `b[b.len - 1]` must be set)
+/// - `q.len >= calcDivQLenExact(a, b)` (the quotient must be able to fit in `q`)
+///   a valid bound for q can be obtained more cheaply using `calcDivQLen`
+/// - no overlap between q, a and b
+fn recursiveDivRem(q: []Limb, a: []Limb, b: []const Limb, allocator: std.mem.Allocator) void {
+    if (builtin.mode == .Debug or builtin.mode == .ReleaseSafe) {
+        assert(!slicesOverlap(q, a));
+        assert(!slicesOverlap(q, b));
+        assert(!slicesOverlap(a, b));
+        assert(b.len >= 2);
+        assert(a.len >= 3);
+        assert(a.len >= b.len);
+        // n >= m
+        assert(2 * b.len >= a.len);
+        assert(q.len >= std.math.big.int.calcDivQLenExact(a, b));
+        // b must be normalized
+        assert(@clz(b[b.len - 1]) == 0);
+        assert(recursive_division_threshold > 2);
+    }
+
+    const n = b.len;
+    const m = a.len - n;
+
+    if (m < recursive_division_threshold) return basecaseDivRem(q, a, b);
+
+    const k = m / 2;
+
+    const b0 = b[0..k];
+    const b1 = b[k..];
+    const q1 = q[k..@min(q.len, m + 1)];
+    const q0 = q[0..k];
+
+    // It is possible to reduce the probability of `a_is_negative`
+    // by adding a Limb to a[2*k..] and b[k..]. In practice, I did not
+    // see any meaningful speed difference
+    recursiveDivRem(q1, a[2 * k ..], b1, allocator);
+
+    // Step 4:
+    // - A mod B^2k is just a[0..2*k], which is left untouched after the recursive call
+    // - R1 B^2k is already written into a[2*k..] by the recursive call
+    // we only need to subtract Q1 B0 B^k
+
+    // we have i <= m + 1 + k = a.len - n + k + 1
+    // and k + 1 < m <= n since m >= recursive_division_threshold > 2
+    // therefore k + 1 - n < 0, so i < a.len
+    const i = q1.len + b0.len + k;
+    // We detect an underflow by using the next limb after the subtraction.
+    // If it is not 0, then a carry cannot propagate, since we
+    // subtract either 0 or 1 from this limb.
+    // If it is a 0, a carry propagates if it becomes a maxInt(Limb).
+    var can_underflow = a[i] == 0;
+    llmulacc(.sub, allocator, a[k .. i + 1], q1, b0);
+    var a_is_negative = can_underflow and a[i] == maxInt(Limb);
+
+    while (a_is_negative) {
+        _ = llaccum(.sub, q1, &.{1});
+        a_is_negative = !llaccum(.add, a[k .. i + 1], b);
+    }
+
+    recursiveDivRem(q0, a[k..][0..n], b1, allocator);
+
+    // Step 7.
+    // same as above
+    can_underflow = a[2 * k] == 0;
+    llmulacc(.sub, allocator, a[0 .. 2 * k + 1], q0, b0);
+    a_is_negative = can_underflow and a[2 * k] == maxInt(Limb);
+
+    while (a_is_negative) {
+        _ = llaccum(.sub, q0, &.{1});
+        a_is_negative = !llaccum(.add, a[0 .. 2 * k + 1], b);
+    }
+}
+
 /// Algorithm BasecaseDivRem from "Modern Computer Arithmetic" by Richard P. Brent and Paul Zimmermann
 /// modified to use Algorithm 5 from "Improved division by invariant integers"
 /// by Niels Möller and Torbjörn Granlund
@@ -3961,6 +4110,7 @@ fn basecaseDivRem(q: []Limb, a: []Limb, b: []const Limb) void {
         assert(b.len >= 2);
         assert(a.len >= 3);
         assert(q.len >= calcDivQLenExact(a, b));
+        assert(a.len >= b.len);
         // b must be normalized
         assert(@clz(b[b.len - 1]) == 0);
     }

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1970,7 +1970,7 @@ pub const Const = struct {
         for (self.limbs[0..self.limbs.len]) |limb| {
             std.debug.print("{x} ", .{limb});
         }
-        std.debug.print("len={} positive={}\n", .{ self.len, self.positive });
+        std.debug.print("len={} positive={}\n", .{ self.limbs.len, self.positive });
     }
 
     pub fn abs(self: Const) Const {

--- a/lib/std/math/big/int.zig
+++ b/lib/std/math/big/int.zig
@@ -1617,8 +1617,9 @@ pub const Mutable = struct {
             const result = div3by2(0, a_limbs[1], a_limbs[0], b.limbs[1], b.limbs[0], reciprocal);
 
             q.limbs[0] = result.q;
-            a_limbs[0] = result.r[0];
-            a_limbs[1] = result.r[1];
+            // result.r[0] is the high part of r and result.r[1] its low part
+            a_limbs[1] = result.r[0];
+            a_limbs[0] = result.r[1];
         } else {
             basecaseDivRem(q.limbs, a_limbs, b_limbs);
         }

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -329,7 +329,7 @@ test "string to" {
     defer testing.allocator.free(as);
     const es = "120317241209124781241290847124";
 
-    try testing.expect(mem.eql(u8, as, es));
+    try testing.expectEqualSlices(u8, es, as);
 }
 
 test "string to base base error" {
@@ -347,7 +347,7 @@ test "string to base 2" {
     defer testing.allocator.free(as);
     const es = "-1011";
 
-    try testing.expect(mem.eql(u8, as, es));
+    try testing.expectEqualSlices(u8, es, as);
 }
 
 test "string to base 16" {
@@ -358,7 +358,7 @@ test "string to base 16" {
     defer testing.allocator.free(as);
     const es = "efffffff00000001eeeeeeefaaaaaaab";
 
-    try testing.expect(mem.eql(u8, as, es));
+    try testing.expectEqualSlices(u8, es, as);
 }
 
 test "string to base 36" {
@@ -369,7 +369,7 @@ test "string to base 36" {
     defer testing.allocator.free(as);
     const es = "fifvthrv1mzt79ez9";
 
-    try testing.expect(mem.eql(u8, as, es));
+    try testing.expectEqualSlices(u8, es, as);
 }
 
 test "neg string to" {
@@ -380,7 +380,7 @@ test "neg string to" {
     defer testing.allocator.free(as);
     const es = "-123907434";
 
-    try testing.expect(mem.eql(u8, as, es));
+    try testing.expectEqualSlices(u8, es, as);
 }
 
 test "zero string to" {
@@ -391,7 +391,7 @@ test "zero string to" {
     defer testing.allocator.free(as);
     const es = "0";
 
-    try testing.expect(mem.eql(u8, as, es));
+    try testing.expectEqualSlices(u8, es, as);
 }
 
 test "clone" {
@@ -3001,26 +3001,26 @@ test "big int conversion read twos complement with padding" {
 
     var bit_count: usize = 12 * 8 + 1;
     a.toConst().writeTwosComplement(buffer1[0..13], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0xaa, 0xaa, 0xaa }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0xaa, 0xaa, 0xaa }, buffer1);
     a.toConst().writeTwosComplement(buffer1[0..13], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xaa, 0xaa, 0xaa }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xaa, 0xaa, 0xaa }, buffer1);
     a.toConst().writeTwosComplement(buffer1[0..16], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0x0, 0x0, 0x0 }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0x0, 0x0, 0x0 }, buffer1);
     a.toConst().writeTwosComplement(buffer1[0..16], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd }, buffer1);
 
     @memset(buffer1, 0xaa);
     try a.set(-0x01_02030405_06070809_0a0b0c0d);
     bit_count = 12 * 8 + 2;
 
     a.toConst().writeTwosComplement(buffer1[0..13], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0xf3, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xaa, 0xaa, 0xaa }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xf3, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xaa, 0xaa, 0xaa }, buffer1);
     a.toConst().writeTwosComplement(buffer1[0..13], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf3, 0xaa, 0xaa, 0xaa }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf3, 0xaa, 0xaa, 0xaa }, buffer1);
     a.toConst().writeTwosComplement(buffer1[0..16], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0xf3, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff, 0xff, 0xff }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xf3, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff, 0xff, 0xff }, buffer1);
     a.toConst().writeTwosComplement(buffer1[0..16], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &[_]u8{ 0xff, 0xff, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf3 }));
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xff, 0xff, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf3 }, buffer1);
 }
 
 test "big int write twos complement +/- zero" {
@@ -3035,13 +3035,13 @@ test "big int write twos complement +/- zero" {
     // Test zero
 
     m.toConst().writeTwosComplement(buffer1[0..13], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3)), buffer1);
     m.toConst().writeTwosComplement(buffer1[0..13], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3)), buffer1);
     m.toConst().writeTwosComplement(buffer1[0..16], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 16))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 16)), buffer1);
     m.toConst().writeTwosComplement(buffer1[0..16], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 16))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 16)), buffer1);
 
     @memset(buffer1, 0xaa);
     m.positive = false;
@@ -3049,13 +3049,13 @@ test "big int write twos complement +/- zero" {
     // Test negative zero
 
     m.toConst().writeTwosComplement(buffer1[0..13], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3)), buffer1);
     m.toConst().writeTwosComplement(buffer1[0..13], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 13) ++ ([_]u8{0xaa} ** 3)), buffer1);
     m.toConst().writeTwosComplement(buffer1[0..16], .little);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 16))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 16)), buffer1);
     m.toConst().writeTwosComplement(buffer1[0..16], .big);
-    try testing.expect(std.mem.eql(u8, buffer1, &(([_]u8{0} ** 16))));
+    try testing.expectEqualSlices(u8, &(([_]u8{0} ** 16)), buffer1);
 }
 
 test "big int conversion write twos complement with padding" {
@@ -3415,8 +3415,8 @@ test "(BigInt) positive" {
     const b_fmt = try std.fmt.allocPrintZ(testing.allocator, "{d}", .{b});
     defer testing.allocator.free(b_fmt);
 
-    try testing.expect(mem.eql(u8, a_fmt, "(BigInt)"));
-    try testing.expect(!mem.eql(u8, b_fmt, "(BigInt)"));
+    try testing.expectEqualSlices(u8, "(BigInt)", a_fmt);
+    try testing.expect(!mem.eql(u8, "(BigInt)", b_fmt));
 }
 
 test "(BigInt) negative" {
@@ -3440,8 +3440,8 @@ test "(BigInt) negative" {
     const b_fmt = try std.fmt.allocPrintZ(testing.allocator, "{d}", .{b});
     defer testing.allocator.free(b_fmt);
 
-    try testing.expect(mem.eql(u8, a_fmt, "(BigInt)"));
-    try testing.expect(!mem.eql(u8, b_fmt, "(BigInt)"));
+    try testing.expectEqualSlices(u8, "(BigInt)", a_fmt);
+    try testing.expect(!mem.eql(u8, "(BigInt)", b_fmt));
 }
 
 test "clz" {

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -3667,3 +3667,64 @@ test "ctz" {
     try testing.expectEqual(0, limb_max_squared.ctz(@bitSizeOf(Limb) * 2));
     try testing.expectEqual(0, limb_max_squared.ctz(@bitSizeOf(Limb) * 2 + 1));
 }
+
+test "divFloor random (positive)" {
+    // This test assumes multiplication is correct
+    var rand = std.Random.DefaultPrng.init(testing.random_seed);
+
+    // must be large enough to trigger advanced division algorithm
+    const max_limb_count = 1000;
+
+    for (0..500) |_| {
+        var a = blk: {
+            const len = 2 + rand.next() % max_limb_count;
+            const bytes = try testing.allocator.alignedAlloc(u8, .of(Limb), @intCast(len * @sizeOf(Limb)));
+            rand.fill(bytes);
+
+            var retry_limit: u8 = 5;
+            while (std.mem.allEqual(u8, bytes, 0) and retry_limit > 0) : (retry_limit -= 1)
+                rand.fill(bytes);
+
+            if (retry_limit == 0)
+                @panic("Failed to fill limbs with non zero values");
+
+            const limbs = std.mem.bytesAsSlice(Limb, bytes);
+            var num = Managed{ .allocator = testing.allocator, .limbs = limbs, .metadata = limbs.len };
+            num.normalize(num.len());
+            break :blk num;
+        };
+        defer a.deinit();
+
+        var b = blk: {
+            const len = 2 + rand.next() % a.len();
+            const bytes = try testing.allocator.alignedAlloc(u8, .of(Limb), @intCast(len * @sizeOf(Limb)));
+            rand.fill(bytes);
+
+            var retry_limit: u8 = 5;
+            while (std.mem.allEqual(u8, bytes, 0) and retry_limit > 0) : (retry_limit -= 1)
+                rand.fill(bytes);
+
+            if (retry_limit == 0)
+                @panic("Failed to fill limbs with non zero values");
+
+            const limbs = std.mem.bytesAsSlice(Limb, bytes);
+            var num = Managed{ .allocator = testing.allocator, .limbs = limbs, .metadata = limbs.len };
+            num.normalize(num.len());
+            break :blk num;
+        };
+        defer b.deinit();
+
+        var q = try Managed.init(testing.allocator);
+        defer q.deinit();
+
+        var r = try Managed.init(testing.allocator);
+        defer r.deinit();
+
+        try q.divFloor(&r, &a, &b);
+
+        try q.mul(&q, &b);
+        try q.add(&q, &r);
+
+        try testing.expect(q.eql(a));
+    }
+}

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -34,7 +34,7 @@ pub var log_level = std.log.Level.warn;
 // Disable printing in tests for simple backends.
 pub const backend_can_print = !(builtin.zig_backend == .stage2_spirv64 or builtin.zig_backend == .stage2_riscv64);
 
-fn print(comptime fmt: []const u8, args: anytype) void {
+pub fn print(comptime fmt: []const u8, args: anytype) void {
     if (@inComptime()) {
         @compileError(std.fmt.comptimePrint(fmt, args));
     } else if (backend_can_print) {

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -8732,7 +8732,10 @@ fn numberLiteral(gz: *GenZir, ri: ResultInfo, node: Ast.Node.Index, source_node:
         },
         .big_int => |base| big: {
             const gpa = astgen.gpa;
-            var big_int = try std.math.big.int.Managed.init(gpa);
+            var sfba_state = std.heap.stackFallback(5 * @sizeOf(std.math.big.Limb), gpa);
+            const sfba = sfba_state.get();
+
+            var big_int = try std.math.big.int.Managed.init(sfba);
             defer big_int.deinit();
             const prefix_offset: usize = if (base == .decimal) 0 else 2;
             big_int.setString(@intFromEnum(base), bytes[prefix_offset..]) catch |err| switch (err) {

--- a/lib/std/zig/ZonGen.zig
+++ b/lib/std/zig/ZonGen.zig
@@ -639,11 +639,14 @@ fn numberLiteral(zg: *ZonGen, num_node: Ast.Node.Index, src_node: Ast.Node.Index
         },
         .big_int => |base| {
             const gpa = zg.gpa;
+            var sfba_state = std.heap.stackFallback(5 * @sizeOf(std.math.big.Limb), gpa);
+            const sfba = sfba_state.get();
+
             const num_without_prefix = switch (base) {
                 .decimal => num_bytes,
                 .hex, .binary, .octal => num_bytes[2..],
             };
-            var big_int: std.math.big.int.Managed = try .init(gpa);
+            var big_int: std.math.big.int.Managed = try .init(sfba);
             defer big_int.deinit();
             big_int.setString(@intFromEnum(base), num_without_prefix) catch |err| switch (err) {
                 error.InvalidCharacter => unreachable, // caught in `parseNumberLiteral`

--- a/src/Sema/arith.zig
+++ b/src/Sema/arith.zig
@@ -1290,7 +1290,7 @@ fn intDivTruncInner(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     if (ty.toIntern() != .comptime_int_type) {
         const info = ty.intInfo(zcu);
         if (!result_q.toConst().fitsInTwosComp(info.signedness, info.bits)) {
@@ -1324,7 +1324,7 @@ fn intDivExact(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !union(enum) {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     if (!result_r.toConst().eqlZero()) {
         return .remainder;
     }
@@ -1370,7 +1370,7 @@ fn intDivFloorInner(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     if (ty.toIntern() != .comptime_int_type) {
         const info = ty.intInfo(zcu);
         if (!result_q.toConst().fitsInTwosComp(info.signedness, info.bits)) {
@@ -1400,7 +1400,7 @@ fn intMod(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     return pt.intValue_big(ty, result_r.toConst());
 }
 fn intRem(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
@@ -1424,7 +1424,7 @@ fn intRem(sema: *Sema, lhs: Value, rhs: Value, ty: Type) !Value {
     );
     var result_q: BigIntMutable = .{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r: BigIntMutable = .{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf);
+    result_q.divTrunc(&result_r, lhs_bigint, rhs_bigint, limbs_buf, null);
     return pt.intValue_big(ty, result_r.toConst());
 }
 

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -1905,7 +1905,7 @@ pub fn intModScalar(lhs: Value, rhs: Value, ty: Type, allocator: Allocator, pt: 
     );
     var result_q = BigIntMutable{ .limbs = limbs_q, .positive = undefined, .len = undefined };
     var result_r = BigIntMutable{ .limbs = limbs_r, .positive = undefined, .len = undefined };
-    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buffer);
+    result_q.divFloor(&result_r, lhs_bigint, rhs_bigint, limbs_buffer, null);
     return pt.intValue_big(ty, result_r.toConst());
 }
 


### PR DESCRIPTION
This PR is ready to be reviewed but depends on functions defined in #23848, so I am marking it as a draft until the other one is merged (hopefully).

This PR massively improve the speed of `toString` and `setString`.
For the former, a subquadratic algorithm has been added, and the quadratic one has also been improved.
For the latter, the previous implementation was, uhh, aiming for accuracy rather than speed, to put it nicely, and was therefore very easy to massively speedup.
I have also used `stackFallback` at 2 locations (in astgen and zongen) to reduce the number of allocations when parsing small numbers.

Graphs for `toString`
![toString_500_final](https://github.com/user-attachments/assets/b035ca37-8478-4cb5-a31b-58d767715a7b)
![toString (long)](https://github.com/user-attachments/assets/272881a9-4d08-4feb-84a3-d9988327aaae)
In the last graph (the `long` one), the current std implementation of `toString` takes 1m10 for `n =  90000` on my machine.

For setString, this is the time the implementation in master takes divided by the time the new implementation takes (for a BigInt of `n` limbs). In short, this graph shows how many times faster is the new implementation.
![setString](https://github.com/user-attachments/assets/18f5fcc6-cc19-417e-b426-9e5ca129040c)



Ast-check of `compiler_rt/udivmodti4_test.zig` comparison (master vs new):
```
Benchmark 1 (17 runs): /home/samy/Downloads/zig/zig-x86_64-linux-0.15.0-dev.833+5f7780c53/zig ast-check ../lib/compiler_rt/udivmodti4_test.zig
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           295ms ± 2.77ms     292ms …  302ms          1 ( 6%)        0%
  peak_rss            105MB ± 1.50MB     103MB …  108MB          0 ( 0%)        0%
  cpu_cycles          986M  ± 1.76M      984M  …  990M           0 ( 0%)        0%
  instructions       3.01G  ±  190      3.01G  … 3.01G           0 ( 0%)        0%
  cache_references   4.35M  ± 22.2K     4.30M  … 4.39M           1 ( 6%)        0%
  cache_misses       2.08M  ±  104K     1.99M  … 2.33M           2 (12%)        0%
  branch_misses      2.29M  ± 8.90K     2.27M  … 2.31M           1 ( 6%)        0%
Benchmark 2 (27 runs): stage3/bin/zig ast-check ../lib/compiler_rt/udivmodti4_test.zig
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           186ms ± 1.73ms     183ms …  192ms          2 ( 7%)        ⚡- 37.0% ±  0.5%
  peak_rss            101MB ± 2.54MB    97.2MB …  104MB          0 ( 0%)        ⚡-  4.2% ±  1.3%
  cpu_cycles          592M  ±  693K      591M  …  594M           1 ( 4%)        ⚡- 40.0% ±  0.1%
  instructions       1.77G  ±  266      1.77G  … 1.77G           0 ( 0%)        ⚡- 41.2% ±  0.0%
  cache_references   3.65M  ± 50.0K     3.56M  … 3.75M           0 ( 0%)        ⚡- 16.2% ±  0.6%
  cache_misses       1.82M  ± 92.3K     1.73M  … 2.16M           1 ( 4%)        ⚡- 12.5% ±  2.9%
  branch_misses      2.31M  ± 3.72K     2.30M  … 2.32M           1 ( 4%)          +  0.9% ±  0.2% 
```