### PR TITLE
std: remove lossy int to float coercion on json parse

### DIFF
--- a/lib/std/json/static.zig
+++ b/lib/std/json/static.zig
@@ -567,8 +567,8 @@ pub fn innerParseFromValue(
             switch (source) {
                 .float => |f| {
                     if (@round(f) != f) return error.InvalidNumber;
-                    if (f > std.math.maxInt(T)) return error.Overflow;
-                    if (f < std.math.minInt(T)) return error.Overflow;
+                    if (f > @as(@TypeOf(f), @floatFromInt(std.math.maxInt(T)))) return error.Overflow;
+                    if (f < @as(@TypeOf(f), @floatFromInt(std.math.minInt(T)))) return error.Overflow;
                     return @as(T, @intFromFloat(f));
                 },
                 .integer => |i| {
@@ -770,7 +770,7 @@ fn sliceToInt(comptime T: type, slice: []const u8) !T {
     // Try to coerce a float to an integer.
     const float = try std.fmt.parseFloat(f128, slice);
     if (@round(float) != float) return error.InvalidNumber;
-    if (float > std.math.maxInt(T) or float < std.math.minInt(T)) return error.Overflow;
+    if (float > @as(f128, @floatFromInt(std.math.maxInt(T))) or float < @as(f128, @floatFromInt(std.math.minInt(T)))) return error.Overflow;
     return @as(T, @intCast(@as(i128, @intFromFloat(float))));
 }
 


### PR DESCRIPTION
Fixes #24728 

The `innerParseFromValue` still had the old way of comparing with `maxInt` and `minInt` that was updated in this commit: [`64bf8bb` (#24632)](https://github.com/ziglang/zig/pull/24632/commits/64bf8bb146099b51d74635a1f116a913e442bcf4)