### PR TITLE
lzma2: fix premature finish

### DIFF
--- a/lib/std/compress/lzma2.zig
+++ b/lib/std/compress/lzma2.zig
@@ -233,7 +233,6 @@ pub const Decode = struct {
 
         while (true) {
             if (accum.len >= expected_unpacked_size) break;
-            if (range_decoder.isFinished()) break;
             switch (try ld.process(reader, allocating, accum, &range_decoder, &n_read)) {
                 .more => continue,
                 .finished => break,


### PR DESCRIPTION
closes: https://github.com/ziglang/zig/issues/25121
lzma2 Decoder already checks if decoding is finished or not inside the process function, `range_decoder`finish does not mean the decoder has finished, also need to check `ld.rep[0] == 0xFFFF_FFFF`, which was already done inside the proccess function. This fix delete the redundant `isFinish()` check for `range_decoder`.