### PR TITLE
std: A few more fixes for serenity

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -1548,6 +1548,7 @@ const have_sigwinch = switch (builtin.os.tag) {
     .visionos,
     .dragonfly,
     .freebsd,
+    .serenity,
     => true,
 
     else => false,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -4121,7 +4121,7 @@ pub const msghdr_const = switch (native_os) {
     .serenity => extern struct {
         name: ?*const anyopaque,
         namelen: socklen_t,
-        iov: [*]const iovec,
+        iov: [*]const iovec_const,
         iovlen: c_uint,
         control: ?*const anyopaque,
         controllen: socklen_t,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -8604,7 +8604,7 @@ pub const O = switch (native_os) {
     },
     // https://github.com/SerenityOS/serenity/blob/2808b0376406a40e31293bb3bcb9170374e90506/Kernel/API/POSIX/fcntl.h#L28-L43
     .serenity => packed struct(c_int) {
-        ACCMODE: std.posix.ACCMODE = .RDONLY,
+        ACCMODE: std.posix.ACCMODE = .NONE,
         EXEC: bool = false,
         CREAT: bool = false,
         EXCL: bool = false,

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -8760,10 +8760,10 @@ pub const MAP = switch (native_os) {
     },
     // https://github.com/SerenityOS/serenity/blob/6d59d4d3d9e76e39112842ec487840828f1c9bfe/Kernel/API/POSIX/sys/mman.h#L16-L26
     .serenity => packed struct(c_int) {
-        FILE: bool = false,
-        SHARED: bool = false,
-        PRIVATE: bool = false,
-        _3: u2 = 0,
+        TYPE: enum(u4) {
+            SHARED = 0x01,
+            PRIVATE = 0x02,
+        },
         FIXED: bool = false,
         ANONYMOUS: bool = false,
         STACK: bool = false,
@@ -8771,7 +8771,7 @@ pub const MAP = switch (native_os) {
         RANDOMIZED: bool = false,
         PURGEABLE: bool = false,
         FIXED_NOREPLACE: bool = false,
-        _: std.meta.Int(.unsigned, @bitSizeOf(c_int) - 12) = 0,
+        _: std.meta.Int(.unsigned, @bitSizeOf(c_int) - 11) = 0,
     },
     else => void,
 };

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -146,7 +146,7 @@ const CAllocator = struct {
     else {};
 
     pub const supports_posix_memalign = switch (builtin.os.tag) {
-        .dragonfly, .netbsd, .freebsd, .solaris, .openbsd, .linux, .macos, .ios, .tvos, .watchos, .visionos => true,
+        .dragonfly, .netbsd, .freebsd, .solaris, .openbsd, .linux, .macos, .ios, .tvos, .watchos, .visionos, .serenity => true,
         else => false,
     };
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -204,6 +204,7 @@ pub const ACCMODE = switch (native_os) {
     // implements this suggestion.
     // https://github.com/SerenityOS/serenity/blob/4adc51fdf6af7d50679c48b39362e062f5a3b2cb/Kernel/API/POSIX/fcntl.h#L28-L30
     .serenity => enum(u2) {
+        NONE = 0,
         RDONLY = 1,
         WRONLY = 2,
         RDWR = 3,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -1129,8 +1129,9 @@ pub fn ftruncate(fd: fd_t, length: u64) TruncateError!void {
 /// * Windows
 /// On these systems, the read races with concurrent writes to the same file descriptor.
 pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
+    // NOTE: serenity does not have preadv but it *does* have pwritev.
     const have_pread_but_not_preadv = switch (native_os) {
-        .windows, .macos, .ios, .watchos, .tvos, .visionos, .haiku => true,
+        .windows, .macos, .ios, .watchos, .tvos, .visionos, .haiku, .serenity => true,
         else => false,
     };
     if (have_pread_but_not_preadv) {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -699,6 +699,7 @@ fn maybeIgnoreSigpipe() void {
         .visionos,
         .dragonfly,
         .freebsd,
+        .serenity,
         => true,
 
         else => false,


### PR DESCRIPTION
Previous patches (#23192, #23198, #24561) were from my in-progress work on updating the SerenityOS Zig port from 0.12 to 0.15. I finally have it running so here are more fixes I collected along the way. There are more patches downstream that I don't consider ready for inclusion quite yet.

<img width="893" height="610" alt="image" src="https://github.com/user-attachments/assets/507b2482-2ed7-46a6-9579-917458d91a97" />
