### PR TITLE
std.fmt: migrate bufPrintZ to bufPrintSentinel

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -602,6 +602,9 @@ pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintErro
     return w.buffered();
 }
 
+/// Deprecated in favor of `bufPrintSentinel`
+pub const bufPrintZ = bufPrintSentinel;
+
 pub fn bufPrintSentinel(
     buf: []u8,
     comptime fmt: []const u8,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -603,7 +603,9 @@ pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintErro
 }
 
 /// Deprecated in favor of `bufPrintSentinel`
-pub const bufPrintZ = bufPrintSentinel;
+pub fn bufPrintZ(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintError![:0]u8 {
+    return try bufPrintSentinel(buf, fmt, args, 0);
+}
 
 pub fn bufPrintSentinel(
     buf: []u8,

--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -602,9 +602,14 @@ pub fn bufPrint(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintErro
     return w.buffered();
 }
 
-pub fn bufPrintZ(buf: []u8, comptime fmt: []const u8, args: anytype) BufPrintError![:0]u8 {
-    const result = try bufPrint(buf, fmt ++ "\x00", args);
-    return result[0 .. result.len - 1 :0];
+pub fn bufPrintSentinel(
+    buf: []u8,
+    comptime fmt: []const u8,
+    args: anytype,
+    comptime sentinel: u8,
+) BufPrintError![:sentinel]u8 {
+    const result = try bufPrint(buf, fmt ++ [_]u8{sentinel}, args);
+    return result[0 .. result.len - 1 :sentinel];
 }
 
 /// Count the characters needed for format.

--- a/lib/std/fs.zig
+++ b/lib/std/fs.zig
@@ -616,9 +616,10 @@ pub fn selfExePath(out_buffer: []u8) SelfExePathError![]u8 {
                 var path_it = mem.tokenizeScalar(u8, PATH, path.delimiter);
                 while (path_it.next()) |a_path| {
                     var resolved_path_buf: [max_path_bytes - 1:0]u8 = undefined;
-                    const resolved_path = std.fmt.bufPrintZ(&resolved_path_buf, "{s}/{s}", .{
+                    const resolved_path = std.fmt.bufPrintSentinel(&resolved_path_buf, "{s}/{s}", .{
                         a_path,
                         std.os.argv[0],
+                        0,
                     }) catch continue;
 
                     var real_path_buf: [max_path_bytes]u8 = undefined;

--- a/lib/std/meta.zig
+++ b/lib/std/meta.zig
@@ -935,7 +935,7 @@ fn CreateUniqueTuple(comptime N: comptime_int, comptime types: [N]type) type {
         @setEvalBranchQuota(10_000);
         var num_buf: [128]u8 = undefined;
         tuple_fields[i] = .{
-            .name = std.fmt.bufPrintZ(&num_buf, "{d}", .{i}) catch unreachable,
+            .name = std.fmt.bufPrintSentinel(&num_buf, "{d}", .{i}, 0) catch unreachable,
             .type = T,
             .default_value_ptr = null,
             .is_comptime = false,

--- a/lib/std/os.zig
+++ b/lib/std/os.zig
@@ -132,7 +132,7 @@ pub fn getFdPath(fd: std.posix.fd_t, out_buffer: *[max_path_bytes]u8) std.posix.
         },
         .linux, .serenity => {
             var procfs_buf: ["/proc/self/fd/-2147483648\x00".len]u8 = undefined;
-            const proc_path = std.fmt.bufPrintZ(procfs_buf[0..], "/proc/self/fd/{d}", .{fd}) catch unreachable;
+            const proc_path = std.fmt.bufPrintSentinel(procfs_buf[0..], "/proc/self/fd/{d}", .{fd}, 0) catch unreachable;
 
             const target = posix.readlinkZ(proc_path, out_buffer) catch |err| {
                 switch (err) {
@@ -149,7 +149,7 @@ pub fn getFdPath(fd: std.posix.fd_t, out_buffer: *[max_path_bytes]u8) std.posix.
         },
         .solaris, .illumos => {
             var procfs_buf: ["/proc/self/path/-2147483648\x00".len]u8 = undefined;
-            const proc_path = std.fmt.bufPrintZ(procfs_buf[0..], "/proc/self/path/{d}", .{fd}) catch unreachable;
+            const proc_path = std.fmt.bufPrintSentinel(procfs_buf[0..], "/proc/self/path/{d}", .{fd}, 0) catch unreachable;
 
             const target = posix.readlinkZ(proc_path, out_buffer) catch |err| switch (err) {
                 error.UnsupportedReparsePointType => unreachable,

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -490,7 +490,7 @@ fn fchmodat2(dirfd: fd_t, path: []const u8, mode: mode_t, flags: u32) FChmodAtEr
         return error.OperationNotSupported;
 
     var procfs_buf: ["/proc/self/fd/-2147483648\x00".len]u8 = undefined;
-    const proc_path = std.fmt.bufPrintZ(procfs_buf[0..], "/proc/self/fd/{d}", .{pathfd}) catch unreachable;
+    const proc_path = std.fmt.bufPrintSentinel(procfs_buf[0..], "/proc/self/fd/{d}", .{pathfd}, 0) catch unreachable;
     while (true) {
         const res = system.chmod(proc_path, mode);
         switch (errno(res)) {

--- a/lib/std/process/Child.zig
+++ b/lib/std/process/Child.zig
@@ -1320,10 +1320,11 @@ fn windowsMakeAsyncPipe(rd: *?windows.HANDLE, wr: *?windows.HANDLE, sattr: *cons
     const pipe_path = blk: {
         var tmp_buf: [128]u8 = undefined;
         // Forge a random path for the pipe.
-        const pipe_path = std.fmt.bufPrintZ(
+        const pipe_path = std.fmt.bufPrintSentinel(
             &tmp_buf,
             "\\\\.\\pipe\\zig-childprocess-{d}-{d}",
             .{ windows.GetCurrentProcessId(), pipe_name_counter.fetchAdd(1, .monotonic) },
+            0,
         ) catch unreachable;
         const len = std.unicode.wtf8ToWtf16Le(&tmp_bufw, pipe_path) catch unreachable;
         tmp_bufw[len] = 0;


### PR DESCRIPTION
I noticed ``std.fmt.allocPrintSentinel`` and migrated ``bufPrintZ`` to ``bufPrintSentinel`` to match.