### PR TITLE
`std.debug`: disable stack traces on loongarch

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -169,6 +169,8 @@ pub const runtime_safety = switch (builtin.mode) {
 pub const sys_can_stack_trace = switch (builtin.cpu.arch) {
     // Observed to go into an infinite loop.
     // TODO: Make this work.
+    .loongarch32,
+    .loongarch64,
     .mips,
     .mipsel,
     .mips64,

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -2293,11 +2293,6 @@ pub fn addModuleTests(b: *std.Build, options: ModuleTestOptions) *Step {
         if (options.skip_single_threaded and test_target.single_threaded == true)
             continue;
 
-        // https://github.com/ziglang/zig/issues/24405
-        if (!builtin.cpu.arch.isLoongArch() and target.cpu.arch.isLoongArch() and
-            (mem.eql(u8, options.name, "behavior") or mem.eql(u8, options.name, "std")))
-            continue;
-
         // TODO get compiler-rt tests passing for self-hosted backends.
         if (((target.cpu.arch != .x86_64 and target.cpu.arch != .aarch64) or target.ofmt == .coff) and
             test_target.use_llvm == false and mem.eql(u8, options.name, "compiler-rt"))


### PR DESCRIPTION
Observed to ~randomly crash during FP-based unwinding.

The path forward here will be DWARF-based unwinding.