### PR TITLE
flate: Handle invalid block type

### DIFF
--- a/lib/std/compress/flate/Decompress.zig
+++ b/lib/std/compress/flate/Decompress.zig
@@ -32,6 +32,7 @@ const BlockType = enum(u2) {
     stored = 0,
     fixed = 1,
     dynamic = 2,
+    invalid = 3,
 };
 
 const State = union(enum) {
@@ -50,6 +51,7 @@ pub const Error = Container.Error || error{
     InvalidCode,
     InvalidMatch,
     WrongStoredBlockNlen,
+    InvalidBlockType,
     InvalidDynamicBlockHeader,
     ReadFailed,
     OversubscribedHuffmanTree,
@@ -361,6 +363,7 @@ fn streamInner(d: *Decompress, w: *Writer, limit: std.Io.Limit) (Error || Reader
 
                     continue :sw .dynamic_block;
                 },
+                .invalid => return error.InvalidBlockType,
             }
         },
         .stored_block => |remaining_len| {
@@ -1150,6 +1153,10 @@ test "puff03" {
 
 test "puff09" {
     try testDecompress(.raw, @embedFile("testdata/fuzz/puff09.input"), "P");
+}
+
+test "invalid block type" {
+    try testFailure(.raw, &[_]u8{0b110}, error.InvalidBlockType);
 }
 
 test "bug 18966" {


### PR DESCRIPTION
Fixes `panic: invalid enum value` when the type bits had the u2 value of 3.

Contributes towards #24741