### PR TITLE
zig std: fix sources.tar generation

### DIFF
--- a/lib/compiler/std-docs.zig
+++ b/lib/compiler/std-docs.zig
@@ -229,6 +229,7 @@ fn serveSourcesTar(request: *std.http.Server.Request, context: *Context) !void {
 
     // intentionally omitting the pointless trailer
     //try archiver.finish();
+    try response_writer.new_interface.flush();
     try response.end();
 }
 


### PR DESCRIPTION
Analogous to #24576 for `-femit-docs`

Without this change, I get "panic: unable to unpack tar: EndOfStream" when the documentation is displayed, but it works with this change applied.