### PR TITLE
Zcu: don't tell linkers about exports if there are compile errors

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -4254,14 +4254,10 @@ fn appendCompileLogLines(log_text: *std.ArrayListUnmanaged(u8), zcu: *Zcu, loggi
     }
 }
 
-fn anyErrors(comp: *Compilation) bool {
-    return (totalErrorCount(comp) catch return true) != 0;
-}
-
-fn totalErrorCount(comp: *Compilation) !u32 {
-    var errors = try comp.getAllErrorsAlloc();
+pub fn anyErrors(comp: *Compilation) bool {
+    var errors = comp.getAllErrorsAlloc() catch return true;
     defer errors.deinit(comp.gpa);
-    return errors.errorMessageCount();
+    return errors.errorMessageCount() > 0;
 }
 
 pub const ErrorNoteHashContext = struct {

--- a/test/cases/compile_errors/exported_function_uses_invalid_type.zig
+++ b/test/cases/compile_errors/exported_function_uses_invalid_type.zig
@@ -1,0 +1,13 @@
+export fn foo() void {
+    const S = struct { x: u32 = "bad default" };
+    const s: S = undefined;
+    _ = s;
+}
+
+// This test case explicitly runs on the LLVM backend as well as self-hosted, as
+// the original bug leading to this test occurred only with the LLVM backend.
+
+// error
+// backend=stage2,llvm
+//
+// :2:33: error: expected type 'u32', found '*const [11:0]u8'


### PR DESCRIPTION
In the best case, this is redundant work, because we aren't actually going to emit a working binary this update. In the worst case, it causes bugs because the linker may not have *seen* the thing being exported due to the compile errors.

Resolves: #24417