### PR TITLE
`test`: enable `arm-freebsd-eabihf` std tests

### DIFF
--- a/test/tests.zig
+++ b/test/tests.zig
@@ -116,8 +116,6 @@ const test_targets = blk: {
                 .abi = .eabihf,
             },
             .link_libc = true,
-            // https://github.com/ziglang/zig/issues/23949
-            .skip_modules = &.{"std"},
         },
 
         .{


### PR DESCRIPTION
Closes #23949.