### PR TITLE
Fix tools by removing usages of deprecatedWriter.

### DIFF
--- a/lib/compiler/reduce.zig
+++ b/lib/compiler/reduce.zig
@@ -68,7 +68,7 @@ pub fn main() !void {
             const arg = args[i];
             if (mem.startsWith(u8, arg, "-")) {
                 if (mem.eql(u8, arg, "-h") or mem.eql(u8, arg, "--help")) {
-                    const stdout = std.fs.File.stdout().deprecatedWriter();
+                    const stdout = std.fs.File.stdout();
                     try stdout.writeAll(usage);
                     return std.process.cleanExit();
                 } else if (mem.eql(u8, arg, "--")) {

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -460,7 +460,8 @@ fn mode(comptime x: comptime_int) comptime_int {
 }
 
 pub fn main() !void {
-    var stdout_buffer: [4096]u8 = undefined;
+    // Size of buffer is about size of printed message.
+    var stdout_buffer: [0x100]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
     const stdout = &stdout_writer.interface;
 

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -47,8 +47,8 @@
 //!     // Print the message to stderr, silently ignoring any errors
 //!     std.debug.lockStdErr();
 //!     defer std.debug.unlockStdErr();
-//!     const stderr = std.fs.File.stderr().deprecatedWriter();
-//!     nosuspend stderr.print(prefix ++ format ++ "\n", args) catch return;
+//!     var stderr = std.fs.File.stderr().writer(&.{});
+//!     nosuspend stderr.interface.print(prefix ++ format ++ "\n", args) catch return;
 //! }
 //!
 //! pub fn main() void {

--- a/lib/std/unicode/throughput_test.zig
+++ b/lib/std/unicode/throughput_test.zig
@@ -39,35 +39,44 @@ fn benchmarkCodepointCount(buf: []const u8) !ResultCount {
 }
 
 pub fn main() !void {
-    const stdout = std.fs.File.stdout().deprecatedWriter();
+    // Size of buffer is about size of printed message.
+    var stdout_buffer: [0x100]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
 
     try stdout.print("short ASCII strings\n", .{});
+    try stdout.flush();
     {
         const result = try benchmarkCodepointCount("abc");
         try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
     }
 
     try stdout.print("short Unicode strings\n", .{});
+    try stdout.flush();
     {
         const result = try benchmarkCodepointCount("ŌŌŌ");
         try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
     }
 
     try stdout.print("pure ASCII strings\n", .{});
+    try stdout.flush();
     {
         const result = try benchmarkCodepointCount("hello" ** 16);
         try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
     }
 
     try stdout.print("pure Unicode strings\n", .{});
+    try stdout.flush();
     {
         const result = try benchmarkCodepointCount("こんにちは" ** 16);
         try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
     }
 
     try stdout.print("mixed ASCII/Unicode strings\n", .{});
+    try stdout.flush();
     {
         const result = try benchmarkCodepointCount("Hyvää huomenta" ** 16);
         try stdout.print("  count: {:5} MiB/s [{d}]\n", .{ result.throughput / (1 * MiB), result.count });
     }
+    try stdout.flush();
 }


### PR DESCRIPTION
I tried to use `zig reduce` but it bitrot a bit since it used old `GenericWriter`. I went and updated it and some other tools to use new Writer.

Also Adler32 API changed so I also updated lib/std/hash/benchmark.zig to handle it properly just so I can test my changes with Writer.
