### PR TITLE
linux: emulate wait4 using waitid

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1586,11 +1586,11 @@ pub fn unlinkat(dirfd: i32, path: [*:0]const u8, flags: u32) usize {
     return syscall3(.unlinkat, @as(usize, @bitCast(@as(isize, dirfd))), @intFromPtr(path), flags);
 }
 
-pub fn waitpid(pid: pid_t, status: *u32, flags: u32) usize {
-    return syscall4(.wait4, @as(usize, @bitCast(@as(isize, pid))), @intFromPtr(status), flags, 0);
+pub fn waitpid(pid: pid_t, status: ?*u32, flags: u32) usize {
+    return wait4(pid, status, flags, null);
 }
 
-pub fn wait4(pid: pid_t, status: *u32, flags: u32, usage: ?*rusage) usize {
+pub fn wait4(pid: pid_t, status: ?*u32, flags: u32, usage: ?*rusage) usize {
     return syscall4(
         .wait4,
         @as(usize, @bitCast(@as(isize, pid))),
@@ -1600,8 +1600,15 @@ pub fn wait4(pid: pid_t, status: *u32, flags: u32, usage: ?*rusage) usize {
     );
 }
 
-pub fn waitid(id_type: P, id: i32, infop: *siginfo_t, flags: u32) usize {
-    return syscall5(.waitid, @intFromEnum(id_type), @as(usize, @bitCast(@as(isize, id))), @intFromPtr(infop), flags, 0);
+pub fn waitid(id_type: P, id: pid_t, infop: *siginfo_t, flags: u32, usage: ?*rusage) usize {
+    return syscall5(
+        .waitid,
+        @intFromEnum(id_type),
+        @as(usize, @bitCast(@as(isize, id))),
+        @intFromPtr(infop),
+        flags,
+        @intFromPtr(usage),
+    );
 }
 
 pub fn fcntl(fd: fd_t, cmd: i32, arg: usize) usize {


### PR DESCRIPTION
Implements `posix.wait4` using  `waitid` on Linux, because the `wait4` syscall is not always available on newer architectures (e.g. riscv32).
At the moment we don't seem to have constants defined for the siginfo codes, so I used the numbers directly since I don't know if and where those constants should be added.

Closes #23262