### PR TITLE
std.Io.Reader: add rebase to the vtable

### DIFF
--- a/lib/std/Io.zig
+++ b/lib/std/Io.zig
@@ -757,7 +757,7 @@ pub fn Poller(comptime StreamEnum: type) type {
                 const unused = r.buffer[r.end..];
                 if (unused.len >= min_len) return unused;
             }
-            if (r.seek > 0) r.rebase();
+            if (r.seek > 0) r.rebase(r.buffer.len) catch unreachable;
             {
                 var list: std.ArrayListUnmanaged(u8) = .{
                     .items = r.buffer[0..r.end],


### PR DESCRIPTION
This eliminates a footgun and special case handling with fixed buffers, as well as allowing decompression streams to keep a window in the output buffer.