### PR TITLE
compiler_rt: export all the chkstk variations for MinGW

### DIFF
--- a/lib/compiler_rt/stack_probe.zig
+++ b/lib/compiler_rt/stack_probe.zig
@@ -13,11 +13,11 @@ comptime {
         // Default stack-probe functions emitted by LLVM
         if (builtin.target.isMinGW()) {
             @export(&_chkstk, .{ .name = "_alloca", .linkage = common.linkage, .visibility = common.visibility });
+            @export(&__chkstk, .{ .name = "__chkstk", .linkage = common.linkage, .visibility = common.visibility });
+            @export(&___chkstk, .{ .name = "__alloca", .linkage = common.linkage, .visibility = common.visibility });
+            @export(&___chkstk, .{ .name = "___chkstk", .linkage = common.linkage, .visibility = common.visibility });
+            @export(&__chkstk_ms, .{ .name = "__chkstk_ms", .linkage = common.linkage, .visibility = common.visibility });
             @export(&___chkstk_ms, .{ .name = "___chkstk_ms", .linkage = common.linkage, .visibility = common.visibility });
-
-            if (arch == .thumb or arch == .aarch64) {
-                @export(&__chkstk, .{ .name = "__chkstk", .linkage = common.linkage, .visibility = common.visibility });
-            }
         } else if (!builtin.link_libc) {
             // This symbols are otherwise exported by MSVCRT.lib
             @export(&_chkstk, .{ .name = "_chkstk", .linkage = common.linkage, .visibility = common.visibility });


### PR DESCRIPTION
I noticed when bootstrapping (and when subsequently building the compiler normally), the following linker warnings:

```
error: warning(link): unexpected LLD stderr:
lld-link: warning: undefined symbol: ___chkstk
>>> referenced by libLLVMSupport.a(DynamicLibrary.cpp.obj):(.refptr.___chkstk)

lld-link: warning: undefined symbol: __alloca
>>> referenced by libLLVMSupport.a(DynamicLibrary.cpp.obj):(.refptr.__alloca)

lld-link: warning: undefined symbol: __chkstk
>>> referenced by libLLVMSupport.a(DynamicLibrary.cpp.obj):(.refptr.__chkstk)

lld-link: warning: undefined symbol: __chkstk_ms
>>> referenced by libLLVMSupport.a(DynamicLibrary.cpp.obj):(.refptr.__chkstk_ms)
```

(these warnings will now be errors thanks to https://github.com/ziglang/zig/pull/24482).

LLVM expects these symbols due to the `EXPLICIT_SYMBOL` mechanism (thanks @jacobly0 for pointing this out!):

ie.
```
llvm\lib\Support\Windows\explicit_symbols.inc
17:EXPLICIT_SYMBOL(___chkstk)
```

The issue is we weren't actually exporting these from stack_probe.zig at all in this case:

- `___chkstk`: not exported
-  `__alloca`: same thing (it's an alias of `___chkstk`)
-  `__chkstk`: was only exported for thumb/aarch64
-  `__chkstk_ms`: not exported

As far as I can tell, there isn't a problem with exporting all these symbols unconditionally, so that's the change here.

Additional context in the discussion here: https://zsf.zulipchat.com/#narrow/channel/454360-compiler/topic/msvc.202022.20windows.20bootstrap/with/529178869