### PR TITLE
Update powi.zig to fix docstring formatting

### DIFF
--- a/lib/std/math/powi.zig
+++ b/lib/std/math/powi.zig
@@ -13,6 +13,7 @@ const testing = std.testing;
 /// Errors:
 ///  - Overflow: Integer overflow or Infinity
 ///  - Underflow: Absolute value of result smaller than 1
+///
 /// Edge case rules ordered by precedence:
 ///  - powi(T, x, 0)   = 1 unless T is i1, i0, u0
 ///  - powi(T, 0, x)   = 0 when x > 0


### PR DESCRIPTION
Without this change, the docs are formatted s.t. the text "Edge case rules ordered by precedence:" is appended onto the prior line of text "Underflow: Absolute value of result smaller than 1", instead of getting its own line.

See issue in docs:
- current docs state: https://ziglang.org/documentation/master/std/#std.math.powi
- original issue docs state: https://ziglang.org/documentation/0.14.1/std/#std.math.powi