### PR TITLE
std.hash.RapidHash: fixed compilation on 32 bit targets

### DIFF
--- a/lib/std/hash/RapidHash.zig
+++ b/lib/std/hash/RapidHash.zig
@@ -20,7 +20,7 @@ pub fn hash(seed: u64, input: []const u8) u64 {
 
     if (len <= 16) {
         if (len >= 4) {
-            const d: u64 = ((len & 24) >> @intCast(len >> 3));
+            const d: usize = ((len & 24) >> @intCast(len >> 3));
             const e = len - 4;
             a = (r32(k) << 32) | r32(k[e..]);
             b = ((r32(k[d..]) << 32) | r32(k[(e - d)..]));


### PR DESCRIPTION
Fixes #24208 

Changed the variable `d` which was used to index a slice from a `u64` to a `usize`.
The only possible values for `d` are 0 and 4, the behavior should be the same.

The test case provided in #24208 now compiles and gives the expected result.

```
$ zig build test
test
└─ run test stderr
sizeof usize is 8, hash is 6df7894534f98aba

$ zig build -Dtarget=riscv32-linux test
test
└─ run test stderr
sizeof usize is 4, hash is 6df7894534f98aba
```