### PR TITLE
autodoc: Use the search input's value on load

### DIFF
--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -128,7 +128,7 @@
         domSearch.addEventListener('keydown', onSearchKeyDown, false);
         domSearch.addEventListener('input', onSearchChange, false);
         window.addEventListener('keydown', onWindowKeyDown, false);
-        onHashChange(null);
+        handleNavigation(null, domSearch.value ? computeSearchHash() : location.hash);
       });
     });
 
@@ -642,14 +642,14 @@
         }
     }
 
-    function onHashChange(state) {
-      history.replaceState({}, "");
-      navigate(location.hash);
+    function handleNavigation(state, location_hash) {
+      history.replaceState("keepScrollPosition", "");
+      navigate(location_hash);
       if (state == null) window.scrollTo({top: 0});
     }
 
     function onPopState(ev) {
-      onHashChange(ev.state);
+      handleNavigation(ev.state, location.hash);
     }
 
     function navigate(location_hash) {

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -643,7 +643,8 @@
     }
 
     function handleNavigation(state, location_hash) {
-      history.replaceState("keepScrollPosition", "");
+      // Use a non-null state value to prevent the window scrolling if the user goes back to this history entry.
+      history.replaceState({}, "");
       navigate(location_hash);
       if (state == null) window.scrollTo({top: 0});
     }

--- a/lib/docs/main.js
+++ b/lib/docs/main.js
@@ -128,7 +128,12 @@
         domSearch.addEventListener('keydown', onSearchKeyDown, false);
         domSearch.addEventListener('input', onSearchChange, false);
         window.addEventListener('keydown', onWindowKeyDown, false);
-        handleNavigation(null, domSearch.value ? computeSearchHash() : location.hash);
+        onHashChange(null);
+        if (domSearch.value) {
+          // user started typing a search query while the page was loading
+          curSearchIndex = -1;
+          startAsyncSearch();
+        }
       });
     });
 
@@ -642,26 +647,30 @@
         }
     }
 
-    function handleNavigation(state, location_hash) {
+    function onHashChange(state) {
       // Use a non-null state value to prevent the window scrolling if the user goes back to this history entry.
       history.replaceState({}, "");
-      navigate(location_hash);
+      navigate(location.hash);
       if (state == null) window.scrollTo({top: 0});
     }
 
     function onPopState(ev) {
-      handleNavigation(ev.state, location.hash);
+      onHashChange(ev.state);
+      syncDomSearch();
     }
 
     function navigate(location_hash) {
       updateCurNav(location_hash);
-      if (domSearch.value !== curNavSearch) {
-          domSearch.value = curNavSearch;
-      }
       render();
       if (imFeelingLucky) {
           imFeelingLucky = false;
           activateSelectedResult();
+      }
+    }
+
+    function syncDomSearch() {
+      if (domSearch.value !== curNavSearch) {
+        domSearch.value = curNavSearch;
       }
     }
 


### PR DESCRIPTION
After the sources tarball is loaded, check the search input for a value. If present, this means the user typed something into it during load - we should use that value for the initial search state instead of always respecting what the hash's search value is.

Future considerations:
- since no event handlers are registered until the tarball loads, we don't get `s` or `?` shortcuts. it would be straightforward to shuffle things around to get these working, but I figured I'd keep this PR short.
- calling `handleNavigation(null ... )` after tarball load forces a scroll to the top - I kept this behavior unchanged, but it does result in users losing their place via a refresh.

Fixes #21458