### PR TITLE
std.Build: improve error for peak RSS exceeding declared value

### DIFF
--- a/lib/std/Build/Step.zig
+++ b/lib/std/Build/Step.zig
@@ -271,7 +271,7 @@ pub fn make(s: *Step, options: MakeOptions) error{ MakeFailed, MakeSkipped }!voi
     }
 
     if (s.max_rss != 0 and s.result_peak_rss > s.max_rss) {
-        const msg = std.fmt.allocPrint(arena, "memory usage peaked at {d} bytes, exceeding the declared upper bound of {d}", .{
+        const msg = std.fmt.allocPrint(arena, "memory usage peaked at {0B:.2} ({0d} bytes), exceeding the declared upper bound of {1B:.2} ({1d} bytes)", .{
             s.result_peak_rss, s.max_rss,
         }) catch @panic("OOM");
         s.result_error_msgs.append(arena, msg) catch @panic("OOM");


### PR DESCRIPTION
As well as the exact byte count, include a human-readable value so it's clearer what the error is actually telling you. The exact byte count might not be worth keeping, but I decided I would in case it's useful in any scenario.

New errors look like:
```
memory usage peaked at 40.65GB (40650104832 bytes), exceeding the declared upper bound of 7.80GB (7800000000 bytes)
```