### PR TITLE
`std.zig.system`: fix check for sparc "v8+" in `getExternalExecutor()`

### DIFF
--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -109,7 +109,7 @@ pub fn getExternalExecutor(
             .riscv64 => Executor{ .qemu = "qemu-riscv64" },
             .s390x => Executor{ .qemu = "qemu-s390x" },
             .sparc => Executor{
-                .qemu = if (candidate.cpu.has(.sparc, .v9))
+                .qemu = if (candidate.cpu.has(.sparc, .v8plus))
                     "qemu-sparc32plus"
                 else
                     "qemu-sparc",


### PR DESCRIPTION
Targeting v9 on sparc32 doesn't by itself imply "v8+" mode (64-bit instructions in 32-bit code).