### PR TITLE
fix glibc version for single_threaded.h (2.32 instead of 2.35)

### DIFF
--- a/lib/libc/include/generic-glibc/sys/single_threaded.h
+++ b/lib/libc/include/generic-glibc/sys/single_threaded.h
@@ -16,10 +16,10 @@
    License along with the GNU C Library; if not, see
    <https://www.gnu.org/licenses/>.  */
 
-// zig patch: sys/single_threaded.h header was added in glibc 2.35
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
-   #error "sys/single_threaded.h did not exist before glibc 2.35"
-#endif /* error for glibc before 2.35 */
+// zig patch: sys/single_threaded.h header was added in glibc 2.32
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 32
+   #error "sys/single_threaded.h did not exist before glibc 2.32"
+#endif /* error for glibc before 2.32 */
 
 #ifndef _SYS_SINGLE_THREADED_H
 #define _SYS_SINGLE_THREADED_H


### PR DESCRIPTION
https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD

```log
924 Version 2.32
[ 925](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l925) 
[ 926](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l926) Major new features:
[ 927](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l927) 
[ 928](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l928) * Unicode 13.0.0 Support: Character encoding, character type info, and
[ 929](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l929)   transliteration tables are all updated to Unicode 13.0.0, using
[ 930](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l930)   generator scripts contributed by Mike FABIAN (Red Hat).
[ 931](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l931) 
[ 932](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l932) * New locale added: ckb_IQ (Kurdish/Sorani spoken in Iraq)
[ 933](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l933) 
[ 934](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l934) * Support for Synopsys ARC HS cores (ARCv2 ISA) running Linux has been
[ 935](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l935)   added. This port requires at least binutils-2.32, gcc-8.3 and Linux-5.1.
[ 936](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l936)   Three ABIs are supported:
[ 937](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l937) 
[ 938](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l938)      - arc-linux-gnu
[ 939](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l939)      - arc-linux-gnuhf
[ 940](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l940)      - arceb-linux-gnu
[ 941](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l941) 
[ 942](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l942)   The arc* ABIs are little-endian while arceb is big-endian.  All ABIs use
[ 943](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l943)   64-bit time (y2038 safe) and 64-bit file offsets (LFS default).
[ 944](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l944) 
[ 945](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l945) * The GNU C Library now loads audit modules listed in the DT_AUDIT and
[ 946](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l946)   DT_DEPAUDIT dynamic section entries of the main executable.
[ 947](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l947) 
[ 948](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l948) * powerpc64le supports IEEE128 long double libm/libc redirects when
[ 949](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l949)   using -mabi=ieeelongdouble to compile C code on supported GCC
[ 950](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l950)   toolchains.  It is recommended to use GCC 8 or newer when testing
[ 951](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l951)   this option.
[ 952](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l952) 
[ 953](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l953) * To help detect buffer overflows and other out-of-bounds accesses
[ 954](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l954)   several APIs have been annotated with GCC 'access' attribute.  This
[ 955](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l955)   should help GCC 10 issue better warnings.
[ 956](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l956) 
[ 957](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l957) * On Linux, functions pthread_attr_setsigmask_np and
[ 958](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l958)   pthread_attr_getsigmask_np have been added.  They allow applications
[ 959](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l959)   to specify the signal mask of a thread created with pthread_create.
[ 960](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l960) 
[ 961](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l961) * The GNU C Library now provides the header file <sys/single_threaded.h>
[ 962](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l962)   which declares the variable __libc_single_threaded.  Applications are
[ 963](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l963)   encouraged to use this variable for single-thread optimizations,
[ 964](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l964)   instead of weak references to symbols historically defined in
[ 965](https://sourceware.org/git?p=glibc.git;a=blob;f=NEWS;h=faa7ec1871da1a34ed943fd8d406496e58fb2c2e;hb=HEAD#l965)   libpthread.
```

Turns out that while I had the commit right, I fumbled the next release date.
This fixes the header availability when compiling projects checking for >= 2.32