### PR TITLE
Add `test-obj` to the help message

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -87,6 +87,7 @@ const normal_usage =
     \\  build-lib        Create library from source or object files
     \\  build-obj        Create object from source or object files
     \\  test             Perform unit testing
+    \\  test-obj         Create object for unit testing
     \\  run              Create executable and run immediately
     \\
     \\  ast-check        Look for simple compile errors in any set of files


### PR DESCRIPTION
The `test-obj` subcommand, introduced in 927f233, was missing from the help output