### PR TITLE
Dedupe types when printing error messages

### DIFF
--- a/src/Air/print.zig
+++ b/src/Air/print.zig
@@ -361,7 +361,7 @@ const Writer = struct {
     }
 
     fn writeType(w: *Writer, s: *std.io.Writer, ty: Type) !void {
-        return ty.print(s, w.pt);
+        return ty.print(s, w.pt, null);
     }
 
     fn writeTy(w: *Writer, s: *std.io.Writer, inst: Air.Inst.Index) Error!void {

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -2440,9 +2440,26 @@ fn failWithErrorSetCodeMissing(
     src_err_set_ty: Type,
 ) CompileError {
     const pt = sema.pt;
-    return sema.fail(block, src, "expected type '{f}', found type '{f}'", .{
-        dest_err_set_ty.fmt(pt), src_err_set_ty.fmt(pt),
+
+    var cmp = try Type.Comparison.init(&.{
+        src_err_set_ty,
+        dest_err_set_ty,
+    }, pt);
+    defer cmp.deinit(sema.gpa);
+
+    const msg = try sema.errMsg(src, "expected type '{f}', found type '{f}'", .{
+        cmp.fmtType(dest_err_set_ty, pt),
+        cmp.fmtType(src_err_set_ty, pt),
     });
+    errdefer msg.destroy(sema.gpa);
+
+    var placeholders_iter = cmp.iterPlaceholders();
+    while (placeholders_iter.next()) |kv| {
+        const placeholder, const ty = kv;
+        try sema.errNote(src, msg, "{f} = {f}", .{ placeholder, ty.fmt(pt) });
+    }
+
+    return sema.failWithOwnedErrorMsg(block, msg);
 }
 
 pub fn failWithIntegerOverflow(sema: *Sema, block: *Block, src: LazySrcLoc, int_ty: Type, val: Value, vector_index: ?usize) CompileError {
@@ -29031,8 +29048,20 @@ fn coerceExtra(
     }
 
     const msg = msg: {
-        const msg = try sema.errMsg(inst_src, "expected type '{f}', found '{f}'", .{ dest_ty.fmt(pt), inst_ty.fmt(pt) });
+        var cmp = try Type.Comparison.init(&.{ inst_ty, dest_ty }, pt);
+        defer cmp.deinit(sema.gpa);
+
+        const msg = try sema.errMsg(inst_src, "expected type '{f}' but found '{f}'", .{
+            cmp.fmtType(dest_ty, sema.pt),
+            cmp.fmtType(inst_ty, sema.pt),
+        });
         errdefer msg.destroy(sema.gpa);
+
+        var placeholders_iter = cmp.iterPlaceholders();
+        while (placeholders_iter.next()) |kv| {
+            const placeholder, const ty = kv;
+            try sema.errNote(inst_src, msg, "{f} = {f}", .{ placeholder, ty.fmt(pt) });
+        }
 
         if (!can_coerce_to) {
             try sema.errNote(inst_src, msg, "cannot coerce to '{f}'", .{dest_ty.fmt(pt)});

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -141,7 +141,7 @@ const Format = struct {
     pt: Zcu.PerThread,
 
     fn default(f: Format, writer: *std.io.Writer) std.io.Writer.Error!void {
-        return print(f.ty, writer, f.pt);
+        return print(f.ty, writer, f.pt, null);
     }
 };
 
@@ -157,7 +157,20 @@ pub fn dump(start_type: Type, writer: *std.io.Writer) std.io.Writer.Error!void {
 
 /// Prints a name suitable for `@typeName`.
 /// TODO: take an `opt_sema` to pass to `fmtValue` when printing sentinels.
-pub fn print(ty: Type, writer: *std.io.Writer, pt: Zcu.PerThread) std.io.Writer.Error!void {
+pub fn print(ty: Type, writer: *std.io.Writer, pt: Zcu.PerThread, ctx: ?*Comparison) std.io.Writer.Error!void {
+    if (ctx) |c| {
+        const should_dedupe = shouldDedupeType(ty, c, pt) catch |err| switch (err) {
+            error.OutOfMemory => return error.WriteFailed,
+        };
+        switch (should_dedupe) {
+            .dont_dedupe => {},
+            .dedupe => |placeholder| {
+                const ret = try writer.print("<{c}>", .{placeholder.index + 'T'});
+                return ret;
+            },
+        }
+    }
+
     const zcu = pt.zcu;
     const ip = &zcu.intern_pool;
     switch (ip.indexToKey(ty.toIntern())) {
@@ -211,39 +224,39 @@ pub fn print(ty: Type, writer: *std.io.Writer, pt: Zcu.PerThread) std.io.Writer.
             if (info.flags.is_const) try writer.writeAll("const ");
             if (info.flags.is_volatile) try writer.writeAll("volatile ");
 
-            try print(Type.fromInterned(info.child), writer, pt);
+            try print(Type.fromInterned(info.child), writer, pt, ctx);
             return;
         },
         .array_type => |array_type| {
             if (array_type.sentinel == .none) {
                 try writer.print("[{d}]", .{array_type.len});
-                try print(Type.fromInterned(array_type.child), writer, pt);
+                try print(Type.fromInterned(array_type.child), writer, pt, ctx);
             } else {
                 try writer.print("[{d}:{f}]", .{
                     array_type.len,
                     Value.fromInterned(array_type.sentinel).fmtValue(pt),
                 });
-                try print(Type.fromInterned(array_type.child), writer, pt);
+                try print(Type.fromInterned(array_type.child), writer, pt, ctx);
             }
             return;
         },
         .vector_type => |vector_type| {
             try writer.print("@Vector({d}, ", .{vector_type.len});
-            try print(Type.fromInterned(vector_type.child), writer, pt);
+            try print(Type.fromInterned(vector_type.child), writer, pt, ctx);
             try writer.writeAll(")");
             return;
         },
         .opt_type => |child| {
             try writer.writeByte('?');
-            return print(Type.fromInterned(child), writer, pt);
+            return print(Type.fromInterned(child), writer, pt, ctx);
         },
         .error_union_type => |error_union_type| {
-            try print(Type.fromInterned(error_union_type.error_set_type), writer, pt);
+            try print(Type.fromInterned(error_union_type.error_set_type), writer, pt, ctx);
             try writer.writeByte('!');
             if (error_union_type.payload_type == .generic_poison_type) {
                 try writer.writeAll("anytype");
             } else {
-                try print(Type.fromInterned(error_union_type.payload_type), writer, pt);
+                try print(Type.fromInterned(error_union_type.payload_type), writer, pt, ctx);
             }
             return;
         },
@@ -325,7 +338,7 @@ pub fn print(ty: Type, writer: *std.io.Writer, pt: Zcu.PerThread) std.io.Writer.
             for (tuple.types.get(ip), tuple.values.get(ip), 0..) |field_ty, val, i| {
                 try writer.writeAll(if (i == 0) " " else ", ");
                 if (val != .none) try writer.writeAll("comptime ");
-                try print(Type.fromInterned(field_ty), writer, pt);
+                try print(Type.fromInterned(field_ty), writer, pt, ctx);
                 if (val != .none) try writer.print(" = {f}", .{Value.fromInterned(val).fmtValue(pt)});
             }
             try writer.writeAll(" }");
@@ -362,7 +375,7 @@ pub fn print(ty: Type, writer: *std.io.Writer, pt: Zcu.PerThread) std.io.Writer.
                 if (param_ty == .generic_poison_type) {
                     try writer.writeAll("anytype");
                 } else {
-                    try print(Type.fromInterned(param_ty), writer, pt);
+                    try print(Type.fromInterned(param_ty), writer, pt, ctx);
                 }
             }
             if (fn_info.is_var_args) {
@@ -389,13 +402,13 @@ pub fn print(ty: Type, writer: *std.io.Writer, pt: Zcu.PerThread) std.io.Writer.
             if (fn_info.return_type == .generic_poison_type) {
                 try writer.writeAll("anytype");
             } else {
-                try print(Type.fromInterned(fn_info.return_type), writer, pt);
+                try print(Type.fromInterned(fn_info.return_type), writer, pt, ctx);
             }
         },
         .anyframe_type => |child| {
             if (child == .none) return writer.writeAll("anyframe");
             try writer.writeAll("anyframe->");
-            return print(Type.fromInterned(child), writer, pt);
+            return print(Type.fromInterned(child), writer, pt, ctx);
         },
 
         // values, not types
@@ -4052,6 +4065,188 @@ pub fn isNullFromType(ty: Type, zcu: *const Zcu) ?bool {
     if (child.zigTypeTag(zcu) == .noreturn) return true; // `?noreturn` is always null
     return null;
 }
+
+/// Recursively walks the type and marks for each subtype how many times it has been seen
+fn collectSubtypes(ty: Type, pt: Zcu.PerThread, visited: *std.AutoArrayHashMapUnmanaged(Type, u32)) error{OutOfMemory}!void {
+    const zcu = pt.zcu;
+    const ip = &zcu.intern_pool;
+
+    const gop = try visited.getOrPut(zcu.gpa, ty);
+    if (gop.found_existing) {
+        gop.value_ptr.* += 1;
+    } else {
+        gop.value_ptr.* = 1;
+    }
+
+    switch (ip.indexToKey(ty.toIntern())) {
+        .ptr_type => try collectSubtypes(Type.fromInterned(ty.ptrInfo(zcu).child), pt, visited),
+        .array_type => |array_type| try collectSubtypes(Type.fromInterned(array_type.child), pt, visited),
+        .vector_type => |vector_type| try collectSubtypes(Type.fromInterned(vector_type.child), pt, visited),
+        .opt_type => |child| try collectSubtypes(Type.fromInterned(child), pt, visited),
+        .error_union_type => |error_union_type| {
+            try collectSubtypes(Type.fromInterned(error_union_type.error_set_type), pt, visited);
+            if (error_union_type.payload_type != .generic_poison_type) {
+                try collectSubtypes(Type.fromInterned(error_union_type.payload_type), pt, visited);
+            }
+        },
+        .tuple_type => |tuple| {
+            for (tuple.types.get(ip)) |field_ty| {
+                try collectSubtypes(Type.fromInterned(field_ty), pt, visited);
+            }
+        },
+        .func_type => |fn_info| {
+            const param_types = fn_info.param_types.get(&zcu.intern_pool);
+            for (param_types) |param_ty| {
+                if (param_ty != .generic_poison_type) {
+                    try collectSubtypes(Type.fromInterned(param_ty), pt, visited);
+                }
+            }
+
+            if (fn_info.return_type != .generic_poison_type) {
+                try collectSubtypes(Type.fromInterned(fn_info.return_type), pt, visited);
+            }
+        },
+        .anyframe_type => |child| try collectSubtypes(Type.fromInterned(child), pt, visited),
+
+        // leaf types
+        .undef,
+        .inferred_error_set_type,
+        .error_set_type,
+        .struct_type,
+        .union_type,
+        .opaque_type,
+        .enum_type,
+        .simple_type,
+        .int_type,
+        => {},
+
+        // values, not types
+        .simple_value,
+        .variable,
+        .@"extern",
+        .func,
+        .int,
+        .err,
+        .error_union,
+        .enum_literal,
+        .enum_tag,
+        .empty_enum_value,
+        .float,
+        .ptr,
+        .slice,
+        .opt,
+        .aggregate,
+        .un,
+        // memoization, not types
+        .memoized_call,
+        => unreachable,
+    }
+}
+
+fn shouldDedupeType(ty: Type, ctx: *Comparison, pt: Zcu.PerThread) error{OutOfMemory}!Comparison.DedupeEntry {
+    if (ctx.type_occurrences.get(ty)) |occ| {
+        if (ctx.type_dedupe_cache.getEntry(ty)) |entry| {
+            return entry.value_ptr.*;
+        }
+
+        var discarding: std.Io.Writer.Discarding = .init(&.{});
+
+        print(ty, &discarding.writer, pt, null) catch
+            unreachable; // we are writing into a discarding writer, it should never fail
+
+        const type_len = discarding.count;
+        const saved_bytes = (type_len * (occ - 1));
+        const should_dedupe = saved_bytes > 8;
+
+        const entry: Comparison.DedupeEntry = if (should_dedupe) b: {
+            ctx.placeholder_index += 1;
+            break :b .{ .dedupe = .{ .index = ctx.placeholder_index - 1 } };
+        } else .{ .dont_dedupe = {} };
+
+        try ctx.type_dedupe_cache.put(pt.zcu.gpa, ty, entry);
+
+        return entry;
+    } else {
+        return .{ .dont_dedupe = {} };
+    }
+}
+
+/// The comparison recursively walks all types given and notes how many times
+/// each subtype occurs. It then while recursively printing decides for each
+/// subtype wheter to print the type inline or create a placeholder based on
+/// the subtype length and number of occurences. Placeholders are then found by
+/// iterating `type_dedupe_cache` which caches the inline/placeholder decisions.
+pub const Comparison = struct {
+    type_occurrences: std.AutoArrayHashMapUnmanaged(Type, u32),
+    type_dedupe_cache: std.AutoArrayHashMapUnmanaged(Type, DedupeEntry),
+    placeholder_index: u8,
+
+    pub const Placeholder = struct {
+        index: u8,
+
+        pub fn format(p: Placeholder, writer: *std.io.Writer) error{WriteFailed}!void {
+            return writer.print("<{c}>", .{p.index + 'T'});
+        }
+    };
+
+    pub const DedupeEntry = union(enum) {
+        dont_dedupe: void,
+        dedupe: Placeholder,
+    };
+
+    pub fn init(types: []const Type, pt: Zcu.PerThread) error{OutOfMemory}!Comparison {
+        var cmp: Comparison = .{
+            .type_occurrences = .empty,
+            .type_dedupe_cache = .empty,
+            .placeholder_index = 0,
+        };
+
+        errdefer cmp.deinit(pt.zcu.gpa);
+
+        for (types) |ty| {
+            try collectSubtypes(ty, pt, &cmp.type_occurrences);
+        }
+
+        return cmp;
+    }
+
+    pub fn deinit(cmp: *Comparison, alc: Allocator) void {
+        cmp.type_occurrences.deinit(alc);
+        cmp.type_dedupe_cache.deinit(alc);
+    }
+
+    pub fn fmtType(ctx: *Comparison, ty: Type, pt: Zcu.PerThread) Comparison.Formatter {
+        return .{ .ty = ty, .ctx = ctx, .pt = pt };
+    }
+    pub const Formatter = struct {
+        ty: Type,
+        ctx: *Comparison,
+        pt: Zcu.PerThread,
+
+        pub fn format(self: Comparison.Formatter, writer: anytype) error{WriteFailed}!void {
+            print(self.ty, writer, self.pt, self.ctx) catch return error.WriteFailed;
+        }
+    };
+
+    pub fn iterPlaceholders(ctx: *Comparison) Comparison.PlaceholdersIterator {
+        return .{ .i = 0, .iter = ctx.type_dedupe_cache.iterator() };
+    }
+    pub const PlaceholdersIterator = struct {
+        i: u32,
+        iter: std.AutoArrayHashMapUnmanaged(Type, DedupeEntry).Iterator,
+
+        pub fn next(s: *PlaceholdersIterator) ?struct { Placeholder, Type } {
+            while (true)
+                if (s.iter.next()) |entry|
+                    switch (entry.value_ptr.*) {
+                        .dedupe => |placeholder| return .{ placeholder, entry.key_ptr.* },
+                        .dont_dedupe => continue,
+                    }
+                else
+                    return null;
+        }
+    };
+};
 
 pub const @"u1": Type = .{ .ip_index = .u1_type };
 pub const @"u8": Type = .{ .ip_index = .u8_type };

--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -2685,7 +2685,7 @@ pub const Object = struct {
     fn allocTypeName(o: *Object, pt: Zcu.PerThread, ty: Type) Allocator.Error![:0]const u8 {
         var aw: std.io.Writer.Allocating = .init(o.gpa);
         defer aw.deinit();
-        ty.print(&aw.writer, pt) catch |err| switch (err) {
+        ty.print(&aw.writer, pt, null) catch |err| switch (err) {
             error.WriteFailed => return error.OutOfMemory,
         };
         return aw.toOwnedSliceSentinel(0);

--- a/src/codegen/spirv/CodeGen.zig
+++ b/src/codegen/spirv/CodeGen.zig
@@ -1213,7 +1213,7 @@ fn resolveTypeName(cg: *CodeGen, ty: Type) ![]const u8 {
     const gpa = cg.module.gpa;
     var aw: std.io.Writer.Allocating = .init(gpa);
     defer aw.deinit();
-    ty.print(&aw.writer, cg.pt) catch |err| switch (err) {
+    ty.print(&aw.writer, cg.pt, null) catch |err| switch (err) {
         error.WriteFailed => return error.OutOfMemory,
     };
     return try aw.toOwnedSlice();

--- a/src/print_value.zig
+++ b/src/print_value.zig
@@ -65,7 +65,7 @@ pub fn print(
         .func_type,
         .error_set_type,
         .inferred_error_set_type,
-        => try Type.print(val.toType(), writer, pt),
+        => try Type.print(val.toType(), writer, pt, null),
         .undef => try writer.writeAll("undefined"),
         .simple_value => |simple_value| switch (simple_value) {
             .void => try writer.writeAll("{}"),

--- a/test/cases/compile_errors/type_dedupe.zig
+++ b/test/cases/compile_errors/type_dedupe.zig
@@ -1,0 +1,20 @@
+const SomeVeryLongName = struct {};
+
+fn foo(a: *SomeVeryLongName) void {
+    _ = a;
+}
+
+export fn entry() void {
+    const a: SomeVeryLongName = .{};
+
+    foo(a);
+}
+
+// error
+// backend=stage2
+// target=native
+//
+// :12:9: error: expected type '*<T>' but found '<T>'
+// :12:9: note: <T> = SomeVeryLongName
+// :3:35: note: struct declared here
+// :5:11: note: parameter type declared here


### PR DESCRIPTION
Hi! :D

Before:
```
file.zig:10:9: error: expected type '*type_dedupe.SomeVeryLongName', found 'type_dedupe.SomeVeryLongName'
    foo(a);
        ^
```
After:
```
file.zig:10:9: error: expected type '*<T>' but found '<T>'
    foo(a);
        ^
file.zig:10:9: note: <T> = type_dedupe.SomeVeryLongName
```

Previously discussed on zulip: [#compiler > Deduped type comparisons in error messages](https://zsf.zulipchat.com/#narrow/channel/454360-compiler/topic/Deduped.20type.20comparisons.20in.20error.20messages)

The placeholder formatting is ready to be bikeshedded. I would like to add more color but I'm not sure how to do that in a way that would respect no-color options from the cli and such.

I'm also not sure if I got all the places where sema diffs types.