### PR TITLE
lzma2: fix array list looping logic in appendLz

### DIFF
--- a/lib/std/compress/lzma2.zig
+++ b/lib/std/compress/lzma2.zig
@@ -83,11 +83,17 @@ pub const AccumBuffer = struct {
             return error.CorruptInput;
         }
 
+        // ensure we have enough capacity for all new bytes.
+        // This prevents the buffer's memory from being reallocated (and freed)
+        // while we are still reading from it.
+        try self.buf.ensureTotalCapacity(allocator, buf_len + len);
+
         var offset = buf_len - dist;
         var i: usize = 0;
         while (i < len) : (i += 1) {
             const x = self.buf.items[offset];
-            try self.buf.append(allocator, x);
+            // Since capacity is guaranteed, it's safe to use appendAssumeCapacity.
+            self.buf.appendAssumeCapacity(x);
             offset += 1;
         }
         self.len += len;


### PR DESCRIPTION
While porting my project to zig, I found that when extracting large xz file, it fails with below stack trace, after some digging, I found out the looping logic in `appendLz` function append to the `ArrayList` while looping over it, which caused use after free, after my change to use `ensureTotalCapacity` before looping. the `ArrayList` memory is not modified while looping. Detailed analyze:

1. The std.ArrayList.append function may need to reallocate the underlying buffer if it runs out of capacity.
2. When a reallocation occurs, the memory location of the buffer's items changes, and the old memory is freed.
3. However, the loop continues to read from self.buf.items[offset]. The slice self.buf.items was implicitly captured at the start of the operation and now points to the old, freed memory.

```
/usr/lib/zig/std/compress/lzma2.zig:241:50: 0x128dd98 in parseLzma (std.zig)
        if (accum.len != expected_unpacked_size) return error.DecompressedSizeMismatch;
                                                 ^
/usr/lib/zig/std/compress/lzma2.zig:136:35: 0x128e9d8 in decompress (std.zig)
                else => n_read += try d.parseLzma(reader, allocating, &accum, status),
                                  ^
/usr/lib/zig/std/compress/xz/Decompress.zig:249:31: 0x128fda1 in readBlock (std.zig)
    const packed_bytes_read = try lzma2_decode.decompress(input, allocating);
                              ^
/usr/lib/zig/std/compress/xz/Decompress.zig:152:13: 0x1292ac6 in readIndirect (std.zig)
            return error.ReadFailed;
            ^
/usr/lib/zig/std/compress/xz/Decompress.zig:112:5: 0x126779c in stream (std.zig)
    return readIndirect(r);
    ^
/usr/lib/zig/std/Io/Reader.zig:178:15: 0x1283832 in stream (std.zig)
    const n = try r.vtable.stream(r, w, limit);
              ^
```