### PR TITLE
Fix regression: std.http.Client basic authorization sending user:user instead of user:password when passed in URI

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1375,7 +1375,7 @@ pub const basic_authorization = struct {
         var buf: [max_user_len + 1 + max_password_len]u8 = undefined;
         var w: Writer = .fixed(&buf);
         const user: Uri.Component = uri.user orelse .empty;
-        const password: Uri.Component = uri.user orelse .empty;
+        const password: Uri.Component = uri.password orelse .empty;
         user.formatUser(&w) catch unreachable;
         w.writeByte(':') catch unreachable;
         password.formatPassword(&w) catch unreachable;


### PR DESCRIPTION
The following example populates the `Authorization` header with `user:user` instead of `user:password`, due to a typo.

```zig
const std = @import("std");

pub fn main() !void {
    const allocator = std.heap.page_allocator;
    var client = std.http.Client{ .allocator = allocator };
    defer client.deinit();
    var response = std.io.Writer.Allocating.init(allocator);
    defer response.deinit();
    const stat = try client.fetch(.{
        .method = .POST,
        .location = .{
            .url = "http://user:password@127.0.0.1",
        },
        .headers = .{ .content_type = .{ .override = "application/json" } },
        .response_writer = &response.writer,
        .payload = "{}",
    });
    std.log.info("OK: status={s}, response={s}", .{ @tagName(stat.status), response.written() });
}
```