### PR TITLE
std.os.linux.setsid(): return raw syscall0 result

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1834,8 +1834,8 @@ pub fn setgroups(size: usize, list: [*]const gid_t) usize {
     }
 }
 
-pub fn setsid() pid_t {
-    return @bitCast(@as(u32, @truncate(syscall0(.setsid))));
+pub fn setsid() usize {
+    return syscall0(.setsid);
 }
 
 pub fn getpid() pid_t {

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -1839,15 +1839,18 @@ pub fn setsid() usize {
 }
 
 pub fn getpid() pid_t {
-    return @bitCast(@as(u32, @truncate(syscall0(.getpid))));
+    // Casts result to a pid_t, safety-checking >= 0, because getpid() cannot fail
+    return @intCast(@as(u32, @truncate(syscall0(.getpid))));
 }
 
 pub fn getppid() pid_t {
-    return @bitCast(@as(u32, @truncate(syscall0(.getppid))));
+    // Casts result to a pid_t, safety-checking >= 0, because getppid() cannot fail
+    return @intCast(@as(u32, @truncate(syscall0(.getppid))));
 }
 
 pub fn gettid() pid_t {
-    return @bitCast(@as(u32, @truncate(syscall0(.gettid))));
+    // Casts result to a pid_t, safety-checking >= 0, because gettid() cannot fail
+    return @intCast(@as(u32, @truncate(syscall0(.gettid))));
 }
 
 pub fn sigprocmask(flags: u32, noalias set: ?*const sigset_t, noalias oldset: ?*sigset_t) usize {

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -7000,7 +7000,7 @@ pub const SetSidError = error{
 pub fn setsid() SetSidError!pid_t {
     const rc = system.setsid();
     switch (errno(rc)) {
-        .SUCCESS => return rc,
+        .SUCCESS => return @intCast(rc),
         .PERM => return error.PermissionDenied,
         else => |err| return unexpectedErrno(err),
     }


### PR DESCRIPTION
When not linking libc on 64-bit Linux and calling posix.setsid(), we get a type error at compile time inside of posix.errno().  This is because posix.errno()'s non-libc branch expects a usize-sized value, which is what all the error-returning os.linux syscalls return, and linux.setsid() instead returned a pid_t, which is only 32 bits wide.

This and the other 3 pid-related calls just below it (getpid(), getppid(), and gettid()) are the only Linux syscall examples here that are casting their return values to pid_t. For the other 3 this makes sense: those calls are documented to have no possible errors and always return a valid pid_t value.

However, setsid() actually can return the error EPERM, and therefore needs to return the raw value from syscall0 for posix.errno() to process like normal.

Additionally, posix.setsid() needs an @intCast(rc) for the success case as a result, like most other such cases.