### PR TITLE
Update readme llvm dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ensure you have the required dependencies:
 
  * CMake >= 3.15
  * System C/C++ Toolchain
- * LLVM, Clang, LLD development libraries == 20.x
+ * LLVM, Clang, LLD development libraries == 21.x
 
 Then it is the standard CMake build process:
 


### PR DESCRIPTION
Changed llvm version from 20.x to 21.x to reflect current depencies.

I was building from source and initially installed version 20.x as stated from listed dependencies and cmake was returned with this. Issue was resolved after installing verison 21.x
```bash
CMake Error at cmake/Findllvm.cmake:30 (message):
  expected LLVM 21.x but found 20.1.2 using /usr/bin/llvm-config
```