### PR TITLE
Amortize `std.crypto.Certificate.Bundle` rescanning in `std.http.Client`

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -23,7 +23,7 @@ pub const disable_tls = std.options.http_disable_tls;
 /// Used for all client allocations. Must be thread-safe.
 allocator: Allocator,
 
-ca_bundle: if (disable_tls) void else std.crypto.Certificate.Bundle = if (disable_tls) {} else .{},
+ca_bundle: if (disable_tls) void else std.crypto.Certificate.Bundle = if (disable_tls) {} else .default,
 ca_bundle_mutex: std.Thread.Mutex = .{},
 /// Used both for the reader and writer buffers.
 tls_buffer_size: if (disable_tls) u0 else usize = if (disable_tls) 0 else std.crypto.tls.Client.min_buffer_len,


### PR DESCRIPTION
Address a few inefficiencies in `std.http.Client`. By default, the client loads the systems' CA bundle every time a new TLS/HTTPS connection is established. That's a good thing on the first connection attempt because it avoids loading the bundle if it's not going to be used. But by default, it's reloading the bundle on every new TLS connection, which [can end up reading a lot of files from disk.](https://github.com/ziglang/zig/blob/ae00a2a84d34417c1fb6229db5919abcdced0ea0/lib/std/crypto/Certificate/Bundle.zig#L82-L96) It would be more efficient to only rescan the system CA bundle when the issuer certificate is not found in the current hashmap. But the difficulty with that approach is that rescanning requires an allocator, and the verify method is called by `std.crypto.tls.Client.init`, which does not have an allocator.

It's possible to workaround this in `std.http.Client` by introducing a verify callback function to `std.crypto.Certificate.Bundle`. (It's analogous to [OpenSSL's `SSL_CTX_set_cert_verify_callback`](https://docs.openssl.org/master/man3/SSL_CTX_set_cert_verify_callback/).) Building on #25261, adding a `callback` source that takes a function pointer adds a mechanism for the `std.http.Client` to intercept `verify` calls to a `Bundle`, and call `verifyRescan` instead, passing in it's allocator. The `verifyRescan` only rescans the system when a matching issuer can't be found in the loaded certificates.

The `callback` source also allows for some further cleanup of `no_verification` & `self_signed` CA verification behavior, which can be implement now in specific callback functions.
