### PR TITLE
Added perf_event_header definition

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -9127,21 +9127,12 @@ pub const perf_event_attr = extern struct {
     config3: u64 = 0,
 };
 
-pub const CPU_MODE = enum(u3) {
-    UNKNOWN = 0,
-    KERNEL = 1,
-    USER = 2,
-    HYPERVISOR = 3,
-    GUEST_KERNEL = 4,
-    GUEST_USER = 5,
-};
-
 pub const perf_event_header = extern struct {
     /// Event type: sample/mmap/fork/etc.
     type: PERF.RECORD,
     /// Additional informations on the event: kernel/user/hypervisor/etc.
     misc: packed struct(u16) {
-        cpu_mode: CPU_MODE,
+        cpu_mode: PERF.RECORD.MISC.CPU_MODE,
         _: u9,
         PROC_MAP_PARSE_TIMEOUT: bool,
         bit13: packed union {
@@ -9155,7 +9146,7 @@ pub const perf_event_header = extern struct {
             SWITCH_OUT_PREEMPT: bool,
             MMAP_BUILD_ID: bool,
         },
-        MISC_EXT_RESERVED: bool,
+        EXT_RESERVED: bool,
     },
     /// Size of the following record
     size: u16,
@@ -9364,6 +9355,17 @@ pub const PERF = struct {
         CGROUP = 19,
         TEXT_POKE = 20,
         AUX_OUTPUT_HW_ID = 21,
+
+        const MISC = struct {
+            pub const CPU_MODE = enum(u3) {
+                UNKNOWN = 0,
+                KERNEL = 1,
+                USER = 2,
+                HYPERVISOR = 3,
+                GUEST_KERNEL = 4,
+                GUEST_USER = 5,
+            };
+        };
     };
 
     pub const FLAG = struct {


### PR DESCRIPTION
While using the Linux perf subsystem in sampling mode, I noticed that the perf_event_header struct and its associated constants were missing from the bindings. This struct is essential as a building block for user-defined structs that can be bitcast to the events in the mmaped output region.

The struct definition and constants are based on the [uapi source](https://github.com/torvalds/linux/blob/7595b66ae9de667bf35a8c99e8f1bfc4792e207e/include/uapi/linux/perf_event.h#L836).

I tried to keep the style and naming consistent with the rest of the codebase. Since this is my first PR to the project, please let me know if anything needs adjustment.