### PR TITLE
Reintroduce result types for switch cases

### DIFF
--- a/lib/std/zig/Zir.zig
+++ b/lib/std/zig/Zir.zig
@@ -342,7 +342,7 @@ pub const Inst = struct {
         /// Uses the `break` union field.
         break_inline,
         /// Branch from within a switch case to the case specified by the operand.
-        /// Uses the `break` union field. `block_inst` refers to a `switch_block` or `switch_block_ref`.
+        /// Uses the `break` union field. `block_inst` refers to a `switch_block`.
         switch_continue,
         /// Checks that comptime control flow does not happen inside a runtime block.
         /// Uses the `un_node` union field.
@@ -695,12 +695,18 @@ pub const Inst = struct {
         /// function call syntax, i.e. `.foo()`.
         /// Uses the `pl_node` union field. Payload is `Field`.
         decl_literal_no_coerce,
+        /// Produces the value that will be switched on. For example, for
+        /// integers, it returns the integer with no modifications. For tagged unions, it
+        /// returns the active enum tag.
+        /// Uses the `un_node` union field.
+        switch_cond,
+        /// Same as `switch_cond`, except the input operand is a pointer to
+        /// what will be switched on.
+        /// Uses the `un_node` union field.
+        switch_cond_ref,
         /// A switch expression. Uses the `pl_node` union field.
         /// AST node is the switch, payload is `SwitchBlock`.
         switch_block,
-        /// A switch expression. Uses the `pl_node` union field.
-        /// AST node is the switch, payload is `SwitchBlock`. Operand is a pointer.
-        switch_block_ref,
         /// A switch on an error union `a catch |err| switch (err) {...}`.
         /// Uses the `pl_node` union field. AST node is the `catch`, payload is `SwitchBlockErrUnion`.
         switch_block_err_union,
@@ -1206,8 +1212,9 @@ pub const Inst = struct {
                 .typeof_log2_int_type,
                 .resolve_inferred_alloc,
                 .set_eval_branch_quota,
+                .switch_cond,
+                .switch_cond_ref,
                 .switch_block,
-                .switch_block_ref,
                 .switch_block_err_union,
                 .validate_deref,
                 .validate_destructure,
@@ -1494,8 +1501,9 @@ pub const Inst = struct {
                 .slice_sentinel_ty,
                 .import,
                 .typeof_log2_int_type,
+                .switch_cond,
+                .switch_cond_ref,
                 .switch_block,
-                .switch_block_ref,
                 .switch_block_err_union,
                 .union_init,
                 .field_type_ref,
@@ -1748,8 +1756,9 @@ pub const Inst = struct {
                 .enum_literal = .str_tok,
                 .decl_literal = .pl_node,
                 .decl_literal_no_coerce = .pl_node,
+                .switch_cond = .un_node,
+                .switch_cond_ref = .un_node,
                 .switch_block = .pl_node,
-                .switch_block_ref = .pl_node,
                 .switch_block_err_union = .pl_node,
                 .validate_deref = .un_node,
                 .validate_destructure = .pl_node,
@@ -3277,10 +3286,13 @@ pub const Inst = struct {
     /// captured payload. Whether this is captured by reference or by value
     /// depends on whether the `byref` bit is set for the corresponding body.
     pub const SwitchBlock = struct {
-        /// The operand passed to the `switch` expression. If this is a
-        /// `switch_block`, this is the operand value; if `switch_block_ref` it
-        /// is a pointer to the operand. `switch_block_ref` is always used if
-        /// any prong has a byref capture.
+        /// This is always a `switch_cond` or `switch_cond_ref` instruction.
+        /// If it is a `switch_cond_ref` instruction, bits.is_ref is always true.
+        /// If it is a `switch_cond` instruction, bits.is_ref is always false.
+        /// Both `switch_cond` and `switch_cond_ref` return a value, not a pointer,
+        /// that is useful for the case items, but cannot be used for capture values.
+        /// For the capture values, Sema is expected to find the operand of this operand
+        /// and use that.
         operand: Ref,
         bits: Bits,
 
@@ -4338,6 +4350,8 @@ fn findTrackableInner(
         .make_ptr_const,
         .@"resume",
         .@"await",
+        .switch_cond,
+        .switch_cond_ref,
         .save_err_ret_index,
         .restore_err_ret_index_unconditional,
         .restore_err_ret_index_fn_entry,
@@ -4676,7 +4690,7 @@ fn findTrackableInner(
             const body = zir.bodySlice(extra.end, extra.data.body_len);
             try zir.findTrackableBody(gpa, contents, defers, body);
         },
-        .switch_block, .switch_block_ref => return zir.findTrackableSwitch(gpa, contents, defers, inst, .normal),
+        .switch_block => return zir.findTrackableSwitch(gpa, contents, defers, inst, .normal),
         .switch_block_err_union => return zir.findTrackableSwitch(gpa, contents, defers, inst, .err_union),
 
         .suspend_block => @panic("TODO iterate suspend block"),

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -1247,8 +1247,9 @@ fn analyzeBodyInner(
             .slice_length                 => try sema.zirSliceLength(block, inst),
             .slice_sentinel_ty            => try sema.zirSliceSentinelTy(block, inst),
             .str                          => try sema.zirStr(inst),
-            .switch_block                 => try sema.zirSwitchBlock(block, inst, false),
-            .switch_block_ref             => try sema.zirSwitchBlock(block, inst, true),
+            .switch_cond                  => try sema.zirSwitchCond(block, inst, false),
+            .switch_cond_ref              => try sema.zirSwitchCond(block, inst, true),
+            .switch_block                 => try sema.zirSwitchBlock(block, inst),
             .switch_block_err_union       => try sema.zirSwitchBlockErrUnion(block, inst),
             .type_info                    => try sema.zirTypeInfo(block, inst),
             .size_of                      => try sema.zirSizeOf(block, inst),
@@ -6775,22 +6776,21 @@ fn zirSwitchContinue(sema: *Sema, start_block: *Block, inst: Zir.Inst.Index) Com
     const tracy = trace(@src());
     defer tracy.end();
 
-    const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].@"break";
+    const datas = sema.code.instructions.items(.data);
+    const inst_data = datas[@intFromEnum(inst)].@"break";
     const extra = sema.code.extraData(Zir.Inst.Break, inst_data.payload_index).data;
     const operand_src = start_block.nodeOffset(extra.operand_src_node.unwrap().?);
     const uncoerced_operand = try sema.resolveInst(inst_data.operand);
     const switch_inst = extra.block_inst;
 
-    switch (sema.code.instructions.items(.tag)[@intFromEnum(switch_inst)]) {
-        .switch_block, .switch_block_ref => {},
-        else => unreachable, // assertion failure
-    }
+    assert(sema.code.instructions.items(.tag)[@intFromEnum(switch_inst)] == .switch_block);
 
-    const switch_payload_index = sema.code.instructions.items(.data)[@intFromEnum(switch_inst)].pl_node.payload_index;
-    const switch_operand_ref = sema.code.extraData(Zir.Inst.SwitchBlock, switch_payload_index).data.operand;
-    const switch_operand_ty = sema.typeOf(try sema.resolveInst(switch_operand_ref));
+    const switch_payload_index = datas[@intFromEnum(switch_inst)].pl_node.payload_index;
+    const switch_cond_index = sema.code.extraData(Zir.Inst.SwitchBlock, switch_payload_index).data.operand.toIndex().?;
+    const switch_cond = sema.resolveInst(datas[@intFromEnum(switch_cond_index)].un_node.operand) catch unreachable;
+    const switch_cond_ty = sema.typeOf(switch_cond);
 
-    const operand = try sema.coerce(start_block, switch_operand_ty, uncoerced_operand, operand_src);
+    const operand = try sema.coerce(start_block, switch_cond_ty, uncoerced_operand, operand_src);
 
     try sema.validateRuntimeValue(start_block, operand_src, operand);
 
@@ -11379,6 +11379,23 @@ const SwitchProngAnalysis = struct {
     }
 };
 
+fn zirSwitchCond(
+    sema: *Sema,
+    block: *Block,
+    inst: Zir.Inst.Index,
+    is_ref: bool,
+) CompileError!Air.Inst.Ref {
+    const inst_data = sema.code.instructions.items(.data)[@intFromEnum(inst)].un_node;
+    const src = block.nodeOffset(inst_data.src_node);
+    const operand_src = block.src(.{ .node_offset_switch_operand = inst_data.src_node });
+    const maybe_ptr = try sema.resolveInst(inst_data.operand);
+    const operand = if (is_ref)
+        try sema.analyzeLoad(block, src, maybe_ptr, operand_src)
+    else
+        maybe_ptr;
+    return sema.switchCond(block, src, operand);
+}
+
 fn switchCond(
     sema: *Sema,
     block: *Block,
@@ -11764,7 +11781,7 @@ fn zirSwitchBlockErrUnion(sema: *Sema, block: *Block, inst: Zir.Inst.Index) Comp
     return sema.resolveAnalyzedBlock(block, main_src, &child_block, merges, false);
 }
 
-fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_ref: bool) CompileError!Air.Inst.Ref {
+fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileError!Air.Inst.Ref {
     const tracy = trace(@src());
     defer tracy.end();
 
@@ -11777,23 +11794,31 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
     const operand_src = block.src(.{ .node_offset_switch_operand = src_node_offset });
     const special_prong_src = block.src(.{ .node_offset_switch_special_prong = src_node_offset });
     const extra = sema.code.extraData(Zir.Inst.SwitchBlock, inst_data.payload_index);
+    const cond = try sema.resolveInst(extra.data.operand);
+    const cond_index = extra.data.operand.toIndex().?;
 
-    const operand: SwitchProngAnalysis.Operand, const raw_operand_ty: Type = op: {
-        const maybe_ptr = try sema.resolveInst(extra.data.operand);
+    const operand: SwitchProngAnalysis.Operand, const raw_operand_ty: Type, const operand_is_ref = op: {
+        const tags = sema.code.instructions.items(.tag);
+        const datas = sema.code.instructions.items(.data);
+        const maybe_ptr =
+            sema.resolveInst(datas[@intFromEnum(cond_index)].un_node.operand) catch unreachable;
+        const operand_is_ref = switch (tags[@intFromEnum(cond_index)]) {
+            .switch_cond_ref => true,
+            .switch_cond => false,
+            else => unreachable,
+        };
         const val, const ref = if (operand_is_ref)
             .{ try sema.analyzeLoad(block, src, maybe_ptr, operand_src), maybe_ptr }
         else
             .{ maybe_ptr, undefined };
 
-        const init_cond = try sema.switchCond(block, operand_src, val);
-
-        const operand_ty = sema.typeOf(val);
+        const raw_operand_ty = sema.typeOf(val);
 
         if (extra.data.bits.has_continue and !block.isComptime()) {
             // Even if the operand is comptime-known, this `switch` is runtime.
-            if (try operand_ty.comptimeOnlySema(pt)) {
+            if (try raw_operand_ty.comptimeOnlySema(pt)) {
                 return sema.failWithOwnedErrorMsg(block, msg: {
-                    const msg = try sema.errMsg(operand_src, "operand of switch loop has comptime-only type '{}'", .{operand_ty.fmt(pt)});
+                    const msg = try sema.errMsg(operand_src, "operand of switch loop has comptime-only type '{}'", .{raw_operand_ty.fmt(pt)});
                     errdefer msg.destroy(gpa);
                     try sema.errNote(operand_src, msg, "switch loops are evaluated at runtime outside of comptime scopes", .{});
                     break :msg msg;
@@ -11810,9 +11835,10 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
                 .{ .loop = .{
                     .operand_alloc = operand_alloc,
                     .operand_is_ref = operand_is_ref,
-                    .init_cond = init_cond,
+                    .init_cond = cond,
                 } },
-                operand_ty,
+                raw_operand_ty,
+                operand_is_ref,
             };
         }
 
@@ -11823,9 +11849,10 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
             .{ .simple = .{
                 .by_val = val,
                 .by_ref = ref,
-                .cond = init_cond,
+                .cond = cond,
             } },
-            operand_ty,
+            raw_operand_ty,
+            operand_is_ref,
         };
     };
 
@@ -11837,7 +11864,7 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
     };
 
     // AstGen guarantees that the instruction immediately preceding
-    // switch_block(_ref) is a dbg_stmt
+    // switch_block is a dbg_stmt
     const cond_dbg_node_index: Zir.Inst.Index = @enumFromInt(@intFromEnum(inst) - 1);
 
     var header_extra_index: usize = extra.end;

--- a/src/print_zir.zig
+++ b/src/print_zir.zig
@@ -269,6 +269,8 @@ const Writer = struct {
             .bit_reverse,
             .@"resume",
             .@"await",
+            .switch_cond,
+            .switch_cond_ref,
             .make_ptr_const,
             .validate_deref,
             .validate_const,
@@ -454,9 +456,7 @@ const Writer = struct {
 
             .error_set_decl => try self.writeErrorSetDecl(stream, inst),
 
-            .switch_block,
-            .switch_block_ref,
-            => try self.writeSwitchBlock(stream, inst),
+            .switch_block => try self.writeSwitchBlock(stream, inst),
 
             .switch_block_err_union => try self.writeSwitchBlockErrUnion(stream, inst),
 

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -1065,3 +1065,21 @@ test "switch on a signed value smaller than the smallest prong value" {
         else => {},
     }
 }
+
+test "decl literals as switch cases" {
+    const E = enum(u8) {
+        bar = 3,
+        _,
+
+        const foo: @This() = @enumFromInt(0xa);
+    };
+
+    var e: E = .foo;
+    _ = &e;
+    const ok = switch (e) {
+        .bar => false,
+        .foo => true,
+        else => false,
+    };
+    try expect(ok);
+}


### PR DESCRIPTION
Resolves #24152

This PR reintroduces the `switch_cond[_ref]` ZIR tags.
These tags were removed in 85e94fed1e058720460560823ac09d7b64e49b97 as a consequence of result types for switch cases being removed in cebd80032a2dcc9f516f8183d1bfade5d1f12e45. They have since become necessary again because of the existence of decl literals. Reintroducing them makes `switch_cond_ref` superfluous.
This change is also in preparation of switching on packed structs (#22214).

I tried to keep the changes as unintrusive as possible but this does increase the amount of ZIR tags by 1.