### PR TITLE
docs(zon/stringify.zig): Added missing non-serializable type

### DIFF
--- a/lib/std/zon/stringify.zig
+++ b/lib/std/zon/stringify.zig
@@ -12,6 +12,7 @@
 //! * `noreturn`
 //! * Error sets/error unions
 //! * Untagged unions
+//! * Non-exhaustive enums
 //! * Many-pointers or C-pointers
 //! * Opaque types, including `anyopaque`
 //! * Async frame types, including `anyframe` and `anyframe->T`


### PR DESCRIPTION
Simple change to `std.zon.stringify.zig` to document that non-exhaustive enums are not serializable.

Non-exhaustive enums are marked not serializable here:
https://github.com/ziglang/zig/blob/14f11377cbcc4ff2da75e3dee9bb1d9e06013de1/lib/std/zon/Serializer.zig#L849
