### PR TITLE
std.fmt: check result types in parseInt functions

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1514,17 +1514,27 @@ pub fn Formatter(comptime formatFn: anytype) type {
 ///
 /// Ignores '_' character in `buf`.
 /// See also `parseUnsigned`.
+///
+/// Asserts 'T' is an integer type
 pub fn parseInt(comptime T: type, buf: []const u8, base: u8) ParseIntError!T {
+    if (@typeInfo(T) != .int) {
+        @compileError("Cannot parse an integer into a non-integer type");
+    }
     return parseIntWithGenericCharacter(T, u8, buf, base);
 }
 
 /// Like `parseInt`, but with a generic `Character` type.
+///
+/// Asserts that 'Result' is an integer type
 pub fn parseIntWithGenericCharacter(
     comptime Result: type,
     comptime Character: type,
     buf: []const Character,
     base: u8,
 ) ParseIntError!Result {
+    if (@typeInfo(Result) != .int) {
+        @compileError("Cannot parse an integer into a non-integer type");
+    }
     if (buf.len == 0) return error.InvalidCharacter;
     if (buf[0] == '+') return parseIntWithSign(Result, Character, buf[1..], base, .pos);
     if (buf[0] == '-') return parseIntWithSign(Result, Character, buf[1..], base, .neg);
@@ -1591,6 +1601,19 @@ test parseInt {
     try std.testing.expectEqual(@as(i5, -16), try std.fmt.parseInt(i5, "-10", 16));
 }
 
+/// Parses an integer with a specified `sign`, accepting a generic `Character`
+/// type for width and a buffer of `Character`s, in the specified `base` of an
+/// integral type of value `Result`
+///
+/// When `base` is zero the string prefix is examined to detect the true base:
+///  * A prefix of "0b" implies base=2,
+///  * A prefix of "0o" implies base=8,
+///  * A prefix of "0x" implies base=16,
+///  * Otherwise base=10 is assumed.
+///
+/// Ignores '_' character in `buf`.
+///
+/// Asserts that `Result` is an integer type
 fn parseIntWithSign(
     comptime Result: type,
     comptime Character: type,
@@ -1598,6 +1621,10 @@ fn parseIntWithSign(
     base: u8,
     comptime sign: enum { pos, neg },
 ) ParseIntError!Result {
+    if (@typeInfo(Result) != .int) {
+        @compileError("Cannot parse an integer into a non-integer type");
+    }
+
     if (buf.len == 0) return error.InvalidCharacter;
 
     var buf_base = base;
@@ -1670,7 +1697,12 @@ fn parseIntWithSign(
 ///
 /// Ignores '_' character in `buf`.
 /// See also `parseInt`.
+///
+/// Asserts 'T' is an integer type
 pub fn parseUnsigned(comptime T: type, buf: []const u8, base: u8) ParseIntError!T {
+    if (@typeInfo(T) != .int) {
+        @compileError("Cannot parse an integer into a non-integer type");
+    }
     return parseIntWithSign(T, u8, buf, base, .pos);
 }
 


### PR DESCRIPTION
The `parseInt()` family of functions do not perform type checking thus accepting erroneous inputs for result types.

Sample subject case, built with zig `0.15.0-dev.869+640a13065`:
```
const std = @import("std");

pub fn main() !void {
    const i = "1234";

    // selectively run with any of the following; error is the same
    _ = try std.fmt.parseInt(f32, i, 10);
    // _ = try std.fmt.parseIntWithGenericCharacter(f32, u8, i, 10);
    // _ = try std.fmt.parseUnsigned(f32, i, 10);
}
```
Outputs:
```
/home/user/zig/lib/std/fmt.zig:1636:41: error: access of union field 'int' while field 'float' is active
    const Accumulate = std.meta.Int(info.int.signedness, @max(8, info.int.bits));
                                    ~~~~^~~~
/home/user/zig/lib/std/builtin.zig:572:18: note: union declared here
pub const Type = union(enum) {
                 ^~~~~
referenced by:
    parseIntWithGenericCharacter__anon_23506: /home/user/zig/lib/std/fmt.zig:1529:47
    parseInt__anon_23379: /home/user/zig/lib/std/fmt.zig:1518:40
    6 reference(s) hidden; use '-freference-trace=8' to see all references
/home/user/zig/lib/std/fmt.zig:1636:41: error: access of union field 'int' while field 'float' is active
    const Accumulate = std.meta.Int(info.int.signedness, @max(8, info.int.bits));
                                    ~~~~^~~~
/home/user/zig/lib/std/builtin.zig:572:18: note: union declared here
pub const Type = union(enum) {
                 ^~~~~
```

This PR checks that the given input (T or Result) is an integer and ouputs a compiler error when this is not true. The specific form of error output was taken from prior art in `parseFloat()`. While the code will not compile without this change, it is desirable to make this a clear compiler error, both to prevent processing of invalid inputs and improve user experience.

Output with patch:
```
/home/user/zig/lib/std/fmt.zig:1521:9: error: Cannot parse an integer into a non-integer point type.
        @compileError("Cannot parse an integer into a non-integer point type.");
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    main: test/t.zig:7:29
    callMain [inlined]: /home/user/zig/lib/std/start.zig:681:37
    callMainWithArgs [inlined]: /home/user/zig/lib/std/start.zig:641:20
    posixCallMainAndExit: /home/user/zig/lib/std/start.zig:596:36
    2 reference(s) hidden; use '-freference-trace=6' to see all references
```

`parseIntWithSign()` is not exported from the container but I believe its inclusion has merit. Type check is compile- time and an assertion of expected input type(s); docs (which, to be fair, are largely taken from other `parseInt()` fn's) ease readability of source code.