### PR TITLE
zstd.Decompress: Assert buffer length requirements as early as possible

### DIFF
--- a/lib/std/compress/zstd/Decompress.zig
+++ b/lib/std/compress/zstd/Decompress.zig
@@ -92,6 +92,7 @@ const indirect_vtable: Reader.VTable = .{
 ///
 /// Otherwise, `buffer` has those requirements.
 pub fn init(input: *Reader, buffer: []u8, options: Options) Decompress {
+    if (buffer.len != 0) assert(buffer.len >= options.window_len + zstd.block_size_max);
     return .{
         .input = input,
         .state = .new_frame,


### PR DESCRIPTION
Without this assert, providing a buffer that's smaller than required results in more cryptic assertion failures later on.

From https://github.com/ziglang/zig/issues/24741#issuecomment-3169424325:

> The implementation chooses:
>
> - What the minimum buffer capacity is asserted to be (perhaps zero)
> - Under what conditions an undersized buffer capacity can cause runtime failures (as opposed to assertions)
>
> The implementation documents these things carefully, and asserts as early as possible.