### PR TITLE
std.c: add getresuid & getresgid

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10756,6 +10756,8 @@ pub extern "c" fn setresgid(rgid: gid_t, egid: gid_t, sgid: gid_t) c_int;
 pub extern "c" fn setpgid(pid: pid_t, pgid: pid_t) c_int;
 pub extern "c" fn getuid() uid_t;
 pub extern "c" fn geteuid() uid_t;
+pub extern "c" fn getresuid(ruid: *uid_t, euid: *uid_t, suid: *uid_t) c_int;
+pub extern "c" fn getresgid(rgid: *gid_t, egid: *gid_t, sgid: *gid_t) c_int;
 
 pub extern "c" fn malloc(usize) ?*anyopaque;
 pub extern "c" fn calloc(usize, usize) ?*anyopaque;


### PR DESCRIPTION
The getresuid(2) & getresgid(2) calls are available on a bunch of systems, including: glibc/Linux, musl/Linux, OpenBSD, FreeBSD, and even POSIX.1-2024.