### PR TITLE
Fix warning WasmMut_toC not all control paths return a value

### DIFF
--- a/stage1/wasm.h
+++ b/stage1/wasm.h
@@ -50,10 +50,9 @@ static const char *WasmMut_toC(enum WasmMut val_type) {
     switch (val_type) {
         case WasmMut_const: return "const ";
         case WasmMut_var: return "";
-        default:
-            panic("unsupported mut");
-            return NULL;
+        default: panic("unsupported mut");
     }
+    return NULL;
 }
 
 enum WasmOpcode {


### PR DESCRIPTION
This is a follow up to https://github.com/ziglang/zig/pull/24206 where I had previously submitted different mechanisms to fix this warning. This PR is a suggestion by Alex to return NULL instead and Andrew confirmed this is his preference.

I confirmed this change fixes the warning when using the MSVC compiler.