### PR TITLE
Sema: remove incorrect safety check for saturating left shift

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -14134,7 +14134,7 @@ fn zirShl(
     try sema.requireRuntimeBlock(block, src, runtime_src);
     if (block.wantSafety()) {
         const bit_count = scalar_ty.intInfo(zcu).bits;
-        if (!std.math.isPowerOfTwo(bit_count)) {
+        if (air_tag != .shl_sat and !std.math.isPowerOfTwo(bit_count)) {
             const bit_count_val = try pt.intValue(scalar_rhs_ty, bit_count);
             const ok = if (rhs_ty.zigTypeTag(zcu) == .vector) ok: {
                 const bit_count_inst = Air.internedToRef((try sema.splat(rhs_ty, bit_count_val)).toIntern());

--- a/test/behavior/bit_shifting.zig
+++ b/test/behavior/bit_shifting.zig
@@ -169,8 +169,6 @@ test "Saturating Shift Left" {
 
     const S = struct {
         fn shlSat(x: anytype, y: std.math.Log2Int(@TypeOf(x))) @TypeOf(x) {
-            // workaround https://github.com/ziglang/zig/issues/23033
-            @setRuntimeSafety(false);
             return x <<| y;
         }
 

--- a/test/behavior/x86_64/binary.zig
+++ b/test/behavior/x86_64/binary.zig
@@ -5473,8 +5473,6 @@ inline fn shlSaturate(comptime Type: type, lhs: Type, rhs: Type) Type {
         // workaround https://github.com/ziglang/zig/issues/23139
         return lhs <<| @min(@abs(rhs), splat(ChangeScalar(Type, u64), imax(u64)));
     }
-    // workaround https://github.com/ziglang/zig/issues/23033
-    @setRuntimeSafety(false);
     return lhs <<| @abs(rhs);
 }
 test shlSaturate {


### PR DESCRIPTION
This seems to do it.

```
zig build-obj repro.zig --verbose-air
```

<details>
<summary>old</summary>

```
thread 172206856 panic: reached unreachable code
# Begin Function AIR: repro.shlSat:
# Total AIR+Liveness bytes: 469B
# AIR Instructions:         21 (189B)
# AIR Extra Data:           28 (112B)
# Liveness tomb_bits:       16B
# Liveness Extra Data:      6 (24B)
# Liveness special table:   2 (16B)
  %13 = alloc(*[32]usize)
  %14 = alloc(*builtin.StackTrace)
  %15 = struct_field_ptr_index_1(*[]usize, %14)
  %16 = array_to_slice([]usize, %13!)
  %17!= store(%15!, %16!)
  %18 = struct_field_ptr_index_0(*usize, %14)
  %19!= store(%18!, @.zero_usize)
  %20!= set_err_return_trace(%14!)
  %0!= save_err_return_trace_index()
  %1!= dbg_stmt(2:5)
  %2 = load(u3, <*u3, &repro.lhs>)
  %3 = load(u1, <*u1, &repro.rhs>)
  %4 = cmp_lt(%3, <u1, 3>)
  %7!= block(void, {
    %8!= cond_br(%4!, likely {
      %9!= br(%7, @.void_value)
    }, cold {
      %2! %3!
      %5!= call(<fn () noreturn, (function 'shiftRhsTooBig')>, [])
      %6!= unreach()
    })
  } %4!)
  %10 = shl_sat(%2!, %3!)
  %11!= store_safe(<*u3, &repro.lhs>, %10!)
  %12!= ret_safe(@.void_value)
# End Function AIR: repro.shlSat

[stack trace...]
```
</details>

<details>
<summary>new</summary>

```
# Begin Function AIR: repro.shlSat:
# Total AIR+Liveness bytes: 219B
# AIR Instructions:         7 (63B)
# AIR Extra Data:           9 (36B)
# Liveness tomb_bits:       8B
# Liveness Extra Data:      0 (0B)
# Liveness special table:   0 (0B)
  %0!= save_err_return_trace_index()
  %1!= dbg_stmt(2:5)
  %2 = load(u3, <*u3, &repro.lhs>)
  %3 = load(u1, <*u1, &repro.rhs>)
  %4 = shl_sat(%2!, %3!)
  %5!= store_safe(<*u3, &repro.lhs>, %4!)
  %6!= ret_safe(@.void_value)
# End Function AIR: repro.shlSat
```
</details>