### PR TITLE
std.os.linux.socketpair(): switch to unsigned args

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -2141,11 +2141,11 @@ pub fn sendfile(outfd: i32, infd: i32, offset: ?*i64, count: usize) usize {
     }
 }
 
-pub fn socketpair(domain: i32, socket_type: i32, protocol: i32, fd: *[2]i32) usize {
+pub fn socketpair(domain: u32, socket_type: u32, protocol: u32, fd: *[2]i32) usize {
     if (native_arch == .x86) {
-        return socketcall(SC.socketpair, &[4]usize{ @as(usize, @intCast(domain)), @as(usize, @intCast(socket_type)), @as(usize, @intCast(protocol)), @intFromPtr(fd) });
+        return socketcall(SC.socketpair, &[4]usize{ domain, socket_type, protocol, @intFromPtr(fd) });
     }
-    return syscall4(.socketpair, @as(usize, @intCast(domain)), @as(usize, @intCast(socket_type)), @as(usize, @intCast(protocol)), @intFromPtr(fd));
+    return syscall4(.socketpair, domain, socket_type, protocol, @intFromPtr(fd));
 }
 
 pub fn accept(fd: i32, noalias addr: ?*sockaddr, noalias len: ?*socklen_t) usize {


### PR DESCRIPTION
We need std.os.linux and std.c to agree on the types here, or else we'd have to pointlessly cast across the difference up in the std.posix wrapper.  I ran into this as a type error the first time I tried to compile my code that calls posix.socketpair() on Linux without libc.

All of our existing socket calls with these kinds of arguments in std (including the existing c.socketpair as well as os.linux.socket in this same file) use unsigned for all of these parameters, and so this brings linux.socketpair() into alignment with everything else.