### PR TITLE
add Darwin family systems handling for totalSystemMemory

### DIFF
--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1764,7 +1764,8 @@ pub fn totalSystemMemory() TotalSystemMemoryError!u64 {
             };
             return @as(u64, @intCast(physmem));
         },
-        .macos => {
+        // whole Darwin family
+        .driverkit, .ios, .macos, .tvos, .visionos, .watchos => {
             // "hw.memsize" returns uint64_t
             var physmem: u64 = undefined;
             var len: usize = @sizeOf(u64);

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1762,7 +1762,7 @@ pub fn totalSystemMemory() TotalSystemMemoryError!u64 {
                 error.UnknownName => unreachable,
                 else => return error.UnknownTotalSystemMemory,
             };
-            return @as(usize, @intCast(physmem));
+            return @as(u64, @intCast(physmem));
         },
         .macos => {
             // "hw.memsize" returns uint64_t


### PR DESCRIPTION
Hi, I just started learing zig. I was trying to fetch total system memory on macOS and noticed that `totalSystemMemory` does not support it.

This PR adds it.

I believe there are a few issues with `totalSystemMemory` for `.freebsd` and `std.posix.sysctlbynameZ`, but I do not know what the correct approach to take here

1. `totalSystemMemory` for `.freebsd` returns `usize` instead of `u64`, I believe this should be fixed
2. `totalSystemMemory` for `.freebsd` does not handle all the errors from `std.posix.sysctlbynameZ`.
3. Last but not least, `std.posix.sysctlbynameZ` never returns `NameTooLong`. So either we should change the return type, or, as @andrewrk did in https://github.com/ziglang/zig/commit/3640303ce1585f266f94e2c815287cb590478e0d we should add [`name_len` handling](https://github.com/ziglang/zig/commit/3640303ce1585f266f94e2c815287cb590478e0d#diff-3524af3d9f3dbb356c9cc7061a43a06bed2196e13ab54f5045f751cefe7e6ca4R2085). I did not find any mention of `ENAMETOOLONG` in manpages for freebsd/posix. So I am having a hard time understanding which way is correct here.

Just for the context I know that there were discussions in https://github.com/ziglang/zig/pull/16350 that resulted in the rollback of patches that already implemented [this functionality before](https://github.com/ziglang/zig/pull/16350/files#diff-2c3ce4020bb6b3181eb9afefddb44e1860d428573a0107076a572095bc3d8974L1166). Please let me know what should be done to meet contributing standards to avoid same fate as [previous contributor](https://github.com/ziglang/zig/commit/70d1bb8049b1ac3bbff48c4147bf61e77b7ed7d5) 🙂

I am ready to provide patches for 1 and 2 in this PR or create separate one

Thanks! 


