### PR TITLE
stage2-wasm: implement try_ptr + is_(non_)err_ptr

### DIFF
--- a/test/behavior/try.zig
+++ b/test/behavior/try.zig
@@ -121,3 +121,82 @@ test "'return try' through conditional" {
         comptime std.debug.assert(result == 123);
     }
 }
+
+test "try ptr propagation const" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn foo0() !u32 {
+            return 0;
+        }
+
+        fn foo1() error{Bad}!u32 {
+            return 1;
+        }
+
+        fn foo2() anyerror!u32 {
+            return 2;
+        }
+
+        fn doTheTest() !void {
+            const res0: *const u32 = &(try foo0());
+            const res1: *const u32 = &(try foo1());
+            const res2: *const u32 = &(try foo2());
+            try expect(res0.* == 0);
+            try expect(res1.* == 1);
+            try expect(res2.* == 2);
+        }
+    };
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}
+
+test "try ptr propagation mutate" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
+
+    const S = struct {
+        fn foo0() !u32 {
+            return 0;
+        }
+
+        fn foo1() error{Bad}!u32 {
+            return 1;
+        }
+
+        fn foo2() anyerror!u32 {
+            return 2;
+        }
+
+        fn doTheTest() !void {
+            var f0 = foo0();
+            var f1 = foo1();
+            var f2 = foo2();
+
+            const res0: *u32 = &(try f0);
+            const res1: *u32 = &(try f1);
+            const res2: *u32 = &(try f2);
+
+            res0.* += 1;
+            res1.* += 1;
+            res2.* += 1;
+
+            try expect(f0 catch unreachable == 1);
+            try expect(f1 catch unreachable == 2);
+            try expect(f2 catch unreachable == 3);
+
+            try expect(res0.* == 1);
+            try expect(res1.* == 2);
+            try expect(res2.* == 3);
+        }
+    };
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -800,6 +800,8 @@ const TestManifestConfigDefaults = struct {
                 }
                 // Windows
                 defaults = defaults ++ "x86_64-windows" ++ ",";
+                // Wasm
+                defaults = defaults ++ "wasm32-wasi";
                 break :blk defaults;
             };
         } else if (std.mem.eql(u8, key, "output_mode")) {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1369,16 +1369,15 @@ const test_targets = blk: {
 
         // WASI Targets
 
-        // TODO: lowerTry for pointers
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .wasm32,
-        //        .os_tag = .wasi,
-        //        .abi = .none,
-        //    },
-        //    .use_llvm = false,
-        //    .use_lld = false,
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .wasm32,
+                .os_tag = .wasi,
+                .abi = .none,
+            },
+            .use_llvm = false,
+            .use_lld = false,
+        },
         .{
             .target = .{
                 .cpu_arch = .wasm32,


### PR DESCRIPTION
@andrewrk I can pop revert, if needed.

@mlugg I decided to keep `.is_(non_)err_ptr` and etc as there is some symmetry with `.is_(non_)null_ptr`.