### PR TITLE
add missing advance of writer end position in `Io.File.Reader.stream`

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1430,6 +1430,7 @@ pub const Reader = struct {
                     return error.EndOfStream;
                 }
                 r.pos += n;
+                w.advance(n);
                 return n;
             },
             .streaming_reading => {
@@ -1453,6 +1454,7 @@ pub const Reader = struct {
                     return error.EndOfStream;
                 }
                 r.pos += n;
+                w.advance(n);
                 return n;
             },
             .failure => return error.ReadFailed,


### PR DESCRIPTION
The stream functions keeps reading into the same buffer, overriding its own data. Don't forget to ~flush~ advance.
