### PR TITLE
std.Io.Writer: fix upper case hex float formatting

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -1090,7 +1090,7 @@ pub fn printValue(
                 else => invalidFmtError(fmt, value),
             },
             'X' => switch (@typeInfo(T)) {
-                .float, .comptime_float => return printFloatHexOptions(w, value, options.toNumber(.hex, .lower)),
+                .float, .comptime_float => return printFloatHexOptions(w, value, options.toNumber(.hex, .upper)),
                 .int, .comptime_int => return printInt(w, value, 16, .upper, options),
                 .@"enum" => return printInt(w, @intFromEnum(value), 16, .upper, options),
                 .@"struct" => return value.formatNumber(w, options.toNumber(.hex, .upper)),


### PR DESCRIPTION
```zig
std.debug.print("{X}", .{@as(f32, 123)});
// old: 0x1.ecp6
// new: 0x1.ECp6
```

The 'p' being lower case is in line with the 'e' being lower case in the 'E' format specifier.

```zig
std.debug.print("{E}", .{@as(f32, 123)}); // 1.23e2
```