### PR TITLE
Some union fixes

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -29442,8 +29442,6 @@ fn coerceExtra(
         if (maybe_inst_val) |val| if (val.toIntern() == .undef) return pt.undefRef(dest_ty);
     }
 
-    if (!opts.report_err) return error.NotCoercible;
-
     if (opts.is_ret and dest_ty.zigTypeTag(zcu) == .noreturn) {
         const msg = msg: {
             const msg = try sema.errMsg(inst_src, "function declared 'noreturn' returns", .{});
@@ -29458,6 +29456,8 @@ fn coerceExtra(
         };
         return sema.failWithOwnedErrorMsg(block, msg);
     }
+
+    if (!opts.report_err) return error.NotCoercible;
 
     const msg = msg: {
         const msg = try sema.errMsg(inst_src, "expected type '{}', found '{}'", .{ dest_ty.fmt(pt), inst_ty.fmt(pt) });
@@ -36141,6 +36141,11 @@ fn unionFields(
                 };
                 return sema.failWithOwnedErrorMsg(&block_scope, msg);
             }
+        } else if (!small.auto_enum_tag and tag_type_ref != .none) {
+            const tag_ty = union_type.tagTypeUnordered(ip);
+            return sema.fail(&block_scope, name_src, "no field named '{}' in enum '{}'", .{
+                field_name.fmt(ip), Type.fromInterned(tag_ty).fmt(pt),
+            });
         }
 
         if (field_ty.zigTypeTag(zcu) == .@"opaque") {

--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -3032,7 +3032,7 @@ fn updateComptimeNavInner(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPoo
                 const field_type: Type = .fromInterned(loaded_union.field_types.get(ip)[field_index]);
                 try wip_nav.refType(field_type);
                 try uleb128(diw, loaded_union.fieldAlign(ip, field_index).toByteUnits() orelse
-                    field_type.abiAlignment(zcu).toByteUnits().?);
+                    if (field_type.isNoReturn(zcu)) 1 else field_type.abiAlignment(zcu).toByteUnits().?);
             }
             try uleb128(diw, @intFromEnum(AbbrevCode.null));
             break :tag .done;

--- a/test/cases/compile_errors/empty_enum_as_nonempty_union_tag_type.zig
+++ b/test/cases/compile_errors/empty_enum_as_nonempty_union_tag_type.zig
@@ -12,5 +12,5 @@ pub fn main() void {
 // backend=stage2
 // target=native
 //
-// :4:5: error: no field named 'one' in enum 'tmp.E'
-// :2:11: note: enum declared here
+// :3:5: error: no field named 'one' in enum 'tmp.E'
+// :1:11: note: enum declared here

--- a/test/cases/compile_errors/empty_enum_as_nonempty_union_tag_type.zig
+++ b/test/cases/compile_errors/empty_enum_as_nonempty_union_tag_type.zig
@@ -1,0 +1,16 @@
+const E = enum {};
+const U = union(E) {
+    one,
+    two,
+};
+
+pub fn main() void {
+    _ = U.one;
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:5: error: no field named 'one' in enum 'tmp.E'
+// :2:11: note: enum declared here


### PR DESCRIPTION
Fixes #24265, fixes #24262. 

Turns out #24262 wasn't related to linking, but to `Sema` failing to return an error if analyzing a union with multiple fields that had an empty tag type.

Also fixes a potential bug I introduced in #21665 by (again) moving things around in `coerceExtra`.