### PR TITLE
memory safety fix for Io.Writer.Allocating.toOwnedSlice*()

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -2420,12 +2420,14 @@ pub const Allocating = struct {
 
     pub fn toOwnedSlice(a: *Allocating) error{OutOfMemory}![]u8 {
         var list = a.toArrayList();
+        defer a.setArrayList(list);
         return list.toOwnedSlice(a.allocator);
     }
 
     pub fn toOwnedSliceSentinel(a: *Allocating, comptime sentinel: u8) error{OutOfMemory}![:sentinel]u8 {
         const gpa = a.allocator;
         var list = toArrayList(a);
+        defer a.setArrayList(list);
         return list.toOwnedSliceSentinel(gpa, sentinel);
     }
 


### PR DESCRIPTION
don't forget to save the list.  this allows a
`testing.checkAllAllocationFailures()` test to pass in one of my projects which newly failed since #24329 was merged.