### PR TITLE
fix std.Io.takeDelimiter delimiter tossing

### DIFF
--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -864,17 +864,11 @@ pub fn takeDelimiterExclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
 /// * `takeDelimiterInclusive`
 /// * `takeDelimiterExclusive`
 pub fn takeDelimiter(r: *Reader, delimiter: u8) error{ ReadFailed, StreamTooLong }!?[]u8 {
-    const result = r.peekDelimiterInclusive(delimiter) catch |err| switch (err) {
-        error.EndOfStream => {
-            const remaining = r.buffer[r.seek..r.end];
-            if (remaining.len == 0) return null;
-            r.toss(remaining.len);
-            return remaining;
-        },
+    const result = r.takeDelimiterExclusive(delimiter) catch |err| switch (err) {
+        error.EndOfStream => return null,
         else => |e| return e,
     };
-    r.toss(result.len);
-    return result[0 .. result.len - 1];
+    return result;
 }
 
 /// Returns a slice of the next bytes of buffered data from the stream until

--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -1391,16 +1391,27 @@ test stream {
 }
 
 test takeSentinel {
-    var r: Reader = .fixed("ab\nc");
+    var r: Reader = .fixed("ab\ncd\ne");
     try testing.expectEqualStrings("ab", try r.takeSentinel('\n'));
+    try testing.expectEqualStrings("cd", try r.takeSentinel('\n'));
     try testing.expectError(error.EndOfStream, r.takeSentinel('\n'));
-    try testing.expectEqualStrings("c", try r.peek(1));
+
+    try testing.expectEqualStrings("e", try r.peek(1));
 }
 
 test peekSentinel {
     var r: Reader = .fixed("ab\nc");
     try testing.expectEqualStrings("ab", try r.peekSentinel('\n'));
     try testing.expectEqualStrings("ab", try r.peekSentinel('\n'));
+    r.toss(2);
+    try testing.expectEqualStrings("", try r.peekSentinel('\n'));
+    try testing.expectEqualStrings("", try r.peekSentinel('\n'));
+    r.toss(1);
+    try testing.expectEqual(error.EndOfStream, r.peekSentinel('\n'));
+    try testing.expectEqual(error.EndOfStream, r.peekSentinel('\n'));
+
+    try testing.expectEqualStrings("c", try r.peek(1));
+}
 
 test takeDelimiter {
     var r: Reader = .fixed("ab\ncd\ne");
@@ -1412,23 +1423,32 @@ test takeDelimiter {
 }
 
 test takeDelimiterInclusive {
-    var r: Reader = .fixed("ab\nc");
+    var r: Reader = .fixed("ab\ncd\ne");
     try testing.expectEqualStrings("ab\n", try r.takeDelimiterInclusive('\n'));
+    try testing.expectEqualStrings("cd\n", try r.takeDelimiterInclusive('\n'));
     try testing.expectError(error.EndOfStream, r.takeDelimiterInclusive('\n'));
+
+    try testing.expectEqualStrings("e", try r.peek(1));
 }
 
 test peekDelimiterInclusive {
     var r: Reader = .fixed("ab\nc");
     try testing.expectEqualStrings("ab\n", try r.peekDelimiterInclusive('\n'));
     try testing.expectEqualStrings("ab\n", try r.peekDelimiterInclusive('\n'));
-    r.toss(3);
+    r.toss(2);
+    try testing.expectEqualStrings("\n", try r.peekDelimiterInclusive('\n'));
+    r.toss(1);
     try testing.expectError(error.EndOfStream, r.peekDelimiterInclusive('\n'));
+    try testing.expectError(error.EndOfStream, r.peekDelimiterInclusive('\n'));
+
+    try testing.expectEqualStrings("c", try r.peek(1));
 }
 
 test takeDelimiterExclusive {
-    var r: Reader = .fixed("ab\nc");
+    var r: Reader = .fixed("ab\ncd\ne");
     try testing.expectEqualStrings("ab", try r.takeDelimiterExclusive('\n'));
-    try testing.expectEqualStrings("c", try r.takeDelimiterExclusive('\n'));
+    try testing.expectEqualStrings("cd", try r.takeDelimiterExclusive('\n'));
+    try testing.expectEqualStrings("e", try r.takeDelimiterExclusive('\n'));
     try testing.expectError(error.EndOfStream, r.takeDelimiterExclusive('\n'));
 }
 
@@ -1436,9 +1456,15 @@ test peekDelimiterExclusive {
     var r: Reader = .fixed("ab\nc");
     try testing.expectEqualStrings("ab", try r.peekDelimiterExclusive('\n'));
     try testing.expectEqualStrings("ab", try r.peekDelimiterExclusive('\n'));
-    r.toss(3);
+    r.toss(2);
+    try testing.expectEqualStrings("", try r.peekDelimiterExclusive('\n'));
+    try testing.expectEqualStrings("", try r.peekDelimiterExclusive('\n'));
+    r.toss(1);
     try testing.expectEqualStrings("c", try r.peekDelimiterExclusive('\n'));
     try testing.expectEqualStrings("c", try r.peekDelimiterExclusive('\n'));
+    r.toss(1);
+    try testing.expectError(error.EndOfStream, r.peekDelimiterExclusive('\n'));
+    try testing.expectError(error.EndOfStream, r.peekDelimiterExclusive('\n'));
 }
 
 test streamDelimiter {

--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -873,7 +873,7 @@ pub fn takeDelimiter(r: *Reader, delimiter: u8) error{ ReadFailed, StreamTooLong
         },
         else => |e| return e,
     };
-    r.toss(result.len + 1);
+    r.toss(result.len);
     return result[0 .. result.len - 1];
 }
 
@@ -1401,6 +1401,14 @@ test peekSentinel {
     var r: Reader = .fixed("ab\nc");
     try testing.expectEqualStrings("ab", try r.peekSentinel('\n'));
     try testing.expectEqualStrings("ab", try r.peekSentinel('\n'));
+
+test takeDelimiter {
+    var r: Reader = .fixed("ab\ncd\ne");
+
+    try testing.expectEqualStrings("ab", try r.takeDelimiter('\n') orelse "null");
+    try testing.expectEqualStrings("cd", try r.takeDelimiter('\n') orelse "null");
+    try testing.expectEqualStrings("e", try r.takeDelimiter('\n') orelse "null");
+    try testing.expectEqual(null, try r.takeDelimiter('\n'));
 }
 
 test takeDelimiterInclusive {

--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -832,6 +832,7 @@ pub fn peekDelimiterInclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
 /// See also:
 /// * `takeDelimiterInclusive`
 /// * `peekDelimiterExclusive`
+/// * `streamDelimiter`
 pub fn takeDelimiterExclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
     const result = r.peekDelimiterInclusive(delimiter) catch |err| switch (err) {
         error.EndOfStream => {
@@ -863,6 +864,7 @@ pub fn takeDelimiterExclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
 /// See also:
 /// * `takeDelimiterInclusive`
 /// * `takeDelimiterExclusive`
+/// * `streamDelimiter`
 pub fn takeDelimiter(r: *Reader, delimiter: u8) error{ ReadFailed, StreamTooLong }!?[]u8 {
     const result = r.takeDelimiterExclusive(delimiter) catch |err| switch (err) {
         error.EndOfStream => return null,
@@ -879,9 +881,7 @@ pub fn takeDelimiter(r: *Reader, delimiter: u8) error{ ReadFailed, StreamTooLong
 /// case `error.EndOfStream` is returned instead.
 ///
 /// If the delimiter is not found within a number of bytes matching the
-/// capacity of this `Reader`, `error.StreamTooLong` is returned. In
-/// such case, the stream state is unmodified as if this function was never
-/// called.
+/// capacity of this `Reader`, `error.StreamTooLong` is returned.
 ///
 /// Invalidates previously returned values from `peek`.
 ///
@@ -1416,6 +1416,12 @@ test takeDelimiter {
     try testing.expectEqual(null, try r.takeDelimiter('\n'));
 }
 
+// test "takeDelimiter no delimiter" {
+//     var r: Reader = .fixed("abc");
+//     try testing.expectEqualStrings("abc", try r.takeDelimiter('\n') orelse "null");
+//     try testing.expectEqual(null, try r.takeDelimiter('\n'));
+// }
+
 test takeDelimiterInclusive {
     var r: Reader = .fixed("ab\ncd\ne");
     try testing.expectEqualStrings("ab\n", try r.takeDelimiterInclusive('\n'));
@@ -1437,6 +1443,11 @@ test peekDelimiterInclusive {
 
     try testing.expectEqualStrings("c", try r.peek(1));
 }
+
+// test "peekDelimiterInclusive no delimiter" {
+//     var r: Reader = .fixed("abc");
+//     try testing.expectEqual(error.EndOfStream, r.peekDelimiterInclusive('\n'));
+// }
 
 test takeDelimiterExclusive {
     var r: Reader = .fixed("ab\ncd\ne");
@@ -1460,6 +1471,11 @@ test peekDelimiterExclusive {
     try testing.expectError(error.EndOfStream, r.peekDelimiterExclusive('\n'));
     try testing.expectError(error.EndOfStream, r.peekDelimiterExclusive('\n'));
 }
+
+// test "peekDelimiterExclusive no delimiter" {
+//     var r: Reader = .fixed("abc");
+//     try testing.expectEqualStrings("abc", try r.peekDelimiterExclusive('\n'));
+// }
 
 test streamDelimiter {
     var out_buffer: [10]u8 = undefined;


### PR DESCRIPTION
fixes #25132
