### PR TITLE
Use readStreaming, not readPositional, for streaming file readVec on Windows

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1398,9 +1398,9 @@ pub const Reader = struct {
                     }
                     const first = data[0];
                     if (first.len >= io_reader.buffer.len - io_reader.end) {
-                        return readPositional(r, first);
+                        return readStreaming(r, first);
                     } else {
-                        io_reader.end += try readPositional(r, io_reader.buffer[io_reader.end..]);
+                        io_reader.end += try readStreaming(r, io_reader.buffer[io_reader.end..]);
                         return 0;
                     }
                 }


### PR DESCRIPTION
Fixes an unfortunate copy/paste error introduced in 9e9cb3ad6dacf65cb8e48fa095afef14c666c7b9

Thankfully, because `ReadFile` updates the file pointer on positional reads, and also ignores `OVERLAPPED` `Offset/OffsetHigh` fields for handles that don't support offsets, this mistake shouldn't have affected any observable behavior. Regardless, it should be fixed.

https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile