### PR TITLE
std/zip.zig: perform backslash-to-forward-slash before isBadFilename()

### DIFF
--- a/lib/std/zip.zig
+++ b/lib/std/zip.zig
@@ -536,15 +536,15 @@ pub const Iterator = struct {
                     @as(u64, local_header.extra_len);
             };
 
-            if (isBadFilename(filename))
-                return error.ZipBadFilename;
-
             if (options.allow_backslashes) {
                 std.mem.replaceScalar(u8, filename, '\\', '/');
             } else {
                 if (std.mem.indexOfScalar(u8, filename, '\\')) |_|
                     return error.ZipFilenameHasBackslash;
             }
+
+            if (isBadFilename(filename))
+                return error.ZipBadFilename;
 
             // All entries that end in '/' are directories
             if (filename[filename.len - 1] == '/') {


### PR DESCRIPTION
Previously, when extracting a ZIP file, `isBadFilename()`, which is designed to reject `../` patterns to prevent directory traversal, was called before normalizing backslashes to forward slashes.

This allowed path traversal sequences like `..\\..\\..\\etc\\passwd` which pass validation but are then converted to `../../../etc/passwd` for file extraction.