### PR TITLE
std.debug: remove `@frameAddress()` "UAF"

### DIFF
--- a/test/standalone/stack_iterator/unwind.zig
+++ b/test/standalone/stack_iterator/unwind.zig
@@ -10,7 +10,7 @@ noinline fn frame3(expected: *[4]usize, unwound: *[4]usize) void {
     testing.expect(debug.getContext(&context)) catch @panic("failed to getContext");
 
     const debug_info = debug.getSelfDebugInfo() catch @panic("failed to openSelfDebugInfo");
-    var it = debug.StackIterator.initWithContext(expected[0], debug_info, &context) catch @panic("failed to initWithContext");
+    var it = debug.StackIterator.initWithContext(expected[0], debug_info, &context, @frameAddress()) catch @panic("failed to initWithContext");
     defer it.deinit();
 
     for (unwound) |*addr| {


### PR DESCRIPTION
We can't call `@frameAddress()` and then immediately `return`! That invalidates the frame. This *usually* isn't a problem, because the stack walk `next` call will *probably* have a stack frame and it will *probably* be at the exact same address, but neither of those is a guarantee. On powerpc, presumably some unfortunate inlining was going on, so this frame was indeed invalidated when we started walking frames.

We need to explicitly pass `@frameAddress` into any function which will return before we actually walk the stack. Pretty simple patch.

Resolves: #24970