### PR TITLE
`std.fs.Dir`: fix `updateFile()` to flush the file before updating its times

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -2583,8 +2583,9 @@ pub fn updateFile(
         error.ReadFailed => return src_reader.err.?,
         error.WriteFailed => return atomic_file.file_writer.err.?,
     };
+    try atomic_file.flush();
     try atomic_file.file_writer.file.updateTimes(src_stat.atime, src_stat.mtime);
-    try atomic_file.finish();
+    try atomic_file.renameIntoPlace();
     return .stale;
 }
 


### PR DESCRIPTION
`AtomicFile.finish()` calls `flush()` which renders any previous `updateTimes()` calls useless. Regression introduced in f2a3ac7c0534a74ee544fdf6ef9d2176a8d62389.

Closes #24927.