### PR TITLE
Fix illegal behavior from syscalls on powerpc64le

### DIFF
--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -22,7 +22,7 @@ pub fn syscall0(number: SYS) usize {
         \\ 1:
         : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@intFromEnum(number)),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -35,7 +35,7 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@intFromEnum(number)),
           [arg1] "{r3}" (arg1),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -49,7 +49,7 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         : [number] "{r0}" (@intFromEnum(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -64,7 +64,7 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -80,7 +80,7 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -97,7 +97,7 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -123,7 +123,7 @@ pub fn syscall6(
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
           [arg6] "{r8}" (arg6),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -22,7 +22,7 @@ pub fn syscall0(number: SYS) usize {
         \\ 1:
         : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@intFromEnum(number)),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -35,7 +35,7 @@ pub fn syscall1(number: SYS, arg1: usize) usize {
         : [ret] "={r3}" (-> usize),
         : [number] "{r0}" (@intFromEnum(number)),
           [arg1] "{r3}" (arg1),
-        : "memory", "cr0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -49,7 +49,7 @@ pub fn syscall2(number: SYS, arg1: usize, arg2: usize) usize {
         : [number] "{r0}" (@intFromEnum(number)),
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
-        : "memory", "cr0", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -64,7 +64,7 @@ pub fn syscall3(number: SYS, arg1: usize, arg2: usize, arg3: usize) usize {
           [arg1] "{r3}" (arg1),
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
-        : "memory", "cr0", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -80,7 +80,7 @@ pub fn syscall4(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize)
           [arg2] "{r4}" (arg2),
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
-        : "memory", "cr0", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -97,7 +97,7 @@ pub fn syscall5(number: SYS, arg1: usize, arg2: usize, arg3: usize, arg4: usize,
           [arg3] "{r5}" (arg3),
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
-        : "memory", "cr0", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 
@@ -123,7 +123,7 @@ pub fn syscall6(
           [arg4] "{r6}" (arg4),
           [arg5] "{r7}" (arg5),
           [arg6] "{r8}" (arg6),
-        : "memory", "cr0", "r9", "r10", "r11", "r12"
+        : "memory", "cr0", "r0", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
     );
 }
 


### PR DESCRIPTION
Fixes #24230.

On powerpc64le Linux, the [registers used for passing syscall parameters](https://www.kernel.org/doc/html/v6.15/arch/powerpc/syscall64-abi.html#register-preservation-rules) (r3–r8, as well as r0 for the syscall number) are volatile, or caller-saved. However, Zig's syscall wrappers for this architecture do not include all such registers in the list of clobbers, leading the compiler to assume these registers will maintain their values after the syscall completes.

In practice, this resulted in a segfault when allocating memory with `std.heap.SmpAllocator`, which calls `std.os.linux.sched_getaffinity`. The third parameter to `sched_getaffinity` is a pointer to a `cpu_set_t` and is stored in register r5. After the syscall, the code attempts to access data in the `cpu_set_t`, but because the compiler doesn't realize the value of r5 may have changed, it uses r5 as the memory address, which in practice resulted in a memory access at address 0x8.

This PR adds all volatile registers to the list of clobbers.

### Prior art

glibc lists r0 and r3–r8 as output registers in [its syscall implementation](https://github.com/bminor/glibc/blob/glibc-2.41/sysdeps/unix/sysv/linux/powerpc/sysdep.h#L113-L115), which has the effect of preventing the compiler from assuming their values will stay the same. Zig specifies r3 as an output in [its implementation](https://github.com/ziglang/zig/blob/75d0ec9c0476da61c6f32b3d386d8844faaeb1c5/lib/std/os/linux/powerpc64.zig#L118), but r0 and some subset of r4–r8 (depending on the number of syscall params) are marked only as inputs, and the compiler assumes their values are stable. Because only one register can be specified as an output in Zig, I believe the correct approach is to add the other registers as clobbers.

### 32-bit

The syscall wrappers for 32-bit PowerPC [correctly include the registers](https://github.com/ziglang/zig/blob/75d0ec9c0476da61c6f32b3d386d8844faaeb1c5/lib/std/os/linux/powerpc.zig#L126) used for syscall parameters in the list of clobbers, similar to this PR. However, they do *not* include r0. I suspect this is incorrect (the above glibc implementation is used for both 32- and 64-bit PowerPC and lists r0 as an output/clobber), but I'm not 100% sure and don't have hardware to test on, so I think it's best left as a future PR. Please feel free to weigh in if you have experience with this sort of thing.