### PR TITLE
std.c: Remove serenity's internet_checksum() function

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -11263,7 +11263,6 @@ pub const serenity_readlink = serenity.serenity_readlink;
 pub const serenity_open = serenity.serenity_open;
 pub const getkeymap = serenity.getkeymap;
 pub const setkeymap = serenity.setkeymap;
-pub const internet_checksum = serenity.internet_checksum;
 
 /// External definitions shared by two or more operating systems.
 const private = struct {

--- a/lib/std/c/serenity.zig
+++ b/lib/std/c/serenity.zig
@@ -71,5 +71,3 @@ pub extern "c" fn serenity_open(path: [*]const u8, path_length: usize, options: 
 
 pub extern "c" fn getkeymap(name_buffer: [*]u8, name_buffer_size: usize, map: [*]u32, shift_map: [*]u32, alt_map: [*]u32, altgr_map: [*]u32, shift_altgr_map: [*]u32) c_int;
 pub extern "c" fn setkeymap(name: [*]const u8, map: [*]const u32, shift_map: [*]const u32, alt_map: [*]const u32, altgr_map: [*]const u32, shift_altgr_map: [*]const u32) c_int;
-
-pub extern "c" fn internet_checksum(ptr: *const anyopaque, count: usize) u16;


### PR DESCRIPTION
See: https://github.com/SerenityOS/serenity/commit/59911d8da3da36aefd2d4902a0fdfc21e1f6f8ac