### PR TITLE
fetch: remove calls to fsync

### DIFF
--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1386,7 +1386,6 @@ fn unpackGitPack(f: *Fetch, out_dir: fs.Dir, resource: *Resource.Git) anyerror!U
         defer pack_file.close();
         var fifo = std.fifo.LinearFifo(u8, .{ .Static = 4096 }).init();
         try fifo.pump(resource.fetch_stream.reader(), pack_file.deprecatedWriter());
-        try pack_file.sync();
 
         var index_file = try pack_dir.createFile("pkg.idx", .{ .read = true });
         defer index_file.close();
@@ -1396,7 +1395,6 @@ fn unpackGitPack(f: *Fetch, out_dir: fs.Dir, resource: *Resource.Git) anyerror!U
             var index_buffered_writer = std.io.bufferedWriter(index_file.deprecatedWriter());
             try git.indexPack(gpa, object_format, pack_file, index_buffered_writer.writer());
             try index_buffered_writer.flush();
-            try index_file.sync();
         }
 
         {

--- a/src/Package/Fetch/git.zig
+++ b/src/Package/Fetch/git.zig
@@ -238,7 +238,6 @@ pub const Repository = struct {
                     };
                     defer file.close();
                     try file.writeAll(file_object.data);
-                    try file.sync();
                 },
                 .symlink => {
                     try repository.odb.seekOid(entry.oid);
@@ -1690,7 +1689,6 @@ pub fn main() !void {
     var index_buffered_writer = std.io.bufferedWriter(index_file.deprecatedWriter());
     try indexPack(allocator, format, pack_file, index_buffered_writer.writer());
     try index_buffered_writer.flush();
-    try index_file.sync();
 
     std.debug.print("Starting checkout...\n", .{});
     var repository = try Repository.init(allocator, format, pack_file, index_file);


### PR DESCRIPTION
fsync blocks until the contents have been actually written to disk, which would be useful if we didn't want to report success until having achieved durability. But the OS will ensure coherency; i.e. if one process writes stuff without calling fsync, then another process reads that stuff, the writes will be seen even if they didn't get flushed to disk yet.

Since this code deals with ephemeral cache data, it's not worth trying to achieve this kind of durability guarantee. This is consistent with all the other tooling on the system.

Certainly, if we wanted to change our stance on this, it would not be something that affects only the git fetching logic.