### PR TITLE
#24471: add mlock syscalls in std.os.linux

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1015,6 +1015,44 @@ pub fn munmap(address: [*]const u8, length: usize) usize {
     return syscall2(.munmap, @intFromPtr(address), length);
 }
 
+pub fn mlock(address: [*]const u8, length: usize) usize {
+    return syscall2(.mlock, @intFromPtr(address), length);
+}
+
+pub fn munlock(address: [*]const u8, length: usize) usize {
+    return syscall2(.munlock, @intFromPtr(address), length);
+}
+
+pub const MLOCK = packed struct(u32) {
+    ONFAULT: bool = false,
+    _1: u31 = 0,
+};
+
+pub fn mlock2(address: [*]const u8, length: usize, flags: MLOCK) usize {
+    return syscall3(.mlock2, @intFromPtr(address), length, @as(u32, @bitCast(flags)));
+}
+
+pub const MCL = if (native_arch.isSPARC() or native_arch.isPowerPC()) packed struct(u32) {
+    _0: u13 = 0,
+    CURRENT: bool = false,
+    FUTURE: bool = false,
+    ONFAULT: bool = false,
+    _4: u16 = 0,
+} else packed struct(u32) {
+    CURRENT: bool = false,
+    FUTURE: bool = false,
+    ONFAULT: bool = false,
+    _3: u29 = 0,
+};
+
+pub fn mlockall(flags: MCL) usize {
+    return syscall1(.mlockall, @as(u32, @bitCast(flags)));
+}
+
+pub fn munlockall() usize {
+    return syscall0(.munlockall);
+}
+
 pub fn poll(fds: [*]pollfd, n: nfds_t, timeout: i32) usize {
     if (@hasField(SYS, "poll")) {
         return syscall3(.poll, @intFromPtr(fds), n, @as(u32, @bitCast(timeout)));


### PR DESCRIPTION
closes #24471

## MCL Flags

Please double-check the implementation of `MCL`. I interpreted results of searching the linux source tree:
https://github.com/search?q=repo%3Atorvalds%2Flinux+MCL_ONFAULT&type=code

I found the flags by referencing `man mlock`: https://man7.org/linux/man-pages/man2/mlock.2.html

## Verification evidence

* on WSL2 on windows

Create file `mlock-test.zig`:

```zig
const std = @import("std");

test "mlock syscalls" {
    const allocator = std.testing.allocator;
    const my_memory_area: []u8 = try allocator.alloc(u8, 2048);
    defer allocator.free(my_memory_area);

    const mlock_result = std.os.linux.mlock(my_memory_area.ptr, my_memory_area.len);
    std.log.warn("mlock errno: {}", .{std.posix.errno(mlock_result)});
    try std.testing.expect(mlock_result == 0);

    const munlock_result = std.os.linux.munlock(my_memory_area.ptr, my_memory_area.len);
    std.log.warn("munlock errno: {}", .{std.posix.errno(munlock_result)});
    try std.testing.expect(munlock_result == 0);

    const mlock2_result = std.os.linux.mlock2(my_memory_area.ptr, my_memory_area.len, std.os.linux.MLOCK{ .ONFAULT = false });
    std.log.warn("mlock2 errno: {}", .{std.posix.errno(mlock2_result)});
    try std.testing.expect(mlock2_result == 0);

    const munlock_result2 = std.os.linux.munlock(my_memory_area.ptr, my_memory_area.len);
    std.log.warn("munlock errno: {}", .{std.posix.errno(munlock_result2)});
    try std.testing.expect(munlock_result2 == 0);

    const mlockall_result = std.os.linux.mlockall(std.os.linux.MCL{ .CURRENT = true });
    std.log.warn("mlockall errno: {}", .{std.posix.errno(mlockall_result)});
    try std.testing.expect(mlockall_result == 0);

    const munlockall_result = std.os.linux.munlockall();
    std.log.warn("munlockall errno: {}", .{std.posix.errno(munlockall_result)});
    try std.testing.expect(munlockall_result == 0);
}

```

Run using zig built from source at commit 7caf40b6f8a5a94876513ab4557e02ef9beb6617 (this PR)

```
janderson@DESKTOP-RN10O9U:~/repos/untracked$ sudo ../zig/build/stage3/bin/zig test --zig-lib-dir /home/janderson/repos/zig/lib/ mlock-test.zig
[default] (warn): mlock errno: .SUCCESS
[default] (warn): munlock errno: .SUCCESS
[default] (warn): mlock2 errno: .SUCCESS
[default] (warn): munlock errno: .SUCCESS
[default] (warn): mlockall errno: .SUCCESS
[default] (warn): munlockall errno: .SUCCESS
All 1 tests passed.
```

## Prior Art
https://github.com/tigerbeetle/tigerbeetle/blob/41c9a90dd930d360914f96bb2bd8a46d0ea2104d/src/stdx/mlock.zig#L29

