### PR TITLE
`std.mem`: add namespace for comparing sentinel-terminated pointers

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -651,6 +651,7 @@ test order {
     try testing.expect(order(u8, "abc", "abc0") == .lt);
     try testing.expect(order(u8, "", "") == .eq);
     try testing.expect(order(u8, "", "a") == .lt);
+    try testing.expect(order(i8, &.{ -1, -2 }, &.{ -1, -2, -3 }) == .lt);
 }
 
 test orderZ {
@@ -659,6 +660,7 @@ test orderZ {
     try testing.expect(orderZ(u8, "abc", "abc0") == .lt);
     try testing.expect(orderZ(u8, "", "") == .eq);
     try testing.expect(orderZ(u8, "", "a") == .lt);
+    try testing.expect(order(i8, &.{ -1, -2 }, &.{ -1, -2, -3 }) == .lt);
 }
 
 /// Returns true if lhs < rhs, false otherwise

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -18,7 +18,7 @@ pub const byte_size_in_bits = 8;
 
 pub const Allocator = @import("mem/Allocator.zig");
 
-pub const sentinelPtrs = @import("mem/sentinelPtrs.zig");
+pub const sentinel_terminated = @import("mem/sentinel_terminated.zig");
 
 /// Stored as a power-of-two.
 pub const Alignment = enum(math.Log2Int(usize)) {
@@ -642,7 +642,7 @@ pub fn order(comptime T: type, lhs: []const T, rhs: []const T) math.Order {
 
 /// Compares two many-item pointers with NUL-termination lexicographically.
 pub fn orderZ(comptime T: type, lhs: [*:0]const T, rhs: [*:0]const T) math.Order {
-    return sentinelPtrs.order(T, 0, lhs, rhs);
+    return sentinel_terminated.order(T, 0, lhs, rhs);
 }
 
 test order {
@@ -4844,5 +4844,5 @@ test "read/write(Var)PackedInt" {
 }
 
 test {
-    _ = &sentinelPtrs;
+    _ = sentinel_terminated;
 }

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -642,9 +642,7 @@ pub fn order(comptime T: type, lhs: []const T, rhs: []const T) math.Order {
 
 /// Compares two many-item pointers with NUL-termination lexicographically.
 pub fn orderZ(comptime T: type, lhs: [*:0]const T, rhs: [*:0]const T) math.Order {
-    var i: usize = 0;
-    while (lhs[i] == rhs[i] and lhs[i] != 0) : (i += 1) {}
-    return math.order(lhs[i], rhs[i]);
+    return sentinelPtrs.order(T, 0, lhs, rhs);
 }
 
 test order {

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -18,6 +18,8 @@ pub const byte_size_in_bits = 8;
 
 pub const Allocator = @import("mem/Allocator.zig");
 
+pub const sentinelPtrs = @import("mem/sentinelPtrs.zig");
+
 /// Stored as a power-of-two.
 pub const Alignment = enum(math.Log2Int(usize)) {
     @"1" = 0,
@@ -4841,4 +4843,8 @@ test "read/write(Var)PackedInt" {
             }
         }
     }
+}
+
+test {
+    _ = &sentinelPtrs;
 }

--- a/lib/std/mem/sentinelPtrs.zig
+++ b/lib/std/mem/sentinelPtrs.zig
@@ -1,0 +1,58 @@
+const std = @import("../std.zig");
+const testing = std.testing;
+
+/// Returns true if and only if the pointers have the same length and all elements
+/// compare true using equality operator.
+pub fn eql(comptime T: type, comptime sentinel: T, a: [*:sentinel]const T, b: [*:sentinel]const T) bool {
+    if (a == b) return true;
+
+    var i: usize = 0;
+    while (a[i] == b[i]) : (i += 1) {
+        if (a[i] == sentinel) return true;
+    }
+    return false;
+}
+
+test eql {
+    try testing.expect(eql(u8, 0, "abcd", "abcd"));
+    try testing.expect(!eql(u8, 0, "abcdef", "abZdef"));
+    try testing.expect(!eql(u8, 0, "abcdefg", "abcdef"));
+
+    try testing.expect(eql(u16, 1, ([5]u16{ 5, 6, 7, 8, 1 })[0..4 :1].ptr, ([5]u16{ 5, 6, 7, 8, 1 })[0..4 :1].ptr));
+    try testing.expect(!eql(u16, 1, ([7]u16{ 5, 6, 7, 8, 9, 10, 1 })[0..6 :1].ptr, ([7]u16{ 5, 6, 17, 8, 9, 10, 1 })[0..6 :1].ptr));
+    try testing.expect(!eql(u16, 1, ([8]u16{ 5, 6, 7, 8, 9, 10, 11, 1 })[0..7 :1].ptr, ([7]u16{ 5, 6, 7, 8, 9, 10, 1 })[0..6 :1].ptr));
+}
+
+/// Returns true if and only if the pointer and slice have the same length and all elements
+/// compare true using equality operator.
+pub fn eqlSlice(comptime T: type, comptime sentinel: T, a: [*:sentinel]const T, b: []const T) bool {
+    for (b, 0..) |b_elem, i| {
+        if (a[i] == sentinel or a[i] != b_elem) return false;
+    }
+    return a[b.len] == sentinel;
+}
+
+test eqlSlice {
+    try testing.expect(eqlSlice(u8, 0, "abcd", "abcd"));
+    try testing.expect(!eqlSlice(u8, 0, "abcdef", "abZdef"));
+    try testing.expect(!eqlSlice(u8, 0, "abcdefg", "abcdef"));
+
+    try testing.expect(eqlSlice(u16, 1, ([5]u16{ 5, 6, 7, 8, 1 })[0..4 :1].ptr, &[4]u16{ 5, 6, 7, 8 }));
+    try testing.expect(!eqlSlice(u16, 1, ([7]u16{ 5, 6, 7, 8, 9, 10, 1 })[0..6 :1].ptr, &[6]u16{ 5, 6, 17, 8, 9, 10 }));
+    try testing.expect(!eqlSlice(u16, 1, ([8]u16{ 5, 6, 7, 8, 9, 10, 11, 1 })[0..7 :1].ptr, &[6]u16{ 5, 6, 7, 8, 9, 10 }));
+}
+
+/// Returns true if all elements in the pointer are equal to the scalar value provided
+pub fn allEqual(comptime T: type, comptime sentinel: T, ptr: [*:sentinel]const T, scalar: T) bool {
+    var i: usize = 0;
+    while (ptr[i] != sentinel) : (i += 1) {
+        if (ptr[i] != scalar) return false;
+    }
+    return true;
+}
+
+test allEqual {
+    try testing.expect(allEqual(u8, 0, "aaaa", 'a'));
+    try testing.expect(!allEqual(u8, 0, "abaa", 'a'));
+    try testing.expect(allEqual(u8, 0, "", 'a'));
+}

--- a/lib/std/mem/sentinel_terminated.zig
+++ b/lib/std/mem/sentinel_terminated.zig
@@ -110,6 +110,12 @@ test order {
     try testing.expect(order(u8, 0, "abc", "abc0") == .lt);
     try testing.expect(order(u8, 0, "", "") == .eq);
     try testing.expect(order(u8, 0, "", "a") == .lt);
+
+    try testing.expect(order(u16, 1, ([_]u16{ 2, 3, 4, 5, 1 })[0..4 :1].ptr, ([_]u16{ 2, 3, 4, 5, 1 })[0..4 :1].ptr) == .eq);
+    try testing.expect(order(u16, 1, ([_]u16{ 2, 3, 4, 1 })[0..3 :1].ptr, ([_]u16{ 2, 3, 4, 5, 1 })[0..4 :1].ptr) == .lt);
+    try testing.expect(order(u16, 1, ([_]u16{ 3, 4, 5, 6, 1 })[0..4 :1].ptr, ([_]u16{ 2, 3, 4, 5, 1 })[0..4 :1].ptr) == .gt);
+    try testing.expect(order(u16, 1, ([_]u16{1})[0..0 :1].ptr, ([_]u16{1})[0..0 :1].ptr) == .eq);
+    try testing.expect(order(u16, 1, ([_]u16{1})[0..0 :1].ptr, ([_]u16{ 2, 1 })[0..1 :1].ptr) == .lt);
 }
 
 /// Returns true if lhs < rhs, false otherwise

--- a/lib/std/mem/sentinel_terminated.zig
+++ b/lib/std/mem/sentinel_terminated.zig
@@ -101,7 +101,7 @@ test max {
 pub fn order(comptime T: type, comptime sentinel: T, lhs: [*:sentinel]const T, rhs: [*:sentinel]const T) math.Order {
     var i: usize = 0;
     while (lhs[i] == rhs[i] and lhs[i] != sentinel) : (i += 1) {}
-    return math.order(lhs[i], rhs[i]);
+    return if (lhs[i] == sentinel) if (rhs[i] == sentinel) .eq else .lt else if (rhs[i] == sentinel) .gt else math.order(lhs[i], rhs[i]);
 }
 
 test order {
@@ -116,6 +116,8 @@ test order {
     try testing.expect(order(u16, 1, ([_]u16{ 3, 4, 5, 6, 1 })[0..4 :1].ptr, ([_]u16{ 2, 3, 4, 5, 1 })[0..4 :1].ptr) == .gt);
     try testing.expect(order(u16, 1, ([_]u16{1})[0..0 :1].ptr, ([_]u16{1})[0..0 :1].ptr) == .eq);
     try testing.expect(order(u16, 1, ([_]u16{1})[0..0 :1].ptr, ([_]u16{ 2, 1 })[0..1 :1].ptr) == .lt);
+
+    try testing.expect(order(i8, 0, ([_]i8{ -1, -2, 0 })[0..2 :0].ptr, ([_]i8{ -1, -2, -3, 0 })[0..3 :0].ptr) == .lt);
 }
 
 /// Returns true if lhs < rhs, false otherwise


### PR DESCRIPTION
This adds a new namespace to `std.mem` for comparing sentinel-terminated pointers: `std.mem.sentinel_terminated`.

This includes both a function for comparing two such pointers and a function for comparing one to a slice (latter addresses https://github.com/ziglang/zig/pull/7848#issuecomment-765467508).
Ordering is also provided, which also works if the sentinel is not the minimal possible value in the slice (copied from and closes https://github.com/ziglang/zig/pull/22618).

I also included `allEqual()`, `min()` and `max()` functions.
`len()` and `span()` link to the implementation currently in `std.mem`, though if this get accepted, moving the implementations and deprecating the original functions might be a possibility.

The naming I chose isn't final, if a better one is suggested, I can change it.
Similarly, I am not quite sure on the explicitness of the sentinel value in the function calls, though it does follow a similar pattern as many functions in `std.mem` do currently.

I tested the speed of `eql()` and `eqlSlice()`. Both are faster than using `std.mem.eql()` with sentinel-terminated pointer to slice conversion, especially at smaller lengths.
If operating on sentinel-terminated slices it is actually sometimes faster to use `std.mem.sentinel_terminated.eql()` on the pointers than it is to pass the slices to `std.mem.eql()`, though more testing should be done before this is used.

Lastly, if there are any more functions I should add, or any usecase in the standard library or the compiler where these functions could help, tell me and I will implement them to the best of my ability.