### PR TITLE
zig fmt help: mention that the argument can be a directory

### DIFF
--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -156,7 +156,7 @@ pub fn run(gpa: Allocator, arena: Allocator, args: []const []const u8) !void {
     }
 
     if (input_files.items.len == 0) {
-        fatal("expected at least one source file argument", .{});
+        fatal("expected at least one file or directory argument", .{});
     }
 
     var stdout_buffer: [4096]u8 = undefined;


### PR DESCRIPTION
I’ve been typing `zig fmt **/.zig` for a long time, until I discovered that the argument can actually be a directory.

Mention this feature explicitly in the help message.