### PR TITLE
Replace `unreachable` with error return for non-standard Windows targets

### DIFF
--- a/src/link/Lld.zig
+++ b/src/link/Lld.zig
@@ -37,12 +37,12 @@ const Coff = struct {
                 .Exe => switch (target.cpu.arch) {
                     .aarch64, .x86_64 => 0x140000000,
                     .thumb, .x86 => 0x400000,
-                    else => unreachable,
+                    else => return error.UnsupportedCoffArchitecture,
                 },
                 .Lib => switch (target.cpu.arch) {
                     .aarch64, .x86_64 => 0x180000000,
                     .thumb, .x86 => 0x10000000,
-                    else => unreachable,
+                    else => return error.UnsupportedCoffArchitecture,
                 },
                 .Obj => 0,
             },


### PR DESCRIPTION
This new error (`error.UnsupportedCoffArchitecture`) mirrors the error returned from the Elf struct (`error.UnsupportedElfArchitecture`):

https://github.com/ziglang/zig/blob/0adcfd60f4fcfd01c74a6477cbcef187ce06f533/src/link/Lld.zig#L112

Before:

```
$ zig build-exe -target riscv64-windows-gnu main.zig
thread 543087 panic: reached unreachable code
```

After:

```
$ zig build-exe -target riscv64-windows-gnu main.zig
error: unable to create compilation: UnsupportedCoffArchitecture
```

Closes #24287