### PR TITLE
android: detect native ABI and API level correctly

### DIFF
--- a/lib/compiler/aro/aro/Driver.zig
+++ b/lib/compiler/aro/aro/Driver.zig
@@ -407,7 +407,7 @@ pub fn parseArgs(
                     try d.comp.addDiagnostic(.{ .tag = .cli_invalid_target, .extra = .{ .str = arg } }, &.{});
                     continue;
                 };
-                const target = std.zig.system.resolveTargetQuery(query) catch |e| {
+                const target = std.zig.system.resolveTargetQuery(query, d.comp.gpa) catch |e| {
                     return d.fatal("unable to resolve target: {s}", .{errorDescription(e)});
                 };
                 d.comp.target = target;

--- a/lib/compiler/aro/aro/Value.zig
+++ b/lib/compiler/aro/aro/Value.zig
@@ -71,7 +71,7 @@ test "minUnsignedBits" {
     var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     const target_query = try std.Target.Query.parse(.{ .arch_os_abi = "x86_64-linux-gnu" });
-    comp.target = try std.zig.system.resolveTargetQuery(target_query);
+    comp.target = try std.zig.system.resolveTargetQuery(target_query, comp.gpa);
 
     try Test.checkIntBits(&comp, 0, 0);
     try Test.checkIntBits(&comp, 1, 1);
@@ -106,7 +106,7 @@ test "minSignedBits" {
     var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     const target_query = try std.Target.Query.parse(.{ .arch_os_abi = "x86_64-linux-gnu" });
-    comp.target = try std.zig.system.resolveTargetQuery(target_query);
+    comp.target = try std.zig.system.resolveTargetQuery(target_query, comp.gpa);
 
     try Test.checkIntBits(&comp, -1, 1);
     try Test.checkIntBits(&comp, -2, 2);

--- a/lib/compiler/aro/aro/toolchains/Linux.zig
+++ b/lib/compiler/aro/aro/toolchains/Linux.zig
@@ -423,7 +423,7 @@ test Linux {
 
     const raw_triple = "x86_64-linux-gnu";
     const target_query = try std.Target.Query.parse(.{ .arch_os_abi = raw_triple });
-    comp.target = try std.zig.system.resolveTargetQuery(target_query);
+    comp.target = try std.zig.system.resolveTargetQuery(target_query, arena);
     comp.langopts.setEmulatedCompiler(.gcc);
 
     var driver: Driver = .{ .comp = &comp };

--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -79,7 +79,7 @@ pub fn main() !void {
         .zig_lib_directory = zig_lib_directory,
         .host = .{
             .query = .{},
-            .result = try std.zig.system.resolveTargetQuery(.{}),
+            .result = try std.zig.system.resolveTargetQuery(.{}, arena),
         },
         .time_report = false,
     };

--- a/lib/compiler/libc.zig
+++ b/lib/compiler/libc.zig
@@ -66,7 +66,7 @@ pub fn main() !void {
     const target_query = std.zig.parseTargetQueryOrReportFatalError(gpa, .{
         .arch_os_abi = target_arch_os_abi,
     });
-    const target = std.zig.resolveTargetQueryOrFatal(target_query);
+    const target = std.zig.resolveTargetQueryOrFatal(target_query, gpa);
 
     if (print_includes) {
         const libc_installation: ?*LibCInstallation = libc: {

--- a/lib/compiler/resinator/main.zig
+++ b/lib/compiler/resinator/main.zig
@@ -582,7 +582,7 @@ fn getIncludePaths(arena: std.mem.Allocator, auto_includes_option: cli.Options.A
                     .cpu_arch = includes_arch,
                     .abi = .msvc,
                 };
-                const target = std.zig.resolveTargetQueryOrFatal(target_query);
+                const target = std.zig.resolveTargetQueryOrFatal(target_query, arena);
                 const is_native_abi = target_query.isNativeAbi();
                 const detected_libc = std.zig.LibCDirs.detect(arena, zig_lib_dir, &target, is_native_abi, true, null) catch {
                     if (includes == .any) {
@@ -608,7 +608,7 @@ fn getIncludePaths(arena: std.mem.Allocator, auto_includes_option: cli.Options.A
                     .cpu_arch = includes_arch,
                     .abi = .gnu,
                 };
-                const target = std.zig.resolveTargetQueryOrFatal(target_query);
+                const target = std.zig.resolveTargetQueryOrFatal(target_query, arena);
                 const is_native_abi = target_query.isNativeAbi();
                 const detected_libc = std.zig.LibCDirs.detect(arena, zig_lib_dir, &target, is_native_abi, true, null) catch |err| switch (err) {
                     error.OutOfMemory => |e| return e,

--- a/lib/compiler/std-docs.zig
+++ b/lib/compiler/std-docs.zig
@@ -258,7 +258,10 @@ fn serveWasm(
         .target = &(std.zig.system.resolveTargetQuery(std.Build.parseTargetQuery(.{
             .arch_os_abi = autodoc_arch_os_abi,
             .cpu_features = autodoc_cpu_features,
-        }) catch unreachable) catch unreachable),
+        }) catch unreachable, gpa) catch |err| switch (err) {
+            error.OutOfMemory => |e| return e,
+            else => unreachable,
+        }),
         .output_mode = .Exe,
     });
     // std.http.Server does not have a sendfile API yet.

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2650,7 +2650,7 @@ pub fn resolveTargetQuery(b: *Build, query: Target.Query) ResolvedTarget {
     }
     return .{
         .query = query,
-        .result = std.zig.system.resolveTargetQuery(query) catch
+        .result = std.zig.system.resolveTargetQuery(query, b.allocator) catch
             @panic("unable to resolve target query"),
     };
 }

--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -546,7 +546,7 @@ test Options {
         .global_cache_root = .{ .path = "test", .handle = std.fs.cwd() },
         .host = .{
             .query = .{},
-            .result = try std.zig.system.resolveTargetQuery(.{}),
+            .result = try std.zig.system.resolveTargetQuery(.{}, arena.allocator()),
         },
         .zig_lib_directory = std.Build.Cache.Directory.cwd(),
         .time_report = false,

--- a/lib/std/Build/WebServer.zig
+++ b/lib/std/Build/WebServer.zig
@@ -666,7 +666,10 @@ fn buildClientWasm(ws: *WebServer, arena: Allocator, optimize: std.builtin.Optim
         .target = &(std.zig.system.resolveTargetQuery(std.Build.parseTargetQuery(.{
             .arch_os_abi = arch_os_abi,
             .cpu_features = cpu_features,
-        }) catch unreachable) catch unreachable),
+        }) catch unreachable, ws.gpa) catch |err| switch (err) {
+            error.OutOfMemory => |e| return e,
+            else => unreachable,
+        }),
         .output_mode = .Exe,
     });
     return base_path.join(arena, bin_name);

--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -2045,6 +2045,10 @@ pub inline fn isMuslLibC(target: *const Target) bool {
     return target.os.tag == .linux and target.abi.isMusl();
 }
 
+pub inline fn isBionicLibC(target: *const Target) bool {
+    return target.os.tag == .linux and target.abi.isAndroid();
+}
+
 pub inline fn isDarwinLibC(target: *const Target) bool {
     return switch (target.abi) {
         .none, .macabi, .simulator => target.os.tag.isDarwin(),

--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -648,7 +648,7 @@ test parse {
             .arch_os_abi = "x86_64-linux-gnu",
             .cpu_features = "x86_64-sse-sse2-avx-cx8",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, std.testing.allocator);
 
         try std.testing.expect(target.os.tag == .linux);
         try std.testing.expect(target.abi == .gnu);
@@ -673,7 +673,7 @@ test parse {
             .arch_os_abi = "arm-linux-musleabihf",
             .cpu_features = "generic+v8a",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, std.testing.allocator);
 
         try std.testing.expect(target.os.tag == .linux);
         try std.testing.expect(target.abi == .musleabihf);
@@ -690,7 +690,7 @@ test parse {
             .arch_os_abi = "aarch64-linux.3.10...4.4.1-gnu.2.27",
             .cpu_features = "generic+v8a",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, std.testing.allocator);
 
         try std.testing.expect(target.cpu.arch == .aarch64);
         try std.testing.expect(target.os.tag == .linux);
@@ -713,7 +713,7 @@ test parse {
         const query = try Query.parse(.{
             .arch_os_abi = "aarch64-linux.3.10...4.4.1-android.30",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, std.testing.allocator);
 
         try std.testing.expect(target.cpu.arch == .aarch64);
         try std.testing.expect(target.os.tag == .linux);
@@ -734,7 +734,7 @@ test parse {
         const query = try Query.parse(.{
             .arch_os_abi = "x86-windows.xp...win8-msvc",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, std.testing.allocator);
 
         try std.testing.expect(target.cpu.arch == .x86);
         try std.testing.expect(target.os.tag == .windows);

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -619,8 +619,8 @@ pub fn putAstErrorsIntoBundle(
     try wip_errors.addZirErrorMessages(zir, tree, tree.source, path);
 }
 
-pub fn resolveTargetQueryOrFatal(target_query: std.Target.Query) std.Target {
-    return std.zig.system.resolveTargetQuery(target_query) catch |err|
+pub fn resolveTargetQueryOrFatal(target_query: std.Target.Query, gpa: Allocator) std.Target {
+    return std.zig.system.resolveTargetQuery(target_query, gpa) catch |err|
         std.process.fatal("unable to resolve target: {s}", .{@errorName(err)});
 }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5369,7 +5369,10 @@ fn workerDocsWasmFallible(comp: *Compilation, prog_node: std.Progress.Node) SubU
                 //.simd128,
                 // .tail_call, not supported by Safari
             }),
-        }) catch unreachable,
+        }, gpa) catch |err| switch (err) {
+            error.OutOfMemory => |e| return e,
+            else => unreachable,
+        },
 
         .is_native_os = false,
         .is_native_abi = false,

--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -39,7 +39,7 @@ pub fn cmdEnv(
     const zig_std_dir = try dirs.zig_lib.join(arena, &.{"std"});
     const global_cache_dir = dirs.global_cache.path orelse "";
 
-    const host = try std.zig.system.resolveTargetQuery(.{});
+    const host = try std.zig.system.resolveTargetQuery(.{}, arena);
     const triple = try host.zigTriple(arena);
 
     var serializer: std.zon.Serializer = .{ .writer = out };

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -618,7 +618,7 @@ pub fn lowerToBuildSteps(
     parent_step: *std.Build.Step,
     options: CaseTestOptions,
 ) void {
-    const host = std.zig.system.resolveTargetQuery(.{}) catch |err|
+    const host = std.zig.system.resolveTargetQuery(.{}, b.allocator) catch |err|
         std.debug.panic("unable to detect native host: {s}\n", .{@errorName(err)});
     const cases_dir_path = b.build_root.join(b.allocator, &.{ "test", "cases" }) catch @panic("OOM");
 
@@ -1126,14 +1126,6 @@ const TestManifest = struct {
         }
     }
 };
-
-fn resolveTargetQuery(query: std.Target.Query) std.Build.ResolvedTarget {
-    return .{
-        .query = query,
-        .target = std.zig.system.resolveTargetQuery(query) catch
-            @panic("unable to resolve target query"),
-    };
-}
 
 fn knownFileExtension(filename: []const u8) bool {
     // List taken from `Compilation.classifyFileExt` in the compiler.

--- a/tools/doctest.zig
+++ b/tools/doctest.zig
@@ -123,7 +123,7 @@ fn printOutput(
     var env_map = try process.getEnvMap(arena);
     try env_map.put("CLICOLOR_FORCE", "1");
 
-    const host = try std.zig.system.resolveTargetQuery(.{});
+    const host = try std.zig.system.resolveTargetQuery(.{}, arena);
     const obj_ext = builtin.object_format.fileExt(builtin.cpu.arch);
     const print = std.debug.print;
 
@@ -238,7 +238,7 @@ fn printOutput(
             const target_query = try std.Target.Query.parse(.{
                 .arch_os_abi = code.target_str orelse "native",
             });
-            const target = try std.zig.system.resolveTargetQuery(target_query);
+            const target = try std.zig.system.resolveTargetQuery(target_query, arena);
 
             const path_to_exe = try std.fmt.allocPrint(arena, "./{s}{s}", .{
                 code_name, target.exeFileExt(),
@@ -316,9 +316,7 @@ fn printOutput(
                 const target_query = try std.Target.Query.parse(.{
                     .arch_os_abi = triple,
                 });
-                const target = try std.zig.system.resolveTargetQuery(
-                    target_query,
-                );
+                const target = try std.zig.system.resolveTargetQuery(target_query, arena);
                 switch (getExternalExecutor(&host, &target, .{
                     .link_libc = code.link_libc,
                 })) {

--- a/tools/fetch_them_macos_headers.zig
+++ b/tools/fetch_them_macos_headers.zig
@@ -85,7 +85,7 @@ pub fn main() anyerror!void {
     }
 
     const sysroot_path = sysroot orelse blk: {
-        const target = try std.zig.system.resolveTargetQuery(.{});
+        const target = try std.zig.system.resolveTargetQuery(.{}, gpa);
         break :blk std.zig.system.darwin.getSdk(allocator, &target) orelse
             fatal("no SDK found; you can provide one explicitly with '--sysroot' flag", .{});
     };

--- a/tools/generate_c_size_and_align_checks.zig
+++ b/tools/generate_c_size_and_align_checks.zig
@@ -40,7 +40,7 @@ pub fn main() !void {
     }
 
     const query = try std.Target.Query.parse(.{ .arch_os_abi = args[1] });
-    const target = try std.zig.system.resolveTargetQuery(query);
+    const target = try std.zig.system.resolveTargetQuery(query, gpa);
 
     var buffer: [2000]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writerStreaming(&buffer);

--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -86,7 +86,7 @@ pub fn main() !void {
     else
         null;
 
-    const host = try std.zig.system.resolveTargetQuery(.{});
+    const host = try std.zig.system.resolveTargetQuery(.{}, arena);
 
     const debug_log_verbose = debug_zcu or debug_dwarf or debug_link;
 
@@ -696,7 +696,7 @@ const Case = struct {
                         },
                     }) catch fatal("line {d}: invalid target query '{s}'", .{ line_n, query });
 
-                    const resolved = try std.zig.system.resolveTargetQuery(parsed_query);
+                    const resolved = try std.zig.system.resolveTargetQuery(parsed_query, arena);
 
                     try targets.append(arena, .{
                         .query = query,


### PR DESCRIPTION
Fixes ABI detection and adds API level detection (#24630).

I was planning on also including a fix for #24860, but I am not sure how to proceed due to the `faccessat` syscall not supporting flags (#16606).