### PR TITLE
std.Io.Reader: fix delimiter bugs

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1393,7 +1393,7 @@ fn parseHosts(
     br: *Io.Reader,
 ) error{ OutOfMemory, ReadFailed }!void {
     while (true) {
-        const line = br.takeDelimiterExclusive('\n') catch |err| switch (err) {
+        const line = br.takeDelimiter('\n') catch |err| switch (err) {
             error.StreamTooLong => {
                 // Skip lines that are too long.
                 _ = br.discardDelimiterInclusive('\n') catch |e| switch (e) {
@@ -1403,7 +1403,8 @@ fn parseHosts(
                 continue;
             },
             error.ReadFailed => return error.ReadFailed,
-            error.EndOfStream => break,
+        } orelse {
+            break; // end of stream
         };
         var split_it = mem.splitScalar(u8, line, '#');
         const no_comment_line = split_it.first();

--- a/lib/std/zig/system/linux.zig
+++ b/lib/std/zig/system/linux.zig
@@ -359,14 +359,11 @@ fn CpuinfoParser(comptime impl: anytype) type {
     return struct {
         fn parse(arch: Target.Cpu.Arch, reader: *std.Io.Reader) !?Target.Cpu {
             var obj: impl = .{};
-            while (reader.takeDelimiterExclusive('\n')) |line| {
+            while (try reader.takeDelimiter('\n')) |line| {
                 const colon_pos = mem.indexOfScalar(u8, line, ':') orelse continue;
                 const key = mem.trimEnd(u8, line[0..colon_pos], " \t");
                 const value = mem.trimStart(u8, line[colon_pos + 1 ..], " \t");
                 if (!try obj.line_hook(key, value)) break;
-            } else |err| switch (err) {
-                error.EndOfStream => {},
-                else => |e| return e,
             }
             return obj.finalize(arch);
         }


### PR DESCRIPTION
* Fix `takeDelimiter` and `takeDelimiterExclusive` tossing too many bytes (#25132)

* Remove questionably-legal use of `stream` in `peekDelimiterInclusive`. The doc comment of `VTable.stream` appears to contradict itself, by saying that new data should be written to `w` which may fill more data into the buffer, but *also* that the implementation may choose to write data to `buffer` instead of or after writing to `w`. If an implementation chose to do the "after" one, then under the "fill more of the buffer" use case it would overwrite the bytes it just wrote to `w`, silently dropping bytes (and causing probable IB in the caller). The documentation needs fixing here, at which point we should audit our buffer-filling strategies across the interface, but I don't know what's intended, so for now I just switched to a definitely-safe approach.

Also add/improve test coverage for all delimiter and sentinel methods, update usages of `takeDelimiterExclusive` to not rely on the fixed bug, tweak a handful of doc comments, and slightly simplify some logic.

I have not fixed #24950 in this commit because I am a little less certain about the appropriate solution there.

Resolves: #25132