### PR TITLE
std.os.uefi.protocol.file: use @alignCast in getInfo() method to fix #24480

### DIFF
--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -225,7 +225,7 @@ pub const File = extern struct {
             &len,
             buffer.ptr,
         )) {
-            .success => return @as(*InfoType, @ptrCast(buffer.ptr)),
+            .success => return @as(*InfoType, @ptrCast(@alignCast(buffer.ptr))),
             .buffer_too_small => return Error.BufferTooSmall,
             .unsupported => return Error.Unsupported,
             .no_media => return Error.NoMedia,

--- a/lib/std/os/uefi/protocol/file.zig
+++ b/lib/std/os/uefi/protocol/file.zig
@@ -214,7 +214,7 @@ pub const File = extern struct {
     pub fn getInfo(
         self: *const File,
         comptime info: std.meta.Tag(Info),
-        buffer: []u8,
+        buffer: []align(@alignOf(@FieldType(Info, @tagName(info)))) u8,
     ) GetInfoError!*@FieldType(Info, @tagName(info)) {
         const InfoType = @FieldType(Info, @tagName(info));
 
@@ -225,7 +225,7 @@ pub const File = extern struct {
             &len,
             buffer.ptr,
         )) {
-            .success => return @as(*InfoType, @ptrCast(@alignCast(buffer.ptr))),
+            .success => return @as(*InfoType, @ptrCast(buffer.ptr)),
             .buffer_too_small => return Error.BufferTooSmall,
             .unsupported => return Error.Unsupported,
             .no_media => return Error.NoMedia,


### PR DESCRIPTION
Hi.

This is a PR of mine to try and fix `getInfo()` method in the stdlib in file `lib/std/os/uefi/protocol/file.zig`.
My fix was based on the message from the compiler that can be read in the issue #24480 . Since I am new to Zig, I have no clue if this is the actual fix or just some kind of "band-aid". Feel free to mention better ways of improving this.

Thanks!