### PR TITLE
`std`: test for `ArrayList(u0).toOwnedSlice()`

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -2184,6 +2184,10 @@ test "ArrayList(u0)" {
         count += 1;
     }
     try testing.expectEqual(count, 3);
+
+    const ownedSlice = try list.toOwnedSlice();
+    defer a.free(ownedSlice);
+    try testing.expectEqualSlices(u0, ownedSlice, &.{ 0, 0, 0 });
 }
 
 test "ArrayList(?u32).pop()" {

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -2185,6 +2185,7 @@ test "ArrayList(u0)" {
     }
     try testing.expectEqual(count, 3);
 
+    // Test toOwnedSlice to ensure https://github.com/ziglang/zig/issues/22483 doesn't regress
     const ownedSlice = try list.toOwnedSlice();
     defer a.free(ownedSlice);
     try testing.expectEqualSlices(u0, ownedSlice, &.{ 0, 0, 0 });


### PR DESCRIPTION
As described in https://github.com/ziglang/zig/issues/22483, previously, calling `toOwnedSlice()` on an `ArrayList` of zero-sized type could result in an assertion error depending on the allocator used.
The issue has since been fixed in https://github.com/ziglang/zig/commit/7eeef5fb2b9dc78679f4091e2a8173d07968b3e5 due to `remap()`'s special handling of zero-sized types, but to ensure this doesn't regress I modified the existing test concerning `Arraylist(u0)` to also include `toOwnedSlice()`.

Edit: Forgot to put this here initially (cause I didn't know the syntax), but this should close https://github.com/ziglang/zig/issues/22483