### PR TITLE
re-enable std.math.modf vector tests

### DIFF
--- a/lib/std/math/modf.zig
+++ b/lib/std/math/modf.zig
@@ -1,4 +1,5 @@
 const std = @import("../std.zig");
+const builtin = @import("builtin");
 const math = std.math;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
@@ -84,6 +85,8 @@ fn ModfTests(comptime T: type) type {
             try expectApproxEqAbs(expected_c, r.fpart, epsilon);
         }
         test "vector" {
+            if (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64) return error.SkipZigTest;
+
             const widths = [_]comptime_int{ 1, 2, 3, 4, 8, 16 };
 
             inline for (widths) |len| {

--- a/lib/std/math/modf.zig
+++ b/lib/std/math/modf.zig
@@ -84,18 +84,7 @@ fn ModfTests(comptime T: type) type {
             try expectApproxEqAbs(expected_c, r.fpart, epsilon);
         }
         test "vector" {
-            // Currently, a compiler bug is breaking the usage
-            // of @trunc on @Vector types
-
-            // TODO: Repopulate the below array and
-            // remove the skip statement once this
-            // bug is fixed
-
-            // const widths = [_]comptime_int{ 1, 2, 3, 4, 8, 16 };
-            const widths = [_]comptime_int{};
-
-            if (widths.len == 0)
-                return error.SkipZigTest;
+            const widths = [_]comptime_int{ 1, 2, 3, 4, 8, 16 };
 
             inline for (widths) |len| {
                 const V: type = @Vector(len, T);

--- a/lib/std/math/modf.zig
+++ b/lib/std/math/modf.zig
@@ -86,6 +86,7 @@ fn ModfTests(comptime T: type) type {
         }
         test "vector" {
             if (builtin.os.tag == .macos and builtin.cpu.arch == .aarch64) return error.SkipZigTest;
+            if (builtin.cpu.arch == .s390x) return error.SkipZigTest;
 
             const widths = [_]comptime_int{ 1, 2, 3, 4, 8, 16 };
 


### PR DESCRIPTION
Whatever the compiler bug that prevented the usage of `@trunc()` on `@Vector()` types was, I don't think it exists anymore.

Tested with `stage4/bin/zig build test-std -Dskip-non-native` on x86_64 linux.