### PR TITLE
std.crypto.aegis: Absorb ad instead of encrypting it.

### DIFF
--- a/lib/std/crypto/aegis.zig
+++ b/lib/std/crypto/aegis.zig
@@ -585,12 +585,12 @@ fn Aegis256XGeneric(comptime degree: u7, comptime tag_bits: u9) type {
             var dst: [block_length]u8 align(alignment) = undefined;
             var i: usize = 0;
             while (i + block_length <= ad.len) : (i += block_length) {
-                state.enc(&dst, ad[i..][0..block_length]);
+                state.absorb(ad[i..][0..block_length]);
             }
             if (ad.len % block_length != 0) {
                 @memset(src[0..], 0);
                 @memcpy(src[0 .. ad.len % block_length], ad[i..][0 .. ad.len % block_length]);
-                state.enc(&dst, &src);
+                state.absorb(&src);
             }
             i = 0;
             while (i + block_length <= m.len) : (i += block_length) {


### PR DESCRIPTION
`Aegis256XGeneric` behaves differently than `Aegis128XGeneric` in that it currently encrypts associated data instead of just absorbing it. Even though the end result is the same, there's no point in encrypting and copying the ad into a buffer that gets overwritten anyway. This fix makes `Aegis256XGeneric` behave the same as `Aegis128XGeneric`.