### PR TITLE
compiler: disable self-hosted x86_64 backend on OpenBSD

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -236,7 +236,7 @@ pub fn hasLldSupport(ofmt: std.Target.ObjectFormat) bool {
 pub fn selfHostedBackendIsAsRobustAsLlvm(target: *const std.Target) bool {
     if (target.cpu.arch.isSpirV()) return true;
     if (target.cpu.arch == .x86_64 and target.ptrBitWidth() == 64) {
-        if (target.os.tag == .netbsd) {
+        if (target.os.tag == .netbsd or target.os.tag == .openbsd) {
             // Self-hosted linker needs work: https://github.com/ziglang/zig/issues/24341
             return false;
         }


### PR DESCRIPTION
Same as 97ecb6c551eb628e5a37d18d5a9720d3714a04ef for NetBSD.