### PR TITLE
`std.Target`: bump default android API level from 24 to 29

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -482,7 +482,7 @@ pub const Os = struct {
 
                             break :blk default_min;
                         },
-                        .android = 24,
+                        .android = 29,
                     },
                 },
                 .rtems => .{


### PR DESCRIPTION
According to https://apilevels.com, 88.5% of Android users are on 29+. Older API levels require libc as of https://github.com/ziglang/zig/pull/24629, which has confused some users. Seems reasonable to bump the default so most people won't be confused by this.