### PR TITLE
std.Io.Reader: make fillUnbuffered respect prexisting buffer

### DIFF
--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -1055,15 +1055,6 @@ pub fn fill(r: *Reader, n: usize) Error!void {
 /// Missing this optimization can result in wall-clock time for the most affected benchmarks
 /// increasing by a factor of 5 or more.
 fn fillUnbuffered(r: *Reader, n: usize) Error!void {
-    if (r.seek + n <= r.buffer.len) while (true) {
-        const end_cap = r.buffer[r.end..];
-        var writer: Writer = .fixed(end_cap);
-        r.end += r.vtable.stream(r, &writer, .limited(end_cap.len)) catch |err| switch (err) {
-            error.WriteFailed => unreachable,
-            else => |e| return e,
-        };
-        if (r.seek + n <= r.end) return;
-    };
     try rebase(r, n);
     var writer: Writer = .{
         .buffer = r.buffer,

--- a/lib/std/compress/zstd/Decompress.zig
+++ b/lib/std/compress/zstd/Decompress.zig
@@ -100,9 +100,8 @@ fn rebase(r: *Reader, capacity: usize) Reader.RebaseError!void {
     const d: *Decompress = @alignCast(@fieldParentPtr("reader", r));
     assert(capacity <= r.buffer.len - d.window_len);
     assert(r.end + capacity > r.buffer.len);
-    const buffered = r.buffer[0..r.end];
-    const discard = buffered.len - d.window_len;
-    const keep = buffered[discard..];
+    const discard = r.end - d.window_len;
+    const keep = r.buffer[discard..r.end];
     @memmove(r.buffer[0..keep.len], keep);
     r.end = keep.len;
     r.seek -= discard;


### PR DESCRIPTION
addresses only one usage pattern in #24608