### PR TITLE
Implement switching on packed structs

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -2304,6 +2304,12 @@ or
       {#code|test_packed_struct_equality.zig#}
 
       <p>
+      Switching on packed structs works according to the same principle,
+	  comparing the backing integer.
+      </p>
+      {#code|test_switch_packed_struct.zig#}
+
+      <p>
       Field access and assignment can be understood as shorthand for bitshifts
       on the backing integer. These operations are not {#link|atomic|Atomics#},
       so beware using field access syntax when combined with memory-mapped

--- a/doc/langref/test_switch_packed_struct.zig
+++ b/doc/langref/test_switch_packed_struct.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const expect = std.testing.expect;
+
+test "switch on packed struct" {
+    const S = packed struct {
+        a: u5,
+        b: u7,
+    };
+    const x: S = .{ .a = 1, .b = 2 };
+    const result = switch (x) {
+        .{ .b = 1, .a = 2 }, .{ .a = 0, .b = 0 } => false,
+        .{ .a = 1, .b = 2 } => true,
+        else => false,
+    };
+    try expect(result);
+}
+
+// test

--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -342,7 +342,7 @@ pub const Inst = struct {
         /// Uses the `break` union field.
         break_inline,
         /// Branch from within a switch case to the case specified by the operand.
-        /// Uses the `break` union field. `block_inst` refers to a `switch_block` or `switch_block_ref`.
+        /// Uses the `break` union field. `block_inst` refers to a `switch_block`.
         switch_continue,
         /// Checks that comptime control flow does not happen inside a runtime block.
         /// Uses the `un_node` union field.
@@ -695,12 +695,18 @@ pub const Inst = struct {
         /// function call syntax, i.e. `.foo()`.
         /// Uses the `pl_node` union field. Payload is `Field`.
         decl_literal_no_coerce,
+        /// Produces the value that will be switched on. For example, for
+        /// integers, it returns the integer with no modifications. For tagged unions, it
+        /// returns the active enum tag.
+        /// Uses the `un_node` union field.
+        switch_cond,
+        /// Same as `switch_cond`, except the input operand is a pointer to
+        /// what will be switched on.
+        /// Uses the `un_node` union field.
+        switch_cond_ref,
         /// A switch expression. Uses the `pl_node` union field.
         /// AST node is the switch, payload is `SwitchBlock`.
         switch_block,
-        /// A switch expression. Uses the `pl_node` union field.
-        /// AST node is the switch, payload is `SwitchBlock`. Operand is a pointer.
-        switch_block_ref,
         /// A switch on an error union `a catch |err| switch (err) {...}`.
         /// Uses the `pl_node` union field. AST node is the `catch`, payload is `SwitchBlockErrUnion`.
         switch_block_err_union,
@@ -1206,8 +1212,9 @@ pub const Inst = struct {
                 .typeof_log2_int_type,
                 .resolve_inferred_alloc,
                 .set_eval_branch_quota,
+                .switch_cond,
+                .switch_cond_ref,
                 .switch_block,
-                .switch_block_ref,
                 .switch_block_err_union,
                 .validate_deref,
                 .validate_destructure,
@@ -1494,8 +1501,9 @@ pub const Inst = struct {
                 .slice_sentinel_ty,
                 .import,
                 .typeof_log2_int_type,
+                .switch_cond,
+                .switch_cond_ref,
                 .switch_block,
-                .switch_block_ref,
                 .switch_block_err_union,
                 .union_init,
                 .field_type_ref,
@@ -1748,8 +1756,9 @@ pub const Inst = struct {
                 .enum_literal = .str_tok,
                 .decl_literal = .pl_node,
                 .decl_literal_no_coerce = .pl_node,
+                .switch_cond = .un_node,
+                .switch_cond_ref = .un_node,
                 .switch_block = .pl_node,
-                .switch_block_ref = .pl_node,
                 .switch_block_err_union = .pl_node,
                 .validate_deref = .un_node,
                 .validate_destructure = .pl_node,
@@ -3277,10 +3286,13 @@ pub const Inst = struct {
     /// captured payload. Whether this is captured by reference or by value
     /// depends on whether the `byref` bit is set for the corresponding body.
     pub const SwitchBlock = struct {
-        /// The operand passed to the `switch` expression. If this is a
-        /// `switch_block`, this is the operand value; if `switch_block_ref` it
-        /// is a pointer to the operand. `switch_block_ref` is always used if
-        /// any prong has a byref capture.
+        /// This is always a `switch_cond` or `switch_cond_ref` instruction.
+        /// If it is a `switch_cond_ref` instruction, bits.is_ref is always true.
+        /// If it is a `switch_cond` instruction, bits.is_ref is always false.
+        /// Both `switch_cond` and `switch_cond_ref` return a value, not a pointer,
+        /// that is useful for the case items, but cannot be used for capture values.
+        /// For the capture values, Sema is expected to find the operand of this operand
+        /// and use that.
         operand: Ref,
         bits: Bits,
 
@@ -4338,6 +4350,8 @@ fn findTrackableInner(
         .make_ptr_const,
         .@"resume",
         .@"await",
+        .switch_cond,
+        .switch_cond_ref,
         .save_err_ret_index,
         .restore_err_ret_index_unconditional,
         .restore_err_ret_index_fn_entry,
@@ -4676,7 +4690,7 @@ fn findTrackableInner(
             const body = zir.bodySlice(extra.end, extra.data.body_len);
             try zir.findTrackableBody(gpa, contents, defers, body);
         },
-        .switch_block, .switch_block_ref => return zir.findTrackableSwitch(gpa, contents, defers, inst, .normal),
+        .switch_block => return zir.findTrackableSwitch(gpa, contents, defers, inst, .normal),
         .switch_block_err_union => return zir.findTrackableSwitch(gpa, contents, defers, inst, .err_union),
 
         .suspend_block => @panic("TODO iterate suspend block"),

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -6410,7 +6410,7 @@ pub const FuncGen = struct {
             const cond_ty = self.typeOf(switch_br.operand);
             switch (cond_ty.zigTypeTag(zcu)) {
                 .bool, .pointer => break :jmp_table null,
-                .@"enum", .int, .error_set => {},
+                .@"enum", .int, .error_set, .@"struct" => {},
                 else => unreachable,
             }
 

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -269,6 +269,8 @@ const Writer = struct {
             .bit_reverse,
             .@"resume",
             .@"await",
+            .switch_cond,
+            .switch_cond_ref,
             .make_ptr_const,
             .validate_deref,
             .validate_const,
@@ -454,9 +456,7 @@ const Writer = struct {
 
             .error_set_decl => try self.writeErrorSetDecl(stream, inst),
 
-            .switch_block,
-            .switch_block_ref,
-            => try self.writeSwitchBlock(stream, inst),
+            .switch_block => try self.writeSwitchBlock(stream, inst),
 
             .switch_block_err_union => try self.writeSwitchBlockErrUnion(stream, inst),
 

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -1065,3 +1065,21 @@ test "switch on a signed value smaller than the smallest prong value" {
         else => {},
     }
 }
+
+test "decl literals as switch cases" {
+    const E = enum(u8) {
+        bar = 3,
+        _,
+
+        const foo: @This() = @enumFromInt(0xa);
+    };
+
+    var e: E = .foo;
+    _ = &e;
+    const ok = switch (e) {
+        .bar => false,
+        .foo => true,
+        else => false,
+    };
+    try expect(ok);
+}

--- a/test/behavior/switch_loop.zig
+++ b/test/behavior/switch_loop.zig
@@ -216,3 +216,24 @@ test "switch loop with pointer capture" {
     try S.doTheTest();
     try comptime S.doTheTest();
 }
+
+test "switch loop with packed structs" {
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest; // TODO
+
+    const S = struct {
+        const P = packed struct { a: u7, b: u20 };
+
+        fn doTheTest() !void {
+            const p: P = .{ .a = 5, .b = 0 };
+            const result = s: switch (p) {
+                .{ .a = 5, .b = 10 } => |x| x,
+                else => |x| continue :s .{ .a = x.a, .b = x.b + 1 },
+            };
+            try expect(result == P{ .a = 5, .b = 10 });
+        }
+    };
+
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}

--- a/test/cases/compile_errors/invalid_switch_item.zig
+++ b/test/cases/compile_errors/invalid_switch_item.zig
@@ -36,11 +36,11 @@ export fn f3() void {
 
 // error
 //
-// :8:10: error: no field named 'x' in enum 'tmp.E'
+// :8:10: error: enum 'tmp.E' has no member named 'x'
 // :1:11: note: enum declared here
-// :16:10: error: no field named 'x' in enum 'tmp.E'
+// :16:10: error: enum 'tmp.E' has no member named 'x'
 // :1:11: note: enum declared here
-// :24:10: error: no field named 'x' in enum 'tmp.E'
+// :24:10: error: enum 'tmp.E' has no member named 'x'
 // :1:11: note: enum declared here
-// :32:10: error: no field named 'x' in enum 'tmp.E'
+// :32:10: error: enum 'tmp.E' has no member named 'x'
 // :1:11: note: enum declared here

--- a/test/cases/compile_errors/switch_expression-ranges_not_allowed_on_packed_struct.zig
+++ b/test/cases/compile_errors/switch_expression-ranges_not_allowed_on_packed_struct.zig
@@ -1,0 +1,15 @@
+export fn f() void {
+    const P = packed struct { a: u1, b: u1 };
+    const p = P{ .a = 0, .b = 0 };
+    switch (p) {
+        .{ .a = 0, .b = 0 }....{ .a = 1, .b = 0 } => {},
+        else => unreachable,
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:13: error: ranges not allowed when switching on type 'tmp.f.P'
+// :5:28: note: range here

--- a/test/cases/compile_errors/switch_expression-switch_on_unpacked_struct.zig
+++ b/test/cases/compile_errors/switch_expression-switch_on_unpacked_struct.zig
@@ -1,0 +1,15 @@
+export fn f() void {
+    const P = struct { a: u1, b: u1 };
+    const p = P{ .a = 0, .b = 0 };
+    switch (p) {
+        .{ .a = 0, .b = 0 } => {},
+        else => unreachable,
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:13: error: switch on struct requires 'packed' layout; type 'tmp.f.P' has 'auto' layout
+// :2:15: note: consider 'packed struct' here

--- a/test/cases/compile_errors/switch_expression-unreachable_else_prong_packed_struct.zig
+++ b/test/cases/compile_errors/switch_expression-unreachable_else_prong_packed_struct.zig
@@ -1,0 +1,23 @@
+const P = packed struct(u2) {
+    a: u1,
+    b: u1,
+};
+
+fn foo(p: P) void {
+    switch (p) {
+        .{ .a = 0, .b = 0 } => {},
+        .{ .a = 1, .b = 0 }, .{ .a = 0, .b = 1 } => {},
+        .{ .a = 1, .b = 1 } => {},
+        else => {},
+    }
+}
+
+export fn bar() void {
+    foo(.{ .a = 1, .b = 1 });
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :11:14: error: unreachable else prong; all cases already handled


### PR DESCRIPTION
Closes #22214
Resolves #24152

The first commit reintroduces the `switch_cond[_ref]` ZIR tags. This fixes switching on decl literals.
These tags were removed in 85e94fed1e058720460560823ac09d7b64e49b97 as a consequence of result types for switch cases being removed in cebd80032a2dcc9f516f8183d1bfade5d1f12e45. Reintroducing them makes `switch_block_ref` superfluous.

I tried to keep the changes as unintrusive as possible but this does increase the amount of ZIR tags by 1.

The second commit implements switching on packed structs. It does this by enabling a more int-like analysis of packed structs (and packed unions as a consequence), mainly by making them comparable to other int-like types. This minimizes special-casing in Sema and codegen.