### PR TITLE
os.linux: faccessat syscall wrapper  prefer to faccessat when flags is zero

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1238,11 +1238,14 @@ pub fn access(path: [*:0]const u8, mode: u32) usize {
     if (@hasField(SYS, "access")) {
         return syscall2(.access, @intFromPtr(path), mode);
     } else {
-        return syscall4(.faccessat, @as(usize, @bitCast(@as(isize, AT.FDCWD))), @intFromPtr(path), mode, 0);
+        return faccessat(AT.FDCWD, path, mode, 0);
     }
 }
 
 pub fn faccessat(dirfd: i32, path: [*:0]const u8, mode: u32, flags: u32) usize {
+    if (flags == 0) {
+        return syscall3(.faccessat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode);
+    }
     return syscall4(.faccessat2, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), mode, flags);
 }
 


### PR DESCRIPTION

This make `fs.Dir.access` has more compatibility as the zig version 0.14.

With this change the `zig build --search-prefix` command would work again like the zig 0.14 version when used on Ubuntu20.04, kernel version 5.4.

Partly Align with [go](https://github.com/golang/go/blob/44c5956bf7454ca178c596eb87578ea61d6c9dee/src/syscall/syscall_linux.go#L155) and musl-libc preference.

No intent to fix issue #24860, as this only try to add more compatibility but no emulation.
