### PR TITLE
`zig_clang`: fix `ZigClangAPValueLValueBase` struct layout to match Clang 21

### DIFF
--- a/src/clang.zig
+++ b/src/clang.zig
@@ -37,9 +37,15 @@ pub const QualType = extern struct {
 };
 
 pub const APValueLValueBase = extern struct {
-    Ptr: ?*anyopaque,
-    CallIndex: c_uint,
-    Version: c_uint,
+    Ptr: ?*anyopaque align(@alignOf(u64)),
+    State: extern union {
+        Local: extern struct {
+            CallIndex: c_uint,
+            Version: c_uint,
+        },
+        TypeInfoType: ?*anyopaque,
+        DynamicAllocType: ?*anyopaque,
+    },
 
     pub const dyn_cast_Expr = ZigClangAPValueLValueBase_dyn_cast_Expr;
     extern fn ZigClangAPValueLValueBase_dyn_cast_Expr(APValueLValueBase) ?*const Expr;

--- a/src/zig_clang.h
+++ b/src/zig_clang.h
@@ -43,10 +43,16 @@ struct ZigClangQualType {
     void *ptr;
 };
 
-struct ZigClangAPValueLValueBase {
-    void *Ptr;
-    unsigned CallIndex;
-    unsigned Version;
+struct alignas(uint64_t) ZigClangAPValueLValueBase {
+    void* Ptr;
+    union {
+        struct {
+            unsigned CallIndex;
+            unsigned Version;
+        } Local;
+        void* TypeInfoType;
+        void* DynamicAllocType;
+    };
 };
 
 enum ZigClangAPValueKind {


### PR DESCRIPTION
Fixes the compiler build for various targets, especially 32-bit.