### PR TITLE
optimize `@intCast` in ReleaseFast mode

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9271,16 +9271,16 @@ pub const FuncGen = struct {
                     const vec_ty = ok_maybe_vec.typeOfWip(&fg.wip);
                     break :ok try fg.wip.callIntrinsic(.normal, .none, .@"vector.reduce.and", &.{vec_ty}, &.{ok_maybe_vec}, "");
                 } else ok_maybe_vec;
-                const fail_block = try fg.wip.block(1, "IntMinFail");
-                const ok_block = try fg.wip.block(1, "IntMinOk");
-                _ = try fg.wip.brCond(ok, ok_block, fail_block, .none);
-                fg.wip.cursor = .{ .block = fail_block };
                 if (safety) {
+                    const fail_block = try fg.wip.block(1, "IntMinFail");
+                    const ok_block = try fg.wip.block(1, "IntMinOk");
+                    _ = try fg.wip.brCond(ok, ok_block, fail_block, .none);
+                    fg.wip.cursor = .{ .block = fail_block };
                     try fg.buildSimplePanic(panic_id);
+                    fg.wip.cursor = .{ .block = ok_block };
                 } else {
-                    _ = try fg.wip.@"unreachable"();
+                    _ = try fg.wip.callIntrinsic(.normal, .none, .assume, &.{}, &.{ok}, "");
                 }
-                fg.wip.cursor = .{ .block = ok_block };
             }
 
             if (have_max_check) {
@@ -9291,16 +9291,16 @@ pub const FuncGen = struct {
                     const vec_ty = ok_maybe_vec.typeOfWip(&fg.wip);
                     break :ok try fg.wip.callIntrinsic(.normal, .none, .@"vector.reduce.and", &.{vec_ty}, &.{ok_maybe_vec}, "");
                 } else ok_maybe_vec;
-                const fail_block = try fg.wip.block(1, "IntMaxFail");
-                const ok_block = try fg.wip.block(1, "IntMaxOk");
-                _ = try fg.wip.brCond(ok, ok_block, fail_block, .none);
-                fg.wip.cursor = .{ .block = fail_block };
                 if (safety) {
+                    const fail_block = try fg.wip.block(1, "IntMaxFail");
+                    const ok_block = try fg.wip.block(1, "IntMaxOk");
+                    _ = try fg.wip.brCond(ok, ok_block, fail_block, .none);
+                    fg.wip.cursor = .{ .block = fail_block };
                     try fg.buildSimplePanic(panic_id);
+                    fg.wip.cursor = .{ .block = ok_block };
                 } else {
-                    _ = try fg.wip.@"unreachable"();
+                    _ = try fg.wip.callIntrinsic(.normal, .none, .assume, &.{}, &.{ok}, "");
                 }
-                fg.wip.cursor = .{ .block = ok_block };
             }
         }
 


### PR DESCRIPTION
(probably) closes https://github.com/ziglang/zig/issues/11312

*Probably* because I haven't tested all backends, only C, llvm and self-hosted x86_64.

The described, unoptimized behaviour only occurred in the llvm backend, and there I fixed it by explicitly marking branches where the integer to be converted wouldn't fit as unreachable.