### PR TITLE
OpenGL SPIR-V support

### DIFF
--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -4510,7 +4510,7 @@ pub fn callconvSupported(zcu: *Zcu, cc: std.builtin.CallingConvention) union(enu
         },
         .stage2_spirv => switch (cc) {
             .spirv_device, .spirv_kernel => true,
-            .spirv_fragment, .spirv_vertex => target.os.tag == .vulkan,
+            .spirv_fragment, .spirv_vertex => target.os.tag == .vulkan or target.os.tag == .opengl,
             else => false,
         },
     };


### PR DESCRIPTION
The support was already there but somebody forgot to allow to use the calling conventions spirv_fragment and spirv_vertex when having opengl as os tag.