### PR TITLE
Fix `std.Build.Step.Run` directory caching

### DIFF
--- a/lib/std/Build/Step/WriteFile.zig
+++ b/lib/std/Build/Step/WriteFile.zig
@@ -236,7 +236,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
                         try step.addDirectoryWatchInputFromPath(entry_path);
                     }
                 },
-                .file => {
+                .file, .sym_link => {
                     const entry_path = try src_dir_path.join(arena, entry.path);
                     _ = try man.addFilePath(entry_path, null);
                 },
@@ -330,7 +330,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
             const dest_path = b.pathJoin(&.{ dest_dirname, entry.path });
             switch (entry.kind) {
                 .directory => try cache_dir.makePath(dest_path),
-                .file => {
+                .file, .sym_link => {
                     const prev_status = fs.Dir.updateFile(
                         src_entry_path.root_dir.handle,
                         src_entry_path.sub_path,


### PR DESCRIPTION
Currently, `std.Build.Step.Run` has no way to properly cache or watch a directory. `run_step.addDirectoryArg` is basically useless, as it only caches the name of the directory, not the contents.

There are two potential workarounds:

- Traverse the directory and write a depfile. This doesn't detect new directory entries. Allowing depfiles to specify directory prerequisites could solve this problem, but would require making directories first-class within the cache system, which they currently aren't.
- Use a `WriteFile` step to copy the entire directory into the cache. This *works*, but it results in a completely pointless copy, and absolutely blows up the size of the cache dir if the files in the directory change frequently.

This PR makes `addDirectoryArg` actually useful, by having it walk the directory and recursively add files to the cache manifest. I'm not certain that this is the intended behaviour, or even the best behaviour, but it's certainly what I would expect the function to do.

Another possible option for the behaviour of this function is to cache based on just the names and types of the files in the tree - ie. changes to the directory structure will trigger rebuilds, but changes to file contents will not.
This seems less useful, but would speed up building the cache manifest. The full caching behaviour could still be achieved by writing a depfile.
I'm tempted to split `addDirectoryArg` into two functions, or give it an `options` parameter, in order to allow selecting between these two behaviours. However, I still think the default should be what I've implemented in this PR, as it is the most reliable option, and the one least likely to surprise users.