### PR TITLE
translate-c: fix function pointer casting + alignCast and constCast at the same time

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -4030,7 +4030,10 @@ fn transCPtrCast(
     const src_child_type = src_ty.getPointeeType();
     const dst_type_node = try transType(c, scope, ty, loc);
 
-    if (!src_ty.isArrayType() and ((src_child_type.isConstQualified() and
+    if (!src_ty.isArrayType() and (((
+            src_child_type.isConstQualified() or
+            qualTypeIsFunction(src_child_type)   // C function pointers get translated to Zig const function pointers
+        ) and
         !child_type.isConstQualified()) or
         (src_child_type.isVolatileQualified() and
             !child_type.isVolatileQualified())))
@@ -4340,6 +4343,11 @@ fn qualTypeIsPtr(qt: clang.QualType) bool {
 
 fn qualTypeIsBoolean(qt: clang.QualType) bool {
     return qualTypeCanon(qt).isBooleanType();
+}
+
+fn qualTypeIsFunction(qt: clang.QualType) bool {
+    const type_class = qualTypeCanon(qt).getTypeClass();
+    return type_class == .FunctionProto or type_class == .FunctionNoProto;
 }
 
 fn qualTypeIntBitWidth(c: *Context, qt: clang.QualType) !u32 {


### PR DESCRIPTION
This fixes #24513 and another issue I noticed: casting `const void*` to `int*` did not work.

Both of those issues are fixed with [translate-c](https://github.com/ziglang/translate-c), so this PR might be useless though.

examples:
```c
void *g = (void*)f;
```
used to translate to:
```zig
var g: ?*anyopaque = @as(?*anyopaque, @ptrCast(f));
```
forgetting a `@constCast`.

and
```c
const void *c;
int *d = (int*)c;
}
```
the second line used to translate to:
```zig
var d: [*c]c_int = @as([*c]c_int, @ptrCast(@volatileCast(@constCast(c))));
```
forgetting a `@alignCast`.