### PR TITLE
std.fs.File: fix discarding past end of file in positional mode

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1386,6 +1386,7 @@ pub const Reader = struct {
                 };
                 const delta = @min(@intFromEnum(limit), size - pos);
                 r.pos = pos + delta;
+                if (r.pos == size) return error.EndOfStream;
                 return delta;
             },
             .streaming, .streaming_reading => {


### PR DESCRIPTION
`std.Io.Reader.discardShort` will loop infinitely if the read position is at the end of the file.

In `std/fs/File.zig`:

https://github.com/ziglang/zig/blob/32a1aabff78234b428234189ee1093fb65f85fa3/lib/std/fs/File.zig#L1382-L1390

on L1387, if `pos == size` then `delta == 0`, so the function will return 0. Then in `std/Io/Reader.zig`

https://github.com/ziglang/zig/blob/32a1aabff78234b428234189ee1093fb65f85fa3/lib/std/Io/Reader.zig#L605-L622

on L615, `discard_len` will be 0, so `remaining` will never decrement.

A simple reproduction `zig run repro.zig`:

```zig
pub fn main() !void {
    const file = try std.fs.cwd().openFile("repro.zig", .{});
    var buffer: [4096]u8 = undefined;
    var reader = file.reader(&buffer);
    try reader.interface.discardAll(512);
}

const std = @import("std");
```

There are probably multiple ways to address this, and I don't know if this is the best one, but I am reasonably confident that infinite looping is not the correct behavior here.
