### PR TITLE
std.Io.Reader: use readVec for fill functions

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1312,7 +1312,16 @@ pub const Reader = struct {
                 if (is_windows) {
                     // Unfortunately, `ReadFileScatter` cannot be used since it
                     // requires page alignment.
-                    return readPositional(r, data[0]);
+                    assert(io_reader.seek == io_reader.end);
+                    io_reader.seek = 0;
+                    io_reader.end = 0;
+                    const first = data[0];
+                    if (first.len >= io_reader.buffer.len) {
+                        return readPositional(r, first);
+                    } else {
+                        io_reader.end += try readPositional(r, io_reader.buffer);
+                        return 0;
+                    }
                 }
                 var iovecs_buffer: [max_buffers_len]posix.iovec = undefined;
                 const dest_n, const data_size = try io_reader.writableVectorPosix(&iovecs_buffer, data);
@@ -1352,7 +1361,16 @@ pub const Reader = struct {
                 if (is_windows) {
                     // Unfortunately, `ReadFileScatter` cannot be used since it
                     // requires page alignment.
-                    return readStreaming(r, data[0]);
+                    assert(io_reader.seek == io_reader.end);
+                    io_reader.seek = 0;
+                    io_reader.end = 0;
+                    const first = data[0];
+                    if (first.len >= io_reader.buffer.len) {
+                        return readStreaming(r, first);
+                    } else {
+                        io_reader.end += try readStreaming(r, io_reader.buffer);
+                        return 0;
+                    }
                 }
                 var iovecs_buffer: [max_buffers_len]posix.iovec = undefined;
                 const dest_n, const data_size = try io_reader.writableVectorPosix(&iovecs_buffer, data);


### PR DESCRIPTION
addresses #24695, as well as just being a better, simpler implementation for these functions now that readVec is back in the vtable.