### PR TITLE
std.hash_map.zig: Resolved doc TODOs

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -413,26 +413,19 @@ pub fn HashMap(
 
         /// If there is an `Entry` with a matching key, it is deleted from
         /// the hash map, and this function returns true.  Otherwise this
-        /// function returns false.
-        ///
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// function returns false. Increases the unused capacity by one.
         pub fn remove(self: *Self, key: K) bool {
             return self.unmanaged.removeContext(key, self.ctx);
         }
 
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// Increases the unused capacity by one.
         pub fn removeAdapted(self: *Self, key: anytype, ctx: anytype) bool {
             return self.unmanaged.removeAdapted(key, ctx);
         }
 
         /// Delete the entry with key pointed to by key_ptr from the hash map.
         /// key_ptr is assumed to be a valid pointer to a key that is present
-        /// in the hash map.
-        ///
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// in the hash map. Increases the unused capacity by one.
         pub fn removeByPtr(self: *Self, key_ptr: *K) void {
             self.unmanaged.removeByPtr(key_ptr);
         }
@@ -1233,24 +1226,19 @@ pub fn HashMapUnmanaged(
 
         /// If there is an `Entry` with a matching key, it is deleted from
         /// the hash map, and this function returns true.  Otherwise this
-        /// function returns false.
-        ///
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// function returns false. Increases the unused capacity by one.
         pub fn remove(self: *Self, key: K) bool {
             if (@sizeOf(Context) != 0)
                 @compileError("Cannot infer context " ++ @typeName(Context) ++ ", call removeContext instead.");
             return self.removeContext(key, undefined);
         }
 
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// Increases the unused capacity by one.
         pub fn removeContext(self: *Self, key: K, ctx: Context) bool {
             return self.removeAdapted(key, ctx);
         }
 
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// Increases the unused capacity by one.
         pub fn removeAdapted(self: *Self, key: anytype, ctx: anytype) bool {
             if (self.getIndex(key, ctx)) |idx| {
                 self.removeByIndex(idx);
@@ -1262,10 +1250,7 @@ pub fn HashMapUnmanaged(
 
         /// Delete the entry with key pointed to by key_ptr from the hash map.
         /// key_ptr is assumed to be a valid pointer to a key that is present
-        /// in the hash map.
-        ///
-        /// TODO: answer the question in these doc comments, does this
-        /// increase the unused capacity by one?
+        /// in the hash map. Increases the unused capacity by one.
         pub fn removeByPtr(self: *Self, key_ptr: *K) void {
             // TODO: replace with pointer subtraction once supported by zig
             // if @sizeOf(K) == 0 then there is at most one item in the hash


### PR DESCRIPTION
Answered the open questions regarding hash_map capacities.
> /// TODO: answer the question in these doc comments, does this
   /// increase the unused capacity by one?
   
The unused capacity is the difference between `.capacity()` and `size`. The capacity is not altered during entry removal, but size does become smaller by one. Thus the unused capacity is incremented by one on these function calls.

Answers based on manual tests, can include them if needed. 