### PR TITLE
`std.posix.faccessat`: fallback to older `faccessat` syscall if possible

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1238,11 +1238,15 @@ pub fn access(path: [*:0]const u8, mode: u32) usize {
     if (@hasField(SYS, "access")) {
         return syscall2(.access, @intFromPtr(path), mode);
     } else {
-        return syscall4(.faccessat, @as(usize, @bitCast(@as(isize, AT.FDCWD))), @intFromPtr(path), mode, 0);
+        return faccessat(AT.FDCWD, path, mode);
     }
 }
 
-pub fn faccessat(dirfd: i32, path: [*:0]const u8, mode: u32, flags: u32) usize {
+pub fn faccessat(dirfd: i32, path: [*:0]const u8, mode: u32) usize {
+    return syscall3(.faccessat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode);
+}
+
+pub fn faccessat2(dirfd: i32, path: [*:0]const u8, mode: u32, flags: u32) usize {
     return syscall4(.faccessat2, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode, flags);
 }
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -5054,7 +5054,16 @@ pub fn faccessatZ(dirfd: fd_t, path: [*:0]const u8, mode: u32, flags: u32) Acces
     } else if (native_os == .wasi and !builtin.link_libc) {
         return faccessat(dirfd, mem.sliceTo(path, 0), mode, flags);
     }
-    switch (errno(system.faccessat(dirfd, path, mode, flags))) {
+
+    const need_flags = (flags != 0);
+    const faccessat_result = switch (system) {
+        linux => if (need_flags) //the older, simpler syscall should stay supported, so we only need to use faccessat2 if we need flags
+            linux.faccessat2(dirfd, path, mode, flags)
+        else
+            linux.faccessat(dirfd, path, mode),
+        else => system.faccessat(dirfd, path, mode, flags),
+    };
+    switch (errno(faccessat_result)) {
         .SUCCESS => return,
         .ACCES => return error.AccessDenied,
         .PERM => return error.PermissionDenied,


### PR DESCRIPTION
This is my attempt to implement the suggestion in https://github.com/ziglang/zig/issues/24860#issuecomment-3194609458.
I'm not too familiar with the `std` coding style - I looked at surrounding code, but feel free to suggest or directly edit and apply improvements.

This is my third attempt in trying to make the change not look too gnarly.
I split it up into 2 commits, but due to the indentation change the regular git diff in the second still comes out rather ugly.

I'm also not on linux / building anything for android, so couldn't actually test this locally - hoping there's no typo, or that this can otherwise at least serve as basis for discussion.
Should close https://github.com/ziglang/zig/issues/24860 , if it works as intended.