### PR TITLE
Writergate compile error fixes

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1368,7 +1368,10 @@ pub const Reader = struct {
                 r.pos = offset;
             },
             .streaming, .streaming_reading => {
-                if (offset >= r.pos) return Reader.seekBy(r, offset - r.pos);
+                if (offset >= r.pos) return Reader.seekBy(
+                    r,
+                    std.math.cast(i64, offset - r.pos) orelse return Reader.SeekError.Unexpected,
+                );
                 if (r.seek_err) |err| return err;
                 posix.lseek_SET(r.file.handle, offset) catch |err| {
                     r.seek_err = err;

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1656,6 +1656,7 @@ pub const Writer = struct {
             .file = w.file,
             .mode = w.mode,
             .pos = w.pos,
+            .interface = Reader.initInterface(w.interface.buffer),
             .seek_err = w.seek_err,
         };
     }


### PR DESCRIPTION
When attempting to transition a project to post-writergate Zig master, got some compile errors in the standard library. 

Notably, `File.Writer`'s `moveToReader` was not initializing the `Reader` interface; I chose to initialize reusing the writer interface's buffer, which I hope aligns with what I understood as the purpose of this function ("move" to reader, e.g. writer should no longer exist to use that buffer).

Additionally, there was a integer type error in the reader's `seekTo`, but I wasn't sure how best to resolve this; any seek position larger than max i64 when starting from file position 0 would still be a type-safe input for the user, but wouldn't fit into `seekBy`. I chose to return a `SeekError.Unexpected`, but was also debating whether it should throw a `SeekError.Unseekable`. Any input here would be appreciated.