### PR TITLE
std.Build: keep compiler alive under `-fincremental --webui`

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -1851,7 +1851,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
     const maybe_output_dir = step.evalZigProcess(
         zig_args,
         options.progress_node,
-        (b.graph.incremental == true) and options.watch,
+        (b.graph.incremental == true) and (options.watch or options.web_server != null),
         options.web_server,
         options.gpa,
     ) catch |err| switch (err) {


### PR DESCRIPTION
Previously, this only applied when using `-fincremental --watch`, but `--webui` makes the build runner stay alive just like `--watch` does, so the same logic applies here. Without this, attempting to perform incremental updates with `--webui` performs full rebuilds. (I did test that before merging the PR, but at that time I was passing `--watch` too -- which has since been disallowed -- so I missed that it doesn't work as expected without that option!)