### PR TITLE
Optimize adler32

### DIFF
--- a/lib/std/hash/Adler32.zig
+++ b/lib/std/hash/Adler32.zig
@@ -9,69 +9,52 @@ adler: u32 = 1,
 
 pub fn permute(state: u32, input: []const u8) u32 {
     const base = 65521;
-    const nmax = 5552;
 
-    var s1 = state & 0xffff;
-    var s2 = (state >> 16) & 0xffff;
+    // nmax is the largest n such that 255n(n+1)/2 + (n+1)(base-1) does not overflow
+    const b = 0xff.0 / 2.0 + (base - 1);
+    const nmax: comptime_int = std.math.floor((-b + @sqrt(b * b - 2 * 0xff.0 * (base - 1 - std.math.maxInt(usize)))) / 0xff.0);
 
-    if (input.len == 1) {
-        s1 +%= input[0];
-        if (s1 >= base) {
-            s1 -= base;
-        }
-        s2 +%= s1;
-        if (s2 >= base) {
-            s2 -= base;
-        }
-    } else if (input.len < 16) {
-        for (input) |b| {
-            s1 +%= b;
-            s2 +%= s1;
-        }
-        if (s1 >= base) {
-            s1 -= base;
+    var s1: usize = state & 0xffff;
+    var s2: usize = (state >> 16) & 0xffff;
+
+    const vec_len = std.simd.suggestVectorLength(u16) orelse 1;
+    const Vec = @Vector(vec_len, u16);
+
+    var i: usize = 0;
+
+    while (i + nmax <= input.len) {
+        const rounds = nmax / vec_len;
+        for (0..rounds) |_| {
+            const vec: Vec = input[i..][0..vec_len].*;
+
+            s2 += vec_len * s1;
+            s1 += @reduce(.Add, vec);
+            s2 += @reduce(.Add, vec * std.simd.reverseOrder(std.simd.iota(u32, vec_len) + @as(Vec, @splat(1))));
+
+            i += vec_len;
         }
 
+        s1 %= base;
         s2 %= base;
-    } else {
-        const n = nmax / 16; // note: 16 | nmax
-
-        var i: usize = 0;
-
-        while (i + nmax <= input.len) {
-            var rounds: usize = 0;
-            while (rounds < n) : (rounds += 1) {
-                comptime var j: usize = 0;
-                inline while (j < 16) : (j += 1) {
-                    s1 +%= input[i + j];
-                    s2 +%= s1;
-                }
-                i += 16;
-            }
-
-            s1 %= base;
-            s2 %= base;
-        }
-
-        if (i < input.len) {
-            while (i + 16 <= input.len) : (i += 16) {
-                comptime var j: usize = 0;
-                inline while (j < 16) : (j += 1) {
-                    s1 +%= input[i + j];
-                    s2 +%= s1;
-                }
-            }
-            while (i < input.len) : (i += 1) {
-                s1 +%= input[i];
-                s2 +%= s1;
-            }
-
-            s1 %= base;
-            s2 %= base;
-        }
     }
 
-    return s1 | (s2 << 16);
+    while (i + vec_len <= input.len) : (i += vec_len) {
+        const vec: Vec = input[i..][0..vec_len].*;
+
+        s2 += vec_len * s1;
+        s1 += @reduce(.Add, vec);
+        s2 += @reduce(.Add, vec * std.simd.reverseOrder(std.simd.iota(u32, vec_len) + @as(Vec, @splat(1))));
+    }
+
+    for (input[i..]) |byte| {
+        s1 += byte;
+        s2 += s1;
+    }
+
+    s1 %= base;
+    s2 %= base;
+
+    return (@as(u32, @intCast(s2)) << 16) | @as(u32, @intCast(s1));
 }
 
 pub fn update(a: *Adler32, input: []const u8) void {
@@ -82,12 +65,12 @@ pub fn hash(input: []const u8) u32 {
     return permute(1, input);
 }
 
-test "sanity" {
+test "adler32 sanity" {
     try testing.expectEqual(@as(u32, 0x620062), hash("a"));
     try testing.expectEqual(@as(u32, 0xbc002ed), hash("example"));
 }
 
-test "long" {
+test "adler32 long" {
     const long1 = [_]u8{1} ** 1024;
     try testing.expectEqual(@as(u32, 0x06780401), hash(long1[0..]));
 
@@ -95,12 +78,12 @@ test "long" {
     try testing.expectEqual(@as(u32, 0x0a7a0402), hash(long2[0..]));
 }
 
-test "very long" {
+test "adler32 very long" {
     const long = [_]u8{1} ** 5553;
     try testing.expectEqual(@as(u32, 0x707f15b2), hash(long[0..]));
 }
 
-test "very long with variation" {
+test "adler32 very long with variation" {
     const long = comptime blk: {
         @setEvalBranchQuota(7000);
         var result: [6000]u8 = undefined;


### PR DESCRIPTION
also fixes `lib/std/hash/benchmark.zig` which was broken.

Benchmark on an Intel Core i7-12700K:

before (after the changes in `lib/std/hash/benchmark.zig`):

```
$ zig run lib/std/hash/benchmark.zig -O ReleaseFast -mcpu baseline -- --filter adler32
adler32
   iterative:  4232 MiB/s [99c7e30000000000]
  small keys:  32B  4564 MiB/s 149576949 Hashes/s [1bf9e9d4621b7b00]
$ zig run lib/std/hash/benchmark.zig -O ReleaseFast -mcpu native -- --filter adler32
adler32
   iterative:  4255 MiB/s [99c7e30000000000]
  small keys:  32B  4583 MiB/s 150202122 Hashes/s [1bf9e9d4621b7b00]
```

after:

```
$ zig run lib/std/hash/benchmark.zig -O ReleaseFast -mcpu baseline -- --filter adler32
adler32
   iterative:  8555 MiB/s [99c7e30000000000]
  small keys:  32B  5920 MiB/s 194016186 Hashes/s [1bf9e9d4621b7b00]
$ zig run lib/std/hash/benchmark.zig -O ReleaseFast -mcpu native -- --filter adler32
adler32
   iterative: 13906 MiB/s [99c7e30000000000]
  small keys:  32B  8663 MiB/s 283892027 Hashes/s [1bf9e9d4621b7b00]
```