### PR TITLE
LLVM backend:fix align 1 sret parameter load returned

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -9773,6 +9773,7 @@ pub const FuncGen = struct {
         const ptr = try fg.resolveInst(ty_op.operand);
 
         elide: {
+            if (ptr_info.flags.alignment != .none) break :elide;
             if (!isByRef(Type.fromInterned(ptr_info.child), zcu)) break :elide;
             if (!canElideLoad(fg, body_tail)) break :elide;
             return ptr;


### PR DESCRIPTION
closes #25067

```llvm
; Function Attrs: noredzone nounwind uwtable
define internal fastcc void @test.gimme(ptr noalias sret(%test.S) nonnull %0, ptr align 1 nonnull %1) unnamed_addr #0 {
2:
  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %0, ptr align 4 %1, i64 4, i1 false)
  ret void
}
```

:arrow_down: 

```llvm
; Function Attrs: noredzone nounwind uwtable
define internal fastcc void @test.gimme(ptr noalias sret(%test.S) nonnull %0, ptr align 1 nonnull %1) unnamed_addr #0 {
2:
  %3 = alloca %test.S, align 4
  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %3, ptr align 1 %1, i64 4, i1 false)
  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %0, ptr align 4 %3, i64 4, i1 false)
  ret void
}
```

It's not ideal, but it's correct.