### PR TITLE
zig rc: Fix include directory detection when cross-compiling from certain host archs

### DIFF
--- a/lib/compiler/resinator/main.zig
+++ b/lib/compiler/resinator/main.zig
@@ -121,7 +121,7 @@ pub fn main() !void {
     };
 
     const full_input = full_input: {
-        if (options.preprocess != .no) {
+        if (options.input_format == .rc and options.preprocess != .no) {
             var preprocessed_buf = std.ArrayList(u8).init(allocator);
             errdefer preprocessed_buf.deinit();
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -6058,6 +6058,8 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
                 self_exe_path,
                 "rc",
                 "--zig-integration",
+                "/:target",
+                @tagName(comp.getTarget().cpu.arch),
                 "/:no-preprocess",
                 "/x", // ignore INCLUDE environment variable
                 "/c65001", // UTF-8 codepage
@@ -6115,6 +6117,8 @@ fn updateWin32Resource(comp: *Compilation, win32_resource: *Win32Resource, win32
             self_exe_path,
             "rc",
             "--zig-integration",
+            "/:target",
+            @tagName(comp.getTarget().cpu.arch),
             "/:depfile",
             out_dep_path,
             "/:depfile-fmt",


### PR DESCRIPTION
Previously, resinator would use the host arch as the target arch when looking for windows-gnu include directories. However, Zig only thinks it can provide a libc for targets specified in the `std.zig.target.available_libcs` array, which only includes a few for windows-gnu. Therefore, when cross-compiling from a host architecture that doesn't have a windows-gnu target in the available_libcs list, resinator would fail to detect the MinGW include directories.

Now, the custom option `/:target` is passed to `zig rc` which is intended for the COFF object file target, but can be re-used for the include directory target as well. For the include directory target, resinator will convert the MachineType to the relevant arch, or fail if there is no  equivalent arch/no support for detecting the includes for the MachineType (currently 64-bit Itanium and EBC).

Fixes the `windows_resources` standalone test failing when the host is, for example, `riscv64-linux`.