### PR TITLE
Implement package fetch retries

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1585,7 +1585,7 @@ pub fn connect(
     host: HostName,
     port: u16,
     protocol: Protocol,
-) ConnectError!*Connection {
+) ConnectTcpError!*Connection {
     const proxy = switch (protocol) {
         .plain => client.http_proxy,
         .tls => client.https_proxy,

--- a/lib/std/time/epoch.zig
+++ b/lib/std/time/epoch.zig
@@ -1,6 +1,7 @@
 //! Epoch reference times in terms of their difference from
 //! UTC 1970-01-01 in seconds.
 const std = @import("../std.zig");
+const native_os = @import("builtin").os.tag;
 const testing = std.testing;
 const math = std.math;
 
@@ -39,10 +40,7 @@ pub const brew = gps;
 pub const atsc = gps;
 pub const go = clr;
 
-/// The type that holds the current year, i.e. 2016
-pub const Year = u16;
-
-pub const epoch_year = 1970;
+pub const epoch_year = if (native_os == .windows) 1601 else 1970;
 pub const secs_per_day: u17 = 24 * 60 * 60;
 
 pub fn isLeapYear(year: Year) bool {
@@ -64,6 +62,9 @@ pub fn getDaysInYear(year: Year) u9 {
     return if (isLeapYear(year)) 366 else 365;
 }
 
+/// The type that holds the current year, i.e. 2016
+pub const Year = u16;
+
 pub const Month = enum(u4) {
     jan = 1,
     feb,
@@ -84,6 +85,90 @@ pub const Month = enum(u4) {
         return @intFromEnum(self);
     }
 };
+
+/// Day of month (1 to 31)
+pub const Day = u5;
+
+/// Hour of day (0 to 23)
+pub const Hour = u5;
+
+/// Minute of hour (0 to 59)
+pub const Minute = u6;
+
+/// Second of minute (0 to 59)
+pub const Second = u6;
+
+pub const Datetime = struct {
+    year: Year,
+    month: Month,
+    day: Day,
+    hour: Hour,
+    minute: Minute,
+    second: Second,
+
+    pub fn asTimestamp(d: *const Datetime) !std.Io.Timestamp {
+        if (d.day == 0 or d.day > getDaysInMonth(d.year, d.month)) return error.InvalidDay;
+        if (d.hour >= 24) return error.InvalidHour;
+        if (d.minute >= 60) return error.InvalidMinute;
+        if (d.second >= 60) return error.InvalidSecond;
+
+        // Calculate days from epoch (can be negative for dates before epoch)
+        var total_days: i96 = undefined;
+
+        const total_years: i32 = @as(i32, d.year) - epoch_year;
+
+        var total_leap_years: i30 = undefined;
+        if (d.year >= epoch_year) {
+            total_leap_years = countLeapYearsBetween(epoch_year, d.year);
+        } else {
+            total_leap_years = -@as(i30, countLeapYearsBetween(d.year, epoch_year));
+        }
+        total_days = @as(i96, total_years) * 365 + @as(i96, total_leap_years);
+
+        // Add days for complete months in the given year
+        var m: Month = .jan;
+        while (@intFromEnum(m) < @intFromEnum(d.month)) {
+            total_days += getDaysInMonth(d.year, m);
+            m = @enumFromInt(@intFromEnum(m) + 1);
+        }
+
+        // Add remaining days (subtract 1 because day is 1-indexed)
+        total_days += d.day - 1;
+
+        // Convert to seconds and add time components
+        var total_secs: i96 = total_days * @as(i96, secs_per_day);
+        total_secs += @as(i96, d.hour) * 3600;
+        total_secs += @as(i96, d.minute) * 60;
+        total_secs += d.second;
+
+        const nanoseconds: i96 = total_secs * std.time.ns_per_s;
+
+        return std.Io.Timestamp{ .nanoseconds = nanoseconds };
+    }
+};
+
+/// Counts the number of leap years in the range [start_year, end_year).
+/// The end_year is exclusive.
+pub fn countLeapYearsBetween(start_year: Year, end_year: Year) u15 {
+    // We retrun u15 because `Year` is u16 and leap year is every 4 years.
+    // (2 ** 16) / 4 = 2 ** 14, so u14 is clearly the best fit. But every 100
+    // years is also leap year, which will result in very few extra leap years,
+    // so we are adding 1 bit to make room for that, resulting in u15.
+
+    if (end_year <= start_year) return 0;
+
+    // Count leap years from year 0 to end_year-1, then subtract those before start_year
+    const leaps_before_end = countLeapYearsFromZero(end_year - 1);
+    const leaps_before_start = if (start_year > 0) countLeapYearsFromZero(start_year - 1) else 0;
+
+    return leaps_before_end - leaps_before_start;
+}
+
+/// Counts leap years from year 0 to the given year (inclusive).
+fn countLeapYearsFromZero(y: Year) u15 {
+    // Divisible by 4, minus centuries (divisible by 100), plus quad-centuries (divisible by 400)
+    return @as(u15, @intCast((y / 4) - (y / 100) + (y / 400)));
+}
 
 /// Get the number of days in the given month and year
 pub fn getDaysInMonth(year: Year, month: Month) u5 {
@@ -201,6 +286,10 @@ fn testEpoch(secs: u64, expected_year_day: YearAndDay, expected_month_day: Month
     try testing.expectEqual(expected_day_seconds.seconds_into_minute, day_seconds.getSecondsIntoMinute());
 }
 
+fn testDatetimeToNanoseconds(seconds: i96, dt: Datetime) !void {
+    try testing.expectEqual(seconds * std.time.ns_per_s, (try dt.asTimestamp()).nanoseconds);
+}
+
 test "epoch decoding" {
     try testEpoch(0, .{ .year = 1970, .day = 0 }, .{
         .month = .jan,
@@ -221,4 +310,93 @@ test "epoch decoding" {
         .month = .jul,
         .day_index = 0,
     }, .{ .hours_into_day = 17, .minutes_into_hour = 11, .seconds_into_minute = 13 });
+}
+
+test "datetime to epochseconds" {
+    // epoc time exactly
+    try testDatetimeToNanoseconds(0, .{
+        .year = 1970,
+        .month = .jan,
+        .day = 1,
+        .hour = 0,
+        .minute = 0,
+        .second = 0,
+    });
+
+    // last second of a year
+    try testDatetimeToNanoseconds(31535999, .{
+        .year = 1970,
+        .month = .dec,
+        .day = 31,
+        .hour = 23,
+        .minute = 59,
+        .second = 59,
+    });
+
+    // first second of next year
+    try testDatetimeToNanoseconds(31536000, .{
+        .year = 1971,
+        .month = .jan,
+        .day = 1,
+        .hour = 0,
+        .minute = 0,
+        .second = 0,
+    });
+
+    // leap year
+    try testDatetimeToNanoseconds(68256000, .{
+        .year = 1972,
+        .month = .mar,
+        .day = 1,
+        .hour = 0,
+        .minute = 0,
+        .second = 0,
+    });
+
+    // super far in the future
+    try testDatetimeToNanoseconds(11991628800, .{
+        .year = 2350,
+        .month = .jan,
+        .day = 1,
+        .hour = 0,
+        .minute = 0,
+        .second = 0,
+    });
+
+    // time before epoch
+    try testDatetimeToNanoseconds(-14831769600, .{
+        .year = 1500,
+        .month = .jan,
+        .day = 1,
+        .hour = 0,
+        .minute = 0,
+        .second = 0,
+    });
+
+    // invalid input
+    const dt = Datetime{
+        .year = 1970,
+        .month = .feb,
+        .day = 29, // invalid because it's not leap year
+        .hour = 0,
+        .minute = 0,
+        .second = 0,
+    };
+
+    try testing.expectError(error.InvalidDay, dt.asTimestamp());
+}
+
+test "countLeapYearsBetween" {
+    // Between 1970-1980: 1972, 1976 = 2 leap years
+    try std.testing.expectEqual(@as(u47, 2), countLeapYearsBetween(1970, 1980));
+
+    // Between 1970-2000: excludes 2000 which is a leap year (divisible by 400)
+    try std.testing.expectEqual(@as(u47, 7), countLeapYearsBetween(1970, 2000));
+
+    // Between 1970-2001: adds 2000
+    try std.testing.expectEqual(@as(u47, 8), countLeapYearsBetween(1970, 2001));
+
+    // Century test: 1900 is NOT a leap year, 2000 IS
+    try std.testing.expectEqual(@as(u47, 0), countLeapYearsBetween(1900, 1901));
+    try std.testing.expectEqual(@as(u47, 1), countLeapYearsBetween(2000, 2001));
 }

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -91,7 +91,7 @@ latest_commit: ?git.Oid,
 module: ?*Package.Module,
 
 /// The number of times an HTTP request will retry if it fails
-retry_count: u16 = 2,
+retry_count: u16 = 3,
 
 /// The delay in milliseconds between HTTP request retries
 retry_delay_ms: u32 = 500,

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -91,7 +91,7 @@ latest_commit: ?git.Oid,
 module: ?*Package.Module,
 
 /// The number of times an HTTP request will retry if it fails
-retry_count: u32 = 2,
+retry_count: u16 = 2,
 
 /// The delay in milliseconds between HTTP request retries
 retry_delay_ms: u32 = 500,

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -1057,8 +1057,7 @@ fn initResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u
             };
 
             if (response.head.status != .ok) {
-                // We only need to retry if we run into server-side errors (5xx)
-                if (retries_left > 0 and @intFromEnum(response.head.status) >= 500) {
+                if (retries_left > 0) {
                     std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
                     retries_left -= 1;
                     continue;

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -90,6 +90,12 @@ latest_commit: ?git.Oid,
 /// the root source file.
 module: ?*Package.Module,
 
+/// The number of times an HTTP request will retry if it fails
+retry_count: u32 = 2,
+
+/// The delay in milliseconds between HTTP request retries
+retry_delay_ms: u32 = 500,
+
 pub const LazyStatus = enum {
     /// Not lazy.
     eager,
@@ -1009,9 +1015,18 @@ fn initResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u
     if (ascii.eqlIgnoreCase(uri.scheme, "http") or
         ascii.eqlIgnoreCase(uri.scheme, "https"))
     {
+        var retries_left = f.retry_count;
         resource.* = .{ .http_request = .{
-            .request = http_client.request(.GET, uri, .{}) catch |err|
-                return f.fail(f.location_tok, try eb.printString("unable to connect to server: {t}", .{err})),
+            .request = while (true) {
+                break http_client.request(.GET, uri, .{}) catch |err| {
+                    if (retries_left > 0) {
+                        std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
+                        retries_left -= 1;
+                        continue;
+                    }
+                    return f.fail(f.location_tok, try eb.printString("unable to connect to server: {t}", .{err}));
+                };
+            },
             .response = undefined,
             .transfer_buffer = reader_buffer,
             .decompress_buffer = &.{},
@@ -1020,39 +1035,63 @@ fn initResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u
         const request = &resource.http_request.request;
         errdefer request.deinit();
 
-        request.sendBodiless() catch |err|
-            return f.fail(f.location_tok, try eb.printString("HTTP request failed: {t}", .{err}));
+        while (true) {
+            request.sendBodiless() catch |err| {
+                if (retries_left > 0) {
+                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
+                    retries_left -= 1;
+                    continue;
+                }
+                return f.fail(f.location_tok, try eb.printString("HTTP request failed: {t}", .{err}));
+            };
 
-        var redirect_buffer: [1024]u8 = undefined;
-        const response = &resource.http_request.response;
-        response.* = request.receiveHead(&redirect_buffer) catch |err| switch (err) {
-            error.ReadFailed => {
-                return f.fail(f.location_tok, try eb.printString("HTTP response read failure: {t}", .{
-                    request.connection.?.getReadError().?,
-                }));
-            },
-            else => |e| return f.fail(f.location_tok, try eb.printString("invalid HTTP response: {t}", .{e})),
-        };
+            var redirect_buffer: [1024]u8 = undefined;
+            const response = &resource.http_request.response;
+            response.* = request.receiveHead(&redirect_buffer) catch |err| switch (err) {
+                error.ReadFailed => {
+                    return f.fail(f.location_tok, try eb.printString("HTTP response read failure: {t}", .{
+                        request.connection.?.getReadError().?,
+                    }));
+                },
+                else => |e| return f.fail(f.location_tok, try eb.printString("invalid HTTP response: {t}", .{e})),
+            };
 
-        if (response.head.status != .ok) return f.fail(f.location_tok, try eb.printString(
-            "bad HTTP response code: '{d} {s}'",
-            .{ response.head.status, response.head.status.phrase() orelse "" },
-        ));
+            if (response.head.status != .ok) {
+                // We only need to retry if we run into server-side errors (5xx)
+                if (retries_left > 0 and @intFromEnum(response.head.status) >= 500) {
+                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
+                    retries_left -= 1;
+                    continue;
+                }
+                return f.fail(f.location_tok, try eb.printString(
+                    "bad HTTP response code: '{d} {s}'",
+                    .{ response.head.status, response.head.status.phrase() orelse "" },
+                ));
+            }
 
-        resource.http_request.decompress_buffer = try arena.alloc(u8, response.head.content_encoding.minBufferCapacity());
-        return;
+            resource.http_request.decompress_buffer = try arena.alloc(u8, response.head.content_encoding.minBufferCapacity());
+            return;
+        }
     }
 
     if (ascii.eqlIgnoreCase(uri.scheme, "git+http") or
         ascii.eqlIgnoreCase(uri.scheme, "git+https"))
     {
+        var retries_left = f.retry_count;
         var transport_uri = uri;
         transport_uri.scheme = uri.scheme["git+".len..];
-        var session = git.Session.init(arena, http_client, transport_uri, reader_buffer) catch |err| {
-            return f.fail(
-                f.location_tok,
-                try eb.printString("unable to discover remote git server capabilities: {t}", .{err}),
-            );
+        var session = while (true) {
+            break git.Session.init(arena, http_client, transport_uri, reader_buffer) catch |err| {
+                if (retries_left > 0) {
+                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
+                    retries_left -= 1;
+                    continue;
+                }
+                return f.fail(
+                    f.location_tok,
+                    try eb.printString("unable to discover remote git server capabilities: {t}", .{err}),
+                );
+            };
         };
 
         const want_oid = want_oid: {
@@ -1112,9 +1151,16 @@ fn initResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u
             .want_oid = want_oid,
         } };
         const fetch_stream = &resource.git.fetch_stream;
-        session.fetch(fetch_stream, &.{&want_oid_buf}, reader_buffer) catch |err| {
-            return f.fail(f.location_tok, try eb.printString("unable to create fetch stream: {t}", .{err}));
-        };
+        while (true) {
+            break session.fetch(fetch_stream, &.{&want_oid_buf}, reader_buffer) catch |err| {
+                if (retries_left > 0) {
+                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
+                    retries_left -= 1;
+                    continue;
+                }
+                return f.fail(f.location_tok, try eb.printString("unable to create fetch stream: {t}", .{err}));
+            };
+        }
         errdefer fetch_stream.deinit(fetch_stream);
 
         return;

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -90,11 +90,7 @@ latest_commit: ?git.Oid,
 /// the root source file.
 module: ?*Package.Module,
 
-/// The number of times an HTTP request will retry if it fails
-retry_count: u16 = 3,
-
-/// The delay in milliseconds between HTTP request retries
-retry_delay_ms: u32 = 500,
+retry: Retry = .{},
 
 pub const LazyStatus = enum {
     /// Not lazy.
@@ -328,6 +324,88 @@ pub const RunError = error{
     /// `error_bundle` field.
     FetchFailed,
 };
+
+pub const Retry = struct {
+    /// The number of failed attempts that have been done so far.
+    ///
+    /// Starts at 0, and increases by one each time an attempt fails.
+    cur_retries: u16 = 0,
+    /// The maximum number of times the operation should be retried.
+    ///
+    /// 0 means it should never retry.
+    max_retries: u16 = 3,
+    /// Hard cap of how many milliseconds to wait between retries.
+    const MAX_RETRY_SLEEP_MS = 10 * 1000;
+    /// Minimum time a jittered retry delay could be
+    const MIN_RETRY_JITTER_MS = 500;
+    /// Maximum time a jittered retry delay could be
+    const MAX_RETRY_JITTER_MS = 1500;
+
+    fn calcRetryDelayMs(r: *Retry) i64 {
+        if (r.cur_retries == 0) {
+            return std.crypto.random.intRangeAtMost(i64, MIN_RETRY_JITTER_MS, MAX_RETRY_JITTER_MS);
+        }
+        return @min(r.cur_retries * 3 * 1000, MAX_RETRY_SLEEP_MS);
+    }
+
+    fn callWithRetries(
+        r: *Retry,
+        io: Io,
+        comptime FunctionType: type,
+        callback: FunctionType,
+        args: anytype,
+    ) @typeInfo(FunctionType).@"fn".return_type.? {
+        while (true) {
+            return @call(.auto, callback, args) catch |err| {
+                if (maybeSpurious(err) and r.cur_retries < r.max_retries) {
+                    const delay = Io.Duration.fromMilliseconds(r.calcRetryDelayMs());
+                    io.sleep(delay, .awake) catch |sleep_err| switch (sleep_err) {
+                        // If canceled, cotinue to retry
+                        Io.Cancelable.Canceled => {},
+                        // TODO: Find a better solution than silently not retrying
+                        else => return err,
+                    };
+                    r.cur_retries += 1;
+                    continue;
+                }
+                return err;
+            };
+        }
+    }
+};
+
+const BadHttpStatus = error{
+    MaybeSpurious,
+    NonSpurious,
+};
+
+fn maybeSpurious(err: anyerror) bool {
+    return switch (err) {
+        // tcp errors
+        std.http.Client.ConnectTcpError.Timeout,
+        std.http.Client.ConnectTcpError.ConnectionResetByPeer,
+        std.http.Client.ConnectTcpError.ConnectionRefused,
+        std.http.Client.ConnectTcpError.NetworkUnreachable,
+        std.http.Client.ConnectTcpError.AddressInUse,
+        std.http.Client.ConnectTcpError.NameServerFailure,
+        std.http.Client.ConnectTcpError.SystemResources,
+
+        // io errors
+        std.http.Client.Request.ReceiveHeadError.WriteFailed,
+        std.http.Client.Request.ReceiveHeadError.ReadFailed,
+
+        // http errors
+        std.http.Client.Request.ReceiveHeadError.HttpRequestTruncated,
+        std.http.Client.Request.ReceiveHeadError.HttpConnectionClosing,
+        std.http.Client.Request.ReceiveHeadError.HttpChunkTruncated,
+        std.http.Client.Request.ReceiveHeadError.HttpChunkInvalid,
+        BadHttpStatus.MaybeSpurious,
+
+        Allocator.Error.OutOfMemory,
+        => true,
+        else => false,
+    };
+}
 
 pub fn run(f: *Fetch) RunError!void {
     const io = f.job_queue.io;
@@ -996,10 +1074,10 @@ const init_resource_buffer_size = git.Packet.max_data_length;
 
 fn initResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u8) RunError!void {
     const io = f.job_queue.io;
-    const arena = f.arena.allocator();
     const eb = &f.error_bundle;
 
     if (ascii.eqlIgnoreCase(uri.scheme, "file")) {
+        const arena = f.arena.allocator();
         const path = try uri.path.toRawMaybeAlloc(arena);
         const file = f.parent_package_root.openFile(path, .{}) catch |err| {
             return f.fail(f.location_tok, try eb.printString("unable to open '{f}{s}': {t}", .{
@@ -1010,162 +1088,130 @@ fn initResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u
         return;
     }
 
-    const http_client = f.job_queue.http_client;
-
     if (ascii.eqlIgnoreCase(uri.scheme, "http") or
         ascii.eqlIgnoreCase(uri.scheme, "https"))
     {
-        var retries_left = f.retry_count;
-        resource.* = .{ .http_request = .{
-            .request = while (true) {
-                break http_client.request(.GET, uri, .{}) catch |err| {
-                    if (retries_left > 0) {
-                        std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
-                        retries_left -= 1;
-                        continue;
-                    }
-                    return f.fail(f.location_tok, try eb.printString("unable to connect to server: {t}", .{err}));
-                };
-            },
-            .response = undefined,
-            .transfer_buffer = reader_buffer,
-            .decompress_buffer = &.{},
-            .decompress = undefined,
-        } };
-        const request = &resource.http_request.request;
-        errdefer request.deinit();
-
-        while (true) {
-            request.sendBodiless() catch |err| {
-                if (retries_left > 0) {
-                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
-                    retries_left -= 1;
-                    continue;
-                }
-                return f.fail(f.location_tok, try eb.printString("HTTP request failed: {t}", .{err}));
-            };
-
-            var redirect_buffer: [1024]u8 = undefined;
-            const response = &resource.http_request.response;
-            response.* = request.receiveHead(&redirect_buffer) catch |err| switch (err) {
-                error.ReadFailed => {
-                    return f.fail(f.location_tok, try eb.printString("HTTP response read failure: {t}", .{
-                        request.connection.?.getReadError().?,
-                    }));
-                },
-                else => |e| return f.fail(f.location_tok, try eb.printString("invalid HTTP response: {t}", .{e})),
-            };
-
-            if (response.head.status != .ok) {
-                if (retries_left > 0) {
-                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
-                    retries_left -= 1;
-                    continue;
-                }
-                return f.fail(f.location_tok, try eb.printString(
-                    "bad HTTP response code: '{d} {s}'",
-                    .{ response.head.status, response.head.status.phrase() orelse "" },
-                ));
-            }
-
-            resource.http_request.decompress_buffer = try arena.alloc(u8, response.head.content_encoding.minBufferCapacity());
-            return;
-        }
+        f.retry.callWithRetries(f.io, @TypeOf(initHttpResource), initHttpResource, .{ f, uri, resource, reader_buffer }) catch |err| {
+            const status = resource.http_request.response.head.status;
+            return f.fail(f.location_tok, switch (err) {
+                BadHttpStatus.MaybeSpurious, BadHttpStatus.NonSpurious => try eb.printString("Failed with bad HTTP status code: {d} -> {}", .{ status, status }),
+                else => try eb.printString("Failed to fetch HTTP resource {s}: {t}", .{ uri.path.percent_encoded, err }),
+            });
+        };
+        return;
     }
 
     if (ascii.eqlIgnoreCase(uri.scheme, "git+http") or
         ascii.eqlIgnoreCase(uri.scheme, "git+https"))
     {
-        var retries_left = f.retry_count;
-        var transport_uri = uri;
-        transport_uri.scheme = uri.scheme["git+".len..];
-        var session = while (true) {
-            break git.Session.init(arena, http_client, transport_uri, reader_buffer) catch |err| {
-                if (retries_left > 0) {
-                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
-                    retries_left -= 1;
-                    continue;
-                }
-                return f.fail(
-                    f.location_tok,
-                    try eb.printString("unable to discover remote git server capabilities: {t}", .{err}),
-                );
-            };
+        f.retry.callWithRetries(f.io, @TypeOf(initGitResource), initGitResource, .{ f, uri, resource, reader_buffer }) catch |err| {
+            return f.fail(f.location_tok, try eb.printString("Failed to fetch git resource {s}: {t}", .{ uri.path.percent_encoded, err }));
         };
-
-        const want_oid = want_oid: {
-            const want_ref =
-                if (uri.fragment) |fragment| try fragment.toRawMaybeAlloc(arena) else "HEAD";
-            if (git.Oid.parseAny(want_ref)) |oid| break :want_oid oid else |_| {}
-
-            const want_ref_head = try std.fmt.allocPrint(arena, "refs/heads/{s}", .{want_ref});
-            const want_ref_tag = try std.fmt.allocPrint(arena, "refs/tags/{s}", .{want_ref});
-
-            var ref_iterator: git.Session.RefIterator = undefined;
-            session.listRefs(&ref_iterator, .{
-                .ref_prefixes = &.{ want_ref, want_ref_head, want_ref_tag },
-                .include_peeled = true,
-                .buffer = reader_buffer,
-            }) catch |err| return f.fail(f.location_tok, try eb.printString("unable to list refs: {t}", .{err}));
-            defer ref_iterator.deinit();
-            while (ref_iterator.next() catch |err| {
-                return f.fail(f.location_tok, try eb.printString(
-                    "unable to iterate refs: {s}",
-                    .{@errorName(err)},
-                ));
-            }) |ref| {
-                if (std.mem.eql(u8, ref.name, want_ref) or
-                    std.mem.eql(u8, ref.name, want_ref_head) or
-                    std.mem.eql(u8, ref.name, want_ref_tag))
-                {
-                    break :want_oid ref.peeled orelse ref.oid;
-                }
-            }
-            return f.fail(f.location_tok, try eb.printString("ref not found: {s}", .{want_ref}));
-        };
-        if (f.use_latest_commit) {
-            f.latest_commit = want_oid;
-        } else if (uri.fragment == null) {
-            const notes_len = 1;
-            try eb.addRootErrorMessage(.{
-                .msg = try eb.addString("url field is missing an explicit ref"),
-                .src_loc = try f.srcLoc(f.location_tok),
-                .notes_len = notes_len,
-            });
-            const notes_start = try eb.reserveNotes(notes_len);
-            eb.extra.items[notes_start] = @intFromEnum(try eb.addErrorMessage(.{
-                .msg = try eb.printString("try .url = \"{f}#{f}\",", .{
-                    uri.fmt(.{ .scheme = true, .authority = true, .path = true }),
-                    want_oid,
-                }),
-            }));
-            return error.FetchFailed;
-        }
-
-        var want_oid_buf: [git.Oid.max_formatted_length]u8 = undefined;
-        _ = std.fmt.bufPrint(&want_oid_buf, "{f}", .{want_oid}) catch unreachable;
-        resource.* = .{ .git = .{
-            .session = session,
-            .fetch_stream = undefined,
-            .want_oid = want_oid,
-        } };
-        const fetch_stream = &resource.git.fetch_stream;
-        while (true) {
-            break session.fetch(fetch_stream, &.{&want_oid_buf}, reader_buffer) catch |err| {
-                if (retries_left > 0) {
-                    std.Thread.sleep(std.time.ns_per_ms * f.retry_delay_ms);
-                    retries_left -= 1;
-                    continue;
-                }
-                return f.fail(f.location_tok, try eb.printString("unable to create fetch stream: {t}", .{err}));
-            };
-        }
-        errdefer fetch_stream.deinit(fetch_stream);
-
         return;
     }
 
     return f.fail(f.location_tok, try eb.printString("unsupported URL scheme: {s}", .{uri.scheme}));
+}
+
+fn initHttpResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u8) !void {
+    const arena = f.arena.allocator();
+    const http_client = f.job_queue.http_client;
+
+    resource.* = .{ .http_request = .{
+        .request = try http_client.request(.GET, uri, .{}),
+        .response = undefined,
+        .transfer_buffer = reader_buffer,
+        .decompress_buffer = &.{},
+        .decompress = undefined,
+    } };
+    const request = &resource.http_request.request;
+    errdefer request.deinit();
+
+    try request.sendBodiless();
+
+    var redirect_buffer: [1024]u8 = undefined;
+    const response = &resource.http_request.response;
+    response.* = try request.receiveHead(&redirect_buffer);
+    const status = response.head.status;
+
+    if (@intFromEnum(status) >= 500 or status == .too_many_requests or status == .not_found) {
+        return BadHttpStatus.MaybeSpurious;
+    } else if (status != .ok) {
+        return BadHttpStatus.NonSpurious;
+    }
+
+    resource.http_request.decompress_buffer = try arena.alloc(u8, response.head.content_encoding.minBufferCapacity());
+}
+
+fn initGitResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u8) !void {
+    const eb = &f.error_bundle;
+
+    const arena = f.arena.allocator();
+    const http_client = f.job_queue.http_client;
+
+    var transport_uri = uri;
+    transport_uri.scheme = uri.scheme["git+".len..];
+    var session = try git.Session.init(arena, http_client, transport_uri, reader_buffer);
+
+    const want_oid = want_oid: {
+        const want_ref =
+            if (uri.fragment) |fragment| try fragment.toRawMaybeAlloc(arena) else "HEAD";
+        if (git.Oid.parseAny(want_ref)) |oid| break :want_oid oid else |_| {}
+
+        const want_ref_head = try std.fmt.allocPrint(arena, "refs/heads/{s}", .{want_ref});
+        const want_ref_tag = try std.fmt.allocPrint(arena, "refs/tags/{s}", .{want_ref});
+
+        var ref_iterator: git.Session.RefIterator = undefined;
+        session.listRefs(&ref_iterator, .{
+            .ref_prefixes = &.{ want_ref, want_ref_head, want_ref_tag },
+            .include_peeled = true,
+            .buffer = reader_buffer,
+        }) catch |err| return f.fail(f.location_tok, try eb.printString("unable to list refs: {t}", .{err}));
+        defer ref_iterator.deinit();
+        while (ref_iterator.next() catch |err| {
+            return f.fail(f.location_tok, try eb.printString(
+                "unable to iterate refs: {s}",
+                .{@errorName(err)},
+            ));
+        }) |ref| {
+            if (std.mem.eql(u8, ref.name, want_ref) or
+                std.mem.eql(u8, ref.name, want_ref_head) or
+                std.mem.eql(u8, ref.name, want_ref_tag))
+            {
+                break :want_oid ref.peeled orelse ref.oid;
+            }
+        }
+        return f.fail(f.location_tok, try eb.printString("ref not found: {s}", .{want_ref}));
+    };
+    if (f.use_latest_commit) {
+        f.latest_commit = want_oid;
+    } else if (uri.fragment == null) {
+        const notes_len = 1;
+        try eb.addRootErrorMessage(.{
+            .msg = try eb.addString("url field is missing an explicit ref"),
+            .src_loc = try f.srcLoc(f.location_tok),
+            .notes_len = notes_len,
+        });
+        const notes_start = try eb.reserveNotes(notes_len);
+        eb.extra.items[notes_start] = @intFromEnum(try eb.addErrorMessage(.{
+            .msg = try eb.printString("try .url = \"{f}#{f}\",", .{
+                uri.fmt(.{ .scheme = true, .authority = true, .path = true }),
+                want_oid,
+            }),
+        }));
+        return error.FetchFailed;
+    }
+
+    var want_oid_buf: [git.Oid.max_formatted_length]u8 = undefined;
+    _ = std.fmt.bufPrint(&want_oid_buf, "{f}", .{want_oid}) catch unreachable;
+    resource.* = .{ .git = .{
+        .session = session,
+        .fetch_stream = undefined,
+        .want_oid = want_oid,
+    } };
+    const fetch_stream = &resource.git.fetch_stream;
+    try session.fetch(fetch_stream, &.{&want_oid_buf}, reader_buffer);
+    errdefer fetch_stream.deinit(fetch_stream);
 }
 
 fn unpackResource(

--- a/src/Package/Fetch.zig
+++ b/src/Package/Fetch.zig
@@ -334,6 +334,10 @@ pub const Retry = struct {
     ///
     /// 0 means it should never retry.
     max_retries: u16 = 3,
+    /// Normally, the retry delay is calculated with jitter, but some instances
+    /// may require an override. When this value is used, it is set back to
+    /// `null`.
+    retry_delay_override_ms: ?u32 = null,
     /// Hard cap of how many milliseconds to wait between retries.
     const MAX_RETRY_SLEEP_MS = 10 * 1000;
     /// Minimum time a jittered retry delay could be
@@ -342,6 +346,10 @@ pub const Retry = struct {
     const MAX_RETRY_JITTER_MS = 1500;
 
     fn calcRetryDelayMs(r: *Retry) i64 {
+        if (r.retry_delay_override_ms) |delay| {
+            r.retry_delay_override_ms = null;
+            return delay;
+        }
         if (r.cur_retries == 0) {
             return std.crypto.random.intRangeAtMost(i64, MIN_RETRY_JITTER_MS, MAX_RETRY_JITTER_MS);
         }
@@ -1135,12 +1143,109 @@ fn initHttpResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer:
     const status = response.head.status;
 
     if (@intFromEnum(status) >= 500 or status == .too_many_requests or status == .not_found) {
+        var iter = response.head.iterateHeaders();
+        if (parseRetryAfter(f.io, &iter) catch null) |delay_sec| {
+            // Set max by dividing and multiplying again, because Retry-After
+            // header value needs to be u32, and could be obsurdly large, and
+            // we do not want to multiply that large number by 1000 in case of
+            // overflow. So we cap it first, then convert to milliseconds.
+            f.retry.retry_delay_override_ms = @min(delay_sec, Retry.MAX_RETRY_SLEEP_MS / 1000) * @as(u32, 1000);
+        }
         return BadHttpStatus.MaybeSpurious;
     } else if (status != .ok) {
         return BadHttpStatus.NonSpurious;
     }
 
     resource.http_request.decompress_buffer = try arena.alloc(u8, response.head.content_encoding.minBufferCapacity());
+}
+
+/// Iterate through response headers to find Retry-After header, and parse the
+/// value to return a value that represents how many seconds from now to wait
+/// until a retry may be attempted.
+///
+/// If the header does not exist, `null` is returned. If the header value is
+/// invalid, an error is returned to indicate that parsing failed.
+///
+/// Note that the implementation of this method in Cargo only respects this
+/// header for 503 and 429 status codes, but the specification on MDN does not
+/// restrict this header's usage to only those two status codes, so we won't
+/// either.
+///
+/// For more information, see the MDN documentation:
+/// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After
+fn parseRetryAfter(io: Io, header_iter: *std.http.HeaderIterator) !?u32 {
+    const retry_after: []const u8 = while (header_iter.next()) |header| {
+        if (ascii.eqlIgnoreCase(header.name, "retry-after")) {
+            break header.value;
+        }
+    } else {
+        return null;
+    };
+
+    // Option 1: The value is a positive integer indicating number of seconds
+    // to wait before retrying.
+    if (std.fmt.parseInt(u32, retry_after, 10) catch null) |value| {
+        return value;
+    }
+
+    // Option 2: The value is a timestamp that we need to parse, then use with
+    // current time to calculate how many seconds to wait before retrying.
+    //
+    // Parsing based on this specification:
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Date
+    const RETRY_AFTER_LEN: usize = 29;
+    if (retry_after.len != RETRY_AFTER_LEN) {
+        return error.InvalidHeaderValueLength;
+    }
+
+    // Much more memory compact than an array of string slices, because
+    // pointers are large. Also 12 strings means 11 more `\0` bytes than we
+    // actually need.
+    const months = "JanFebMarAprMayJunJulAugSepOctNovDec";
+
+    const epoch = std.time.epoch;
+
+    // Example date with periodic indices for easy visualization:
+    // Tue, 29 Oct 2024 16:56:32 GMT
+    // ^         ^         ^
+    // 0         10        20
+    const year = try std.fmt.parseInt(epoch.Year, retry_after[12..16], 10);
+    const month: epoch.Month = for (0..12) |i| {
+        const month = months[i * 3 .. (i * 3) + 3];
+        if (std.mem.eql(u8, month, retry_after[8..11])) {
+            break @enumFromInt(i + 1);
+        }
+    } else {
+        return error.CannotFindMonth;
+    };
+    const day = try std.fmt.parseInt(epoch.Day, retry_after[5..7], 10);
+    const hour = try std.fmt.parseInt(epoch.Hour, retry_after[17..19], 10);
+    const minute = try std.fmt.parseInt(epoch.Minute, retry_after[20..22], 10);
+    const second = try std.fmt.parseInt(epoch.Second, retry_after[23..25], 10);
+
+    const datetime = epoch.Datetime{
+        .year = year,
+        .month = month,
+        .day = day,
+        .hour = hour,
+        .minute = minute,
+        .second = second,
+    };
+    const timestamp_retry_after: Io.Timestamp = try datetime.asTimestamp();
+    const timestamp_cur = try Io.Clock.Timestamp.now(io, .real);
+
+    // If Retry-After is before or equal to now, disregard it and calc delay as usual
+    if (timestamp_retry_after.nanoseconds <= timestamp_cur.raw.nanoseconds) {
+        return null;
+    }
+
+    // i96_max / 1_000_000 needs 76 bits if unsigned
+    const diff: u76 = @intCast(@divTrunc(timestamp_retry_after.nanoseconds - timestamp_cur.raw.nanoseconds, std.time.ns_per_s));
+
+    // If we get a number too large to fit into u32, it's way too big anyway, we can cap at u32's max
+    const capped: u32 = @min(diff, std.math.maxInt(u32));
+
+    return capped;
 }
 
 fn initGitResource(f: *Fetch, uri: std.Uri, resource: *Resource, reader_buffer: []u8) !void {


### PR DESCRIPTION
# UPDATE
See here for most recent list of features in this solution:
https://github.com/ziglang/zig/pull/25120#issuecomment-3448003430

# Problem
Like in #17472, the package manager does not retry fetching when communication to the server fails in a way that could possibly be resolved by retrying the fetch.

# Solution
Automatically retry the fetch in these scenarios during http fetches:
1. Connecting to the server fails
2. Sending the payload to the server fails
3. Server returns a non-200 status code

and theses scenarios during git+http fetches:

1. Discovering remote git server capabilities fails
2. Creating a fetch stream fails

This does not expose this fetch config to the end user, for reasons you can read about in the next section. Definitely worth the conversation, but getting this PR out there as is doesn't seem like a bad idea to me.

# Major Considerations

* I thought about how I can expose configuration of the retry behavior to the user (the `retry_count` and `retry_delay_ms`). However, this proved difficult, so it is **not a part of this PR**. Here are some thoughts I had though:
    * I cannot expose config in the `build.zig` file, because (as far as I can tell) the `build.zig` file is not run until all the packages are fetched and ready to be built with the source code.
    * I do not want to include this config for each dep (dependency) because - how do we handle this for deps of deps? We don't want the lib maintainer to determine how many times I fetch the lib's deps. That's the end user's decision. So deps of deps can inherit the config, but then the end user isn't getting the control they are "promised" by having the config attached to each dep.
    * I do not want to include the config in the body of the manifest. Feels out of place, since that body isn't supposed to be about fetch config for dependencies, it's supposed to be about defining the current package along with pointing to it's dependent packages.
    * Maybe we allow config to be passed in the body of `.dependencies`, like this (below) so that `.retry_count` and other props apply to all dependencies, but it's still a part of the `.dependencies` object. Also, this can easily be parsed by checking the type of the prop. If the type is `anytype`, it's a real dep, if it's anything else, it's config code, not a real dep. Fun idea, but it's not a part of this PR and shouldn't be. Here is an example of this idea:
        ```zig
        .dependencies = .{
            .retry_count = 3,
            .retry_delay_ms = 1000,
            .zf = .{
                .url = "https://github.com/natecraddock/zf/archive/7aacbe6d155d64d15937ca95ca6c014905eb531f.tar.gz",
                .hash = "zf-0.10.3-OIRy8aiIAACLrBllz0zjxaH0aOe5oNm3KtEMyCntST-9",
                .lazy = true,
            },
            .vaxis = .{
                .url = "git+https://github.com/rockorager/libvaxis#1f41c121e8fc153d9ce8c6eb64b2bbab68ad7d23",
                .hash = "vaxis-0.1.0-BWNV_FUICQAFZnTCL11TUvnUr1Y0_ZdqtXHhd51d76Rn",
                .lazy = true,
            },
        },
        ```
* Would be cool to show the retry progress like this after it fails the first time. But it might be worth extending `std.Progress.Node` first for that, so this is also **not implemented in this PR**:
    ```
    Compile Build Script
    └─ [1/2] Fetch Packages
       ├─ vaxis (retry 1/2)
       └─ zf
    ```
 
# Minor Considerations

* I intentionally did not attempt to retry during failures that do not seem resolvable by simply refetching, e.g. when receiving the http header because, looking through the possible errors, it seems errors mostly occur because of invalid responses, redirecting, or write failures in that case.
* There are some locations where memory is being freed that wasn't being freed before. This is because, in the case of the user possibly configuring `Fetch` to retry many times, I don't want the allocator to allocate without freeing each time it attempts to refetch the network data, resulting in a memory leak.
* The `Fetch.initResource()` method needs to be refactored. But this PR is big enough, so it made sense to me to merge this, then do a refactor in a future PR.