### PR TITLE
frontend: vectors and arrays no longer support in-memory coercion

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1969,6 +1969,14 @@ or
       </p>
       {#see_also|@splat|@shuffle|@select|@reduce#}
 
+      {#header_open|Relationship with Arrays#}
+      <p>Vectors and {#link|Arrays#} each have a well-defined <strong>bit layout</strong>
+      and therefore support {#link|@bitCast#} between each other. {#link|Type Coercion#} implicitly peforms
+      {#syntax#}@bitCast{#endsyntax#}.</p>
+      <p>Arrays have well-defined byte layout, but vectors do not, making {#link|@ptrCast#} between
+      them {#link|Illegal Behavior#}.</p>
+      {#header_close#}
+
       {#header_open|Destructuring Vectors#}
       <p>
         Vectors can be destructured:

--- a/doc/langref/test_vector.zig
+++ b/doc/langref/test_vector.zig
@@ -17,7 +17,7 @@ test "Basic vector usage" {
 }
 
 test "Conversion between vectors, arrays, and slices" {
-    // Vectors and fixed-length arrays can be automatically assigned back and forth
+    // Vectors can be coerced to arrays, and vice versa.
     const arr1: [4]f32 = [_]f32{ 1.1, 3.2, 4.5, 5.6 };
     const vec: @Vector(4, f32) = arr1;
     const arr2: [4]f32 = vec;

--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -569,7 +569,7 @@ pub fn assertReadable(slice: []const volatile u8) void {
 /// Invokes detectable illegal behavior when the provided array is not aligned
 /// to the provided amount.
 pub fn assertAligned(ptr: anytype, comptime alignment: std.mem.Alignment) void {
-    const aligned_ptr: *align(alignment.toByteUnits()) anyopaque = @ptrCast(@alignCast(ptr));
+    const aligned_ptr: *align(alignment.toByteUnits()) const anyopaque = @ptrCast(@alignCast(ptr));
     _ = aligned_ptr;
 }
 

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1156,10 +1156,10 @@ pub fn indexOfSentinel(comptime T: type, comptime sentinel: T, p: [*:sentinel]co
                     }
                 }
 
-                assert(std.mem.isAligned(@intFromPtr(&p[i]), block_size));
+                std.debug.assertAligned(&p[i], .fromByteUnits(block_size));
                 while (true) {
-                    const block: *const Block = @ptrCast(@alignCast(p[i..][0..block_len]));
-                    const matches = block.* == mask;
+                    const block: Block = p[i..][0..block_len].*;
+                    const matches = block == mask;
                     if (@reduce(.Or, matches)) {
                         return i + std.simd.firstTrue(matches).?;
                     }

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1737,6 +1737,7 @@ test "peer type resolution: array and vector with same child type" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest; // TODO
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     var arr: [2]u32 = .{ 0, 1 };
     var vec: @Vector(2, u32) = .{ 2, 3 };

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -103,7 +103,11 @@ test "basic extern unions" {
     var foo = FooExtern{ .int = 1 };
     try expect(foo.int == 1);
     foo.str.slice = "Well";
-    try expect(std.mem.eql(u8, std.mem.sliceTo(foo.str.slice, 0), "Well"));
+    try expect(foo.str.slice[0] == 'W');
+    try expect(foo.str.slice[1] == 'e');
+    try expect(foo.str.slice[2] == 'l');
+    try expect(foo.str.slice[3] == 'l');
+    try expect(foo.str.slice[4] == 0);
 }
 
 const ExternPtrOrInt = extern union {

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -196,6 +196,7 @@ test "array to vector" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/cases/compile_errors/in_memory_coerce_vector_to_array.zig
+++ b/test/cases/compile_errors/in_memory_coerce_vector_to_array.zig
@@ -1,0 +1,16 @@
+export fn entry() void {
+    _ = foo() catch {};
+}
+fn foo() anyerror![4]u32 {
+    return bar();
+}
+fn bar() anyerror!@Vector(4, u32) {
+    return .{ 1, 2, 3, 4 };
+}
+// error
+// backend=stage2
+// target=native
+//
+// :5:15: error: expected type 'anyerror![4]u32', found 'anyerror!@Vector(4, u32)'
+// :5:15: note: error union payload '@Vector(4, u32)' cannot cast into error union payload '[4]u32'
+// :4:18: note: function return type declared here


### PR DESCRIPTION
closes #25172

## Migration Guide

If you were using `@ptrCast` to convert between array memory and vector memory, use coercion instead.

If you were coercing from `anyerror![4]i32` to `anyerror!@Vector(4, i32)` or similar, you need to unwrap the error first.