### PR TITLE
detect when switch on error shadows it's own switch case capture

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -7448,7 +7448,7 @@ fn switchExprErrUnion(
                 try astgen.appendErrorTok(capture_token, "discard of error capture; omit it instead", .{});
             }
             const tag_name = try astgen.identAsString(capture_token);
-            try astgen.detectLocalShadowing(&case_scope.base, tag_name, capture_token, capture_slice, .capture);
+            try astgen.detectLocalShadowing(&err_scope.base, tag_name, capture_token, capture_slice, .capture);
 
             capture_scope = .{
                 .parent = &case_scope.base,

--- a/test/cases/compile_errors/switch_on_error_shadows_case_capture.zig
+++ b/test/cases/compile_errors/switch_on_error_shadows_case_capture.zig
@@ -1,0 +1,26 @@
+comptime {
+    const e: error{Foo}!u32 = error.Foo;
+    e catch |err| switch (err) {
+        error.Foo => |err| {
+            _ = err catch {};
+        },
+    };
+}
+
+comptime {
+    const e: error{Foo}!u32 = error.Foo;
+    if (e) {} else |err| switch (err) {
+        error.Foo => |err| {
+            _ = err catch {};
+        },
+    }
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :4:23: error: redeclaration of capture 'err'
+// :3:14: note: previous declaration here
+// :13:23: error: redeclaration of capture 'err'
+// :12:21: note: previous declaration here


### PR DESCRIPTION
`zig ast-check` fails to report the right error message for this code:

```zig
e catch |err| switch (err) {
    error.Foo => |err| {
        _ = err catch {};
    },
};
```

It does not detect that there are two declarations of `err` and reports that the inner `err` capture isn't used. This bug happens with the "switch on captured error" syntax pattern which checked the wrong scope for shadowing.
