### PR TITLE
aarch64: avoid switching on > 64 bit values, to facilitiate bootstrapping with C compilers without 128 bit integers

### DIFF
--- a/src/codegen/aarch64.zig
+++ b/src/codegen/aarch64.zig
@@ -113,9 +113,7 @@ pub fn generate(
             },
             .stack_slot => |stack_slot| {
                 assert(stack_slot.base == .sp);
-                passed_vi.setParent(&isel, .{
-                    .stack_slot = named_stack_args.withOffset(stack_slot.offset),
-                });
+                passed_vi.changeStackSlot(&isel, named_stack_args.withOffset(stack_slot.offset));
             },
             .address, .value, .constant => unreachable,
         }

--- a/src/codegen/aarch64/instructions.zon
+++ b/src/codegen/aarch64/instructions.zon
@@ -851,11 +851,21 @@
     },
     // C6.2.228 MRS
     .{
-        .pattern = "MRS <Xt>, CTR_EL0",
+        .pattern = "MRS <Xt>, <systemreg>",
         .symbols = .{
             .Xt = .{ .reg = .{ .format = .{ .integer = .doubleword } } },
+            .systemreg = .systemreg,
         },
-        .encode = .{ .mrs, .Xt, 0b11, 0b011, 0b0000, 0b0000, 0b001 },
+        .encode = .{ .mrs, .Xt, .systemreg },
+    },
+    // C6.2.230 MSR (register)
+    .{
+        .pattern = "MSR <systemreg>, <Xt>",
+        .symbols = .{
+            .systemreg = .systemreg,
+            .Xt = .{ .reg = .{ .format = .{ .integer = .doubleword } } },
+        },
+        .encode = .{ .msr, .systemreg, .Xt },
     },
     // C6.2.234 NEG
     .{

--- a/test/behavior/basic.zig
+++ b/test/behavior/basic.zig
@@ -471,7 +471,6 @@ fn testPointerToVoidReturnType2() *const void {
 }
 
 test "array 2D const double ptr" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
@@ -484,7 +483,6 @@ test "array 2D const double ptr" {
 }
 
 test "array 2D const double ptr with offset" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
@@ -497,7 +495,6 @@ test "array 2D const double ptr with offset" {
 }
 
 test "array 3D const double ptr with offset" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1816,7 +1816,6 @@ test "peer type resolution: C pointer and @TypeOf(null)" {
 }
 
 test "peer type resolution: three-way resolution combines error set and optional" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;

--- a/test/behavior/pointers.zig
+++ b/test/behavior/pointers.zig
@@ -436,7 +436,6 @@ test "pointer sentinel with optional element" {
 }
 
 test "pointer sentinel with +inf" {
-    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;


### PR DESCRIPTION
Not all C compilers natively support 128 bit integer types, and the CBE currently lowers switches as C switch statements. This means that MSVC (or any compiler where `zig_has_int128` is 0) cannot compile zig2.c if it contains any switches on (i|u)128.

Of course, it would be ideal if the CBE could lower these switches differently. In this case however, the switches in question don't require the full 128-bit range.