### PR TITLE
std.Io.Writer.print: Clarify and fix docs for {f}

### DIFF
--- a/lib/std/Io/Writer.zig
+++ b/lib/std/Io/Writer.zig
@@ -586,7 +586,8 @@ pub fn writeAll(w: *Writer, bytes: []const u8) Error!void {
 /// - `!`: output error union value as either the unwrapped value, or the formatted error value; may be followed by a format specifier for the underlying value.
 /// - `*`: output the address of the value instead of the value itself.
 /// - `any`: output a value of any type using its default format.
-/// - `f`: delegates to a method on the type named "format" with the signature `fn (*Writer, args: anytype) Writer.Error!void`.
+/// - `f`: delegates to a method on the type named "format" with the signature `fn (self, *Writer) Writer.Error!void`.
+///   See also `std.fmt.Alt`.
 ///
 /// A user type may be a `struct`, `vector`, `union` or `enum` type.
 ///


### PR DESCRIPTION
Fixes the incorrect signature for the `format` method - it originally copied the one of `std.io.Writer.print`, which is not what is accepted. Additionally, I added a reference to `std.fmt.Alt` for overriding.