### PR TITLE
http: fix handling of limit in chunkedSendFile

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -868,6 +868,8 @@ pub fn sendFile(w: *Writer, file_reader: *File.Reader, limit: Limit) FileError!u
 }
 
 /// Returns how many bytes from `header` and `file_reader` were consumed.
+///
+/// `limit` only applies to `file_reader`.
 pub fn sendFileHeader(
     w: *Writer,
     header: []const u8,
@@ -882,7 +884,7 @@ pub fn sendFileHeader(
     }
     const buffered_contents = limit.slice(file_reader.interface.buffered());
     const n = try w.vtable.drain(w, &.{ header, buffered_contents }, 1);
-    file_reader.interface.toss(n - header.len);
+    file_reader.interface.toss(n -| header.len);
     return n;
 }
 


### PR DESCRIPTION
Progresses #24760

`limit` in chunkedSendFile applies only to the file, not the entire chunk. `limit` in sendFileHeader does not include the header.
    
Additionally adds a comment to clarify what `limit` applies to in sendFileHeader and fixed a small bug in it (`drain` is able to return less then `header.len`).