### PR TITLE
std.net: Replace ArrayLists with fixed size arrays

### DIFF
--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1683,11 +1683,9 @@ const ResolvConf = struct {
 
         var ns_addr_buffer: [3]Address = undefined;
 
-        var index: u2 = 0;
-        while (index < rc.ns_len) : (index += 1) {
-            const ip = rc.ns_buffer[index];
-            ns_addr_buffer[index] = ip.addr;
-            assert(ns_addr_buffer[index].getPort() == 53);
+        for (rc.ns_buffer[0..rc.ns_len], ns_addr_buffer[0..rc.ns_len]) |ip, *addr|
+            addr.* = ip.addr;
+            assert(addr.getPort() == 53);
             if (ip.addr.any.family != posix.AF.INET) {
                 family = posix.AF.INET6;
             }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1786,7 +1786,7 @@ const ResolvConf = struct {
                 // Ignore replies from addresses we didn't send to
                 const ns = for (ns_arr) |ns| {
                     if (ns) |n| {
-                        if (n.eql(sa)) break ns;
+                        if (n.eql(sa)) break n;
                     }
                 } else continue;
 
@@ -1806,7 +1806,7 @@ const ResolvConf = struct {
                     0, 3 => {},
                     2 => if (servfail_retry != 0) {
                         servfail_retry -= 1;
-                        _ = posix.sendto(fd, queries[i], posix.MSG.NOSIGNAL, &ns.?.any, sl) catch undefined;
+                        _ = posix.sendto(fd, queries[i], posix.MSG.NOSIGNAL, &ns.any, sl) catch undefined;
                     },
                     else => continue,
                 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1830,7 +1830,7 @@ fn linuxLookupNameFromNumericUnspec(
     name: []const u8,
     port: u16,
 ) !void {
-    if (addrs_len.* >= addrs.len - 1) return error.OutOfMemory;
+    if (addrs_len.* == addrs.len) return error.OutOfMemory;
 
     const address = try Address.resolveIp(name, port);
     addrs[addrs_len.*] = .{ .addr = address };

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1595,7 +1595,7 @@ const ResolvConf = struct {
 
     /// Returns `error.StreamTooLong` if a line is longer than 512 bytes.
     /// TODO: https://github.com/ziglang/zig/issues/2765 and https://github.com/ziglang/zig/issues/2761
-    fn init(rc: *ResolvConf, gpa: Allocator) !void {
+    fn init(rc: *ResolvConf) !void {
         rc.* = .{
             .gpa = gpa,
             .ns = .{ null, null, null },

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1683,7 +1683,7 @@ const ResolvConf = struct {
 
         var ns_addr_buffer: [3]Address = undefined;
 
-        for (rc.ns_buffer[0..rc.ns_len], ns_addr_buffer[0..rc.ns_len]) |ip, *addr|
+        for (rc.ns_buffer[0..rc.ns_len], ns_addr_buffer[0..rc.ns_len]) |ip, *addr| {
             addr.* = ip.addr;
             assert(addr.getPort() == 53);
             if (ip.addr.any.family != posix.AF.INET) {

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1724,12 +1724,12 @@ const ResolvConf = struct {
             );
             for (&ns_arr) |*ns| {
                 if (ns.*) |*n| {
-                    if (n.*.any.family != posix.AF.INET) continue;
-                    mem.writeInt(u32, n.*.in6.sa.addr[12..], n.*.in.sa.addr, native_endian);
-                    n.*.in6.sa.addr[0..12].* = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff".*;
-                    n.*.any.family = posix.AF.INET6;
-                    n.*.in6.sa.flowinfo = 0;
-                    n.*.in6.sa.scope_id = 0;
+                    if (n.any.family != posix.AF.INET) continue;
+                    mem.writeInt(u32, n.in6.sa.addr[12..], n.in.sa.addr, native_endian);
+                    n.in6.sa.addr[0..12].* = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff".*;
+                    n.any.family = posix.AF.INET6;
+                    n.in6.sa.flowinfo = 0;
+                    n.in6.sa.scope_id = 0;
                 }
             }
             sl = @sizeOf(posix.sockaddr.in6);

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1717,9 +1717,7 @@ const ResolvConf = struct {
                 std.os.linux.IPV6.V6ONLY,
                 &mem.toBytes(@as(c_int, 0)),
             );
-            var i: u2 = 0;
-            while (i < rc.ns_len) : (i += 1) {
-                var n = ns_addr_buffer[i];
+            for (ns_addr_buffer[0..rc.ns_len]) |*n| {
                 if (n.any.family != posix.AF.INET) continue;
                 mem.writeInt(u32, n.in6.sa.addr[12..], n.in.sa.addr, native_endian);
                 n.in6.sa.addr[0..12].* = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff".*;

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1683,10 +1683,10 @@ const ResolvConf = struct {
 
         var ns_addr_buffer: [3]Address = undefined;
 
-        for (rc.ns_buffer[0..rc.ns_len], ns_addr_buffer[0..rc.ns_len]) |ip, *addr| {
-            addr.* = ip.addr;
-            assert(addr.getPort() == 53);
-            if (ip.addr.any.family != posix.AF.INET) {
+        for (ns_addr_buffer[0..rc.ns_len], rc.ns_buffer[0..rc.ns_len]) |*ns, iplit| {
+            ns.* = iplit.addr;
+            assert(ns.getPort() == 53);
+            if (iplit.addr.any.family != posix.AF.INET) {
                 family = posix.AF.INET6;
             }
         }
@@ -1753,7 +1753,7 @@ const ResolvConf = struct {
                 var i: usize = 0;
                 while (i < queries.len) : (i += 1) {
                     if (answers[i].len == 0) {
-                         for (ns_addr_buffer[0..rc.ns_len]) |*ns| {
+                        for (ns_addr_buffer[0..rc.ns_len]) |*ns| {
                             _ = posix.sendto(fd, queries[i], posix.MSG.NOSIGNAL, &ns.any, sl) catch undefined;
                         }
                     }
@@ -1775,7 +1775,7 @@ const ResolvConf = struct {
                 if (rlen < 4) continue;
 
                 // Ignore replies from addresses we didn't send to
-                const ns_addr = for (ns_addr_buffer[0..rc.ns_len]) |*ns| {
+                const ns = for (ns_addr_buffer[0..rc.ns_len]) |*ns| {
                     if (ns.eql(sa)) break ns;
                 } else continue;
 
@@ -1795,7 +1795,7 @@ const ResolvConf = struct {
                     0, 3 => {},
                     2 => if (servfail_retry != 0) {
                         servfail_retry -= 1;
-                        _ = posix.sendto(fd, queries[i], posix.MSG.NOSIGNAL, &ns_addr.any, sl) catch undefined;
+                        _ = posix.sendto(fd, queries[i], posix.MSG.NOSIGNAL, &ns.any, sl) catch undefined;
                     },
                     else => continue,
                 }

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1665,9 +1665,11 @@ const ResolvConf = struct {
             else => |e| return e,
         }
 
-        if (&rc.ns == &[3]?LookupAddr{ null, null, null }) {
-            return linuxLookupNameFromNumericUnspec(&rc.ns, "127.0.0.1", 53);
+        for (rc.ns) |n| {
+            if (n != null) return;
         }
+
+        return linuxLookupNameFromNumericUnspec(&rc.ns, "127.0.0.1", 53);
     }
 
     fn resMSendRc(

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1826,7 +1826,8 @@ fn linuxLookupNameFromNumericUnspec(
     name: []const u8,
     port: u16,
 ) !void {
-    if (addrs_len.* == addrs.len) return error.OutOfMemory;
+    // Ignore new nameserver entries past the third one
+    if (addrs_len.* == addrs.len) return;
 
     const address = try Address.resolveIp(name, port);
     addrs[addrs_len.*] = .{ .addr = address };

--- a/lib/std/net.zig
+++ b/lib/std/net.zig
@@ -1683,7 +1683,8 @@ const ResolvConf = struct {
 
         var ns_buffer: [3]Address = undefined;
 
-        for (0..rc.ns_len) |index| {
+        var index: u2 = 0;
+        while (index < rc.ns_len) : (index += 1) {
             const ip = rc.ns_buffer[index];
             ns_buffer[index] = ip.addr;
             assert(ns_buffer[index].getPort() == 53);
@@ -1718,8 +1719,9 @@ const ResolvConf = struct {
                 std.os.linux.IPV6.V6ONLY,
                 &mem.toBytes(@as(c_int, 0)),
             );
-            for (0..rc.ns_len) |index| {
-                var n = ns_buffer[index];
+            var i: u2 = 0;
+            while (i < rc.ns_len) : (i += 1) {
+                var n = ns_buffer[i];
                 if (n.any.family != posix.AF.INET) continue;
                 mem.writeInt(u32, n.in6.sa.addr[12..], n.in.sa.addr, native_endian);
                 n.in6.sa.addr[0..12].* = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff".*;
@@ -1755,8 +1757,9 @@ const ResolvConf = struct {
                 var i: usize = 0;
                 while (i < queries.len) : (i += 1) {
                     if (answers[i].len == 0) {
-                        for (0..rc.ns_len) |index| {
-                            const n = ns_buffer[index];
+                        var idx: u2 = 0;
+                        while (idx < rc.ns_len) : (idx += 1) {
+                            const n = ns_buffer[idx];
                             _ = posix.sendto(fd, queries[i], posix.MSG.NOSIGNAL, &n.any, sl) catch undefined;
                         }
                     }
@@ -1778,8 +1781,9 @@ const ResolvConf = struct {
                 if (rlen < 4) continue;
 
                 // Ignore replies from addresses we didn't send to
-                const ns = for (0..rc.ns_len) |index| {
-                    const n = ns_buffer[index];
+                var idx: u2 = 0;
+                const ns = while (idx < rc.ns_len) : (idx += 1) {
+                    const n = ns_buffer[idx];
                     if (n.eql(sa)) break n;
                 } else continue;
 


### PR DESCRIPTION
I have resolved an old TODO, replacing some ArrayLists in `std.net` with fixed size arrays. The changes have been tested with `std/net/test.zig`. No changes made to the test itself, since the behaviour stays the same.