### PR TITLE
Ast: allow same-line grouped while then expressions

### DIFF
--- a/lib/std/zig/Ast.zig
+++ b/lib/std/zig/Ast.zig
@@ -493,9 +493,6 @@ pub fn renderError(tree: Ast, parse_error: Error, w: *Writer) Writer.Error!void 
         .varargs_nonfinal => {
             return w.writeAll("function prototype has parameter after varargs");
         },
-        .expected_continue_expr => {
-            return w.writeAll("expected ':' before while continue expression");
-        },
 
         .expected_semi_after_decl => {
             return w.writeAll("expected ';' after declaration");
@@ -2974,7 +2971,6 @@ pub const Error = struct {
         test_doc_comment,
         comptime_doc_comment,
         varargs_nonfinal,
-        expected_continue_expr,
         expected_semi_after_decl,
         expected_semi_after_stmt,
         expected_comma_after_field,

--- a/lib/std/zig/Parse.zig
+++ b/lib/std/zig/Parse.zig
@@ -2977,12 +2977,7 @@ fn expectFieldInit(p: *Parse) !Node.Index {
 
 /// WhileContinueExpr <- COLON LPAREN AssignExpr RPAREN
 fn parseWhileContinueExpr(p: *Parse) !?Node.Index {
-    _ = p.eatToken(.colon) orelse {
-        if (p.tokenTag(p.tok_i) == .l_paren and
-            p.tokensOnSameLine(p.tok_i - 1, p.tok_i))
-            return p.fail(.expected_continue_expr);
-        return null;
-    };
+    _ = p.eatToken(.colon) orelse return null;
     _ = try p.expectToken(.l_paren);
     const node = try p.parseAssignExpr() orelse return p.fail(.expected_expr_or_assignment);
     _ = try p.expectToken(.r_paren);

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5426,17 +5426,11 @@ test "zig fmt: while continue expr" {
         \\    while (i > 0)
         \\        (i * 2);
         \\}
+        \\T: (while (true) ({
+        \\    break usize;
+        \\})),
         \\
     );
-    try testError(
-        \\test {
-        \\    while (i > 0) (i -= 1) {
-        \\        print("test123", .{});
-        \\    }
-        \\}
-    , &[_]Error{
-        .expected_continue_expr,
-    });
 }
 
 test "zig fmt: canonicalize symbols (simple)" {


### PR DESCRIPTION
Beforehand, `while (x) ({ ... })` would fail, however this is not consistent with the PEG grammar specified in the langref which does not require a newline when the then expression starts with parenthesis.