### PR TITLE
Fix standalone test simple/cat/main.zig after Writergate update

### DIFF
--- a/test/standalone/simple/cat/main.zig
+++ b/test/standalone/simple/cat/main.zig
@@ -14,9 +14,9 @@ pub fn main() !void {
     const exe = args[0];
     var catted_anything = false;
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writerStreaming(&stdout_buffer);
+    var stdout_writer = fs.File.stdout().writerStreaming(&stdout_buffer);
     const stdout = &stdout_writer.interface;
-    var stdin_reader = std.fs.File.stdin().readerStreaming(&.{});
+    var stdin_reader = fs.File.stdin().readerStreaming(&.{});
 
     const cwd = fs.cwd();
 


### PR DESCRIPTION
`test/standalone/simple/cat/main.zig` panics on run in version `0.15.1`, but in `0.14.1` it works properly

```console
/.../zig/std/debug.zig:559:14: 0x102e0fe07 in assert (...)
    if (!ok) unreachable; // assertion failure
             ^
/.../zig/0.15.1/lib/zig/std/Io/Writer.zig:939:11: 0x102ea2bb7 in sendFileAll (...)
    assert(w.buffer.len > 0);
          ^
/.../src/main.zig:35:39: 0x102ea28df in main (..)
            _ = try stdout.sendFileAll(&file_reader, .unlimited);
                                      ^
```

Steps to reproduce

```console
$ zig init
# replace contents of src/main.zig with test/standalone/simple/cat/main.zig
$ zig build
$ echo "test" > t.txt
$ ./zig-out/bin/cat t.txt
```

 I was not sure if the code in `simple/cat` should be actually working or only buildable, but this PR makes it work again

JFYI I did start discussion in [ziggit](https://ziggit.dev/t/should-standalone-test-simple-cat-main-zig-actually-work-or-just-be-buildable/11925), but decided to push fix to upstream at the end