### PR TITLE
docs: fix typo in comment by removing repeated 'business' word

### DIFF
--- a/lib/init/build.zig
+++ b/lib/init/build.zig
@@ -44,7 +44,7 @@ pub fn build(b: *std.Build) void {
     // Here we define an executable. An executable needs to have a root module
     // which needs to expose a `main` function. While we could add a main function
     // to the module defined above, it's sometimes preferable to split business
-    // business logic and the CLI into two separate modules.
+    // logic and the CLI into two separate modules.
     //
     // If your goal is to create a Zig library for others to use, consider if
     // it might benefit from also exposing a CLI tool. A parser library for a


### PR DESCRIPTION
fix typo in comment about executable module in generated build.zig

I removed repeated "business" word in the comment in [build.zig](https://github.com/ziglang/zig/blob/master/lib/init/build.zig#L46-L47). 