### PR TITLE
doc/langref: mention union support of `@fieldParentPtr`

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -4897,8 +4897,8 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#header_open|@fieldParentPtr#}
       <pre>{#syntax#}@fieldParentPtr(comptime field_name: []const u8, field_ptr: *T) anytype{#endsyntax#}</pre>
       <p>
-      Given a pointer to a struct field, returns a pointer to the struct containing that field.
-      The return type (and struct in question) is the inferred result type.
+      Given a pointer to a struct or union field, returns a pointer to the struct or union containing that field.
+      The return type (pointer to the parent struct or union in question) is the inferred result type.
       </p>
       <p>
       If {#syntax#}field_ptr{#endsyntax#} does not point to the {#syntax#}field_name{#endsyntax#} field of an instance of


### PR DESCRIPTION
This functionality was implemented in https://github.com/ziglang/zig/pull/14689 , just never documented in the langref section.

From quick testing at `comptime`, the pointer to the union field doesn't have to be the currently active field.
That seemed like expected/intuitive behavior to me anyway, so not sure if there'd be value in explicitly clarifying that.