### PR TITLE
tsan: remove interceptors for termio

### DIFF
--- a/lib/libtsan/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+++ b/lib/libtsan/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
@@ -338,17 +338,9 @@ static void ioctl_table_fill() {
   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
   _(TCFLSH, NONE, 0);
-#if SANITIZER_GLIBC
-  _(TCGETA, WRITE, struct_termio_sz);
-#endif
   _(TCGETS, WRITE, struct_termios_sz);
   _(TCSBRK, NONE, 0);
   _(TCSBRKP, NONE, 0);
-#if SANITIZER_GLIBC
-  _(TCSETA, READ, struct_termio_sz);
-  _(TCSETAF, READ, struct_termio_sz);
-  _(TCSETAW, READ, struct_termio_sz);
-#endif
   _(TCSETS, READ, struct_termios_sz);
   _(TCSETSF, READ, struct_termios_sz);
   _(TCSETSW, READ, struct_termios_sz);

--- a/lib/libtsan/sanitizer_common/sanitizer_platform_limits_posix.cpp
+++ b/lib/libtsan/sanitizer_common/sanitizer_platform_limits_posix.cpp
@@ -485,9 +485,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
   unsigned struct_input_id_sz = sizeof(struct input_id);
   unsigned struct_mtpos_sz = sizeof(struct mtpos);
   unsigned struct_rtentry_sz = sizeof(struct rtentry);
-#if SANITIZER_GLIBC || SANITIZER_ANDROID
-  unsigned struct_termio_sz = sizeof(struct termio);
-#endif
   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);

--- a/lib/libtsan/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/lib/libtsan/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -1043,7 +1043,6 @@ extern unsigned struct_hd_geometry_sz;
 extern unsigned struct_input_absinfo_sz;
 extern unsigned struct_input_id_sz;
 extern unsigned struct_mtpos_sz;
-extern unsigned struct_termio_sz;
 extern unsigned struct_vt_consize_sz;
 extern unsigned struct_vt_sizes_sz;
 extern unsigned struct_vt_stat_sz;

--- a/src/link/Elf/synthetic_sections.zig
+++ b/src/link/Elf/synthetic_sections.zig
@@ -384,7 +384,7 @@ pub const GotSection = struct {
                     try writeInt(value, elf_file, writer);
                 },
                 .tlsld => {
-                    try writeInt(if (is_dyn_lib) @as(u64, 0) else 1, elf_file, writer);
+                    try writeInt(if (is_dyn_lib) @as(i64, 0) else 1, elf_file, writer);
                     try writeInt(0, elf_file, writer);
                 },
                 .tlsgd => {
@@ -392,7 +392,7 @@ pub const GotSection = struct {
                         try writeInt(0, elf_file, writer);
                         try writeInt(0, elf_file, writer);
                     } else {
-                        try writeInt(if (is_dyn_lib) @as(u64, 0) else 1, elf_file, writer);
+                        try writeInt(if (is_dyn_lib) @as(i64, 0) else 1, elf_file, writer);
                         const offset = symbol.?.address(.{}, elf_file) - elf_file.dtpAddress();
                         try writeInt(offset, elf_file, writer);
                     }
@@ -412,17 +412,12 @@ pub const GotSection = struct {
                     }
                 },
                 .tlsdesc => {
-                    if (symbol.?.flags.import) {
-                        try writeInt(0, elf_file, writer);
-                        try writeInt(0, elf_file, writer);
-                    } else {
-                        try writeInt(0, elf_file, writer);
-                        const offset = if (apply_relocs)
-                            symbol.?.address(.{}, elf_file) - elf_file.tlsAddress()
-                        else
-                            0;
-                        try writeInt(offset, elf_file, writer);
-                    }
+                    try writeInt(0, elf_file, writer);
+                    const offset: i64 = if (apply_relocs and !symbol.?.flags.import)
+                        symbol.?.address(.{}, elf_file) - elf_file.tlsAddress()
+                    else
+                        0;
+                    try writeInt(offset, elf_file, writer);
                 },
             }
         }
@@ -1505,9 +1500,9 @@ fn writeInt(value: anytype, elf_file: *Elf, writer: anytype) !void {
     const target = elf_file.getTarget();
     const endian = target.cpu.arch.endian();
     switch (entry_size) {
-        2 => try writer.writeInt(u16, @intCast(value), endian),
-        4 => try writer.writeInt(u32, @intCast(value), endian),
-        8 => try writer.writeInt(u64, @intCast(value), endian),
+        2 => try writer.writeInt(i16, @intCast(value), endian),
+        4 => try writer.writeInt(i32, @intCast(value), endian),
+        8 => try writer.writeInt(i64, value, endian),
         else => unreachable,
     }
 }

--- a/test/standalone/build.zig.zon
+++ b/test/standalone/build.zig.zon
@@ -208,6 +208,9 @@
         .run_cwd = .{
             .path = "run_cwd",
         },
+        .tsan = .{
+            .path = "tsan",
+        },
     },
     .paths = .{
         "build.zig",

--- a/test/standalone/tsan/build.zig
+++ b/test/standalone/tsan/build.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const test_step = b.step("test", "Test the program");
+    b.default_step = test_step;
+
+    const is_macos = b.graph.host.result.os.tag == .macos;
+
+    for ([_]struct { std.Target.Os.Tag, []const std.Target.Cpu.Arch }{
+        // .s390x and mips64(el) fail to build
+        .{ .linux, &.{ .aarch64, .aarch64_be, .loongarch64, .powerpc64, .powerpc64le, .riscv64, .x86_64 } },
+        .{ .macos, &.{ .x86_64, .aarch64 } },
+
+        // Missing system headers
+        // https://github.com/ziglang/zig/issues/24736
+        // .{ .freebsd, &.{ .aarch64, .powerpc64, .powerpc64le, .riscv64, .x86_64 } },
+        // https://github.com/ziglang/zig/issues/24737
+        // .{ .netbsd, &.{ .aarch64, .aarch64_be, .x86_64 } },
+
+        // TSan doesn't have full support for windows yet.
+        // .{ .windows, &.{ .aarch64, .x86_64 } },
+    }) |entry| {
+        switch (entry[0]) {
+            // compiling tsan on macos requires system headers that aren't present during cross-compilation
+            .macos => {
+                if (!is_macos) continue;
+                const target = b.resolveTargetQuery(.{});
+                const exe = b.addExecutable(.{
+                    .name = b.fmt("tsan_{s}_{s}", .{ @tagName(entry[0]), @tagName(target.result.cpu.arch) }),
+                    .root_module = b.createModule(.{
+                        .root_source_file = b.path("main.zig"),
+                        .target = target,
+                        .optimize = .Debug,
+                        .sanitize_thread = true,
+                    }),
+                });
+                const install_exe = b.addInstallArtifact(exe, .{});
+                test_step.dependOn(&install_exe.step);
+            },
+            else => for (entry[1]) |arch| {
+                const target = b.resolveTargetQuery(.{
+                    .os_tag = entry[0],
+                    .cpu_arch = arch,
+                });
+                const exe = b.addExecutable(.{
+                    .name = b.fmt("tsan_{s}_{s}", .{ @tagName(entry[0]), @tagName(arch) }),
+                    .root_module = b.createModule(.{
+                        .root_source_file = b.path("main.zig"),
+                        .target = target,
+                        .optimize = .Debug,
+                        .sanitize_thread = true,
+                    }),
+                });
+                const install_exe = b.addInstallArtifact(exe, .{});
+                test_step.dependOn(&install_exe.step);
+            },
+        }
+    }
+}

--- a/test/standalone/tsan/main.zig
+++ b/test/standalone/tsan/main.zig
@@ -1,0 +1,3 @@
+const std = @import("std");
+
+pub fn main() !void {}


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/137403
makes tsan build again for glibc after #24640 