### PR TITLE
update dump-cov for alignment and writergate changes

### DIFF
--- a/test/standalone/build.zig
+++ b/test/standalone/build.zig
@@ -31,6 +31,7 @@ pub fn build(b: *std.Build) void {
     const tools_target = b.resolveTargetQuery(.{});
     for ([_][]const u8{
         // Alphabetically sorted. No need to build `tools/spirv/grammar.zig`.
+        "../../tools/dump-cov.zig",
         "../../tools/fetch_them_macos_headers.zig",
         "../../tools/gen_macos_headers_c.zig",
         "../../tools/gen_outline_atomics.zig",

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "standalone_test_cases",
+    .name = .standalone_test_cases,
+    .fingerprint = 0xc0dbdf9c818957be,
     .version = "0.0.0",
     .dependencies = .{
         .simple = .{

--- a/tools/dump-cov.zig
+++ b/tools/dump-cov.zig
@@ -33,7 +33,7 @@ pub fn main() !void {
     defer coverage.deinit(gpa);
 
     var debug_info = std.debug.Info.load(gpa, exe_path, &coverage) catch |err| {
-        fatal("failed to load debug info for {}: {s}", .{ exe_path, @errorName(err) });
+        fatal("failed to load debug info for {f}: {s}", .{ exe_path, @errorName(err) });
     };
     defer debug_info.deinit(gpa);
 
@@ -42,10 +42,10 @@ pub fn main() !void {
         cov_path.sub_path,
         1 << 30,
         null,
-        @alignOf(SeenPcsHeader),
+        .of(SeenPcsHeader),
         null,
     ) catch |err| {
-        fatal("failed to load coverage file {}: {s}", .{ cov_path, @errorName(err) });
+        fatal("failed to load coverage file {f}: {s}", .{ cov_path, @errorName(err) });
     };
 
     var stdout_buffer: [4000]u8 = undefined;


### PR DESCRIPTION
I discovered that this tool doesn't compile with the current compiler.

Should I add some CI coverage for Zig programs in `tools/` to ensure they remain working?