### PR TITLE
translate_c: fix ternary operator output in C macros

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -7,10 +7,10 @@ const meta = std.meta;
 const clang = @import("clang.zig");
 const aro = @import("aro");
 const CToken = aro.Tokenizer.Token;
-const Node = ast.Node;
-const Tag = Node.Tag;
 const common = @import("aro_translate_c");
 const ast = common.ast;
+const Node = ast.Node;
+const Tag = Node.Tag;
 const Error = common.Error;
 const MacroProcessingError = common.MacroProcessingError;
 const TypeError = common.TypeError;
@@ -5985,10 +5985,11 @@ fn parseCCondExpr(c: *Context, m: *MacroCtx, scope: *Scope) ParseError!Node {
     }
     _ = m.next();
 
+    const cond_body = try macroIntToBool(c, node);
     const then_body = try parseCOrExpr(c, m, scope);
     try m.skip(c, .colon);
     const else_body = try parseCCondExpr(c, m, scope);
-    return Tag.@"if".create(c.arena, .{ .cond = node, .then = then_body, .@"else" = else_body });
+    return Tag.@"if".create(c.arena, .{ .cond = cond_body, .then = then_body, .@"else" = else_body });
 }
 
 fn parseCOrExpr(c: *Context, m: *MacroCtx, scope: *Scope) ParseError!Node {

--- a/test/cases/translate_c/tenary_in_macro.c
+++ b/test/cases/translate_c/tenary_in_macro.c
@@ -1,0 +1,21 @@
+#define TERNARY_CHECK(i) check(i)
+#define TERNARY_CALL(i) (TERNARY_CHECK(i) ? (i+1) : (i-1))
+
+static inline int check(int obj) {
+    return obj % 2;
+}
+int target_func(int a) {
+    return TERNARY_CALL(a);
+}
+
+// translate-c
+// c_frontend=clang
+//
+// pub inline fn TERNARY_CHECK(i: anytype) @TypeOf(check(i)) {
+//     _ = &i;
+//     return check(i);
+// }
+// pub inline fn TERNARY_CALL(i: anytype) @TypeOf(if (TERNARY_CHECK(i) != 0) i + @as(c_int, 1) else i - @as(c_int, 1)) {
+//     _ = &i;
+//     return if (TERNARY_CHECK(i) != 0) i + @as(c_int, 1) else i - @as(c_int, 1);
+// }

--- a/test/translate_c.zig
+++ b/test/translate_c.zig
@@ -3101,8 +3101,8 @@ pub fn addCases(cases: *tests.TranslateCContext) void {
         \\ int a, b, c;
         \\#define FOO a ? b : c
     , &[_][]const u8{
-        \\pub inline fn FOO() @TypeOf(if (a) b else c) {
-        \\    return if (a) b else c;
+        \\pub inline fn FOO() @TypeOf(if (a != 0) b else c) {
+        \\    return if (a != 0) b else c;
         \\}
     });
 


### PR DESCRIPTION
this is a fix for ziglang/translate-c#44 . Basically it tries to wrap all the conditions in ternary operation with a zero check.