### PR TITLE
compiler-rt: export `__aeabi_read_tp` for `arm-freebsd`

### DIFF
--- a/lib/compiler_rt/arm.zig
+++ b/lib/compiler_rt/arm.zig
@@ -37,7 +37,7 @@ comptime {
             @export(&__aeabi_memclr4, .{ .name = "__aeabi_memclr4", .linkage = common.linkage, .visibility = common.visibility });
             @export(&__aeabi_memclr8, .{ .name = "__aeabi_memclr8", .linkage = common.linkage, .visibility = common.visibility });
 
-            if (builtin.os.tag == .linux) {
+            if (builtin.os.tag == .linux or builtin.os.tag == .freebsd) {
                 @export(&__aeabi_read_tp, .{ .name = "__aeabi_read_tp", .linkage = common.linkage, .visibility = common.visibility });
             }
 


### PR DESCRIPTION
FreeBSD normally provides this symbol in libc, but it's in the `FBSDprivate_1.0` namespace, so it doesn't get included in our `abilists` file. Fortunately, the implementation is identical for Linux and FreeBSD, so we can just provide it in compiler-rt.

It's interesting to note that the same is not true for NetBSD where the implementation is more complex to support older Arm versions. But we do include the symbol in our `abilists` file for NetBSD libc, so that's fine.

closes #25215