### PR TITLE
Io.Reader fix defaultReadVec

### DIFF
--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -426,7 +426,7 @@ pub fn readVec(r: *Reader, data: [][]u8) Error!usize {
 /// Writes to `Reader.buffer` or `data`, whichever has larger capacity.
 pub fn defaultReadVec(r: *Reader, data: [][]u8) Error!usize {
     const first = data[0];
-    if (r.seek == r.end and first.len >= r.buffer.len) {
+    if (first.len >= r.buffer.len - r.end) {
         var writer: Writer = .{
             .buffer = first,
             .end = 0,


### PR DESCRIPTION
Running tar.pipeToFileSystem compressed_mingw_includes.tar file from #24732 finishes in infinite loop calling defaultReadVec with: r.seek = 1024
r.end = 1024
r.buffer.len = 1024
first.len = 512
that combination calls vtable.stream with 0 capacity writer and loops forever.

Comment is to use whichever has larger capacity, and this fix reflects that.