### PR TITLE
`wasi`: Build emulated libraries into `libc.a`

### DIFF
--- a/src/libs/wasi_libc.zig
+++ b/src/libs/wasi_libc.zig
@@ -143,7 +143,16 @@ pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progre
                 // Compile libwasi-emulated-process-clocks.
                 var args = std.ArrayList([]const u8).init(arena);
                 try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
-                try addLibcBottomHalfIncludes(comp, arena, &args);
+                try args.appendSlice(&.{
+                    "-I",
+                    try comp.dirs.zig_lib.join(arena, &.{
+                        "libc",
+                        "wasi",
+                        "libc-bottom-half",
+                        "cloudlibc",
+                        "src",
+                    }),
+                });
 
                 for (emulated_process_clocks_src_files) |file_path| {
                     try libc_sources.append(.{

--- a/src/libs/wasi_libc.zig
+++ b/src/libs/wasi_libc.zig
@@ -10,42 +10,7 @@ pub const CrtFile = enum {
     crt1_reactor_o,
     crt1_command_o,
     libc_a,
-    libdl_a,
-    libwasi_emulated_process_clocks_a,
-    libwasi_emulated_getpid_a,
-    libwasi_emulated_mman_a,
-    libwasi_emulated_signal_a,
 };
-
-pub fn getEmulatedLibCrtFile(lib_name: []const u8) ?CrtFile {
-    if (mem.eql(u8, lib_name, "dl")) {
-        return .libdl_a;
-    }
-    if (mem.eql(u8, lib_name, "wasi-emulated-process-clocks")) {
-        return .libwasi_emulated_process_clocks_a;
-    }
-    if (mem.eql(u8, lib_name, "wasi-emulated-getpid")) {
-        return .libwasi_emulated_getpid_a;
-    }
-    if (mem.eql(u8, lib_name, "wasi-emulated-mman")) {
-        return .libwasi_emulated_mman_a;
-    }
-    if (mem.eql(u8, lib_name, "wasi-emulated-signal")) {
-        return .libwasi_emulated_signal_a;
-    }
-    return null;
-}
-
-pub fn emulatedLibCRFileLibName(crt_file: CrtFile) []const u8 {
-    return switch (crt_file) {
-        .libdl_a => "libdl.a",
-        .libwasi_emulated_process_clocks_a => "libwasi-emulated-process-clocks.a",
-        .libwasi_emulated_getpid_a => "libwasi-emulated-getpid.a",
-        .libwasi_emulated_mman_a => "libwasi-emulated-mman.a",
-        .libwasi_emulated_signal_a => "libwasi-emulated-signal.a",
-        else => unreachable,
-    };
-}
 
 pub fn execModelCrtFile(wasi_exec_model: std.builtin.WasiExecModel) CrtFile {
     return switch (wasi_exec_model) {
@@ -157,114 +122,106 @@ pub fn buildCrtFile(comp: *Compilation, crt_file: CrtFile, prog_node: std.Progre
                 }
             }
 
-            try comp.build_crt_file("c", .Lib, .@"wasi libc.a", prog_node, libc_sources.items, .{});
-        },
-
-        .libdl_a => {
-            var args = std.ArrayList([]const u8).init(arena);
-            try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
-            try addLibcBottomHalfIncludes(comp, arena, &args);
-
-            var emu_dl_sources = std.ArrayList(Compilation.CSourceFile).init(arena);
-            for (emulated_dl_src_files) |file_path| {
-                try emu_dl_sources.append(.{
-                    .src_path = try comp.dirs.zig_lib.join(arena, &.{
-                        "libc", try sanitize(arena, file_path),
-                    }),
-                    .extra_flags = args.items,
-                    .owner = undefined,
-                });
-            }
-            try comp.build_crt_file("dl", .Lib, .@"wasi libdl.a", prog_node, emu_dl_sources.items, .{});
-        },
-
-        .libwasi_emulated_process_clocks_a => {
-            var args = std.ArrayList([]const u8).init(arena);
-            try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
-            try addLibcBottomHalfIncludes(comp, arena, &args);
-
-            var emu_clocks_sources = std.ArrayList(Compilation.CSourceFile).init(arena);
-            for (emulated_process_clocks_src_files) |file_path| {
-                try emu_clocks_sources.append(.{
-                    .src_path = try comp.dirs.zig_lib.join(arena, &.{
-                        "libc", try sanitize(arena, file_path),
-                    }),
-                    .extra_flags = args.items,
-                    .owner = undefined,
-                });
-            }
-            try comp.build_crt_file("wasi-emulated-process-clocks", .Lib, .@"libwasi-emulated-process-clocks.a", prog_node, emu_clocks_sources.items, .{});
-        },
-        .libwasi_emulated_getpid_a => {
-            var args = std.ArrayList([]const u8).init(arena);
-            try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
-            try addLibcBottomHalfIncludes(comp, arena, &args);
-
-            var emu_getpid_sources = std.ArrayList(Compilation.CSourceFile).init(arena);
-            for (emulated_getpid_src_files) |file_path| {
-                try emu_getpid_sources.append(.{
-                    .src_path = try comp.dirs.zig_lib.join(arena, &.{
-                        "libc", try sanitize(arena, file_path),
-                    }),
-                    .extra_flags = args.items,
-                    .owner = undefined,
-                });
-            }
-            try comp.build_crt_file("wasi-emulated-getpid", .Lib, .@"libwasi-emulated-getpid.a", prog_node, emu_getpid_sources.items, .{});
-        },
-        .libwasi_emulated_mman_a => {
-            var args = std.ArrayList([]const u8).init(arena);
-            try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
-            try addLibcBottomHalfIncludes(comp, arena, &args);
-
-            var emu_mman_sources = std.ArrayList(Compilation.CSourceFile).init(arena);
-            for (emulated_mman_src_files) |file_path| {
-                try emu_mman_sources.append(.{
-                    .src_path = try comp.dirs.zig_lib.join(arena, &.{
-                        "libc", try sanitize(arena, file_path),
-                    }),
-                    .extra_flags = args.items,
-                    .owner = undefined,
-                });
-            }
-            try comp.build_crt_file("wasi-emulated-mman", .Lib, .@"libwasi-emulated-mman.a", prog_node, emu_mman_sources.items, .{});
-        },
-        .libwasi_emulated_signal_a => {
-            var emu_signal_sources = std.ArrayList(Compilation.CSourceFile).init(arena);
-
             {
+                // Compile libdl.
                 var args = std.ArrayList([]const u8).init(arena);
                 try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
+                try addLibcBottomHalfIncludes(comp, arena, &args);
+
+                for (emulated_dl_src_files) |file_path| {
+                    try libc_sources.append(.{
+                        .src_path = try comp.dirs.zig_lib.join(arena, &.{
+                            "libc", try sanitize(arena, file_path),
+                        }),
+                        .extra_flags = args.items,
+                        .owner = undefined,
+                    });
+                }
+            }
+
+            {
+                // Compile libwasi-emulated-process-clocks.
+                var args = std.ArrayList([]const u8).init(arena);
+                try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
+                try addLibcBottomHalfIncludes(comp, arena, &args);
+
+                for (emulated_process_clocks_src_files) |file_path| {
+                    try libc_sources.append(.{
+                        .src_path = try comp.dirs.zig_lib.join(arena, &.{
+                            "libc", try sanitize(arena, file_path),
+                        }),
+                        .extra_flags = args.items,
+                        .owner = undefined,
+                    });
+                }
+            }
+
+            {
+                // Compile libwasi-emulated-getpid.
+                var args = std.ArrayList([]const u8).init(arena);
+                try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
+                try addLibcBottomHalfIncludes(comp, arena, &args);
+
+                for (emulated_getpid_src_files) |file_path| {
+                    try libc_sources.append(.{
+                        .src_path = try comp.dirs.zig_lib.join(arena, &.{
+                            "libc", try sanitize(arena, file_path),
+                        }),
+                        .extra_flags = args.items,
+                        .owner = undefined,
+                    });
+                }
+            }
+
+            {
+                // Compile libwasi-emulated-mman.
+                var args = std.ArrayList([]const u8).init(arena);
+                try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
+                try addLibcBottomHalfIncludes(comp, arena, &args);
+
+                for (emulated_mman_src_files) |file_path| {
+                    try libc_sources.append(.{
+                        .src_path = try comp.dirs.zig_lib.join(arena, &.{
+                            "libc", try sanitize(arena, file_path),
+                        }),
+                        .extra_flags = args.items,
+                        .owner = undefined,
+                    });
+                }
+            }
+
+            {
+                // Compile libwasi-emulated-signal.
+                var bottom_args = std.ArrayList([]const u8).init(arena);
+                try addCCArgs(comp, arena, &bottom_args, .{ .want_O3 = true });
 
                 for (emulated_signal_bottom_half_src_files) |file_path| {
-                    try emu_signal_sources.append(.{
+                    try libc_sources.append(.{
                         .src_path = try comp.dirs.zig_lib.join(arena, &.{
                             "libc", try sanitize(arena, file_path),
                         }),
-                        .extra_flags = args.items,
+                        .extra_flags = bottom_args.items,
                         .owner = undefined,
                     });
                 }
-            }
 
-            {
-                var args = std.ArrayList([]const u8).init(arena);
-                try addCCArgs(comp, arena, &args, .{ .want_O3 = true });
-                try addLibcTopHalfIncludes(comp, arena, &args);
-                try args.append("-D_WASI_EMULATED_SIGNAL");
+                var top_args = std.ArrayList([]const u8).init(arena);
+                try addCCArgs(comp, arena, &top_args, .{ .want_O3 = true });
+                try addLibcTopHalfIncludes(comp, arena, &top_args);
+                try top_args.append("-D_WASI_EMULATED_SIGNAL");
 
                 for (emulated_signal_top_half_src_files) |file_path| {
-                    try emu_signal_sources.append(.{
+                    try libc_sources.append(.{
                         .src_path = try comp.dirs.zig_lib.join(arena, &.{
                             "libc", try sanitize(arena, file_path),
                         }),
-                        .extra_flags = args.items,
+                        .extra_flags = top_args.items,
                         .owner = undefined,
                     });
                 }
             }
 
-            try comp.build_crt_file("wasi-emulated-signal", .Lib, .@"libwasi-emulated-signal.a", prog_node, emu_signal_sources.items, .{});
+            try comp.build_crt_file("c", .Lib, .@"wasi libc.a", prog_node, libc_sources.items, .{});
         },
     }
 }

--- a/src/link/Lld.zig
+++ b/src/link/Lld.zig
@@ -1539,13 +1539,6 @@ fn wasmLink(lld: *Lld, arena: Allocator) !void {
 
         if (comp.config.link_libc and is_exe_or_dyn_lib) {
             if (target.os.tag == .wasi) {
-                for (comp.wasi_emulated_libs) |crt_file| {
-                    try argv.append(try comp.crtFileAsString(
-                        arena,
-                        wasi_libc.emulatedLibCRFileLibName(crt_file),
-                    ));
-                }
-
                 try argv.append(try comp.crtFileAsString(
                     arena,
                     wasi_libc.execModelCrtFileFullName(comp.config.wasi_exec_model),

--- a/src/main.zig
+++ b/src/main.zig
@@ -972,8 +972,6 @@ fn buildOutputType(
         .windows_libs = .empty,
         .link_inputs = .empty,
 
-        .wasi_emulated_libs = .{},
-
         .c_source_files = .{},
         .rc_source_files = .{},
 
@@ -3406,7 +3404,6 @@ fn buildOutputType(
         .framework_dirs = create_module.framework_dirs.items,
         .frameworks = resolved_frameworks.items,
         .windows_lib_names = create_module.windows_libs.keys(),
-        .wasi_emulated_libs = create_module.wasi_emulated_libs.items,
         .want_compiler_rt = want_compiler_rt,
         .want_ubsan_rt = want_ubsan_rt,
         .hash_style = hash_style,
@@ -3687,8 +3684,6 @@ const CreateModule = struct {
     /// output. Allocated with gpa.
     link_inputs: std.ArrayListUnmanaged(link.Input),
 
-    wasi_emulated_libs: std.ArrayListUnmanaged(wasi_libc.CrtFile),
-
     c_source_files: std.ArrayListUnmanaged(Compilation.CSourceFile),
     rc_source_files: std.ArrayListUnmanaged(Compilation.RcSourceFile),
 
@@ -3818,14 +3813,6 @@ fn createModule(
         for (create_module.cli_link_inputs.items) |cli_link_input| switch (cli_link_input) {
             .name_query => |nq| {
                 const lib_name = nq.name;
-
-                if (target.os.tag == .wasi) {
-                    if (wasi_libc.getEmulatedLibCrtFile(lib_name)) |crt_file| {
-                        try create_module.wasi_emulated_libs.append(arena, crt_file);
-                        create_module.opts.link_libc = true;
-                        continue;
-                    }
-                }
 
                 if (std.zig.target.isLibCLibName(target, lib_name)) {
                     create_module.opts.link_libc = true;


### PR DESCRIPTION
This matches what we do for small helper libraries like this in MinGW-w64. It simplifies the compiler a bit, and also means the build system doesn't have to treat these library names specially.

Closes #24325.