### PR TITLE
std.log: adjust default level for ReleaseSmall to include info + bonus cleanup

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -287,7 +287,7 @@ fn rawCAlloc(
 ) ?[*]u8 {
     _ = context;
     _ = return_address;
-    assert(alignment.compare(.lte, comptime .fromByteUnits(@alignOf(std.c.max_align_t))));
+    assert(alignment.compare(.lte, .of(std.c.max_align_t)));
     // Note that this pointer cannot be aligncasted to max_align_t because if
     // len is < max_align_t then the alignment can be smaller. For example, if
     // max_align_t is 16, but the user requests 8 bytes, there is no built-in

--- a/lib/std/heap/arena_allocator.zig
+++ b/lib/std/heap/arena_allocator.zig
@@ -42,7 +42,7 @@ pub const ArenaAllocator = struct {
         data: usize,
         node: std.SinglyLinkedList.Node = .{},
     };
-    const BufNode_alignment: Alignment = .fromByteUnits(@alignOf(BufNode));
+    const BufNode_alignment: Alignment = .of(BufNode);
 
     pub fn init(child_allocator: Allocator) ArenaAllocator {
         return (State{}).promote(child_allocator);

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -101,8 +101,7 @@ pub const Level = enum {
 /// The default log level is based on build mode.
 pub const default_level: Level = switch (builtin.mode) {
     .Debug => .debug,
-    .ReleaseSafe => .info,
-    .ReleaseFast, .ReleaseSmall => .err,
+    .ReleaseSafe, .ReleaseFast, .ReleaseSmall => .info,
 };
 
 const level = std.options.log_level;

--- a/lib/std/mem/Allocator.zig
+++ b/lib/std/mem/Allocator.zig
@@ -253,7 +253,7 @@ pub inline fn allocAdvancedWithRetAddr(
     n: usize,
     return_address: usize,
 ) Error![]align(if (alignment) |a| a.toByteUnits() else @alignOf(T)) T {
-    const a = comptime (alignment orelse Alignment.fromByteUnits(@alignOf(T)));
+    const a = comptime (alignment orelse Alignment.of(T));
     const ptr: [*]align(a.toByteUnits()) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
     return ptr[0..n];
 }


### PR DESCRIPTION
it was kind of wild to not do this before. sorry!

bonus commit: refactor some places to use `Alignment.of` helper