### PR TITLE
std.posix.accept: add WSAENOTSOCK

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -3936,6 +3936,7 @@ pub fn accept(
                     .WSANOTINITIALISED => unreachable, // not initialized WSA
                     .WSAECONNRESET => return error.ConnectionResetByPeer,
                     .WSAEFAULT => unreachable,
+                    .WSAENOTSOCK => return error.FileDescriptorNotASocket,
                     .WSAEINVAL => return error.SocketNotListening,
                     .WSAEMFILE => return error.ProcessFdQuotaExceeded,
                     .WSAENETDOWN => return error.NetworkSubsystemFailed,


### PR DESCRIPTION
Add `WSAENOTSOCK`, and avoid `error.Unexpected`.


https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2#WSAENOTSOCK