### PR TITLE
add glibc versioning for a number of headers

### DIFF
--- a/lib/libc/include/generic-glibc/sys/random.h
+++ b/lib/libc/include/generic-glibc/sys/random.h
@@ -29,6 +29,9 @@
 
 __BEGIN_DECLS
 
+// zig patch: getrandom and getentropy were added in glibc 2.25
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25) || __GLIBC__ > 2
+
 /* Write LENGTH bytes of randomness starting at BUFFER.  Return the
    number of bytes written, or -1 on error.  */
 ssize_t getrandom (void *__buffer, size_t __length,
@@ -39,6 +42,8 @@ ssize_t getrandom (void *__buffer, size_t __length,
    success or -1 on error.  */
 int getentropy (void *__buffer, size_t __length) __wur
                 __attr_access ((__write_only__, 1, 2));
+
+#endif /* glibc 2.25 or later */
 
 __END_DECLS
 

--- a/lib/libc/include/generic-glibc/sys/single_threaded.h
+++ b/lib/libc/include/generic-glibc/sys/single_threaded.h
@@ -19,7 +19,7 @@
 // zig patch: sys/single_threaded.h header was added in glibc 2.35
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
    #error "sys/single_threaded.h did not exist before glibc 2.35"
-#endif /* error for glibc 2.35 or earlier */
+#endif /* error for glibc before 2.35 */
 
 #ifndef _SYS_SINGLE_THREADED_H
 #define _SYS_SINGLE_THREADED_H

--- a/lib/libc/include/generic-glibc/sys/single_threaded.h
+++ b/lib/libc/include/generic-glibc/sys/single_threaded.h
@@ -16,7 +16,7 @@
    License along with the GNU C Library; if not, see
    <https://www.gnu.org/licenses/>.  */
 
-// zig patch: sys/single_threaded.h header was added in glibc 35
+// zig patch: sys/single_threaded.h header was added in glibc 2.35
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
    #error "sys/single_threaded.h did not exist before glibc 2.35"
 #endif /* error for glibc 2.35 or earlier */

--- a/lib/libc/include/generic-glibc/sys/single_threaded.h
+++ b/lib/libc/include/generic-glibc/sys/single_threaded.h
@@ -16,6 +16,11 @@
    License along with the GNU C Library; if not, see
    <https://www.gnu.org/licenses/>.  */
 
+// zig patch: sys/single_threaded header was added in glibc 25
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
+   #error "sys/single_threaded.h did not exist before glibc 2.35"
+#endif /* error for glibc 2.35 or earlier */
+
 #ifndef _SYS_SINGLE_THREADED_H
 #define _SYS_SINGLE_THREADED_H
 

--- a/lib/libc/include/generic-glibc/sys/single_threaded.h
+++ b/lib/libc/include/generic-glibc/sys/single_threaded.h
@@ -16,7 +16,7 @@
    License along with the GNU C Library; if not, see
    <https://www.gnu.org/licenses/>.  */
 
-// zig patch: sys/single_threaded header was added in glibc 25
+// zig patch: sys/single_threaded.h header was added in glibc 35
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
    #error "sys/single_threaded.h did not exist before glibc 2.35"
 #endif /* error for glibc 2.35 or earlier */

--- a/lib/libc/include/generic-glibc/threads.h
+++ b/lib/libc/include/generic-glibc/threads.h
@@ -19,7 +19,7 @@
 
 // zig patch: threads header was added in glibc 2.28
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 28
-   #error "threads.h did not exist before glibc 2.35"
+   #error "threads.h did not exist before glibc 2.28"
 #endif /* error for glibc 2.27 or earlier */
 
 #ifndef _THREADS_H

--- a/lib/libc/include/generic-glibc/threads.h
+++ b/lib/libc/include/generic-glibc/threads.h
@@ -16,6 +16,12 @@
    License along with the GNU C Library; if not, see
    <https://www.gnu.org/licenses/>.  */
 
+
+// zig patch: threads header was added in glibc 2.28
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 28
+   #error "threads.h not supported for glibc < 2.28"
+#endif /* error for glibc 2.27 or earlier */
+
 #ifndef _THREADS_H
 #define _THREADS_H	1
 

--- a/lib/libc/include/generic-glibc/threads.h
+++ b/lib/libc/include/generic-glibc/threads.h
@@ -19,7 +19,7 @@
 
 // zig patch: threads header was added in glibc 2.28
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 28
-   #error "threads.h not supported for glibc < 2.28"
+   #error "threads.h did not exist before glibc 2.35"
 #endif /* error for glibc 2.27 or earlier */
 
 #ifndef _THREADS_H

--- a/lib/libc/include/generic-glibc/threads.h
+++ b/lib/libc/include/generic-glibc/threads.h
@@ -20,7 +20,7 @@
 // zig patch: threads header was added in glibc 2.28
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 28
    #error "threads.h did not exist before glibc 2.28"
-#endif /* error for glibc 2.27 or earlier */
+#endif /* error for glibc before 2.28 */
 
 #ifndef _THREADS_H
 #define _THREADS_H	1

--- a/lib/libc/include/generic-glibc/unistd.h
+++ b/lib/libc/include/generic-glibc/unistd.h
@@ -1138,10 +1138,16 @@ extern int lockf64 (int __fd, int __cmd, __off64_t __len) __wur;
        while (__result == -1L && errno == EINTR);			      \
        __result; }))
 
+// zig patch: copy_file_range was added in glibc 2.27
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 27) || __GLIBC__ > 2
+
 /* Copy LENGTH bytes from INFD to OUTFD.  */
 ssize_t copy_file_range (int __infd, __off64_t *__pinoff,
 			 int __outfd, __off64_t *__poutoff,
 			 size_t __length, unsigned int __flags);
+
+#endif /* glibc 2.27 or later */
+
 #endif /* __USE_GNU */
 
 #if defined __USE_POSIX199309 || defined __USE_UNIX98


### PR DESCRIPTION
this makes it possible to build the following libraries with `-target x86_64-linux-gnu.2.17` :
- gettext
- zstd
- curl

which all previously failed.

closes https://github.com/ziglang/zig/issues/24233