### PR TITLE
fs: when linux statx is not exist add fallback syscall to fstatat.

### DIFF
--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -2707,18 +2707,23 @@ pub fn statFile(self: Dir, sub_path: []const u8) StatFileError!Stat {
             &stx,
         );
 
-        return switch (linux.E.init(rc)) {
-            .SUCCESS => Stat.fromLinux(stx),
-            .ACCES => error.AccessDenied,
+        switch (linux.E.init(rc)) {
+            .SUCCESS => return Stat.fromLinux(stx),
+            .ACCES => return error.AccessDenied,
             .BADF => unreachable,
             .FAULT => unreachable,
             .INVAL => unreachable,
-            .LOOP => error.SymLinkLoop,
+            .LOOP => return error.SymLinkLoop,
             .NAMETOOLONG => unreachable, // Handled by posix.toPosixPath() above.
-            .NOENT, .NOTDIR => error.FileNotFound,
-            .NOMEM => error.SystemResources,
-            else => |err| posix.unexpectedErrno(err),
-        };
+            .NOENT, .NOTDIR => return error.FileNotFound,
+            .NOSYS => {
+                // riscv32 and loongarch have not implement fstatat and will not reach here
+                if (builtin.cpu.arch == .riscv32 or builtin.cpu.arch.isLoongArch()) unreachable;
+                // fallback to posix fstatat
+            },
+            .NOMEM => return error.SystemResources,
+            else => |err| return posix.unexpectedErrno(err),
+        }
     }
     const st = try posix.fstatat(self.fd, sub_path, 0);
     return Stat.fromPosix(st);

--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -570,8 +570,8 @@ pub fn stat(self: File) StatError!Stat {
             &stx,
         );
 
-        return switch (linux.E.init(rc)) {
-            .SUCCESS => Stat.fromLinux(stx),
+        switch (linux.E.init(rc)) {
+            .SUCCESS => return Stat.fromLinux(stx),
             .ACCES => unreachable,
             .BADF => unreachable,
             .FAULT => unreachable,
@@ -579,10 +579,15 @@ pub fn stat(self: File) StatError!Stat {
             .LOOP => unreachable,
             .NAMETOOLONG => unreachable,
             .NOENT => unreachable,
-            .NOMEM => error.SystemResources,
+            .NOMEM => return error.SystemResources,
+            .NOSYS => {
+                // riscv32 and loongarch have not implement fstatat and will not reach here
+                if (builtin.cpu.arch == .riscv32 or builtin.cpu.arch.isLoongArch()) unreachable;
+                // fallback to posix fstatat
+            },
             .NOTDIR => unreachable,
-            else => |err| posix.unexpectedErrno(err),
-        };
+            else => |err| return posix.unexpectedErrno(err),
+        }
     }
 
     const st = try posix.fstat(self.handle);


### PR DESCRIPTION
Test on CentOS Linux 7.9.2009, linux kernel version 3.10.1160.

Related: #23514.