### PR TITLE
std.posix: recvmsg

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -6577,7 +6577,11 @@ pub fn recvfrom(
     }
 }
 
-pub fn recvmsg(sockfd: socket_t, msg: *msghdr, flags: u32) RecvFromError!usize {
+pub const RecvMsgError = error{
+    InputOutput,
+} || RecvFromError;
+
+pub fn recvmsg(sockfd: socket_t, msg: *msghdr, flags: u32) RecvMsgError!usize {
     while (true) {
         const rc = system.recvmsg(sockfd, msg, flags);
         switch (errno(rc)) {


### PR DESCRIPTION
Lifted from #19751 verbatim - thanks to @truemedian for the implementation :sweat_smile:. That PR has been closed, and even though the larger effort around io has been subsumed by Andrew's writer refactoring, I didn't see this in the wrangle-writer-buffering branch. I decided it was probably ok to resurrect this bit of code.

I _did_ spot-check the errors against [the man pages](https://man.archlinux.org/man/recvmsg.3p.en) and made sure all the listed errors in that page are present here - although I'll admit I don't truly grasp why some errors are marked as `unreachable`? I suppose we assume that this function will be called with proper arguments, and any issues around that will be caught in debug builds, where those `unreachable`s will be printed with a stacktrace

Closes #20660