### PR TITLE
mem.replace: Document that input/output cannot overlap

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3785,6 +3785,7 @@ test rotate {
 
 /// Replace needle with replacement as many times as possible, writing to an output buffer which is assumed to be of
 /// appropriate size. Use replacementSize to calculate an appropriate buffer size.
+/// The `input` and `output` slices must not overlap.
 /// The needle must not be empty.
 /// Returns the number of replacements made.
 pub fn replace(comptime T: type, input: []const T, needle: []const T, replacement: []const T, output: []T) usize {


### PR DESCRIPTION
This is just clarifying the current behavior of `std.mem.replace`.

Test case showing this adapted from [here](https://ziggit.dev/t/replace-string-in-arraylist/11985/6):

```zig
const std = @import("std");

test "mem.replace overlap" {
    var buf: [256]u8 = undefined;
    const original = "Sweet apple cake. Sour crabapple pie.";
    const expected = "Sweet orange cake. Sour craborange pie.";
    buf[0..original.len].* = original.*;
    const str = buf[0..original.len];

    const needed_size = std.mem.replacementSize(u8, str, "apple", "orange");
    const output = buf[0..needed_size];
    _ = std.mem.replace(u8, str, "apple", "orange", output);
    try std.testing.expectEqualStrings(expected, output);
}

```

```
====== expected this output: =========
Sweet orange cake. Sour craborange pie.␃

======== instead found this: =========
Sweet orangeeeeeeeeeeeeeeeeeeeeeeeeeee�␃

======================================
First difference occurs on line 1:
expected:
Sweet orange cake. Sour craborange pie.
            ^ ('\x20')
found:
Sweet orangeeeeeeeeeeeeeeeeeeeeeeeeeee�
            ^ ('\x65')
```