### PR TITLE
Add setsid to std.(c|posix)

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10808,6 +10808,7 @@ pub extern "c" fn if_nametoindex([*:0]const u8) c_int;
 
 pub extern "c" fn getpid() pid_t;
 pub extern "c" fn getppid() pid_t;
+pub extern "c" fn setsid() pid_t;
 
 /// These are implementation defined but share identical values in at least musl and glibc:
 /// - https://git.musl-libc.org/cgit/musl/tree/include/locale.h?id=ab31e9d6a0fa7c5c408856c89df2dfb12c344039#n18

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -7089,6 +7089,20 @@ pub fn tcsetpgrp(handle: fd_t, pgrp: pid_t) TermioSetPgrpError!void {
     }
 }
 
+pub const SetSidError = error{
+    /// The calling process is already a process group leader, or the process group ID of a process other than the calling process matches the process ID of the calling process.
+    PermissionDenied,
+} || UnexpectedError;
+
+pub fn setsid() SetSidError!pid_t {
+    const rc = system.setsid();
+    switch (errno(rc)) {
+        .SUCCESS => return rc,
+        .PERM => return error.PermissionDenied,
+        else => |err| return unexpectedErrno(err),
+    }
+}
+
 pub fn signalfd(fd: fd_t, mask: *const sigset_t, flags: u32) !fd_t {
     const rc = system.signalfd(fd, mask, flags);
     switch (errno(rc)) {


### PR DESCRIPTION
The interface and errors for this seem to be very universal and generic. Note Linux already has this defined as a syscall as well.