### PR TITLE
`ci`: target `baseline` instead of `spacemit_x60` on `riscv64-linux`

### DIFF
--- a/ci/riscv64-linux-debug.sh
+++ b/ci/riscv64-linux-debug.sh
@@ -7,7 +7,7 @@ set -e
 
 ARCH="$(uname -m)"
 TARGET="$ARCH-linux-musl"
-MCPU="spacemit_x60"
+MCPU="baseline"
 CACHE_BASENAME="zig+llvm+lld+clang-riscv64-linux-musl-0.15.0-dev.929+31e46be74"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"

--- a/ci/riscv64-linux-release.sh
+++ b/ci/riscv64-linux-release.sh
@@ -7,7 +7,7 @@ set -e
 
 ARCH="$(uname -m)"
 TARGET="$ARCH-linux-musl"
-MCPU="spacemit_x60"
+MCPU="baseline"
 CACHE_BASENAME="zig+llvm+lld+clang-riscv64-linux-musl-0.15.0-dev.929+31e46be74"
 PREFIX="$HOME/deps/$CACHE_BASENAME"
 ZIG="$PREFIX/bin/zig"


### PR DESCRIPTION
Just curious to see how much of a performance difference this results in.