### PR TITLE
TLS: use distinct ciphersuites and extensions for TLS 1.2 and TLS 1.3

### DIFF
--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -919,7 +919,7 @@ pub fn init(stream: anytype, options: Options) InitError(@TypeOf(stream))!Client
 
 /// Initiates a TLS handshake restricted to TLS 1.2-compatible cipher suites only.
 /// This is used as a fallback when the server doesn't support TLS 1.3 cipher suites.
-fn initTls12Only(stream: anytype, options: Options) InitError(@TypeOf(stream))!Client {
+pub fn initTls12Only(stream: anytype, options: Options) InitError(@TypeOf(stream))!Client {
     return initWithCipherSuites(stream, options, tls_1_2_cipher_suites, .{.tls_1_2}, true);
 }
 


### PR DESCRIPTION
Do not try to use TLS 1.3-specific ciphersuites and extensions with TLS 1.2. And the other way round.

If a TLS 1.3 handshake fails, retry with TLS 1.2.

This fixes connections with hosts such as ziglang.freetls.fastly.net