### PR TITLE
spirv: fix null file handle crash & improve flush err handling

### DIFF
--- a/src/link.zig
+++ b/src/link.zig
@@ -608,8 +608,15 @@ pub const File = struct {
                     .mode = determineMode(output_mode, link_mode),
                 });
             },
-            .c, .spirv => dev.checkAny(&.{ .c_linker, .spirv_linker }),
-        }
+            .spirv => {
+                if (base.file != null) return;
+                dev.check(.spirv_linker);
+                const emit = base.emit;
+                base.file = try emit.root_dir.handle.createFile(emit.sub_path, .{
+                    .truncate = true,
+                });
+            },
+            .c => dev.check(.c_linker),
     }
 
     /// Some linkers create a separate file for debug info, which we might need to temporarily close

--- a/src/link.zig
+++ b/src/link.zig
@@ -568,9 +568,9 @@ pub const File = struct {
         const gpa = comp.gpa;
         switch (base.tag) {
             .lld => assert(base.file == null),
-            .coff, .elf, .macho, .plan9, .wasm, .goff, .xcoff => {
+            .coff, .elf, .macho, .plan9, .wasm, .goff, .xcoff, .spirv => {
                 if (base.file != null) return;
-                dev.checkAny(&.{ .coff_linker, .elf_linker, .macho_linker, .plan9_linker, .wasm_linker, .goff_linker, .xcoff_linker });
+                dev.checkAny(&.{ .coff_linker, .elf_linker, .macho_linker, .plan9_linker, .wasm_linker, .goff_linker, .xcoff_linker, .spirv_linker });
                 const emit = base.emit;
                 if (base.child_pid) |pid| {
                     if (builtin.os.tag == .windows) {
@@ -608,15 +608,8 @@ pub const File = struct {
                     .mode = determineMode(output_mode, link_mode),
                 });
             },
-            .spirv => {
-                if (base.file != null) return;
-                dev.check(.spirv_linker);
-                const emit = base.emit;
-                base.file = try emit.root_dir.handle.createFile(emit.sub_path, .{
-                    .truncate = true,
-                });
-            },
             .c => dev.check(.c_linker),
+        }
     }
 
     /// Some linkers create a separate file for debug info, which we might need to temporarily close

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -240,6 +240,11 @@ pub fn flush(
         else => |other| return diags.fail("error while linking: {s}", .{@errorName(other)}),
     };
 
+    self.base.makeWritable() catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.LinkFailure,
+    };
+
     self.base.file.?.writeAll(std.mem.sliceAsBytes(linked_module)) catch |err|
         return diags.fail("failed to write: {s}", .{@errorName(err)});
 }


### PR DESCRIPTION
Add makeWritable() call before writeAll() in SPIR-V linker flush function.
SPIR-V linker was trying to write to uninitialized file handle.

**Changes:**
- Add .spirv case to makeWritable() switch in link.zig  
- Call makeWritable() with proper error handling in SpirV.zig
- OutOfMemory propagates up, other errors become LinkFailure

**Testing:**
- SPIR-V shader compilation now works: `zig build-obj shader.zig -target spirv64-vulkan`
- No more null pointer crashes during file writing
- Proper error handling and file lifecycle management

Fixes #23883