### PR TITLE
std.io.writer: enforce a format specifier

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -555,9 +555,8 @@ pub fn writeAll(w: *Writer, bytes: []const u8) Error!void {
 /// - *width* is the total width of the field in bytes. This only applies to number formatting.
 /// - *precision* specifies how many decimals a formatted number should have.
 ///
-/// Note that most of the parameters are optional and may be omitted. Also you
-/// can leave out separators like `:` and `.` when all parameters after the
-/// separator are omitted.
+/// The specifier is required. The other parameters are optional and may be omitted. Also, you
+/// can leave out separators like `:` and `.` when all parameters after the separator are omitted.
 ///
 /// Only exception is the *fill* parameter. If a non-zero *fill* character is
 /// required at the same time as *width* is specified, one has to specify
@@ -1038,6 +1037,7 @@ pub fn printValue(
     const T = @TypeOf(value);
 
     switch (fmt.len) {
+        0 => @compileError("a format specifier is required"),
         1 => switch (fmt[0]) {
             '*' => return w.printAddress(value),
             'f' => return value.format(w),
@@ -1194,27 +1194,20 @@ pub fn printValue(
     }
 
     const is_any = comptime std.mem.eql(u8, fmt, ANY);
-    if (!is_any and std.meta.hasMethod(T, "format") and fmt.len == 0) {
-        // after 0.15.0 is tagged, delete this compile error and its condition
-        @compileError("ambiguous format string; specify {f} to call format method, or {any} to skip it");
-    }
+    if (!is_any) invalidFmtError(fmt, value);
 
     switch (@typeInfo(T)) {
         .float, .comptime_float => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             return printFloat(w, value, options.toNumber(.decimal, .lower));
         },
         .int, .comptime_int => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             return printInt(w, value, 10, .lower, options);
         },
         .bool => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             const string: []const u8 = if (value) "true" else "false";
             return w.alignBufferOptions(string, options);
         },
         .void => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             return w.alignBufferOptions("void", options);
         },
         .optional => {
@@ -1244,12 +1237,10 @@ pub fn printValue(
             }
         },
         .error_set => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             optionsForbidden(options);
             return printErrorSet(w, value);
         },
         .@"enum" => |info| {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             optionsForbidden(options);
             if (info.is_exhaustive) {
                 return printEnumExhaustive(w, value);
@@ -1259,7 +1250,6 @@ pub fn printValue(
         },
         .@"union" => |info| {
             if (!is_any) {
-                if (fmt.len != 0) invalidFmtError(fmt, value);
                 return printValue(w, ANY, options, value, max_depth);
             }
             if (max_depth == 0) {
@@ -1294,10 +1284,6 @@ pub fn printValue(
             }
         },
         .@"struct" => |info| {
-            if (!is_any) {
-                if (fmt.len != 0) invalidFmtError(fmt, value);
-                return printValue(w, ANY, options, value, max_depth);
-            }
             if (info.is_tuple) {
                 // Skip the type and field names when formatting tuples.
                 if (max_depth == 0) {
@@ -1345,13 +1331,10 @@ pub fn printValue(
                 },
             },
             .many, .c => {
-                if (!is_any) @compileError("cannot format pointer without a specifier (i.e. {s} or {*})");
                 optionsForbidden(options);
                 try w.printAddress(value);
             },
             .slice => {
-                if (!is_any)
-                    @compileError("cannot format slice without a specifier (i.e. {s}, {x}, {b64}, or {any})");
                 if (max_depth == 0) return w.writeAll("{ ... }");
                 try w.writeAll("{ ");
                 for (value, 0..) |elem, i| {
@@ -1364,7 +1347,6 @@ pub fn printValue(
             },
         },
         .array => {
-            if (!is_any) @compileError("cannot format array without a specifier (i.e. {s} or {any})");
             if (max_depth == 0) return w.writeAll("{ ... }");
             try w.writeAll("{ ");
             for (value, 0..) |elem, i| {
@@ -1376,22 +1358,18 @@ pub fn printValue(
             try w.writeAll(" }");
         },
         .vector => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             return printVector(w, fmt, options, value, max_depth);
         },
         .@"fn" => @compileError("unable to format function body type, use '*const " ++ @typeName(T) ++ "' for a function pointer type"),
         .type => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             return w.alignBufferOptions(@typeName(value), options);
         },
         .enum_literal => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             optionsForbidden(options);
             var vecs: [2][]const u8 = .{ ".", @tagName(value) };
             return w.writeVecAll(&vecs);
         },
         .null => {
-            if (!is_any and fmt.len != 0) invalidFmtError(fmt, value);
             return w.alignBufferOptions("null", options);
         },
         else => @compileError("unable to format type '" ++ @typeName(T) ++ "'"),


### PR DESCRIPTION
### Enforce a format specifier

Following the reasonings of https://github.com/ziglang/zig/pull/7676 and https://github.com/ziglang/zig/issues/7675, remove the empty `{}` format specifier.

Currently we provide two default specifiers: `{}` and `{any}`. The latter was introduced to catch misuse of arrays at comptime after a [change](https://github.com/ziglang/zig/pull/7676) in their default behavior. Providing an empty format for ambiguous types (e.g. arrays) is [problematic](https://github.com/ziglang/zig/issues/7675) because (a) users may expect something other than the default output, and (b) this is not detectable at comptime. Zig’s strong typing and comptime features should also be reflected in the formatting syntax to prevent misuse and favor errors at compile time. In addition, these changes reduce comptime checks and avoid conflating two behaviors in one default path, improving clarity and maintainability.

@marler8997 you have been involved in several of these discussions. WDYT?
 
### Add support for custom formatting of array-like objects

The current formatter can’t print an array of objects that implement a custom `format`. You must either loop and print each element with `{f}` or wrap the array in a struct that does that loop in its format. By contrast, `{any}` will iterate and pretty‑print array elements as raw values. Add support for using `{f}` on array-like objects so it calls each element’s `format` implementation automatically.