### PR TITLE
std.hash_map.zig: Resolve use pointer subtraction TODO

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -1267,12 +1267,11 @@ pub fn HashMapUnmanaged(
         /// TODO: answer the question in these doc comments, does this
         /// increase the unused capacity by one?
         pub fn removeByPtr(self: *Self, key_ptr: *K) void {
-            // TODO: replace with pointer subtraction once supported by zig
             // if @sizeOf(K) == 0 then there is at most one item in the hash
             // map, which is assumed to exist as key_ptr must be valid.  This
             // item must be at index 0.
             const idx = if (@sizeOf(K) > 0)
-                (@intFromPtr(key_ptr) - @intFromPtr(self.keys())) / @sizeOf(K)
+                (key_ptr - self.keys())
             else
                 0;
 


### PR DESCRIPTION
Resolved the TODO on pointer subtraction, since pointer arithmetic is supported for a while now. Alongside https://github.com/ziglang/zig/pull/25156 making `hash_map.zig` TODO-free.