### PR TITLE
[std] fix compile error in std.Io.Writer.failing

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -141,7 +141,13 @@ pub const failing: Writer = .{
         .sendFile = failingSendFile,
         .rebase = failingRebase,
     },
+    .buffer = &.{},
 };
+
+test failing {
+    var fw: Writer = .failing;
+    try testing.expectError(error.WriteFailed, fw.writeAll("always fails"));
+}
 
 /// Returns the contents not yet drained.
 pub fn buffered(w: *const Writer) []u8 {


### PR DESCRIPTION
I know it's supposed to fail, but probably just at runtime.