### PR TITLE
add support for 128-bit Windows file IDs in std.fs.File.INode

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -20,7 +20,10 @@ handle: Handle,
 
 pub const Handle = posix.fd_t;
 pub const Mode = posix.mode_t;
-pub const INode = posix.ino_t;
+pub const INode = union(enum) {
+    U64: posix.ino_t,
+    U128: windows.FILE_ID_128,
+};
 pub const Uid = posix.uid_t;
 pub const Gid = posix.gid_t;
 
@@ -430,7 +433,7 @@ pub const Stat = struct {
         const mtime = st.mtime();
         const ctime = st.ctime();
         return .{
-            .inode = st.ino,
+            .inode = .{ .U64 = st.ino },
             .size = @bitCast(st.size),
             .mode = st.mode,
             .kind = k: {
@@ -465,7 +468,7 @@ pub const Stat = struct {
         const ctime = stx.ctime;
 
         return .{
-            .inode = stx.ino,
+            .inode = .{ .U64 = stx.ino },
             .size = stx.size,
             .mode = stx.mode,
             .kind = switch (stx.mode & linux.S.IFMT) {
@@ -486,7 +489,7 @@ pub const Stat = struct {
 
     pub fn fromWasi(st: std.os.wasi.filestat_t) Stat {
         return .{
-            .inode = st.ino,
+            .inode = .{ .U64 = st.ino },
             .size = @bitCast(st.size),
             .mode = 0,
             .kind = switch (st.filetype) {

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -20,10 +20,10 @@ handle: Handle,
 
 pub const Handle = posix.fd_t;
 pub const Mode = posix.mode_t;
-pub const INode = union(enum) {
-    U64: posix.ino_t,
-    U128: windows.FILE_ID_128,
-};
+pub const INode = if (builtin.os.tag == .windows)
+    windows.FILE_ID_128
+else
+    posix.ino_t;
 pub const Uid = posix.uid_t;
 pub const Gid = posix.gid_t;
 
@@ -433,7 +433,7 @@ pub const Stat = struct {
         const mtime = st.mtime();
         const ctime = st.ctime();
         return .{
-            .inode = .{ .U64 = st.ino },
+            .inode = st.ino,
             .size = @bitCast(st.size),
             .mode = st.mode,
             .kind = k: {
@@ -468,7 +468,7 @@ pub const Stat = struct {
         const ctime = stx.ctime;
 
         return .{
-            .inode = .{ .U64 = stx.ino },
+            .inode = stx.ino,
             .size = stx.size,
             .mode = stx.mode,
             .kind = switch (stx.mode & linux.S.IFMT) {
@@ -489,7 +489,7 @@ pub const Stat = struct {
 
     pub fn fromWasi(st: std.os.wasi.filestat_t) Stat {
         return .{
-            .inode = .{ .U64 = st.ino },
+            .inode = st.ino,
             .size = @bitCast(st.size),
             .mode = 0,
             .kind = switch (st.filetype) {

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -4915,6 +4915,27 @@ pub const RTL_DRIVE_LETTER_CURDIR = extern struct {
 
 pub const PPS_POST_PROCESS_INIT_ROUTINE = ?*const fn () callconv(.winapi) void;
 
+pub const FILE_ID_128 = [16]u8;
+
+pub const FILE_ID_EXTD_BOTH_DIR_INFORMATION = extern struct {
+    NextEntryOffset: ULONG,
+    FileIndex:       ULONG,
+    CreationTime:    LARGE_INTEGER,
+    LastAccessTime:  LARGE_INTEGER,
+    LastWriteTime:   LARGE_INTEGER,
+    ChangeTime:      LARGE_INTEGER,
+    EndOfFile:       LARGE_INTEGER,
+    AllocationSize:  LARGE_INTEGER,
+    FileAttributes:  ULONG,
+    FileNameLength:  ULONG,
+    EaSize:          ULONG,
+    ReparsePointTag: ULONG,
+    FileId:          FILE_ID_128,
+    ShortNameLength: CHAR,
+    ShortName:       [12]WCHAR,
+    FileName:        [1]WCHAR,
+};
+
 pub const FILE_DIRECTORY_INFORMATION = extern struct {
     NextEntryOffset: ULONG,
     FileIndex: ULONG,

--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -4915,27 +4915,6 @@ pub const RTL_DRIVE_LETTER_CURDIR = extern struct {
 
 pub const PPS_POST_PROCESS_INIT_ROUTINE = ?*const fn () callconv(.winapi) void;
 
-pub const FILE_ID_128 = [16]u8;
-
-pub const FILE_ID_EXTD_BOTH_DIR_INFORMATION = extern struct {
-    NextEntryOffset: ULONG,
-    FileIndex:       ULONG,
-    CreationTime:    LARGE_INTEGER,
-    LastAccessTime:  LARGE_INTEGER,
-    LastWriteTime:   LARGE_INTEGER,
-    ChangeTime:      LARGE_INTEGER,
-    EndOfFile:       LARGE_INTEGER,
-    AllocationSize:  LARGE_INTEGER,
-    FileAttributes:  ULONG,
-    FileNameLength:  ULONG,
-    EaSize:          ULONG,
-    ReparsePointTag: ULONG,
-    FileId:          FILE_ID_128,
-    ShortNameLength: CHAR,
-    ShortName:       [12]WCHAR,
-    FileName:        [1]WCHAR,
-};
-
 pub const FILE_DIRECTORY_INFORMATION = extern struct {
     NextEntryOffset: ULONG,
     FileIndex: ULONG,


### PR DESCRIPTION
- Change `std.fs.File.INode` to a tagged union: `U64` (POSIX) or `U128` (Windows FILE_ID_128).
- Add `FILE_ID_128` and `FILE_ID_EXTD_BOTH_DIR_INFORMATION` definitions to `std.os.windows`.
- Update `Stat` constructors to wrap inode values in the union.

This enables retrieving persistent 128-bit file IDs on Windows
(using FileIdExtdBothDirectoryInformation), improving parity with
POSIX inodes for tools that need stable file identity (e.g. deduplication).