### PR TITLE
std.net.Ip6Address: format numerical scope id

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -747,6 +747,9 @@ pub const Ip6Address = extern struct {
                 try w.writeAll(":");
             }
         }
+        if (self.sa.scope_id != 0) {
+            try w.print("%{}", .{self.sa.scope_id});
+        }
         try w.print("]:{}", .{port});
     }
 

--- a/lib/std/net/test.zig
+++ b/lib/std/net/test.zig
@@ -73,7 +73,7 @@ test "parse and render IPv6 addresses" {
         "2001:db8::",
         "::1234:5678",
         "2001:db8::1234:5678",
-        "ff01::fb",
+        "ff01::fb%1234",
         "::ffff:123.5.123.5",
     };
     for (ips, 0..) |ip, i| {


### PR DESCRIPTION
This is a fairly trivial fix to make `format` usable with IPv6 link-local addresses, where the scope ID identifies the network interface.

With this fix, the formatted string can be parsed back to an address without losing the scope ID.