### PR TITLE
`zig std`: link `ws2_32.dll` on windows

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -334,6 +334,7 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
         return jitCmd(gpa, arena, cmd_args, .{
             .cmd_name = "std",
             .root_src_path = "std-docs.zig",
+            .windows_libs = &.{"ws2_32"},
             .prepend_zig_lib_dir_path = true,
             .prepend_zig_exe_path = true,
             .prepend_global_cache_path = true,


### PR DESCRIPTION
Closes #24450.