### PR TITLE
zstd: Protect against index out-of-bounds when decoding sequences

### DIFF
--- a/lib/std/compress/zstd/Decompress.zig
+++ b/lib/std/compress/zstd/Decompress.zig
@@ -765,6 +765,9 @@ pub const Frame = struct {
                 const match_length: usize = sequence.match_length;
                 const sequence_length = literal_length + match_length;
 
+                if (sequence_length > dest[write_pos..].len)
+                    return error.MalformedSequence;
+
                 const copy_start = std.math.sub(usize, write_pos + sequence.literal_length, sequence.offset) catch
                     return error.MalformedSequence;
 


### PR DESCRIPTION
Previously, index out-of-bounds could occur when copying match_length bytes while decoding whatever sequence happened to overflow `dest`. Now, each sequence checks that there is enough room for the full sequence_length (literal_length + match_length) before doing any copying.

Fixes the failing inputs found here: https://github.com/ziglang/zig/issues/24817#issuecomment-3192927715