### PR TITLE
Revert "std.Io.Reader: work around llvm backend bug"

### DIFF
--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -1163,11 +1163,7 @@ pub inline fn takeStruct(r: *Reader, comptime T: type, endian: std.builtin.Endia
         .@"struct" => |info| switch (info.layout) {
             .auto => @compileError("ill-defined memory layout"),
             .@"extern" => {
-                // This code works around https://github.com/ziglang/zig/issues/25067
-                // by avoiding a call to `peekStructPointer`.
-                const struct_bytes = try r.takeArray(@sizeOf(T));
-                var res: T = undefined;
-                @memcpy(@as([]u8, @ptrCast(&res)), struct_bytes);
+                var res = (try r.takeStructPointer(T)).*;
                 if (native_endian != endian) std.mem.byteSwapAllFields(T, &res);
                 return res;
             },
@@ -1192,11 +1188,7 @@ pub inline fn peekStruct(r: *Reader, comptime T: type, endian: std.builtin.Endia
         .@"struct" => |info| switch (info.layout) {
             .auto => @compileError("ill-defined memory layout"),
             .@"extern" => {
-                // This code works around https://github.com/ziglang/zig/issues/25067
-                // by avoiding a call to `peekStructPointer`.
-                const struct_bytes = try r.peekArray(@sizeOf(T));
-                var res: T = undefined;
-                @memcpy(@as([]u8, @ptrCast(&res)), struct_bytes);
+                var res = (try r.peekStructPointer(T)).*;
                 if (native_endian != endian) std.mem.byteSwapAllFields(T, &res);
                 return res;
             },


### PR DESCRIPTION
This reverts commit 530cc2c1111699d9d02ad9ebef94efa6b99f5205.

The compiler bug has been fixed.