### PR TITLE
Fix bugs in Windows readVec implementations

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1343,14 +1343,15 @@ pub const Reader = struct {
                 if (is_windows) {
                     // Unfortunately, `ReadFileScatter` cannot be used since it
                     // requires page alignment.
-                    assert(io_reader.seek == io_reader.end);
-                    io_reader.seek = 0;
-                    io_reader.end = 0;
+                    if (io_reader.seek == io_reader.end) {
+                        io_reader.seek = 0;
+                        io_reader.end = 0;
+                    }
                     const first = data[0];
-                    if (first.len >= io_reader.buffer.len) {
+                    if (first.len >= io_reader.buffer.len - io_reader.end) {
                         return readPositional(r, first);
                     } else {
-                        io_reader.end += try readPositional(r, io_reader.buffer);
+                        io_reader.end += try readPositional(r, io_reader.buffer[io_reader.end..]);
                         return 0;
                     }
                 }
@@ -1391,14 +1392,15 @@ pub const Reader = struct {
                 if (is_windows) {
                     // Unfortunately, `ReadFileScatter` cannot be used since it
                     // requires page alignment.
-                    assert(io_reader.seek == io_reader.end);
-                    io_reader.seek = 0;
-                    io_reader.end = 0;
+                    if (io_reader.seek == io_reader.end) {
+                        io_reader.seek = 0;
+                        io_reader.end = 0;
+                    }
                     const first = data[0];
-                    if (first.len >= io_reader.buffer.len) {
-                        return readStreaming(r, first);
+                    if (first.len >= io_reader.buffer.len - io_reader.end) {
+                        return readPositional(r, first);
                     } else {
-                        io_reader.end += try readStreaming(r, io_reader.buffer);
+                        io_reader.end += try readPositional(r, io_reader.buffer[io_reader.end..]);
                         return 0;
                     }
                 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1992,8 +1992,7 @@ pub const Stream = struct {
                 };
                 if (n == 0) return error.EndOfStream;
                 if (n > data_size) {
-                    io_r.seek = 0;
-                    io_r.end = n - data_size;
+                    io_r.end += n - data_size;
                     return data_size;
                 }
                 return n;


### PR DESCRIPTION
Closes #24911

This fixes the HTTPS/TLS and package manager problems on Windows. Tested against the repro in the linked issue as well as by `zig build --fetch`ing https://github.com/castholm/zig-examples/tree/master/breakout with an empty global package cache.