### PR TITLE
`std`: Disable `std.zon parse float` on dynamic `x86-linux-musl`

### DIFF
--- a/lib/std/zon/parse.zig
+++ b/lib/std/zon/parse.zig
@@ -2759,6 +2759,8 @@ test "std.zon negative char" {
 }
 
 test "std.zon parse float" {
+    if (builtin.cpu.arch == .x86 and builtin.abi == .musl and builtin.link_mode == .dynamic) return error.SkipZigTest;
+
     const gpa = std.testing.allocator;
 
     // Test decimals


### PR DESCRIPTION
https://github.com/ziglang/zig/issues/23922#issuecomment-3054296672