### PR TITLE
Fix `-M` and `--dep` splitting on every `=` instead of just the first

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1061,8 +1061,8 @@ fn buildOutputType(
                         }
                     } else if (mem.eql(u8, arg, "--dep")) {
                         var it = mem.splitScalar(u8, args_iter.nextOrFatal(), '=');
-                        const key = it.next().?;
-                        const value = it.next() orelse key;
+                        const key = it.first();
+                        const value = if (it.peek() != null) it.rest() else key;
                         if (mem.eql(u8, key, "std") and !mem.eql(u8, value, "std")) {
                             fatal("unable to import as '{s}': conflicts with builtin module", .{
                                 key,
@@ -1081,8 +1081,8 @@ fn buildOutputType(
                         });
                     } else if (mem.startsWith(u8, arg, "-M")) {
                         var it = mem.splitScalar(u8, arg["-M".len..], '=');
-                        const mod_name = it.next().?;
-                        const root_src_orig = it.next();
+                        const mod_name = it.first();
+                        const root_src_orig = if (it.peek() != null) it.rest() else null;
                         try handleModArg(
                             arena,
                             mod_name,


### PR DESCRIPTION
Before this commit, `-Mfoo=bar=baz` would be incorrectly split into mod_name: `foo` and root_src_orig: `bar`
After this commit, `-Mfoo=bar=baz` will be correctly split into mod_name: `foo` and root_src_orig: `bar=baz`

Fixes `-M` when used with a path that has a `=` in it, so, after this PR, this will work:

```
mkdir test=dir
cd test=dir 
zig init
zig build
```

Closes #25059