### PR TITLE
std.os.uefi: Fix typo that causes compile time error #22809"

### DIFF
--- a/lib/std/os/uefi/protocol/service_binding.zig
+++ b/lib/std/os/uefi/protocol/service_binding.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const uefi = std.uefi;
+const uefi = std.os.uefi;
 const Guid = uefi.Guid;
 const Handle = uefi.Handle;
 const Status = uefi.Status;


### PR DESCRIPTION

See #24922
