### PR TITLE
fix(fmt): return correct exit code for `zig fmt --stdin --check`

### DIFF
--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -148,7 +148,7 @@ pub fn run(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
         defer gpa.free(formatted);
 
         if (check_flag) {
-            const code: u8 = @intFromBool(mem.eql(u8, formatted, source_code));
+            const code: u8 = @intFromBool(!mem.eql(u8, formatted, source_code));
             process.exit(code);
         }
 


### PR DESCRIPTION
- Closes #24795

Tested locally:

```
❯ cat foo.zig
pub fn main() !void {

}

[lillis@cachyos-x8664] ~/projects/foo
❯ cat foo.zig | /home/lillis/projects/zig/build/stage4/bin/zig fmt --stdin --check

[lillis@cachyos-x8664] ~/projects/foo
❯ echo $?                                                                                                                                                   ⏎
1

[lillis@cachyos-x8664] ~/projects/foo
❯ zig fmt foo.zig
foo.zig

[lillis@cachyos-x8664] ~/projects/foo
❯ cat foo.zig | /home/lillis/projects/zig/build/stage4/bin/zig fmt --stdin --check

[lillis@cachyos-x8664] ~/projects/foo
❯ echo $?
0
```