### PR TITLE
zig env: improve envvar handling and add command line args support

### DIFF
--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -687,12 +687,12 @@ pub const EnvVar = enum {
     }
 
     pub fn get(ev: EnvVar, arena: std.mem.Allocator) !?[]u8 {
-        if (std.process.getEnvVarOwned(arena, @tagName(ev))) |value| {
-            return value;
-        } else |err| switch (err) {
+        const value = std.process.getEnvVarOwned(arena, @tagName(ev)) catch |err| switch (err) {
             error.EnvironmentVariableNotFound => return null,
             else => |e| return e,
-        }
+        };
+        if (value.len == 0) return null;
+        return value;
     }
 
     pub fn getPosix(comptime ev: EnvVar) ?[:0]const u8 {

--- a/src/introspect.zig
+++ b/src/introspect.zig
@@ -77,7 +77,14 @@ pub fn findZigLibDirFromSelfExe(
     /// Passed as an argument to avoid pointlessly repeating the call.
     cwd_path: []const u8,
     self_exe_path: []const u8,
-) error{ OutOfMemory, FileNotFound }!Cache.Directory {
+) !Cache.Directory {
+    if (try std.zig.EnvVar.ZIG_LIB_DIR.get(allocator)) |value| {
+        return .{
+            .handle = try fs.cwd().openDir(value, .{}),
+            .path = value,
+        };
+    }
+
     const cwd = fs.cwd();
     var cur_path: []const u8 = self_exe_path;
     while (fs.path.dirname(cur_path)) |dirname| : (cur_path = dirname) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -360,7 +360,7 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
         dev.check(.env_command);
         verifyLibcxxCorrectlyLinked();
         var stdout_writer = fs.File.stdout().writer(&stdout_buffer);
-        try @import("print_env.zig").cmdEnv(arena, &stdout_writer.interface);
+        try @import("print_env.zig").cmdEnv(arena, cmd_args, &stdout_writer.interface);
         return stdout_writer.interface.flush();
     } else if (mem.eql(u8, cmd, "reduce")) {
         return jitCmd(gpa, arena, cmd_args, .{

--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -4,18 +4,59 @@ const introspect = @import("introspect.zig");
 const Allocator = std.mem.Allocator;
 const fatal = std.process.fatal;
 
-pub fn cmdEnv(arena: Allocator, out: *std.Io.Writer) !void {
+const usage =
+    \\Usage: zig env [options]
+    \\
+    \\Options:
+    \\  -h, --help                Print this help and exit
+    \\  --global-cache-dir [path] Override the global cache directory
+    \\  --zig-lib-dir [path]      Override path to Zig installation lib directory
+    \\
+;
+
+pub fn cmdEnv(arena: Allocator, args: []const []const u8, out: *std.Io.Writer) !void {
+    var override_lib_dir: ?[]const u8 = null;
+    var override_global_cache_dir: ?[]const u8 = null;
+
+    {
+        var i: usize = 0;
+        while (i < args.len) : (i += 1) {
+            const arg = args[i];
+            if (std.mem.startsWith(u8, arg, "-")) {
+                if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+                    try std.fs.File.stdout().writeAll(usage);
+                    return;
+                } else if (std.mem.eql(u8, arg, "--zig-lib-dir")) {
+                    if (i + 1 >= args.len) fatal("expected argument after '{s}'", .{arg});
+                    i += 1;
+                    override_lib_dir = args[i];
+                    continue;
+                } else if (std.mem.eql(u8, arg, "--global-cache-dir")) {
+                    if (i + 1 >= args.len) fatal("expected argument after '{s}'", .{arg});
+                    i += 1;
+                    override_global_cache_dir = args[i];
+                    continue;
+                }
+            }
+            fatal("invalid argument '{s}'", .{arg});
+        }
+    }
+
     const cwd_path = try introspect.getResolvedCwd(arena);
     const self_exe_path = try std.fs.selfExePathAlloc(arena);
 
-    var zig_lib_directory = introspect.findZigLibDirFromSelfExe(arena, cwd_path, self_exe_path) catch |err| {
-        fatal("unable to find zig installation directory: {s}\n", .{@errorName(err)});
+    const zig_lib_directory = override_lib_dir orelse blk: {
+        var cache_dir = introspect.findZigLibDirFromSelfExe(arena, cwd_path, self_exe_path) catch |err| {
+            fatal("unable to find zig installation directory: {s}\n", .{@errorName(err)});
+        };
+        cache_dir.handle.close();
+        break :blk cache_dir.path.?;
     };
-    defer zig_lib_directory.handle.close();
 
-    const zig_std_dir = try std.fs.path.join(arena, &[_][]const u8{ zig_lib_directory.path.?, "std" });
+    const zig_std_dir = try std.fs.path.join(arena, &[_][]const u8{ zig_lib_directory, "std" });
 
-    const global_cache_dir = try introspect.resolveGlobalCacheDir(arena);
+    const global_cache_dir = override_global_cache_dir orelse
+        try introspect.resolveGlobalCacheDir(arena);
 
     const host = try std.zig.system.resolveTargetQuery(.{});
     const triple = try host.zigTriple(arena);
@@ -24,7 +65,7 @@ pub fn cmdEnv(arena: Allocator, out: *std.Io.Writer) !void {
     var root = try serializer.beginStruct(.{});
 
     try root.field("zig_exe", self_exe_path, .{});
-    try root.field("lib_dir", zig_lib_directory.path.?, .{});
+    try root.field("lib_dir", zig_lib_directory, .{});
     try root.field("std_dir", zig_std_dir, .{});
     try root.field("global_cache_dir", global_cache_dir, .{});
     try root.field("version", build_options.version, .{});


### PR DESCRIPTION
I noticed `zig env` doesn't properly handle the `ZIG_LIB_DIR` envvar, so this fixes that. I also added `--zig-lib-dir` and `--global-cache-dir` args, because eg. a wrapper script for zig might pass those in.