### PR TITLE
never advance seek position in `std.Io.Reader.peekDelimiterExclusive`

### DIFF
--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -836,7 +836,6 @@ pub fn peekDelimiterExclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
         error.EndOfStream => {
             const remaining = r.buffer[r.seek..r.end];
             if (remaining.len == 0) return error.EndOfStream;
-            r.toss(remaining.len);
             return remaining;
         },
         else => |e| return e,


### PR DESCRIPTION
Extends the existing test to fail, then fixes it. Closes https://github.com/ziglang/zig/issues/24609.