### PR TITLE
Avoid logic where we return success in case of an error

### DIFF
--- a/lib/std/crypto/25519/ed25519.zig
+++ b/lib/std/crypto/25519/ed25519.zig
@@ -175,6 +175,10 @@ pub const Ed25519 = struct {
             self.h.update(msg);
         }
 
+        fn isIdentity(p: Curve) bool {
+            return p.x.isZero() and p.y.equivalent(p.z);
+        }
+
         pub const VerifyError = WeakPublicKeyError || IdentityElementError ||
             SignatureVerificationError;
 
@@ -195,9 +199,9 @@ pub const Ed25519 = struct {
                 hram,
             ));
             const check = sb_ah.sub(self.expected_r.clearCofactor());
-            if (check.rejectIdentity()) |_| {
+            if (!isIdentity(check)) {
                 return error.SignatureVerificationFailed;
-            } else |_| {}
+            }
         }
 
         /// Verify that the signature is valid for the entire message using cofactorless verification.
@@ -221,9 +225,9 @@ pub const Ed25519 = struct {
                 hram,
             ));
             const check = sb_ah.sub(self.expected_r);
-            if (check.rejectIdentity()) |_| {
+            if (!isIdentity(check)) {
                 return error.SignatureVerificationFailed;
-            } else |_| {}
+            }
         }
     };
 


### PR DESCRIPTION
In ed25519.zig, we checked if a test succeeds, in which case we returned an error. This was confusing, and Andrew pointed out that Zig weights branches against errors by default.