### PR TITLE
intentionally breaking riscv

### DIFF
--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -222,6 +222,7 @@ fn _start() callconv(.naked) noreturn {
         \\ .option norelax
         \\ lla gp, __global_pointer$
         \\ .option pop
+        \\ intentionally breaking riscv more
     );
 
     // Note that we maintain a very low level of trust with regards to ABI guarantees at this point.


### PR DESCRIPTION
Testing triggering `riscv64-linux` CI via PR labels...