### PR TITLE
Writergate: .fixed flush never breaks out of the loop

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -114,7 +114,10 @@ pub const FileError = error{
 /// Writes to `buffer` and returns `error.WriteFailed` when it is full.
 pub fn fixed(buffer: []u8) Writer {
     return .{
-        .vtable = &.{ .drain = fixedDrain },
+        .vtable = &.{
+            .drain = fixedDrain,
+            .flush = noopFlush,
+        },
         .buffer = buffer,
     };
 }
@@ -242,6 +245,15 @@ pub fn defaultFlush(w: *Writer) Error!void {
 /// Does nothing.
 pub fn noopFlush(w: *Writer) Error!void {
     _ = w;
+}
+
+test "fixed buffer flush" {
+    var buffer: [1]u8 = undefined;
+    var writer: std.io.Writer = .fixed(&buffer);
+
+    try writer.writeByte(10);
+    try writer.flush();
+    try testing.expectEqual(10, buffer[0]);
 }
 
 /// Calls `VTable.drain` but hides the last `preserve_length` bytes from the


### PR DESCRIPTION
For the `.fixed` Writer, we pass Slice, which already points to the original array. Because of this it doesn't need to be flushed, but if it is, `w.end` will never become 0 and the while loop will not break since the `fixedDrain` function never decrements or resets `w.end`

You can reproduce it with a simple test:
```
var buffer: [1]u8 = undefined;
var writer: std.io.Writer = .fixed(&buffer);

try writer.writeByte(10);
try writer.flush();
try testing.expectEqual(10, buffer[0]);
```

As a solution I specified `noopFlush` as a strategy instead of `defaultFlush`.