### PR TITLE
std.c: define freopen() and the stdio streams

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10891,7 +10891,7 @@ pub const FILE = switch (native_os) {
 
 pub fn stdin() *FILE {
     return switch (native_os) {
-        .linux, .serenity, .haiku => private.stdin,
+        .linux, .serenity, .haiku, .wasi => private.stdin,
         .freebsd, .dragonfly, .macos, .ios, .tvos, .watchos, .visionos => private.__stdinp,
         .netbsd, .openbsd => &private.__sF[0],
         .solaris, .illumos => &private.__iob[0],
@@ -10902,7 +10902,7 @@ pub fn stdin() *FILE {
 
 pub fn stdout() *FILE {
     return switch (native_os) {
-        .linux, .serenity, .haiku => private.stdout,
+        .linux, .serenity, .haiku, .wasi => private.stdout,
         .freebsd, .dragonfly, .macos, .ios, .tvos, .watchos, .visionos => private.__stdoutp,
         .netbsd, .openbsd => &private.__sF[1],
         .solaris, .illumos => &private.__iob[1],
@@ -10913,7 +10913,7 @@ pub fn stdout() *FILE {
 
 pub fn stderr() *FILE {
     return switch (native_os) {
-        .linux, .serenity, .haiku => private.stderr,
+        .linux, .serenity, .haiku, .wasi => private.stderr,
         .freebsd, .dragonfly, .macos, .ios, .tvos, .watchos, .visionos => private.__stderrp,
         .netbsd, .openbsd => &private.__sF[2],
         .solaris, .illumos => &private.__iob[2],
@@ -11423,7 +11423,7 @@ const private = struct {
     extern "c" fn __libc_current_sigrtmin() c_int;
     extern "c" fn __libc_current_sigrtmax() c_int;
 
-    // Linux, Serenity, Haiku
+    // Linux, Serenity, Haiku, WASI
     extern "c" var stdin: *FILE;
     extern "c" var stdout: *FILE;
     extern "c" var stderr: *FILE;


### PR DESCRIPTION
This allows for daemonization and output-redirection sorts of code in libc-linked Zig projects on *nix-y platforms to affect the stdio stream usage of other libc-based library code the project may be linking, e.g.:

    // Set stderr to go nowhere without errors:
    _ = std.c.freopen("/dev/null", "r+", std.c.stderr());

    // Append stdout to a file:
    _ = std.c.freopen("/tmp/output.txt", "a", std.c.stdout());

The stdio streams are returned from function calls because they're commonly #defines in the libc headers pointing at variously-named externs, and one doesn't generally assign to them directly anyways (freopen() is the portable way to assign something new to a stdio stream).

NetBSD, OpenBSD, and Solaris stdio streams are not supported in this patch and will cause a compileError if you try to use the them, for now. Supporting them would require a more complex and fragile solution using a definition of "FILE" that is not just an opaque type (because their C libraries publish an extern array of FILE objects and then #define the stdio stream names as pointers to the array elements).