### PR TITLE
langref: added missing newlines to destructuring tuples example

### DIFF
--- a/doc/langref/destructuring_block.zig
+++ b/doc/langref/destructuring_block.zig
@@ -15,8 +15,8 @@ pub fn main() void {
         break :blk .{ min, max };
     };
 
-    print("min = {}", .{ min });
-    print("max = {}", .{ max });
+    print("min = {}\n", .{ min });
+    print("max = {}\n", .{ max });
 }
 
 // exe=succeed


### PR DESCRIPTION
The output for example 'Destructuring Tuples' was `min = 0max = 9` on a single line, now minimum and maximum are each on their own line.