### PR TITLE
Fix std.math.rot(l|r) for vectors of u0-s

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -693,7 +693,7 @@ test shr {
 pub fn rotr(comptime T: type, x: T, r: anytype) T {
     if (@typeInfo(T) == .vector) {
         const C = @typeInfo(T).vector.child;
-        if (C == u0) return 0;
+        if (C == u0) return @splat(0);
 
         if (@typeInfo(C).int.signedness == .signed) {
             @compileError("cannot rotate signed integers");
@@ -725,8 +725,10 @@ test rotr {
     try testing.expect(rotr(u8, 0b00000001, @as(usize, 4)) == 0b00010000);
     try testing.expect(rotr(u8, 0b00000001, @as(isize, -1)) == 0b00000010);
     try testing.expect(rotr(u12, 0o7777, 1) == 0o7777);
-    try testing.expect(rotr(@Vector(1, u32), @Vector(1, u32){1}, @as(usize, 1))[0] == @as(u32, 1) << 31);
-    try testing.expect(rotr(@Vector(1, u32), @Vector(1, u32){1}, @as(isize, -1))[0] == @as(u32, 1) << 1);
+    try testing.expect(rotr(@Vector(1, u32), .{1}, @as(usize, 1))[0] == @as(u32, 1) << 31);
+    try testing.expect(rotr(@Vector(1, u32), .{1}, @as(isize, -1))[0] == @as(u32, 1) << 1);
+    try std.testing.expect(@reduce(.And, rotr(@Vector(2, u0), .{ 0, 0 }, @as(usize, 42)) ==
+        @Vector(2, u0){ 0, 0 }));
 }
 
 /// Rotates left. Only unsigned values can be rotated.  Negative shift
@@ -734,7 +736,7 @@ test rotr {
 pub fn rotl(comptime T: type, x: T, r: anytype) T {
     if (@typeInfo(T) == .vector) {
         const C = @typeInfo(T).vector.child;
-        if (C == u0) return 0;
+        if (C == u0) return @splat(0);
 
         if (@typeInfo(C).int.signedness == .signed) {
             @compileError("cannot rotate signed integers");
@@ -766,8 +768,10 @@ test rotl {
     try testing.expect(rotl(u8, 0b00000001, @as(usize, 4)) == 0b00010000);
     try testing.expect(rotl(u8, 0b00000001, @as(isize, -1)) == 0b10000000);
     try testing.expect(rotl(u12, 0o7777, 1) == 0o7777);
-    try testing.expect(rotl(@Vector(1, u32), @Vector(1, u32){1 << 31}, @as(usize, 1))[0] == 1);
-    try testing.expect(rotl(@Vector(1, u32), @Vector(1, u32){1 << 31}, @as(isize, -1))[0] == @as(u32, 1) << 30);
+    try testing.expect(rotl(@Vector(1, u32), .{1 << 31}, @as(usize, 1))[0] == 1);
+    try testing.expect(rotl(@Vector(1, u32), .{1 << 31}, @as(isize, -1))[0] == @as(u32, 1) << 30);
+    try std.testing.expect(@reduce(.And, rotl(@Vector(2, u0), .{ 0, 0 }, @as(usize, 42)) ==
+        @Vector(2, u0){ 0, 0 }));
 }
 
 /// Returns an unsigned int type that can hold the number of bits in T - 1.


### PR DESCRIPTION
A missed `@splat` in the implementations of `std.math.rotl` and `std.math.rotr` caused a compilation error when calling them with `@Vector(_, u0)` - it is now fixed.