### PR TITLE
std: fix spawning processes from libraries with env map

### DIFF
--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -52,6 +52,8 @@ term: ?(SpawnError!Term),
 argv: []const []const u8,
 
 /// Leave as null to use the current env map using the supplied allocator.
+/// Required if unable to access the current env map (e.g. building a library on
+/// some platforms).
 env_map: ?*const EnvMap,
 
 stdin_behavior: StdIo,
@@ -414,6 +416,8 @@ pub fn run(args: struct {
     argv: []const []const u8,
     cwd: ?[]const u8 = null,
     cwd_dir: ?fs.Dir = null,
+    /// Required if unable to access the current env map (e.g. building a
+    /// library on some platforms).
     env_map: ?*const EnvMap = null,
     max_output_bytes: usize = 50 * 1024,
     expand_arg0: Arg0Expand = .no_expand,
@@ -614,7 +618,7 @@ fn spawnPosix(self: *ChildProcess) SpawnError!void {
             })).ptr;
         } else {
             // TODO come up with a solution for this.
-            @compileError("missing std lib enhancement: ChildProcess implementation has no way to collect the environment variables to forward to the child process");
+            @panic("missing std lib enhancement: ChildProcess implementation has no way to collect the environment variables to forward to the child process");
         }
     };
 


### PR DESCRIPTION
In a library, the two `builtin.link_libc` and `builtin.output_mode == .Exe` checks could both be false. Thus, you would get a compile error even if you specified an `env_map` at runtime. This change turns the compile error into a runtime panic and updates the documentation to reflect the runtime requirement.

I tested this locally with the following library/executable setup:

```
zig init -m
```

```zig
// build.zig
const std = @import("std");

pub fn build(b: *std.Build) void {
    const target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});

    const echo = b.addLibrary(.{
        .name = "echo",
        .root_module = b.createModule(.{
            .root_source_file = b.path("echo.zig"),
            .target = target,
            .optimize = optimize,
            .link_libc = false, // just to be sure
        }),
    });
    b.installArtifact(echo);

    const main = b.addExecutable(.{
        .name = "main",
        .root_module = b.createModule(.{
            .root_source_file = b.path("main.zig"),
            .target = target,
            .optimize = optimize,
            .link_libc = false, // just to be sure
        }),
    });
    main.linkLibrary(echo);
    b.installArtifact(main);
}

```

```zig
// echo.zig
const std = @import("std");

export fn ls(provide_env_map: bool) callconv(.c) void {
    std.log.info("echo with provide_env_map = {}", .{provide_env_map});

    const allocator = std.heap.smp_allocator;

    var env_map: std.process.EnvMap = .init(allocator);
    defer env_map.deinit();

    const result = std.process.Child.run(.{
        .allocator = allocator,
        .argv = &.{ "/bin/echo", "Hello, world!" },
        .env_map = if (provide_env_map) &env_map else null,
    }) catch @panic("failed to run");
    defer allocator.free(result.stderr);
    defer allocator.free(result.stdout);

    std.log.info("stdout={s}", .{result.stdout});
    std.log.info("stderr={s}", .{result.stderr});
    std.log.info("term={}", .{result.term});
}

```

```zig
// main.zig
extern fn ls(provide_env_map: bool) callconv(.c) void;

pub fn main() void {
    ls(true);
    ls(false);
}

```

```
$ uname -a
Linux archlinux 6.16.4-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 28 Aug 2025 19:49:53 +0000 x86_64 GNU/Linux
```

```
$ zig build && ./zig-out/bin/main
info: echo with provide_env_map = true
info: stdout=Hello, world!

info: stderr=
info: term=.{ .Exited = 0 }
info: echo with provide_env_map = false
thread 22121 panic: missing std lib enhancement: ChildProcess implementation has no way to collect the environment variables to forward to the child process
Segmentation fault         (core dumped) ./zig-out/bin/main
```
