### PR TITLE
lib/init: move the fingerprint comment above it

### DIFF
--- a/lib/init/build.zig.zon
+++ b/lib/init/build.zig.zon
@@ -22,7 +22,8 @@
     // original project's identity. Thus it is recommended to leave the comment
     // on the following line intact, so that it shows up in code reviews that
     // modify the field.
-    .fingerprint = .FINGERPRINT, // Changing this has security and trust implications.
+    // Changing this has security and trust implications.
+    .fingerprint = .FINGERPRINT,
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
     .minimum_zig_version = "_ZIGVER",


### PR DESCRIPTION
previously it was possible to clean up the generated files by selecting all lines with `//` in them and deleting. by having a comment at the end of such an important line, that workflow is destroyed so this patch restores it.