### PR TITLE
Dwarf: handle noreturn union fields in more places

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -3241,7 +3241,7 @@ fn updateComptimeNavInner(dwarf: *Dwarf, pt: Zcu.PerThread, nav_index: InternPoo
                 const field_type: Type = .fromInterned(loaded_union.field_types.get(ip)[field_index]);
                 try wip_nav.refType(field_type);
                 try diw.writeUleb128(loaded_union.fieldAlign(ip, field_index).toByteUnits() orelse
-                    field_type.abiAlignment(zcu).toByteUnits().?);
+                    if (field_type.isNoReturn(zcu)) 1 else field_type.abiAlignment(zcu).toByteUnits().?);
             }
             try diw.writeUleb128(@intFromEnum(AbbrevCode.null));
             break :tag .done;
@@ -4599,7 +4599,7 @@ fn updateContainerTypeWriterError(
                     const field_type: Type = .fromInterned(loaded_union.field_types.get(ip)[field_index]);
                     try wip_nav.refType(field_type);
                     try diw.writeUleb128(loaded_union.fieldAlign(ip, field_index).toByteUnits() orelse
-                        field_type.abiAlignment(zcu).toByteUnits().?);
+                        if (field_type.isNoReturn(zcu)) 1 else field_type.abiAlignment(zcu).toByteUnits().?);
                 }
                 if (loaded_union.field_types.len > 0) try diw.writeUleb128(@intFromEnum(AbbrevCode.null));
             },


### PR DESCRIPTION
A little clunky -- maybe the frontend should give an answer here -- but this patch makes sense with the surrounding logic just to fix the crash.

Resolves: #24265