### PR TITLE
Fix compiler crash when passing a comptime extern function arg to a function

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -1907,7 +1907,12 @@ pub const WipNav = struct {
         const ty = value.typeOf(zcu);
         if (std.debug.runtime_safety) assert(ty.comptimeOnly(zcu) and try ty.onePossibleValue(wip_nav.pt) == null);
         if (ty.toIntern() == .type_type) return wip_nav.getTypeEntry(value.toType());
-        if (ip.isFunctionType(ty.toIntern()) and !value.isUndef(zcu)) return wip_nav.getNavEntry(zcu.funcInfo(value.toIntern()).owner_nav);
+        if (ip.isFunctionType(ty.toIntern()) and !value.isUndef(zcu))
+            return wip_nav.getNavEntry(switch (ip.indexToKey(value.toIntern())) {
+                .@"extern" => |ext| ext.owner_nav,
+                .func => |func| func.owner_nav,
+                else => unreachable,
+            });
         const gop = try wip_nav.dwarf.values.getOrPut(wip_nav.dwarf.gpa, value.toIntern());
         const unit: Unit.Index = .main;
         if (gop.found_existing) return .{ unit, gop.value_ptr.* };


### PR DESCRIPTION
This PR fixes a compiler crash that occurs when passing a comptime extern function argument to a function.

The compiler crashes in DWARF debug info code. The function getValueEntry does not handle extern functions correctlt, instead handling all values with a function type as `InternPool.Key.func` values.

### Repro
#### Code
```zig
extern fn func() void;

fn foo(f: fn () callconv(.C) void) void {
    _ = f;
}

pub fn main() !void {
    foo(func);
}
```

#### Stack trace
```
error: access of union field 'func' while field 'extern' is active

src/InternPool.zig:12142:28: in toFunc (main.zig)
    return ip.indexToKey(i).func;
                           ^
src/Zcu.zig:4013:34: in funcInfo (main.zig)
    return zcu.intern_pool.toFunc(func_index);
                                 ^
src/link/Dwarf.zig:1910:110: in getValueEntry (main.zig)
        if (ip.isFunctionType(ty.toIntern()) and !value.isUndef(zcu)) return wip_nav.getNavEntry(zcu.funcInfo(value.toIntern()).owner_nav);
                                                                                                             ^
src/link/Dwarf.zig:1921:60: in refValue (main.zig)
        const unit, const entry = try wip_nav.getValueEntry(value);
                                                           ^
src/link/Dwarf.zig:1526:53: in genLocalConstDebugInfo (main.zig)
        if (has_comptime_state) try wip_nav.refValue(val);
                                                    ^
src/arch/x86_64/Emit.zig:621:61: in emitMir (main.zig)
                            try dwarf.genLocalConstDebugInfo(
                                                            ^
```