### PR TITLE
zig init: allow specifying project path

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -4736,7 +4736,7 @@ const usage_init =
 fn cmdInit(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     dev.check(.init_command);
 
-    var path: ?[]const u8 = "";
+    var path: ?[]const u8 = null;
     var template: enum { example, minimal } = .example;
     {
         var i: usize = 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -4768,7 +4768,6 @@ fn cmdInit(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     if (path != null) {
         fs.cwd().makePath(path.?) catch |e|
             switch (e) {
-                error.PathAlreadyExists => return,
                 error.NotDir => {
                     fatal("specified path contains non-directory", .{});
                 },


### PR DESCRIPTION
This PR allows `zig init` to initialize project when path is specified.

Usage:
```console
$ zig init # path not provided, initialize in the current directory
$ zig init foo # create dir named foo if it does not exists, then initialize under ./foo
$ zig init foo/bar # create dir tree foo/bar if it does not exists, then initialize under ./foo/bar
```

When specified path already exists as non-dir, the cli throws fatal()

Closes: #24290 