### PR TITLE
`ci`: make changes to `riscv64-linux` to try to avoid timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,8 @@ jobs:
       - name: Build and Test
         run: sh ci/aarch64-linux-release.sh
   riscv64-linux-debug:
-    timeout-minutes: 900
+    if: ${{ github.event_name == 'push' }}
+    timeout-minutes: 1020
     runs-on: [self-hosted, Linux, riscv64]
     steps:
       - name: Checkout
@@ -59,13 +60,23 @@ jobs:
       - name: Build and Test
         run: sh ci/riscv64-linux-debug.sh
   riscv64-linux-release:
-    timeout-minutes: 780
+    if: ${{ github.event_name == 'push' }}
+    timeout-minutes: 900
     runs-on: [self-hosted, Linux, riscv64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build and Test
         run: sh ci/riscv64-linux-release.sh
+  riscv64-linux-releasesafe:
+    if: ${{ github.event_name == 'pull_request' }}
+    timeout-minutes: 900
+    runs-on: [self-hosted, Linux, riscv64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Test
+        run: sh ci/riscv64-linux-releasesafe.sh
   x86_64-macos-release:
     runs-on: "macos-13"
     env:

--- a/ci/riscv64-linux-release.sh
+++ b/ci/riscv64-linux-release.sh
@@ -50,7 +50,7 @@ ninja install
 
 # No -fqemu and -fwasmtime here as they're covered by the x86_64-linux scripts.
 stage3-release/bin/zig build test docs \
-  --maxrss 68719476736 \
+  --maxrss 34359738368 \
   -Dstatic-llvm \
   -Dskip-non-native \
   -Dtarget=native-native-musl \


### PR DESCRIPTION
The idea is to have 2 runners per machine, since a lot of time is spent building stage3 and stage4, both of which are largely single-core affairs. This will make the test steps take longer, however, so the timeouts have been bumped a bit, and max RSS for the test step has been lowered from 64G to 32G to prevent OOM. Finally, we now only run a single ReleaseSafe job on PRs; Debug and Release jobs are limited to pushes.