### PR TITLE
std.io.Writer.Allocating: rename getWritten() to written()

### DIFF
--- a/lib/docs/wasm/Walk.zig
+++ b/lib/docs/wasm/Walk.zig
@@ -443,7 +443,7 @@ fn parse(file_name: []const u8, source: []u8) Oom!Ast {
                 error.WriteFailed => return error.OutOfMemory,
             };
             log.err("{s}:{d}:{d}: {s}", .{
-                file_name, err_loc.line + 1, err_loc.column + 1, rendered_err.getWritten(),
+                file_name, err_loc.line + 1, err_loc.column + 1, rendered_err.written(),
             });
         }
         return Ast.parse(gpa, "", .zig);

--- a/lib/std/Build/Step/ConfigHeader.zig
+++ b/lib/std/Build/Step/ConfigHeader.zig
@@ -239,7 +239,7 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
         },
     }
 
-    const output = aw.getWritten();
+    const output = aw.written();
     man.hash.addBytes(output);
 
     if (try step.cacheHit(&man)) {
@@ -347,10 +347,10 @@ fn render_autoconf_at(
     while (line_it.next()) |line| : (line_index += 1) {
         const last_line = line_it.index == line_it.buffer.len;
 
-        const old_len = aw.getWritten().len;
+        const old_len = aw.written().len;
         expand_variables_autoconf_at(bw, line, values, used) catch |err| switch (err) {
             error.MissingValue => {
-                const name = aw.getWritten()[old_len..];
+                const name = aw.written()[old_len..];
                 defer aw.shrinkRetainingCapacity(old_len);
                 try step.addError("{s}:{d}: error: unspecified config header value: '{s}'", .{
                     src_path, line_index + 1, name,
@@ -763,7 +763,7 @@ fn testReplaceVariablesAutoconfAt(
     try expand_variables_autoconf_at(&aw.writer, contents, values, used);
 
     for (used) |u| if (!u) return error.UnusedValue;
-    try std.testing.expectEqualStrings(expected, aw.getWritten());
+    try std.testing.expectEqualStrings(expected, aw.written());
 }
 
 fn testReplaceVariablesCMake(

--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -2557,7 +2557,7 @@ pub const Allocating = struct {
         return list.toOwnedSliceSentinel(gpa, sentinel);
     }
 
-    pub fn getWritten(a: *Allocating) []u8 {
+    pub fn written(a: *Allocating) []u8 {
         return a.writer.buffered();
     }
 
@@ -2624,7 +2624,7 @@ pub const Allocating = struct {
         const y: i32 = 1234;
         try w.print("x: {}\ny: {}\n", .{ x, y });
 
-        try testing.expectEqualSlices(u8, "x: 42\ny: 1234\n", a.getWritten());
+        try testing.expectEqualSlices(u8, "x: 42\ny: 1234\n", a.written());
     }
 };
 

--- a/lib/std/compress/flate/Decompress.zig
+++ b/lib/std/compress/flate/Decompress.zig
@@ -1272,5 +1272,5 @@ fn testDecompress(container: Container, compressed: []const u8, expected_plain: 
     var decompress: Decompress = .init(&in, container, &.{});
     const decompressed_len = try decompress.reader.streamRemaining(&aw.writer);
     try testing.expectEqual(expected_plain.len, decompressed_len);
-    try testing.expectEqualSlices(u8, expected_plain, aw.getWritten());
+    try testing.expectEqualSlices(u8, expected_plain, aw.written());
 }

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -318,7 +318,7 @@ test dumpHexFallible {
         @sizeOf(usize) * 2,
     });
     defer std.testing.allocator.free(expected);
-    try std.testing.expectEqualStrings(expected, aw.getWritten());
+    try std.testing.expectEqualStrings(expected, aw.written());
 }
 
 /// Tries to print the current stack trace to stderr, unbuffered, and ignores any error returned.
@@ -1258,7 +1258,7 @@ test printLineFromFileAnyOs {
         try expectError(error.EndOfFile, printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 }));
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings("no new lines in this file, but one is printed anyway\n", aw.getWritten());
+        try expectEqualStrings("no new lines in this file, but one is printed anyway\n", aw.written());
         aw.clearRetainingCapacity();
     }
     {
@@ -1274,11 +1274,11 @@ test printLineFromFileAnyOs {
         });
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings("1\n", aw.getWritten());
+        try expectEqualStrings("1\n", aw.written());
         aw.clearRetainingCapacity();
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 3, .column = 0 });
-        try expectEqualStrings("3\n", aw.getWritten());
+        try expectEqualStrings("3\n", aw.written());
         aw.clearRetainingCapacity();
     }
     {
@@ -1297,7 +1297,7 @@ test printLineFromFileAnyOs {
         try writer.flush();
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 });
-        try expectEqualStrings(("a" ** overlap) ++ "\n", aw.getWritten());
+        try expectEqualStrings(("a" ** overlap) ++ "\n", aw.written());
         aw.clearRetainingCapacity();
     }
     {
@@ -1311,7 +1311,7 @@ test printLineFromFileAnyOs {
         try writer.splatByteAll('a', std.heap.page_size_max);
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings(("a" ** std.heap.page_size_max) ++ "\n", aw.getWritten());
+        try expectEqualStrings(("a" ** std.heap.page_size_max) ++ "\n", aw.written());
         aw.clearRetainingCapacity();
     }
     {
@@ -1327,17 +1327,17 @@ test printLineFromFileAnyOs {
         try expectError(error.EndOfFile, printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 }));
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings(("a" ** (3 * std.heap.page_size_max)) ++ "\n", aw.getWritten());
+        try expectEqualStrings(("a" ** (3 * std.heap.page_size_max)) ++ "\n", aw.written());
         aw.clearRetainingCapacity();
 
         try writer.writeAll("a\na");
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 1, .column = 0 });
-        try expectEqualStrings(("a" ** (3 * std.heap.page_size_max)) ++ "a\n", aw.getWritten());
+        try expectEqualStrings(("a" ** (3 * std.heap.page_size_max)) ++ "a\n", aw.written());
         aw.clearRetainingCapacity();
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = 2, .column = 0 });
-        try expectEqualStrings("a\n", aw.getWritten());
+        try expectEqualStrings("a\n", aw.written());
         aw.clearRetainingCapacity();
     }
     {
@@ -1353,11 +1353,11 @@ test printLineFromFileAnyOs {
         try writer.writeAll("abc\ndef");
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = real_file_start + 1, .column = 0 });
-        try expectEqualStrings("abc\n", aw.getWritten());
+        try expectEqualStrings("abc\n", aw.written());
         aw.clearRetainingCapacity();
 
         try printLineFromFileAnyOs(output_stream, .{ .file_name = path, .line = real_file_start + 2, .column = 0 });
-        try expectEqualStrings("def\n", aw.getWritten());
+        try expectEqualStrings("def\n", aw.written());
         aw.clearRetainingCapacity();
     }
 }

--- a/lib/std/http/test.zig
+++ b/lib/std/http/test.zig
@@ -1020,7 +1020,7 @@ fn echoTests(client: *http.Client, port: u16) !void {
             .response_writer = &body.writer,
         });
         try expectEqual(.ok, res.status);
-        try expectEqualStrings("Hello, World!\n", body.getWritten());
+        try expectEqualStrings("Hello, World!\n", body.written());
     }
 
     { // expect: 100-continue

--- a/lib/std/json.zig
+++ b/lib/std/json.zig
@@ -57,7 +57,7 @@ test Stringify {
         \\  "foo": 123
         \\}
     ;
-    try testing.expectEqualSlices(u8, expected, out.getWritten());
+    try testing.expectEqualSlices(u8, expected, out.written());
 }
 
 pub const ObjectMap = @import("json/dynamic.zig").ObjectMap;

--- a/lib/std/json/Stringify.zig
+++ b/lib/std/json/Stringify.zig
@@ -582,7 +582,7 @@ test value {
 
     const T = struct { a: i32, b: []const u8 };
     try value(T{ .a = 123, .b = "xy" }, .{}, writer);
-    try std.testing.expectEqualSlices(u8, "{\"a\":123,\"b\":\"xy\"}", out.getWritten());
+    try std.testing.expectEqualSlices(u8, "{\"a\":123,\"b\":\"xy\"}", out.written());
 
     try testStringify("9999999999999999", 9999999999999999, .{});
     try testStringify("\"9999999999999999\"", 9999999999999999, .{ .emit_nonportable_numbers_as_strings = true });

--- a/lib/std/tar/Writer.zig
+++ b/lib/std/tar/Writer.zig
@@ -403,7 +403,7 @@ test "write files" {
         for (files) |file|
             try w.writeFileBytes(file.path, file.content, .{});
 
-        var input: std.Io.Reader = .fixed(output.getWritten());
+        var input: std.Io.Reader = .fixed(output.written());
         var it: std.tar.Iterator = .init(&input, .{
             .file_name_buffer = &file_name_buffer,
             .link_name_buffer = &link_name_buffer,
@@ -427,7 +427,7 @@ test "write files" {
             var content: std.Io.Writer.Allocating = .init(testing.allocator);
             defer content.deinit();
             try it.streamRemaining(actual, &content.writer);
-            try testing.expectEqualSlices(u8, expected.content, content.getWritten());
+            try testing.expectEqualSlices(u8, expected.content, content.written());
         }
     }
     // without root
@@ -440,7 +440,7 @@ test "write files" {
             try w.writeFileStream(file.path, file.content.len, &content, .{});
         }
 
-        var input: std.Io.Reader = .fixed(output.getWritten());
+        var input: std.Io.Reader = .fixed(output.written());
         var it: std.tar.Iterator = .init(&input, .{
             .file_name_buffer = &file_name_buffer,
             .link_name_buffer = &link_name_buffer,
@@ -455,7 +455,7 @@ test "write files" {
             var content: std.Io.Writer.Allocating = .init(testing.allocator);
             defer content.deinit();
             try it.streamRemaining(actual, &content.writer);
-            try testing.expectEqualSlices(u8, expected.content, content.getWritten());
+            try testing.expectEqualSlices(u8, expected.content, content.written());
         }
         try w.finishPedantically();
     }

--- a/lib/std/tar/test.zig
+++ b/lib/std/tar/test.zig
@@ -361,7 +361,7 @@ fn testCase(case: Case) !void {
             var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
             defer aw.deinit();
             try it.streamRemaining(actual, &aw.writer);
-            const chksum = std.fmt.bytesToHex(std.crypto.hash.Md5.hashResult(aw.getWritten()), .lower);
+            const chksum = std.fmt.bytesToHex(std.crypto.hash.Md5.hashResult(aw.written()), .lower);
             try testing.expectEqualStrings(case.chksums[i], &chksum);
         } else {
             if (expected.truncated) {

--- a/lib/std/zig/Ast/Render.zig
+++ b/lib/std/zig/Ast/Render.zig
@@ -2189,12 +2189,12 @@ fn renderArrayInit(
         var single_line = true;
         var contains_newline = false;
         for (section_exprs, 0..) |expr, i| {
-            const start = sub_expr_buffer.getWritten().len;
+            const start = sub_expr_buffer.written().len;
             sub_expr_buffer_starts[i] = start;
 
             if (i + 1 < section_exprs.len) {
                 try renderExpression(&sub_render, expr, .none);
-                const written = sub_expr_buffer.getWritten();
+                const written = sub_expr_buffer.written();
                 const width = written.len - start;
                 const this_contains_newline = mem.indexOfScalar(u8, written[start..], '\n') != null;
                 contains_newline = contains_newline or this_contains_newline;
@@ -2218,7 +2218,7 @@ fn renderArrayInit(
                 try renderExpression(&sub_render, expr, .comma);
                 ais.popSpace();
 
-                const written = sub_expr_buffer.getWritten();
+                const written = sub_expr_buffer.written();
                 const width = written.len - start - 2;
                 const this_contains_newline = mem.indexOfScalar(u8, written[start .. written.len - 1], '\n') != null;
                 contains_newline = contains_newline or this_contains_newline;
@@ -2231,14 +2231,14 @@ fn renderArrayInit(
                 }
             }
         }
-        sub_expr_buffer_starts[section_exprs.len] = sub_expr_buffer.getWritten().len;
+        sub_expr_buffer_starts[section_exprs.len] = sub_expr_buffer.written().len;
 
         // Render exprs in current section.
         column_counter = 0;
         for (section_exprs, 0..) |expr, i| {
             const start = sub_expr_buffer_starts[i];
             const end = sub_expr_buffer_starts[i + 1];
-            const expr_text = sub_expr_buffer.getWritten()[start..end];
+            const expr_text = sub_expr_buffer.written()[start..end];
             if (!expr_newlines[i]) {
                 try ais.writeAll(expr_text);
             } else {

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -13765,19 +13765,19 @@ fn lowerAstErrors(astgen: *AstGen) error{OutOfMemory}!void {
         };
         msg.clearRetainingCapacity();
         tree.renderError(ast_err, msg_w) catch return error.OutOfMemory;
-        return try astgen.appendErrorTokNotesOff(tok, bad_off, "{s}", .{msg.getWritten()}, notes.items);
+        return try astgen.appendErrorTokNotesOff(tok, bad_off, "{s}", .{msg.written()}, notes.items);
     }
 
     var cur_err = tree.errors[0];
     for (tree.errors[1..]) |err| {
         if (err.is_note) {
             tree.renderError(err, msg_w) catch return error.OutOfMemory;
-            try notes.append(gpa, try astgen.errNoteTok(err.token, "{s}", .{msg.getWritten()}));
+            try notes.append(gpa, try astgen.errNoteTok(err.token, "{s}", .{msg.written()}));
         } else {
             // Flush error
             const extra_offset = tree.errorOffset(cur_err);
             tree.renderError(cur_err, msg_w) catch return error.OutOfMemory;
-            try astgen.appendErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.getWritten()}, notes.items);
+            try astgen.appendErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.written()}, notes.items);
             notes.clearRetainingCapacity();
             cur_err = err;
 
@@ -13791,7 +13791,7 @@ fn lowerAstErrors(astgen: *AstGen) error{OutOfMemory}!void {
     // Flush error
     const extra_offset = tree.errorOffset(cur_err);
     tree.renderError(cur_err, msg_w) catch return error.OutOfMemory;
-    try astgen.appendErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.getWritten()}, notes.items);
+    try astgen.appendErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.written()}, notes.items);
 }
 
 const DeclarationName = union(enum) {

--- a/lib/std/zig/ErrorBundle.zig
+++ b/lib/std/zig/ErrorBundle.zig
@@ -817,6 +817,6 @@ pub const Wip = struct {
         defer copy_buf.deinit();
         try copy.renderToWriter(.{ .ttyconf = ttyconf }, copy_bw);
 
-        try std.testing.expectEqualStrings(bundle_bw.getWritten(), copy_bw.getWritten());
+        try std.testing.expectEqualStrings(bundle_bw.written(), copy_bw.written());
     }
 };

--- a/lib/std/zig/ZonGen.zig
+++ b/lib/std/zig/ZonGen.zig
@@ -896,12 +896,12 @@ fn lowerAstErrors(zg: *ZonGen) Allocator.Error!void {
     for (tree.errors[1..]) |err| {
         if (err.is_note) {
             tree.renderError(err, msg_bw) catch return error.OutOfMemory;
-            try notes.append(gpa, try zg.errNoteTok(err.token, "{s}", .{msg.getWritten()}));
+            try notes.append(gpa, try zg.errNoteTok(err.token, "{s}", .{msg.written()}));
         } else {
             // Flush error
             tree.renderError(cur_err, msg_bw) catch return error.OutOfMemory;
             const extra_offset = tree.errorOffset(cur_err);
-            try zg.addErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.getWritten()}, notes.items);
+            try zg.addErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.written()}, notes.items);
             notes.clearRetainingCapacity();
             cur_err = err;
 
@@ -917,5 +917,5 @@ fn lowerAstErrors(zg: *ZonGen) Allocator.Error!void {
     // Flush error
     const extra_offset = tree.errorOffset(cur_err);
     tree.renderError(cur_err, msg_bw) catch return error.OutOfMemory;
-    try zg.addErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.getWritten()}, notes.items);
+    try zg.addErrorTokNotesOff(cur_err.token, extra_offset, "{s}", .{msg.written()}, notes.items);
 }

--- a/lib/std/zon/stringify.zig
+++ b/lib/std/zon/stringify.zig
@@ -125,7 +125,7 @@ fn expectSerializeEqual(
     defer aw.deinit();
 
     try serialize(value, options, bw);
-    try std.testing.expectEqualStrings(expected, aw.getWritten());
+    try std.testing.expectEqualStrings(expected, aw.written());
 }
 
 test "std.zon stringify whitespace, high level API" {
@@ -233,42 +233,42 @@ test "std.zon stringify whitespace, low level API" {
         {
             var container = try s.beginStruct(.{});
             try container.end();
-            try std.testing.expectEqualStrings(".{}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{}", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             var container = try s.beginTuple(.{});
             try container.end();
-            try std.testing.expectEqualStrings(".{}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{}", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             var container = try s.beginStruct(.{ .whitespace_style = .{ .wrap = false } });
             try container.end();
-            try std.testing.expectEqualStrings(".{}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{}", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             var container = try s.beginTuple(.{ .whitespace_style = .{ .wrap = false } });
             try container.end();
-            try std.testing.expectEqualStrings(".{}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{}", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             var container = try s.beginStruct(.{ .whitespace_style = .{ .fields = 0 } });
             try container.end();
-            try std.testing.expectEqualStrings(".{}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{}", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             var container = try s.beginTuple(.{ .whitespace_style = .{ .fields = 0 } });
             try container.end();
-            try std.testing.expectEqualStrings(".{}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{}", aw.written());
             aw.clearRetainingCapacity();
         }
 
@@ -282,9 +282,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\.{
                     \\    .a = 1,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -298,9 +298,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\.{
                     \\    1,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -310,9 +310,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field("a", 1, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ .a = 1 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ .a = 1 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -324,9 +324,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field(1, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ 1 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ 1 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -336,9 +336,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field("a", 1, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ .a = 1 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ .a = 1 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -347,7 +347,7 @@ test "std.zon stringify whitespace, low level API" {
             var container = try s.beginTuple(.{ .whitespace_style = .{ .fields = 1 } });
             try container.field(1, .{});
             try container.end();
-            try std.testing.expectEqualStrings(".{1}", aw.getWritten());
+            try std.testing.expectEqualStrings(".{1}", aw.written());
             aw.clearRetainingCapacity();
         }
 
@@ -363,9 +363,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\    .a = 1,
                     \\    .b = 2,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1,.b=2}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1,.b=2}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -381,9 +381,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\    1,
                     \\    2,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1,2}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1,2}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -394,9 +394,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field("b", 2, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ .a = 1, .b = 2 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ .a = 1, .b = 2 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1,.b=2}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1,.b=2}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -407,9 +407,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field(2, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ 1, 2 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ 1, 2 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1,2}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1,2}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -420,9 +420,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field("b", 2, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ .a = 1, .b = 2 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ .a = 1, .b = 2 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1,.b=2}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1,.b=2}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -433,9 +433,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field(2, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ 1, 2 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ 1, 2 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1,2}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1,2}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -454,9 +454,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\    .b = 2,
                     \\    .c = 3,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1,.b=2,.c=3}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1,.b=2,.c=3}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -474,9 +474,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\    2,
                     \\    3,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1,2,3}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1,2,3}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -488,9 +488,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field("c", 3, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ .a = 1, .b = 2, .c = 3 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ .a = 1, .b = 2, .c = 3 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1,.b=2,.c=3}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1,.b=2,.c=3}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -502,9 +502,9 @@ test "std.zon stringify whitespace, low level API" {
             try container.field(3, .{});
             try container.end();
             if (whitespace) {
-                try std.testing.expectEqualStrings(".{ 1, 2, 3 }", aw.getWritten());
+                try std.testing.expectEqualStrings(".{ 1, 2, 3 }", aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1,2,3}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1,2,3}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -522,9 +522,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\    .b = 2,
                     \\    .c = 3,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{.a=1,.b=2,.c=3}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{.a=1,.b=2,.c=3}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -542,9 +542,9 @@ test "std.zon stringify whitespace, low level API" {
                     \\    2,
                     \\    3,
                     \\}
-                , aw.getWritten());
+                , aw.written());
             } else {
-                try std.testing.expectEqualStrings(".{1,2,3}", aw.getWritten());
+                try std.testing.expectEqualStrings(".{1,2,3}", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -566,11 +566,11 @@ test "std.zon stringify whitespace, low level API" {
                     \\    5,
                     \\    6,
                     \\} }
-                , aw.getWritten());
+                , aw.written());
             } else {
                 try std.testing.expectEqualStrings(
                     ".{.first=.{1,2,3},.second=.{4,5,6}}",
-                    aw.getWritten(),
+                    aw.written(),
                 );
             }
             aw.clearRetainingCapacity();
@@ -585,108 +585,108 @@ test "std.zon stringify utf8 codepoints" {
 
     // Printable ASCII
     try s.int('a');
-    try std.testing.expectEqualStrings("97", aw.getWritten());
+    try std.testing.expectEqualStrings("97", aw.written());
     aw.clearRetainingCapacity();
 
     try s.codePoint('a');
-    try std.testing.expectEqualStrings("'a'", aw.getWritten());
+    try std.testing.expectEqualStrings("'a'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('a', .{ .emit_codepoint_literals = .always });
-    try std.testing.expectEqualStrings("'a'", aw.getWritten());
+    try std.testing.expectEqualStrings("'a'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('a', .{ .emit_codepoint_literals = .printable_ascii });
-    try std.testing.expectEqualStrings("'a'", aw.getWritten());
+    try std.testing.expectEqualStrings("'a'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('a', .{ .emit_codepoint_literals = .never });
-    try std.testing.expectEqualStrings("97", aw.getWritten());
+    try std.testing.expectEqualStrings("97", aw.written());
     aw.clearRetainingCapacity();
 
     // Short escaped codepoint
     try s.int('\n');
-    try std.testing.expectEqualStrings("10", aw.getWritten());
+    try std.testing.expectEqualStrings("10", aw.written());
     aw.clearRetainingCapacity();
 
     try s.codePoint('\n');
-    try std.testing.expectEqualStrings("'\\n'", aw.getWritten());
+    try std.testing.expectEqualStrings("'\\n'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('\n', .{ .emit_codepoint_literals = .always });
-    try std.testing.expectEqualStrings("'\\n'", aw.getWritten());
+    try std.testing.expectEqualStrings("'\\n'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('\n', .{ .emit_codepoint_literals = .printable_ascii });
-    try std.testing.expectEqualStrings("10", aw.getWritten());
+    try std.testing.expectEqualStrings("10", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('\n', .{ .emit_codepoint_literals = .never });
-    try std.testing.expectEqualStrings("10", aw.getWritten());
+    try std.testing.expectEqualStrings("10", aw.written());
     aw.clearRetainingCapacity();
 
     // Large codepoint
     try s.int('⚡');
-    try std.testing.expectEqualStrings("9889", aw.getWritten());
+    try std.testing.expectEqualStrings("9889", aw.written());
     aw.clearRetainingCapacity();
 
     try s.codePoint('⚡');
-    try std.testing.expectEqualStrings("'\\u{26a1}'", aw.getWritten());
+    try std.testing.expectEqualStrings("'\\u{26a1}'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('⚡', .{ .emit_codepoint_literals = .always });
-    try std.testing.expectEqualStrings("'\\u{26a1}'", aw.getWritten());
+    try std.testing.expectEqualStrings("'\\u{26a1}'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('⚡', .{ .emit_codepoint_literals = .printable_ascii });
-    try std.testing.expectEqualStrings("9889", aw.getWritten());
+    try std.testing.expectEqualStrings("9889", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value('⚡', .{ .emit_codepoint_literals = .never });
-    try std.testing.expectEqualStrings("9889", aw.getWritten());
+    try std.testing.expectEqualStrings("9889", aw.written());
     aw.clearRetainingCapacity();
 
     // Invalid codepoint
     try s.codePoint(0x110000 + 1);
-    try std.testing.expectEqualStrings("'\\u{110001}'", aw.getWritten());
+    try std.testing.expectEqualStrings("'\\u{110001}'", aw.written());
     aw.clearRetainingCapacity();
 
     try s.int(0x110000 + 1);
-    try std.testing.expectEqualStrings("1114113", aw.getWritten());
+    try std.testing.expectEqualStrings("1114113", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(0x110000 + 1, .{ .emit_codepoint_literals = .always });
-    try std.testing.expectEqualStrings("1114113", aw.getWritten());
+    try std.testing.expectEqualStrings("1114113", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(0x110000 + 1, .{ .emit_codepoint_literals = .printable_ascii });
-    try std.testing.expectEqualStrings("1114113", aw.getWritten());
+    try std.testing.expectEqualStrings("1114113", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(0x110000 + 1, .{ .emit_codepoint_literals = .never });
-    try std.testing.expectEqualStrings("1114113", aw.getWritten());
+    try std.testing.expectEqualStrings("1114113", aw.written());
     aw.clearRetainingCapacity();
 
     // Valid codepoint, not a codepoint type
     try s.value(@as(u22, 'a'), .{ .emit_codepoint_literals = .always });
-    try std.testing.expectEqualStrings("97", aw.getWritten());
+    try std.testing.expectEqualStrings("97", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(@as(u22, 'a'), .{ .emit_codepoint_literals = .printable_ascii });
-    try std.testing.expectEqualStrings("97", aw.getWritten());
+    try std.testing.expectEqualStrings("97", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(@as(i32, 'a'), .{ .emit_codepoint_literals = .never });
-    try std.testing.expectEqualStrings("97", aw.getWritten());
+    try std.testing.expectEqualStrings("97", aw.written());
     aw.clearRetainingCapacity();
 
     // Make sure value options are passed to children
     try s.value(.{ .c = '⚡' }, .{ .emit_codepoint_literals = .always });
-    try std.testing.expectEqualStrings(".{ .c = '\\u{26a1}' }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ .c = '\\u{26a1}' }", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(.{ .c = '⚡' }, .{ .emit_codepoint_literals = .never });
-    try std.testing.expectEqualStrings(".{ .c = 9889 }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ .c = 9889 }", aw.written());
     aw.clearRetainingCapacity();
 }
 
@@ -697,7 +697,7 @@ test "std.zon stringify strings" {
 
     // Minimal case
     try s.string("abc⚡\n");
-    try std.testing.expectEqualStrings("\"abc\\xe2\\x9a\\xa1\\n\"", aw.getWritten());
+    try std.testing.expectEqualStrings("\"abc\\xe2\\x9a\\xa1\\n\"", aw.written());
     aw.clearRetainingCapacity();
 
     try s.tuple("abc⚡\n", .{});
@@ -711,11 +711,11 @@ test "std.zon stringify strings" {
         \\    161,
         \\    10,
         \\}
-    , aw.getWritten());
+    , aw.written());
     aw.clearRetainingCapacity();
 
     try s.value("abc⚡\n", .{});
-    try std.testing.expectEqualStrings("\"abc\\xe2\\x9a\\xa1\\n\"", aw.getWritten());
+    try std.testing.expectEqualStrings("\"abc\\xe2\\x9a\\xa1\\n\"", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value("abc⚡\n", .{ .emit_strings_as_containers = true });
@@ -729,12 +729,12 @@ test "std.zon stringify strings" {
         \\    161,
         \\    10,
         \\}
-    , aw.getWritten());
+    , aw.written());
     aw.clearRetainingCapacity();
 
     // Value options are inherited by children
     try s.value(.{ .str = "abc" }, .{});
-    try std.testing.expectEqualStrings(".{ .str = \"abc\" }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ .str = \"abc\" }", aw.written());
     aw.clearRetainingCapacity();
 
     try s.value(.{ .str = "abc" }, .{ .emit_strings_as_containers = true });
@@ -744,7 +744,7 @@ test "std.zon stringify strings" {
         \\    98,
         \\    99,
         \\} }
-    , aw.getWritten());
+    , aw.written());
     aw.clearRetainingCapacity();
 
     // Arrays (rather than pointers to arrays) of u8s are not considered strings, so that data can
@@ -756,7 +756,7 @@ test "std.zon stringify strings" {
         \\    98,
         \\    99,
         \\}
-    , aw.getWritten());
+    , aw.written());
     aw.clearRetainingCapacity();
 }
 
@@ -770,46 +770,46 @@ test "std.zon stringify multiline strings" {
 
         {
             try s.multilineString("", .{ .top_level = true });
-            try std.testing.expectEqualStrings("\\\\", aw.getWritten());
+            try std.testing.expectEqualStrings("\\\\", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             try s.multilineString("abc⚡", .{ .top_level = true });
-            try std.testing.expectEqualStrings("\\\\abc⚡", aw.getWritten());
+            try std.testing.expectEqualStrings("\\\\abc⚡", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             try s.multilineString("abc⚡\ndef", .{ .top_level = true });
-            try std.testing.expectEqualStrings("\\\\abc⚡\n\\\\def", aw.getWritten());
+            try std.testing.expectEqualStrings("\\\\abc⚡\n\\\\def", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             try s.multilineString("abc⚡\r\ndef", .{ .top_level = true });
-            try std.testing.expectEqualStrings("\\\\abc⚡\n\\\\def", aw.getWritten());
+            try std.testing.expectEqualStrings("\\\\abc⚡\n\\\\def", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             try s.multilineString("\nabc⚡", .{ .top_level = true });
-            try std.testing.expectEqualStrings("\\\\\n\\\\abc⚡", aw.getWritten());
+            try std.testing.expectEqualStrings("\\\\\n\\\\abc⚡", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             try s.multilineString("\r\nabc⚡", .{ .top_level = true });
-            try std.testing.expectEqualStrings("\\\\\n\\\\abc⚡", aw.getWritten());
+            try std.testing.expectEqualStrings("\\\\\n\\\\abc⚡", aw.written());
             aw.clearRetainingCapacity();
         }
 
         {
             try s.multilineString("abc\ndef", .{});
             if (whitespace) {
-                try std.testing.expectEqualStrings("\n\\\\abc\n\\\\def\n", aw.getWritten());
+                try std.testing.expectEqualStrings("\n\\\\abc\n\\\\def\n", aw.written());
             } else {
-                try std.testing.expectEqualStrings("\\\\abc\n\\\\def\n", aw.getWritten());
+                try std.testing.expectEqualStrings("\\\\abc\n\\\\def\n", aw.written());
             }
             aw.clearRetainingCapacity();
         }
@@ -817,7 +817,7 @@ test "std.zon stringify multiline strings" {
         {
             const str: []const u8 = &.{ 'a', '\r', 'c' };
             try s.string(str);
-            try std.testing.expectEqualStrings("\"a\\rc\"", aw.getWritten());
+            try std.testing.expectEqualStrings("\"a\\rc\"", aw.written());
             aw.clearRetainingCapacity();
         }
 
@@ -834,7 +834,7 @@ test "std.zon stringify multiline strings" {
                 error.InnerCarriageReturn,
                 s.multilineString(@as([]const u8, &.{ 'a', '\r', 'c', '\r', '\n' }), .{}),
             );
-            try std.testing.expectEqualStrings("", aw.getWritten());
+            try std.testing.expectEqualStrings("", aw.written());
             aw.clearRetainingCapacity();
         }
     }
@@ -989,11 +989,11 @@ test "std.zon depth limits" {
 
     // Normal operation
     try serializeMaxDepth(.{ 1, .{ 2, 3 } }, .{}, bw, 16);
-    try std.testing.expectEqualStrings(".{ 1, .{ 2, 3 } }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ 1, .{ 2, 3 } }", aw.written());
     aw.clearRetainingCapacity();
 
     try serializeArbitraryDepth(.{ 1, .{ 2, 3 } }, .{}, bw);
-    try std.testing.expectEqualStrings(".{ 1, .{ 2, 3 } }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ 1, .{ 2, 3 } }", aw.written());
     aw.clearRetainingCapacity();
 
     // Max depth failing on non recursive type
@@ -1001,14 +1001,14 @@ test "std.zon depth limits" {
         error.ExceededMaxDepth,
         serializeMaxDepth(.{ 1, .{ 2, .{ 3, 4 } } }, .{}, bw, 3),
     );
-    try std.testing.expectEqualStrings("", aw.getWritten());
+    try std.testing.expectEqualStrings("", aw.written());
     aw.clearRetainingCapacity();
 
     // Max depth passing on recursive type
     {
         const maybe_recurse = Recurse{ .r = &.{} };
         try serializeMaxDepth(maybe_recurse, .{}, bw, 2);
-        try std.testing.expectEqualStrings(".{ .r = .{} }", aw.getWritten());
+        try std.testing.expectEqualStrings(".{ .r = .{} }", aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1016,7 +1016,7 @@ test "std.zon depth limits" {
     {
         const maybe_recurse = Recurse{ .r = &.{} };
         try serializeArbitraryDepth(maybe_recurse, .{}, bw);
-        try std.testing.expectEqualStrings(".{ .r = .{} }", aw.getWritten());
+        try std.testing.expectEqualStrings(".{ .r = .{} }", aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1028,7 +1028,7 @@ test "std.zon depth limits" {
             error.ExceededMaxDepth,
             serializeMaxDepth(maybe_recurse, .{}, bw, 2),
         );
-        try std.testing.expectEqualStrings("", aw.getWritten());
+        try std.testing.expectEqualStrings("", aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1041,7 +1041,7 @@ test "std.zon depth limits" {
             error.ExceededMaxDepth,
             serializeMaxDepth(maybe_recurse, .{}, bw, 2),
         );
-        try std.testing.expectEqualStrings("", aw.getWritten());
+        try std.testing.expectEqualStrings("", aw.written());
         aw.clearRetainingCapacity();
 
         var s: Serializer = .{ .writer = bw };
@@ -1050,11 +1050,11 @@ test "std.zon depth limits" {
             error.ExceededMaxDepth,
             s.tupleMaxDepth(maybe_recurse, .{}, 2),
         );
-        try std.testing.expectEqualStrings("", aw.getWritten());
+        try std.testing.expectEqualStrings("", aw.written());
         aw.clearRetainingCapacity();
 
         try s.tupleArbitraryDepth(maybe_recurse, .{});
-        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.getWritten());
+        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1064,17 +1064,17 @@ test "std.zon depth limits" {
         const maybe_recurse: []const Recurse = &temp;
 
         try serializeMaxDepth(maybe_recurse, .{}, bw, 3);
-        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.getWritten());
+        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.written());
         aw.clearRetainingCapacity();
 
         var s: Serializer = .{ .writer = bw };
 
         try s.tupleMaxDepth(maybe_recurse, .{}, 3);
-        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.getWritten());
+        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.written());
         aw.clearRetainingCapacity();
 
         try s.tupleArbitraryDepth(maybe_recurse, .{});
-        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.getWritten());
+        try std.testing.expectEqualStrings(".{.{ .r = .{} }}", aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1088,7 +1088,7 @@ test "std.zon depth limits" {
             error.ExceededMaxDepth,
             serializeMaxDepth(maybe_recurse, .{}, bw, 128),
         );
-        try std.testing.expectEqualStrings("", aw.getWritten());
+        try std.testing.expectEqualStrings("", aw.written());
         aw.clearRetainingCapacity();
 
         var s: Serializer = .{ .writer = bw };
@@ -1096,7 +1096,7 @@ test "std.zon depth limits" {
             error.ExceededMaxDepth,
             s.tupleMaxDepth(maybe_recurse, .{}, 128),
         );
-        try std.testing.expectEqualStrings("", aw.getWritten());
+        try std.testing.expectEqualStrings("", aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1146,7 +1146,7 @@ test "std.zon depth limits" {
             \\    9,
             \\    .{},
             \\}
-        , aw.getWritten());
+        , aw.written());
     }
 }
 
@@ -1248,35 +1248,35 @@ test "std.zon stringify ident" {
 
     try expectSerializeEqual(".{ .a = 0 }", .{ .a = 0 }, .{});
     try s.ident("a");
-    try std.testing.expectEqualStrings(".a", aw.getWritten());
+    try std.testing.expectEqualStrings(".a", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("foo_1");
-    try std.testing.expectEqualStrings(".foo_1", aw.getWritten());
+    try std.testing.expectEqualStrings(".foo_1", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("_foo_1");
-    try std.testing.expectEqualStrings("._foo_1", aw.getWritten());
+    try std.testing.expectEqualStrings("._foo_1", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("foo bar");
-    try std.testing.expectEqualStrings(".@\"foo bar\"", aw.getWritten());
+    try std.testing.expectEqualStrings(".@\"foo bar\"", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("1foo");
-    try std.testing.expectEqualStrings(".@\"1foo\"", aw.getWritten());
+    try std.testing.expectEqualStrings(".@\"1foo\"", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("var");
-    try std.testing.expectEqualStrings(".@\"var\"", aw.getWritten());
+    try std.testing.expectEqualStrings(".@\"var\"", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("true");
-    try std.testing.expectEqualStrings(".true", aw.getWritten());
+    try std.testing.expectEqualStrings(".true", aw.written());
     aw.clearRetainingCapacity();
 
     try s.ident("_");
-    try std.testing.expectEqualStrings("._", aw.getWritten());
+    try std.testing.expectEqualStrings("._", aw.written());
     aw.clearRetainingCapacity();
 
     const Enum = enum {
@@ -1295,17 +1295,17 @@ test "std.zon stringify as tuple" {
 
     // Tuples
     try s.tuple(.{ 1, 2 }, .{});
-    try std.testing.expectEqualStrings(".{ 1, 2 }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ 1, 2 }", aw.written());
     aw.clearRetainingCapacity();
 
     // Slice
     try s.tuple(@as([]const u8, &.{ 1, 2 }), .{});
-    try std.testing.expectEqualStrings(".{ 1, 2 }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ 1, 2 }", aw.written());
     aw.clearRetainingCapacity();
 
     // Array
     try s.tuple([2]u8{ 1, 2 }, .{});
-    try std.testing.expectEqualStrings(".{ 1, 2 }", aw.getWritten());
+    try std.testing.expectEqualStrings(".{ 1, 2 }", aw.written());
     aw.clearRetainingCapacity();
 }
 
@@ -1316,12 +1316,12 @@ test "std.zon stringify as float" {
 
     // Comptime float
     try s.float(2.5);
-    try std.testing.expectEqualStrings("2.5", aw.getWritten());
+    try std.testing.expectEqualStrings("2.5", aw.written());
     aw.clearRetainingCapacity();
 
     // Sized float
     try s.float(@as(f32, 2.5));
-    try std.testing.expectEqualStrings("2.5", aw.getWritten());
+    try std.testing.expectEqualStrings("2.5", aw.written());
     aw.clearRetainingCapacity();
 }
 
@@ -1446,7 +1446,7 @@ test "std.zon tuple/struct field" {
             \\        .b = 1,
             \\    },
             \\}
-        , aw.getWritten());
+        , aw.written());
         aw.clearRetainingCapacity();
     }
 
@@ -1478,7 +1478,7 @@ test "std.zon tuple/struct field" {
             \\        .b = 1,
             \\    },
             \\}
-        , aw.getWritten());
+        , aw.written());
         aw.clearRetainingCapacity();
     }
 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1123,7 +1123,7 @@ pub const CObject = struct {
                 var aw: Writer.Allocating = .init(eb.gpa);
                 defer aw.deinit();
                 _ = file_reader.interface.streamDelimiterEnding(&aw.writer, '\n') catch break :source_line 0;
-                break :source_line try eb.addString(aw.getWritten());
+                break :source_line try eb.addString(aw.written());
             };
 
             return .{

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -2029,7 +2029,7 @@ const UnpackResult = struct {
             \\    note: unable to create symlink from 'dir2/file2' to 'filename': SymlinkError
             \\    note: file 'dir2/file4' has unsupported type 'x'
             \\
-        , aw.getWritten());
+        , aw.written());
     }
 };
 
@@ -2333,7 +2333,7 @@ const TestFetchBuilder = struct {
         var aw: std.io.Writer.Allocating = .init(std.testing.allocator);
         defer aw.deinit();
         try errors.renderToWriter(.{ .ttyconf = .no_color }, &aw.writer);
-        try std.testing.expectEqualStrings(msg, aw.getWritten());
+        try std.testing.expectEqualStrings(msg, aw.written());
     }
 };
 

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -3071,7 +3071,7 @@ pub fn createTypeName(
 
             w.writeByte(')') catch return error.OutOfMemory;
             return .{
-                .name = try ip.getOrPutString(gpa, pt.tid, aw.getWritten(), .no_embedded_nulls),
+                .name = try ip.getOrPutString(gpa, pt.tid, aw.written(), .no_embedded_nulls),
                 .nav = .none,
             };
         },
@@ -5484,7 +5484,7 @@ fn zirCompileLog(
         }
     }
 
-    const line_data = try zcu.intern_pool.getOrPutString(gpa, pt.tid, aw.getWritten(), .no_embedded_nulls);
+    const line_data = try zcu.intern_pool.getOrPutString(gpa, pt.tid, aw.written(), .no_embedded_nulls);
 
     const line_idx: Zcu.CompileLogLine.Index = if (zcu.free_compile_log_lines.pop()) |idx| idx: {
         zcu.compile_log_lines.items[@intFromEnum(idx)] = .{
@@ -36892,11 +36892,11 @@ fn notePathToComptimeAllocPtr(
     switch (deriv_start) {
         .int, .nav_ptr => unreachable,
         .uav_ptr => |uav| {
-            try sema.errNote(src, msg, "'{s}' points to '{s}', where", .{ first_path.items, second_path_aw.getWritten() });
+            try sema.errNote(src, msg, "'{s}' points to '{s}', where", .{ first_path.items, second_path_aw.written() });
             return .{ .new_val = .fromInterned(uav.val) };
         },
         .comptime_alloc_ptr => |cta_info| {
-            try sema.errNote(src, msg, "'{s}' points to '{s}', where", .{ first_path.items, second_path_aw.getWritten() });
+            try sema.errNote(src, msg, "'{s}' points to '{s}', where", .{ first_path.items, second_path_aw.written() });
             const cta = sema.getComptimeAlloc(cta_info.idx);
             if (cta.is_const) {
                 return .{ .new_val = cta_info.val };
@@ -36906,7 +36906,7 @@ fn notePathToComptimeAllocPtr(
             }
         },
         .comptime_field_ptr => {
-            try sema.errNote(src, msg, "'{s}' points to '{s}', where", .{ first_path.items, second_path_aw.getWritten() });
+            try sema.errNote(src, msg, "'{s}' points to '{s}', where", .{ first_path.items, second_path_aw.written() });
             try sema.errNote(src, msg, "'{s}' is a comptime field", .{inter_name});
             return .done;
         },

--- a/src/codegen/c.zig
+++ b/src/codegen/c.zig
@@ -728,7 +728,7 @@ pub const Object = struct {
     }
     fn outdent(o: *Object) !void {
         o.indent_counter -= indent_width;
-        const written = o.code.getWritten();
+        const written = o.code.written();
         switch (written[written.len - 1]) {
             indent_char => o.code.shrinkRetainingCapacity(written.len - indent_width),
             '\n' => try o.code.writer.splatByteAll(indent_char, o.indent_counter),

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -341,7 +341,7 @@ fn fmtPathFile(
     tree.render(gpa, &fmt.out_buffer.writer, .{}) catch |err| switch (err) {
         error.WriteFailed, error.OutOfMemory => return error.OutOfMemory,
     };
-    if (mem.eql(u8, fmt.out_buffer.getWritten(), source_code))
+    if (mem.eql(u8, fmt.out_buffer.written(), source_code))
         return;
 
     if (check_mode) {
@@ -351,7 +351,7 @@ fn fmtPathFile(
         var af = try dir.atomicFile(sub_path, .{ .mode = stat.mode, .write_buffer = &.{} });
         defer af.deinit();
 
-        try af.file_writer.interface.writeAll(fmt.out_buffer.getWritten());
+        try af.file_writer.interface.writeAll(fmt.out_buffer.written());
         try af.finish();
         try fmt.stdout_writer.interface.print("{s}\n", .{file_path});
     }

--- a/src/link/C.zig
+++ b/src/link/C.zig
@@ -268,8 +268,8 @@ fn updateUav(self: *C, pt: Zcu.PerThread, i: usize) link.File.FlushError!void {
 
     object.dg.ctype_pool.freeUnusedCapacity(gpa);
     self.uavs.values()[i] = .{
-        .fwd_decl = try self.addString(object.dg.fwd_decl.getWritten()),
-        .code = try self.addString(object.code.getWritten()),
+        .fwd_decl = try self.addString(object.dg.fwd_decl.written()),
+        .code = try self.addString(object.code.written()),
         .ctype_pool = object.dg.ctype_pool.move(),
     };
 }
@@ -335,8 +335,8 @@ pub fn updateNav(self: *C, pt: Zcu.PerThread, nav_index: InternPool.Nav.Index) l
         },
         error.WriteFailed, error.OutOfMemory => return error.OutOfMemory,
     };
-    gop.value_ptr.fwd_decl = try self.addString(object.dg.fwd_decl.getWritten());
-    gop.value_ptr.code = try self.addString(object.code.getWritten());
+    gop.value_ptr.fwd_decl = try self.addString(object.dg.fwd_decl.written());
+    gop.value_ptr.code = try self.addString(object.code.written());
     try self.addUavsFromCodegen(&object.dg.uavs);
 }
 
@@ -409,7 +409,7 @@ pub fn flush(self: *C, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.P
     // Covers defines, zig.h, ctypes, asm, lazy fwd.
     try f.all_buffers.ensureUnusedCapacity(gpa, 5);
 
-    f.appendBufAssumeCapacity(abi_defines_aw.getWritten());
+    f.appendBufAssumeCapacity(abi_defines_aw.written());
     f.appendBufAssumeCapacity(zig_h);
 
     const ctypes_index = f.all_buffers.items.len;
@@ -420,7 +420,7 @@ pub fn flush(self: *C, arena: Allocator, tid: Zcu.PerThread.Id, prog_node: std.P
     codegen.genGlobalAsm(zcu, &asm_aw.writer) catch |err| switch (err) {
         error.WriteFailed => return error.OutOfMemory,
     };
-    f.appendBufAssumeCapacity(asm_aw.getWritten());
+    f.appendBufAssumeCapacity(asm_aw.written());
 
     const lazy_index = f.all_buffers.items.len;
     f.all_buffers.items.len += 1;
@@ -849,7 +849,7 @@ pub fn updateExports(
     codegen.genExports(&dg, exported, export_indices) catch |err| switch (err) {
         error.WriteFailed, error.OutOfMemory => return error.OutOfMemory,
     };
-    exported_block.* = .{ .fwd_decl = try self.addString(dg.fwd_decl.getWritten()) };
+    exported_block.* = .{ .fwd_decl = try self.addString(dg.fwd_decl.written()) };
 }
 
 pub fn deleteExport(

--- a/src/link/Elf.zig
+++ b/src/link/Elf.zig
@@ -3156,7 +3156,7 @@ fn writeSyntheticSections(self: *Elf) !void {
         try aw.ensureUnusedCapacity(self.gnu_hash.size());
         defer aw.deinit();
         try self.gnu_hash.write(self, &aw.writer);
-        try self.pwriteAll(aw.getWritten(), shdr.sh_offset);
+        try self.pwriteAll(aw.written(), shdr.sh_offset);
     }
 
     if (self.section_indexes.versym) |shndx| {

--- a/src/link/SpirV.zig
+++ b/src/link/SpirV.zig
@@ -274,7 +274,7 @@ pub fn flush(
         ) catch return error.OutOfMemory;
     }
     try linker.module.sections.debug_strings.emit(gpa, .OpSourceExtension, .{
-        .extension = error_info.getWritten(),
+        .extension = error_info.written(),
     });
 
     const module = try linker.module.finalize(arena);

--- a/src/main.zig
+++ b/src/main.zig
@@ -7198,7 +7198,7 @@ fn cmdFetch(
     var aw: std.Io.Writer.Allocating = .init(gpa);
     defer aw.deinit();
     try ast.render(gpa, &aw.writer, fixups);
-    const rendered = aw.getWritten();
+    const rendered = aw.written();
 
     build_root.directory.handle.writeFile(.{ .sub_path = Package.Manifest.basename, .data = rendered }) catch |err| {
         fatal("unable to write {s} file: {t}", .{ Package.Manifest.basename, err });


### PR DESCRIPTION
This "get" is useless noise and was copied from FixedBufferWriter. Since this API has not yet landed in a release, now is a good time to make the breaking change to fix this.