### PR TITLE
expose darwin.PT in std.c

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -11064,6 +11064,7 @@ pub const kinfo_getfile = freebsd.kinfo_getfile;
 
 pub const COPYFILE = darwin.COPYFILE;
 pub const CPUFAMILY = darwin.CPUFAMILY;
+pub const PT = darwin.PT;
 pub const DB_RECORDTYPE = darwin.DB_RECORDTYPE;
 pub const EXC = darwin.EXC;
 pub const EXCEPTION = darwin.EXCEPTION;


### PR DESCRIPTION
I just tried to use ptrace on macOS (which is already a miserable experience!) and noticed that `darwin.PT` isn't exposed anywhere. I'm guessing it was missed in #20679.