### PR TITLE
Expose `dbHelper` functions

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1499,7 +1499,7 @@ pub fn HashMapUnmanaged(
 
         /// This function is used in the debugger pretty formatters in tools/ to fetch the
         /// header type to facilitate fancy debug printing for this type.
-        fn dbHelper(self: *Self, hdr: *Header, entry: *Entry) void {
+        pub fn dbHelper(self: *Self, hdr: *Header, entry: *Entry) void {
             _ = self;
             _ = hdr;
             _ = entry;

--- a/lib/std/multi_array_list.zig
+++ b/lib/std/multi_array_list.zig
@@ -137,7 +137,7 @@ pub fn MultiArrayList(comptime T: type) type {
 
             /// This function is used in the debugger pretty formatters in tools/ to fetch the
             /// child field order and entry type to facilitate fancy debug printing for this type.
-            fn dbHelper(self: *Slice, child: *Elem, field: *Field, entry: *Entry) void {
+            pub fn dbHelper(self: *Slice, child: *Elem, field: *Field, entry: *Entry) void {
                 _ = self;
                 _ = child;
                 _ = field;
@@ -584,7 +584,7 @@ pub fn MultiArrayList(comptime T: type) type {
         };
         /// This function is used in the debugger pretty formatters in tools/ to fetch the
         /// child field order and entry type to facilitate fancy debug printing for this type.
-        fn dbHelper(self: *Self, child: *Elem, field: *Field, entry: *Entry) void {
+        pub fn dbHelper(self: *Self, child: *Elem, field: *Field, entry: *Entry) void {
             _ = self;
             _ = child;
             _ = field;

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -4730,7 +4730,7 @@ pub const Index = enum(u32) {
 
     /// This function is used in the debugger pretty formatters in tools/ to fetch the
     /// Tag to encoding mapping to facilitate fancy debug printing for this type.
-    fn dbHelper(self: *Index, tag_to_encoding_map: *struct {
+    pub fn dbHelper(self: *Index, tag_to_encoding_map: *struct {
         const DataIsIndex = struct { data: Index };
         const DataIsExtraIndexOfEnumExplicit = struct {
             const @"data.fields_len" = opaque {};


### PR DESCRIPTION
Make `dbHelper` functions public so we can manually make them appear used so they can be used in lldb and work with our build system