### PR TITLE
`zig cc`: don't pass `-mcmodel` for assembly files

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -6831,10 +6831,6 @@ pub fn addCCArgs(
         try argv.append("-municode");
     }
 
-    if (mod.code_model != .default) {
-        try argv.append(try std.fmt.allocPrint(arena, "-mcmodel={s}", .{@tagName(mod.code_model)}));
-    }
-
     try argv.ensureUnusedCapacity(2);
     switch (comp.config.debug_format) {
         .strip => {},
@@ -7129,6 +7125,10 @@ pub fn addCCArgs(
         .ll,
         .bc,
         => {
+            if (mod.code_model != .default) {
+                try argv.append(try std.fmt.allocPrint(arena, "-mcmodel={s}", .{@tagName(mod.code_model)}));
+            }
+
             if (target_util.clangSupportsTargetCpuArg(target)) {
                 if (target.cpu.model.llvm_name) |llvm_name| {
                     try argv.appendSlice(&[_][]const u8{


### PR DESCRIPTION
It does nothing but generate a warning for these.