### PR TITLE
std.Io: handle packed structs better

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -796,16 +796,9 @@ pub inline fn writeInt(w: *Writer, comptime T: type, value: T, endian: std.built
     return w.writeAll(&bytes);
 }
 
-pub fn writeStruct(w: *Writer, value: anytype) Error!void {
-    // Only extern and packed structs have defined in-memory layout.
-    comptime assert(@typeInfo(@TypeOf(value)).@"struct".layout != .auto);
-    return w.writeAll(std.mem.asBytes(&value));
-}
-
 /// The function is inline to avoid the dead code in case `endian` is
 /// comptime-known and matches host endianness.
-/// TODO: make sure this value is not a reference type
-pub inline fn writeStructEndian(w: *Writer, value: anytype, endian: std.builtin.Endian) Error!void {
+pub inline fn writeStruct(w: *Writer, value: anytype, endian: std.builtin.Endian) Error!void {
     switch (@typeInfo(@TypeOf(value))) {
         .@"struct" => |info| switch (info.layout) {
             .auto => @compileError("ill-defined memory layout"),

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -1001,6 +1001,11 @@ test "sigset_t bits" {
     if (native_os == .wasi or native_os == .windows)
         return error.SkipZigTest;
 
+    if (true) {
+        // https://github.com/ziglang/zig/issues/24380
+        return error.SkipZigTest;
+    }
+
     const S = struct {
         var expected_sig: i32 = undefined;
         var handler_called_count: u32 = 0;

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -2809,7 +2809,7 @@ pub fn loadZirCache(gpa: Allocator, cache_file: std.fs.File) !Zir {
     var buffer: [2000]u8 = undefined;
     var file_reader = cache_file.reader(&buffer);
     return result: {
-        const header = file_reader.interface.takeStruct(Zir.Header) catch |err| break :result err;
+        const header = file_reader.interface.takeStructReference(Zir.Header) catch |err| break :result err;
         break :result loadZirCacheBody(gpa, header.*, &file_reader.interface);
     } catch |err| switch (err) {
         error.ReadFailed => return file_reader.err.?,

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -349,7 +349,7 @@ fn loadZirZoirCache(
     const cache_br = &cache_fr.interface;
 
     // First we read the header to determine the lengths of arrays.
-    const header = (cache_br.takeStruct(Header) catch |err| switch (err) {
+    const header = (cache_br.takeStructReference(Header) catch |err| switch (err) {
         error.ReadFailed => return cache_fr.err.?,
         // This can happen if Zig bails out of this function between creating
         // the cached file and writing it.


### PR DESCRIPTION
Rather than having the endian-suffixed functions be the preferred ones the unsuffixed ones are the preferred ones and the tricky functions get a special suffix.

Makes packed structs read and written the same as integers.

closes #12960