### PR TITLE
http.Client: don't forget to flush

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1797,7 +1797,7 @@ pub fn fetch(client: *Client, options: FetchOptions) FetchError!FetchResult {
 
     if (options.payload) |payload| {
         req.transfer_encoding = .{ .content_length = payload.len };
-        var body = try req.sendBody(&.{});
+        var body = try req.sendBodyUnflushed(&.{});
         try body.writer.writeAll(payload);
         try body.end();
         try req.connection.?.flush();

--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1800,6 +1800,7 @@ pub fn fetch(client: *Client, options: FetchOptions) FetchError!FetchResult {
         var body = try req.sendBody(&.{});
         try body.writer.writeAll(payload);
         try body.end();
+        try req.connection.?.flush();
     } else {
         try req.sendBodiless();
     }


### PR DESCRIPTION
When using ``http.Client.fetch`` with a payload, the http requests did not work because the client forgot to flush.

This fixes it.

I was hoping we could use ``req.sendBodyComplete(payload)`` but got a type error since payload is ``[]const u8`` and that function expects ``[]u8``.