### PR TITLE
add formatting modifier for arrays and slices

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -1350,12 +1350,16 @@ pub fn printValue(
                 try w.printAddress(value);
             },
             .slice => {
-                if (!is_any)
-                    @compileError("cannot format slice without a specifier (i.e. {s}, {x}, {b64}, or {any})");
+                const remaining_fmt = comptime if (fmt.len > 0 and fmt[0] == '#')
+                    stripOptionalOrErrorUnionSpec(fmt)
+                else if (is_any)
+                    ANY
+                else
+                    @compileError("cannot format slice without a specifier (i.e. {#}, {s}, {x}, {b64}, or {any})");
                 if (max_depth == 0) return w.writeAll("{ ... }");
                 try w.writeAll("{ ");
                 for (value, 0..) |elem, i| {
-                    try w.printValue(fmt, options, elem, max_depth - 1);
+                    try w.printValue(remaining_fmt, options, elem, max_depth - 1);
                     if (i != value.len - 1) {
                         try w.writeAll(", ");
                     }
@@ -1364,11 +1368,16 @@ pub fn printValue(
             },
         },
         .array => {
-            if (!is_any) @compileError("cannot format array without a specifier (i.e. {s} or {any})");
+            const remaining_fmt = comptime if (fmt.len > 0 and fmt[0] == '#')
+                stripOptionalOrErrorUnionSpec(fmt)
+            else if (is_any)
+                ANY
+            else
+                @compileError("cannot format array without a specifier (i.e. {#}, {s} or {any})");
             if (max_depth == 0) return w.writeAll("{ ... }");
             try w.writeAll("{ ");
             for (value, 0..) |elem, i| {
-                try w.printValue(fmt, options, elem, max_depth - 1);
+                try w.printValue(remaining_fmt, options, elem, max_depth - 1);
                 if (i < value.len - 1) {
                     try w.writeAll(", ");
                 }


### PR DESCRIPTION
Printing a slice of strings has (intentionally) regressed in 0.15.1. The old functionality of passing `{s}` was admittedly inconsistent, if convenient.

I am suggesting a new format specifier, akin to optionals and error sets, `#` for printing slices and arrays. So to print a slice of strings one would pass {#s} , an array of numbers is {#d}. an array of arrays of strings is {##s}, and so on.

Note the character itself does not matter. It could never `%` or `A`. I thought `#` looks like a list. It exists in almost [every variant of QWERTY keyboard I could find on wikipedia](https://en.wikipedia.org/wiki/List_of_QWERTY_keyboard_language_variants).

Example

```zig
pub fn main() !void {
    const slice = [_][]const u8{ "Hello", "Zig" };
    std.debug.print("{#s}\n", .{slice}); // { Hello, Zig }
}
```

I prefer the modifier approach for arrays and slices (shown above and in the PR) is that it is useful beyond lists of strings. For example a list of new types. (Say an enum(u7) {_} with some named variants that I'd like to render all as numbers). The other alternative is a specific modifier for lists of strings specially, but this in my opinion is less generically useful.