### PR TITLE
std.Build.WebServer: fix race

### DIFF
--- a/lib/std/Build/WebServer.zig
+++ b/lib/std/Build/WebServer.zig
@@ -323,7 +323,7 @@ fn serveWebSocket(ws: *WebServer, sock: *http.Server.WebSocket) !noreturn {
                 // Temporarily unlock, then re-lock after the message is sent.
                 ws.time_report_mutex.unlock();
                 defer ws.time_report_mutex.lock();
-                try sock.writeMessage(msg, .binary);
+                try sock.writeMessage(owned_msg, .binary);
             }
         }
 


### PR DESCRIPTION
Just a typo: I wasn't actually using the duped message, so the message I sent could be freed in this interval.

Thanks to @scottredig for noticing this and flagging it up to me.