### PR TITLE
fix: print error set members in a consistent order

### DIFF
--- a/test/cases/compile_errors/error_set_display.zig
+++ b/test/cases/compile_errors/error_set_display.zig
@@ -1,0 +1,11 @@
+const Set0 = error{ A, B, C, D, E, F };
+const Set1 = error{ F, E, D, C, A };
+comptime {
+    const x = Set0.B;
+    const y: Set1 = @errorCast(x);
+    _ = y;
+}
+
+// error
+//
+// :5:21: error: 'error.B' not a member of error set 'error{A,C,D,E,F}'

--- a/test/cases/compile_errors/invalid_pointer_coercions.zig
+++ b/test/cases/compile_errors/invalid_pointer_coercions.zig
@@ -54,8 +54,8 @@ export fn ptr_to_underaligned_ptr() void {
 
 // error
 //
-// :16:33: error: expected type '*error{Foo,Bar}', found '*error{Foo}'
-// :16:33: note: pointer type child 'error{Foo}' cannot cast into pointer type child 'error{Foo,Bar}'
+// :16:33: error: expected type '*error{Bar,Foo}', found '*error{Foo}'
+// :16:33: note: pointer type child 'error{Foo}' cannot cast into pointer type child 'error{Bar,Foo}'
 // :16:33: note: 'error.Bar' not a member of destination error set
 // :22:24: error: expected type '*anyerror', found '*error{Foo}'
 // :22:24: note: pointer type child 'error{Foo}' cannot cast into pointer type child 'anyerror'

--- a/test/src/Debugger.zig
+++ b/test/src/Debugger.zig
@@ -491,16 +491,16 @@ pub fn addTestsForTarget(db: *Debugger, target: *const Target) void {
             \\    (error{One,Two}) Two = error.Two
             \\  }
             \\  (type) Three = error {
-            \\    (error{One,Two,Three}) One = error.One
-            \\    (error{One,Two,Three}) Two = error.Two
-            \\    (error{One,Two,Three}) Three = error.Three
+            \\    (error{One,Three,Two}) One = error.One
+            \\    (error{One,Three,Two}) Two = error.Two
+            \\    (error{One,Three,Two}) Three = error.Three
             \\  }
             \\}
             \\(lldb) frame variable --show-types -- errors
             \\(root.errors.Errors) errors = {
             \\  (error{One}) .one = error.One
             \\  (error{One,Two}) .two = error.Two
-            \\  (error{One,Two,Three}) .three = error.Three
+            \\  (error{One,Three,Two}) .three = error.Three
             \\  (anyerror) .any = error.Any
             \\  (anyerror!void) .any_void = {
             \\    (anyerror) .error = error.NotVoid


### PR DESCRIPTION
This PR alters the error set printing logic to sort its members' names before displaying them. This patch is just @mlugg's code from https://github.com/ziglang/zig/issues/21829#issuecomment-3175203876 (thanks so much for the help!) with one small tweak, along with an added test case. 

- Closes #21829