### PR TITLE
std.compress.flate.Decompress: return correct size for unbuffered decompression

### DIFF
--- a/lib/std/compress/flate/Decompress.zig
+++ b/lib/std/compress/flate/Decompress.zig
@@ -373,7 +373,7 @@ fn streamInner(d: *Decompress, w: *Writer, limit: std.Io.Limit) (Error || Reader
                 d.state = .{ .stored_block = @intCast(remaining_len - n) };
             }
             w.advance(n);
-            return n;
+            return @intFromEnum(limit) - remaining + n;
         },
         .fixed_block => {
             while (remaining > 0) {
@@ -1265,6 +1265,7 @@ fn testDecompress(container: Container, compressed: []const u8, expected_plain: 
     defer aw.deinit();
 
     var decompress: Decompress = .init(&in, container, &.{});
-    _ = try decompress.reader.streamRemaining(&aw.writer);
+    const decompressed_len = try decompress.reader.streamRemaining(&aw.writer);
+    try testing.expectEqual(expected_plain.len, decompressed_len);
     try testing.expectEqualSlices(u8, expected_plain, aw.getWritten());
 }


### PR DESCRIPTION
Closes #24686

As a bonus, this commit also makes the `git.zig` "testing `main`" compile again.

---

Tested on both examples provided in #24686:

```
ian@ian-laptop:~/src/zig/build$ stage4/bin/zig fetch git+https://github.com/Not-Nik/raylib-zig.git#a6e9ce520f056200bc8aaecb6ca3c35ffe84cccd
raylib_zig-5.6.0-dev-KE8REBMwBQD5YduSugg8Iimkyc-G6Daz6OBEjUI94xCz
ian@ian-laptop:~/src/zig/build$ stage4/bin/zig fetch git+https://github.com/blocksds/maxmod.git#v1.8.0-blocks
N-V-__8AAOW1DgDA2yLdI8SMucr-YkH1Y-1JfUI_CR49OBbI
```