### PR TITLE
atomic fixes and clarification

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4319,7 +4319,7 @@ comptime {
       </p>
       <p>
       {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
-      an integer or an enum.
+      an integer, an enum, or a packed struct.
       </p>
       <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
       {#see_also|@atomicStore|@atomicRmw||@cmpxchgWeak|@cmpxchgStrong#}
@@ -4333,7 +4333,7 @@ comptime {
       </p>
       <p>
       {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
-      an integer or an enum.
+      an integer, an enum, or a packed struct.
       </p>
       <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
       <p>{#syntax#}AtomicRmwOp{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicRmwOp{#endsyntax#}.</p>
@@ -4347,7 +4347,7 @@ comptime {
       </p>
       <p>
       {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
-      an integer or an enum.
+      an integer, an enum, or a packed struct.
       </p>
       <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
       {#see_also|@atomicLoad|@atomicRmw|@cmpxchgWeak|@cmpxchgStrong#}
@@ -4576,8 +4576,8 @@ comptime {
       more efficiently in machine instructions.
       </p>
       <p>
-      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
-      an integer or an enum.
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#},
+      an integer, an enum, or a packed struct.
       </p>
       <p>{#syntax#}@typeInfo(@TypeOf(ptr)).pointer.alignment{#endsyntax#} must be {#syntax#}>= @sizeOf(T).{#endsyntax#}</p>
       <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
@@ -4608,8 +4608,8 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       However if you need a stronger guarantee, use {#link|@cmpxchgStrong#}.
       </p>
       <p>
-      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
-      an integer or an enum.
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#},
+      an integer, an enum, or a packed struct.
       </p>
       <p>{#syntax#}@typeInfo(@TypeOf(ptr)).pointer.alignment{#endsyntax#} must be {#syntax#}>= @sizeOf(T).{#endsyntax#}</p>
       <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -3859,7 +3859,12 @@ pub fn atomicPtrAlignment(
         }
         return .none;
     }
-    if (ty.isAbiInt(zcu)) {
+    if (switch (ty.zigTypeTag(zcu)) {
+        .int, .@"enum" => true,
+        .@"struct" => ty.containerLayout(zcu) == .@"packed",
+        else => false,
+    }) {
+        assert(ty.isAbiInt(zcu));
         const bit_count = ty.intInfo(zcu).bits;
         if (bit_count > max_atomic_bits) {
             diags.* = .{

--- a/test/cases/compile_errors/atomics_with_invalid_type.zig
+++ b/test/cases/compile_errors/atomics_with_invalid_type.zig
@@ -5,8 +5,19 @@ export fn float() void {
 
 const NormalStruct = struct { x: u32 };
 export fn normalStruct() void {
-    var x: NormalStruct = 0;
+    var x: NormalStruct = .{ .x = 0 };
     _ = @cmpxchgWeak(NormalStruct, &x, .{ .x = 1 }, .{ .x = 2 }, .seq_cst, .seq_cst);
+}
+
+export fn anyError() void {
+    var x: anyerror = error.A;
+    _ = @cmpxchgWeak(anyerror, &x, error.A, error.B, .seq_cst, .seq_cst);
+}
+
+const ErrorSet = error{ A, B };
+export fn errorSet() void {
+    var x: ErrorSet = error.A;
+    _ = @cmpxchgWeak(ErrorSet, &x, error.A, error.B, .seq_cst, .seq_cst);
 }
 
 // error
@@ -14,5 +25,7 @@ export fn normalStruct() void {
 // target=native
 //
 // :3:22: error: expected bool, integer, enum, packed struct, or pointer type; found 'f32'
-// :8:27: error: expected type 'tmp.NormalStruct', found 'comptime_int'
+// :9:22: error: expected bool, integer, float, enum, packed struct, or pointer type; found 'tmp.NormalStruct'
 // :6:22: note: struct declared here
+// :14:22: error: expected bool, integer, float, enum, packed struct, or pointer type; found 'anyerror'
+// :20:22: error: expected bool, integer, float, enum, packed struct, or pointer type; found 'error{A,B}'


### PR DESCRIPTION
This PR fixes the lowering of packed structs with non-power-of-two backing integers in the LLVM backend; previously LLVM would throw the error "`atomic memory access' operand must have a power-of-two size`". Additionally, error sets are now caught when used in atomic instructions. Furthermore, I clarified the langref on which types are allowed in atomic builtins.