### PR TITLE
Sema: give src loc to `requireRuntimeBlock`

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -20134,7 +20134,7 @@ fn structInitAnon(
         return sema.addConstantMaybeRef(struct_val, is_ref);
     };
 
-    try sema.requireRuntimeBlock(block, LazySrcLoc.unneeded, block.src(.{ .init_elem = .{
+    try sema.requireRuntimeBlock(block, src, block.src(.{ .init_elem = .{
         .init_node_offset = src.offset.node_offset.x,
         .elem_index = @intCast(runtime_index),
     } }));
@@ -20282,7 +20282,7 @@ fn zirArrayInit(
         return sema.addConstantMaybeRef(result_val.toIntern(), is_ref);
     };
 
-    try sema.requireRuntimeBlock(block, LazySrcLoc.unneeded, block.src(.{ .init_elem = .{
+    try sema.requireRuntimeBlock(block, src, block.src(.{ .init_elem = .{
         .init_node_offset = src.offset.node_offset.x,
         .elem_index = runtime_index,
     } }));

--- a/test/cases/compile_errors/runtime_value_in_comptime_array.zig
+++ b/test/cases/compile_errors/runtime_value_in_comptime_array.zig
@@ -1,0 +1,16 @@
+fn comptimeArray(comptime _: []const u8) void {}
+fn bar() u8 {
+    return 123;
+}
+
+pub fn main() void {
+    const y = bar();
+    comptimeArray(&.{y});
+}
+
+// error
+//
+// :8:21: error: unable to evaluate comptime expression
+// :8:22: note: operation is runtime due to this operand
+// :8:19: note: argument to comptime parameter must be comptime-known
+// :1:18: note: parameter declared comptime here

--- a/test/cases/compile_errors/runtime_value_in_comptime_struct.zig
+++ b/test/cases/compile_errors/runtime_value_in_comptime_struct.zig
@@ -1,0 +1,16 @@
+fn comptimeStruct(comptime _: anytype) void {}
+fn bar() u8 {
+    return 123;
+}
+
+pub fn main() void {
+    const y = bar();
+    comptimeStruct(.{ .foo = y });
+}
+
+// error
+//
+// :8:21: error: unable to evaluate comptime expression
+// :8:24: note: operation is runtime due to this operand
+// :8:21: note: argument to comptime parameter must be comptime-known
+// :1:19: note: parameter declared comptime here


### PR DESCRIPTION
Fixes #24273.

It looks like the regression was caused by 1eaeb4a0, which removed the handling for `error.NeededSourceLocation`.