### PR TITLE
Update comment for `ptr_type` and `ptr_type_bit_range` to `.extra_and_node`

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -3341,7 +3341,7 @@ pub const Node = struct {
         /// The `main_token` might be a ** token, which is shared with a
         /// parent/child pointer type and may require special handling.
         ptr_type_sentinel,
-        /// The `data` field is a `.opt_node_and_node`:
+        /// The `data` field is a `.extra_and_node`:
         ///   1. a `ExtraIndex` to `PtrType`.
         ///   2. a `Node.Index` to the element type expression.
         ///
@@ -3350,7 +3350,7 @@ pub const Node = struct {
         /// The `main_token` might be a ** token, which is shared with a
         /// parent/child pointer type and may require special handling.
         ptr_type,
-        /// The `data` field is a `.opt_node_and_node`:
+        /// The `data` field is a `.extra_and_node`:
         ///   1. a `ExtraIndex` to `PtrTypeBitRange`.
         ///   2. a `Node.Index` to the element type expression.
         ///


### PR DESCRIPTION
The other pointer tags contain `.opt_node_and_node` in their `.data` but `ptr_type` and `ptr_type_bit_range` contain `.extra_and_node` in their `data` field.