### PR TITLE
Fix `restore_rt` on PowerPC and remove unnecessary clobbers

### DIFF
--- a/lib/std/os/linux/aarch64.zig
+++ b/lib/std/os/linux/aarch64.zig
@@ -141,12 +141,12 @@ pub fn restore_rt() callconv(.naked) noreturn {
             \\ svc #0
             :
             : [number] "i" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true }),
+        ),
         else => asm volatile (
             \\ svc #0
             :
             : [number] "{x8}" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true }),
+        ),
     }
 }
 

--- a/lib/std/os/linux/arm.zig
+++ b/lib/std/os/linux/arm.zig
@@ -150,12 +150,12 @@ pub fn restore_rt() callconv(.naked) noreturn {
             \\ svc #0
             :
             : [number] "I" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true }),
+        ),
         else => asm volatile (
             \\ svc #0
             :
             : [number] "{r7}" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true }),
+        ),
     }
 }
 

--- a/lib/std/os/linux/hexagon.zig
+++ b/lib/std/os/linux/hexagon.zig
@@ -135,7 +135,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ trap0(#0)
         :
         : [number] "{r6}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/loongarch64.zig
+++ b/lib/std/os/linux/loongarch64.zig
@@ -143,7 +143,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ syscall 0
         :
         : [number] "r" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .r12 = true, .r13 = true, .r14 = true, .r15 = true, .r16 = true, .r17 = true, .r18 = true, .r19 = true, .r20 = true, .memory = true });
+    );
 }
 
 pub const msghdr = extern struct {

--- a/lib/std/os/linux/m68k.zig
+++ b/lib/std/os/linux/m68k.zig
@@ -148,7 +148,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
     asm volatile ("trap #0"
         :
         : [number] "{d0}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/mips.zig
+++ b/lib/std/os/linux/mips.zig
@@ -254,7 +254,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ syscall
         :
         : [number] "{$2}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .r1 = true, .r3 = true, .r4 = true, .r5 = true, .r6 = true, .r7 = true, .r8 = true, .r9 = true, .r10 = true, .r11 = true, .r12 = true, .r13 = true, .r14 = true, .r15 = true, .r24 = true, .r25 = true, .hi = true, .lo = true, .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/mips64.zig
+++ b/lib/std/os/linux/mips64.zig
@@ -233,7 +233,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ syscall
         :
         : [number] "{$2}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .r1 = true, .r3 = true, .r4 = true, .r5 = true, .r6 = true, .r7 = true, .r8 = true, .r9 = true, .r10 = true, .r11 = true, .r12 = true, .r13 = true, .r14 = true, .r15 = true, .r24 = true, .r25 = true, .hi = true, .lo = true, .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/powerpc.zig
+++ b/lib/std/os/linux/powerpc.zig
@@ -253,12 +253,12 @@ pub fn restore_rt() callconv(.naked) noreturn {
             \\ sc
             :
             : [number] "i" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true, .cr0 = true, .r4 = true, .r5 = true, .r6 = true, .r7 = true, .r8 = true, .r9 = true, .r10 = true, .r11 = true, .r12 = true }),
+        ),
         else => _ = asm volatile (
             \\ sc
             :
             : [number] "{r0}" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true, .cr0 = true, .r4 = true, .r5 = true, .r6 = true, .r7 = true, .r8 = true, .r9 = true, .r10 = true, .r11 = true, .r12 = true }),
+        ),
     }
 }
 

--- a/lib/std/os/linux/powerpc64.zig
+++ b/lib/std/os/linux/powerpc64.zig
@@ -238,12 +238,12 @@ pub fn restore_rt() callconv(.naked) noreturn {
             \\ sc
             :
             : [number] "i" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true, .cr0 = true, .r4 = true, .r5 = true, .r6 = true, .r7 = true, .r8 = true, .r9 = true, .r10 = true, .r11 = true, .r12 = true }),
+        ),
         else => _ = asm volatile (
             \\ sc
             :
             : [number] "{r0}" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true, .cr0 = true, .r4 = true, .r5 = true, .r6 = true, .r7 = true, .r8 = true, .r9 = true, .r10 = true, .r11 = true, .r12 = true }),
+        ),
     }
 }
 

--- a/lib/std/os/linux/riscv32.zig
+++ b/lib/std/os/linux/riscv32.zig
@@ -142,7 +142,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ ecall
         :
         : [number] "{x17}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/riscv64.zig
+++ b/lib/std/os/linux/riscv64.zig
@@ -142,7 +142,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ ecall
         :
         : [number] "{x17}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/s390x.zig
+++ b/lib/std/os/linux/s390x.zig
@@ -154,7 +154,7 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\svc 0
         :
         : [number] "{r1}" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .memory = true });
+    );
 }
 
 pub const F = struct {

--- a/lib/std/os/linux/thumb.zig
+++ b/lib/std/os/linux/thumb.zig
@@ -151,5 +151,5 @@ pub fn restore_rt() callconv(.naked) noreturn {
         \\ svc #0
         :
         : [number] "I" (@intFromEnum(SYS.rt_sigreturn)),
-        : .{ .memory = true });
+    );
 }

--- a/lib/std/os/linux/x86.zig
+++ b/lib/std/os/linux/x86.zig
@@ -187,12 +187,12 @@ pub fn restore_rt() callconv(.naked) noreturn {
             \\ int $0x80
             :
             : [number] "i" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true }),
+        ),
         else => asm volatile (
             \\ int $0x80
             :
             : [number] "{eax}" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .memory = true }),
+        ),
     }
 }
 

--- a/lib/std/os/linux/x86_64.zig
+++ b/lib/std/os/linux/x86_64.zig
@@ -137,12 +137,12 @@ pub fn restore_rt() callconv(.naked) noreturn {
             \\ syscall
             :
             : [number] "i" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .rcx = true, .r11 = true, .memory = true }),
+        ),
         else => asm volatile (
             \\ syscall
             :
             : [number] "{rax}" (@intFromEnum(SYS.rt_sigreturn)),
-            : .{ .rcx = true, .r11 = true, .memory = true }),
+        ),
     }
 }
 


### PR DESCRIPTION
On PowerPC, Clang fails to compile code generated by the C backend, due to the implementation of `restore_rt`:

```console
$ cat main.zig
pub fn main() void {}
$ zig build-exe -ofmt=c -OReleaseSmall main.zig
$ clang -I/opt/zig/lib -nostartfiles main.c
main.c:1488:2: error: non-ASM statement in naked function is not supported
 1488 |  register uintptr_t const t0 __asm("r0") = (uintptr_t)172ul;
      |  ^
main.c:1487:8: note: attribute is here
 1487 | static zig_naked zig_noreturn void os_linux_powerpc64_restore_rt__3126(void) {
      |        ^

```

This is because `restore_rt` on PowerPC uses a [register input operand](https://github.com/ziglang/zig/blob/32a1aabff78234b428234189ee1093fb65f85fa3/lib/std/os/linux/powerpc64.zig#L184) for the syscall number, which is compiled as a separate `register uintptr_t` declaration, disallowed in naked functions.

Following the same approach as [x86](https://github.com/ziglang/zig/blob/32a1aabff78234b428234189ee1093fb65f85fa3/lib/std/os/linux/x86_64.zig#L135) and [ARM](https://github.com/ziglang/zig/blob/32a1aabff78234b428234189ee1093fb65f85fa3/lib/std/os/linux/aarch64.zig#L139), when using the C backend, this PR employs alternative inline assembly that avoids using non-immediate input operands.

This PR also removes clobbers from `restore_rt` on all targets[^1]. Per @alexrp, this is unnecessary in naked functions.

[^1]: Except SPARC64, whose `restore_rc` is `callconv(.c)`.