### PR TITLE
load a std.crypto.Certificate.Bundle from file or buffer

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -23,7 +23,7 @@ pub const disable_tls = std.options.http_disable_tls;
 /// Used for all client allocations. Must be thread-safe.
 allocator: Allocator,
 
-ca_bundle: if (disable_tls) void else std.crypto.Certificate.Bundle = if (disable_tls) {} else .{},
+ca_bundle: if (disable_tls) void else std.crypto.Certificate.Bundle = if (disable_tls) {} else .default,
 ca_bundle_mutex: std.Thread.Mutex = .{},
 /// Used both for the reader and writer buffers.
 tls_buffer_size: if (disable_tls) u0 else usize = if (disable_tls) 0 else std.crypto.tls.Client.min_buffer_len,


### PR DESCRIPTION
Simplify CA Bundle loading for single files and byte buffers of CA certificate data.

This also fixes a footgun I encountered while using a `std.http.Client` with a custom `ca_bundle`:

```zig
var ca_bundle: Bundle = .{};
try ca_bundle.addCertsFromFilePath(allocator, cwd, "path/to/cacert.pem");

var http_client: http.Client = .{
        .allocator = gpa,
        .ca_bundle = ca_bundle,
        
          // failing to set this will cause the bundle to rescan from only the system certs,
          // which drops the certs in path/to/cacert.pem above.
        .next_https_rescan_certs = false,
};
```

Tracking the source now in `Bundle` won't cause the system certs to load on a `rescan`:

```zig
var bundle: Bundle = try .init(gpa, .{ .file = "path/to/cacert.pem" });
defer bundle.deinit(gpa);

var http_client: http.Client = .{
    .allocator = gpa,
    .ca_bundle = ca_bundle,
};
```
