### PR TITLE
Reenable failing vector tests

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1211,10 +1211,6 @@ test "positional/alignment/width/precision" {
 
 test "vector" {
     if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
-    if (builtin.target.cpu.arch == .riscv64) {
-        // https://github.com/ziglang/zig/issues/4486
-        return error.SkipZigTest;
-    }
 
     const vbool: @Vector(4, bool) = [_]bool{ true, false, true, false };
     const vi64: @Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -1210,8 +1210,6 @@ test "positional/alignment/width/precision" {
 }
 
 test "vector" {
-    if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
-
     const vbool: @Vector(4, bool) = [_]bool{ true, false, true, false };
     const vi64: @Vector(4, i64) = [_]i64{ -2, -1, 0, 1 };
     const vu64: @Vector(4, u64) = [_]u64{ 1000, 2000, 3000, 4000 };

--- a/lib/std/simd.zig
+++ b/lib/std/simd.zig
@@ -448,7 +448,6 @@ pub fn prefixScan(comptime op: std.builtin.ReduceOp, comptime hop: isize, vec: a
 }
 
 test "vector prefix scan" {
-    if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     if (builtin.cpu.arch == .aarch64_be and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/21893
     if (builtin.zig_backend == .stage2_llvm and builtin.cpu.arch == .hexagon) return error.SkipZigTest;
 

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -638,7 +638,6 @@ test "vector division operators" {
     };
 
     try comptime S.doTheTest();
-    if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     if (builtin.cpu.arch == .hexagon and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
     try S.doTheTest();
 }
@@ -1119,7 +1118,6 @@ test "@addWithOverflow" {
         }
     };
     try comptime S.doTheTest();
-    if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     try S.doTheTest();
 }
 
@@ -1153,7 +1151,6 @@ test "@subWithOverflow" {
         }
     };
     try comptime S.doTheTest();
-    if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     try S.doTheTest();
 }
 
@@ -1176,7 +1173,6 @@ test "@mulWithOverflow" {
         }
     };
     try comptime S.doTheTest();
-    if ((builtin.cpu.arch == .armeb or builtin.cpu.arch == .thumbeb) and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/22060
     try S.doTheTest();
 }
 


### PR DESCRIPTION
#4486 and #22060 seem to be fixed by LLVM. I have run all relevant tests using qemu, it would be great if someone else could also confirm (since I don't think we have armeb/thumbeb CI).

closes #4486
closes #22060