### PR TITLE
std.Build.Step.TranslateC forward --cache-dir argument

### DIFF
--- a/lib/std/Build/Step/TranslateC.zig
+++ b/lib/std/Build/Step/TranslateC.zig
@@ -163,6 +163,12 @@ fn make(step: *Step, options: Step.MakeOptions) !void {
         try argv_list.append("-fno-clang");
     }
 
+    try argv_list.append("--cache-dir");
+    try argv_list.append(b.cache_root.path orelse ".");
+
+    try argv_list.append("--global-cache-dir");
+    try argv_list.append(b.graph.global_cache_root.path orelse ".");
+
     try argv_list.append("--listen=-");
 
     if (!translate_c.target.query.isNative()) {


### PR DESCRIPTION
Closes #24958

Let me know if this should also pass on `--global-cache-dir`. I'm not familiar enough with the caching system to be sure but my initial impression was that it isn't necessary.