### PR TITLE
std.fmt.formatInt() - don't add plus "+" for width specified positive ints

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1234,12 +1234,6 @@ pub fn formatInt(
             // Negative integer
             index -= 1;
             buf[index] = '-';
-        } else if (options.width == null or options.width.? == 0) {
-            // Positive integer, omit the plus sign
-        } else {
-            // Positive integer
-            index -= 1;
-            buf[index] = '+';
         }
     }
 
@@ -2627,7 +2621,7 @@ test "vector" {
 
     try expectFmt("{ true, false, true, false }", "{}", .{vbool});
     try expectFmt("{ -2, -1, 0, 1 }", "{}", .{vi64});
-    try expectFmt("{    -2,    -1,    +0,    +1 }", "{d:5}", .{vi64});
+    try expectFmt("{    -2,    -1,     0,     1 }", "{d:5}", .{vi64});
     try expectFmt("{ 1000, 2000, 3000, 4000 }", "{}", .{vu64});
     try expectFmt("{ 3e8, 7d0, bb8, fa0 }", "{x}", .{vu64});
 


### PR DESCRIPTION
Fix `std.fmt.formatInt()` to match `formatFloat` and match common sense, don't add a plus `"+"` to formatted integers only because you specified a width. Specifying a width does not mean you want to add a plus `"+"` to the formatted integer. The behavior should be the same as not specifying a width, which is don't a `"+"` and only add a negative `"-"` sign if the integer is negative. Otherwise you get incorrect and unexpected behavior when you specify a width for your formatted integers.

## Example:

```zig


const std = @import("std");

pub fn main() void {

   const ns = std.time.nanoTimestamp();

   const hr, const am_pm = blk: {
      const h = @divTrunc(@rem(ns, std.time.ns_per_day), std.time.ns_per_hour);
      break :blk if (h > 12) .{h-12, "pm"} else .{h, "am"};
   };

   const min = @divTrunc(@rem(ns, std.time.ns_per_hour), std.time.ns_per_min);

   std.debug.print("{d: >2}:{d:0>2}{s}", .{hr, min, am_pm});

   // Before: "+11:+46pm"
   // After:  "11:46pm"

   // Before: "+3:+2am"
   // After:  " 3:02am"
}
```