### PR TITLE
sema: add basic compile-time detection for stack escape violations

### DIFF
--- a/src/codegen/aarch64/Assemble.zig
+++ b/src/codegen/aarch64/Assemble.zig
@@ -42,8 +42,11 @@ fn zonCast(comptime Result: type, zon_value: anytype, symbols: anytype) Result {
         .@"struct" => |zon_struct| switch (@typeInfo(Result)) {
             .pointer => |result_pointer| {
                 comptime assert(result_pointer.size == .slice and result_pointer.is_const);
-                var elems: [zon_value.len]result_pointer.child = undefined;
-                inline for (&elems, zon_value) |*elem, zon_elem| elem.* = zonCast(result_pointer.child, zon_elem, symbols);
+                const elems = comptime blk: {
+                    var temp_elems: [zon_value.len]result_pointer.child = undefined;
+                    for (&temp_elems, zon_value) |*elem, zon_elem| elem.* = zonCast(result_pointer.child, zon_elem, symbols);
+                    break :blk temp_elems;
+                };
                 return &elems;
             },
             .@"struct" => |result_struct| {

--- a/test/cases/compile_errors/issue_4207_coerce_from_non-terminated-slice_to_terminated-pointer.zig
+++ b/test/cases/compile_errors/issue_4207_coerce_from_non-terminated-slice_to_terminated-pointer.zig
@@ -1,10 +1,11 @@
+var global_buffer: [64]u8 = undefined;
+
 export fn foo() [*:0]const u8 {
-    var buffer: [64]u8 = undefined;
-    return buffer[0..];
+    return global_buffer[0..];
 }
 
 // error
 //
-// :3:18: error: expected type '[*:0]const u8', found '*[64]u8'
-// :3:18: note: destination pointer requires '0' sentinel
-// :1:17: note: function return type declared here
+// :4:25: error: expected type '[*:0]const u8', found '*[64]u8'
+// :4:25: note: destination pointer requires '0' sentinel
+// :3:17: note: function return type declared here

--- a/test/cases/compile_errors/return_pointer_to_stack_allocated_memory_1.zig
+++ b/test/cases/compile_errors/return_pointer_to_stack_allocated_memory_1.zig
@@ -1,0 +1,50 @@
+// Test: Stack escape detection - Part 1: Basic pointer escapes
+// This file tests basic cases of returning pointers to stack-allocated memory
+
+// Force runtime evaluation with this global
+var runtime_value: i32 = 42;
+
+fn returnLocalPtr() *i32 {
+    var x: i32 = runtime_value;
+    return &x;
+}
+
+fn returnLocalPtrConst() *const i32 {
+    var x: i32 = runtime_value;
+    return &x;
+}
+
+fn returnPtrFromBlock() *i32 {
+    var x: i32 = runtime_value;
+    {
+        return &x;
+    }
+}
+
+fn returnPtrFromOptional() ?*i32 {
+    var x: i32 = runtime_value;
+    return &x;
+}
+
+fn returnPtrFromErrorUnion() !*i32 {
+    var x: i32 = runtime_value;
+    return &x;
+}
+
+pub fn main() void {
+    _ = returnLocalPtr();
+    _ = returnLocalPtrConst();
+    _ = returnPtrFromBlock();
+    _ = returnPtrFromOptional();
+    _ = returnPtrFromErrorUnion() catch {};
+}
+
+// error
+// backend=auto
+// target=native
+//
+// :9:12: error: cannot return pointer to stack-allocated memory
+// :14:12: error: cannot return pointer to stack-allocated memory
+// :20:16: error: cannot return pointer to stack-allocated memory
+// :26:12: error: cannot return pointer to stack-allocated memory
+// :31:12: error: cannot return pointer to stack-allocated memory

--- a/test/cases/compile_errors/return_pointer_to_stack_allocated_memory_2.zig
+++ b/test/cases/compile_errors/return_pointer_to_stack_allocated_memory_2.zig
@@ -1,0 +1,59 @@
+// Test: Stack escape detection - Part 2: Struct field pointer escapes
+// This file tests returning pointers to fields of stack-allocated structs
+
+// Force runtime evaluation with this global
+var runtime_value: i32 = 42;
+
+fn returnStructFieldPtr() *i32 {
+    const S = struct { x: i32, y: i32 };
+    var s = S{ .x = runtime_value, .y = 2 };
+    return &s.x;
+}
+
+fn returnStructFieldPtr2() *i32 {
+    const S = struct { x: i32, y: i32 };
+    var s = S{ .x = 1, .y = runtime_value };
+    return &s.y;
+}
+
+fn returnAnonymousStructField() *u32 {
+    var s = struct {
+        a: i32,
+        b: u32,
+        c: u8,
+    }{
+        .a = runtime_value,
+        .b = 100,
+        .c = 0,
+    };
+    return &s.b;
+}
+
+// Struct field by index (these use struct_field_ptr_index_0, etc. in AIR)
+fn returnStructFieldIndex0() *i32 {
+    var s = struct { a: i32, b: i32 }{ .a = runtime_value, .b = 0 };
+    return &s.a;
+}
+
+fn returnStructFieldIndex1() *i32 {
+    var s = struct { a: i32, b: i32 }{ .a = 0, .b = runtime_value };
+    return &s.b;
+}
+
+pub fn main() void {
+    _ = returnStructFieldPtr();
+    _ = returnStructFieldPtr2();
+    _ = returnAnonymousStructField();
+    _ = returnStructFieldIndex0();
+    _ = returnStructFieldIndex1();
+}
+
+// error
+// backend=auto
+// target=native
+//
+// :10:12: error: cannot return pointer to stack-allocated memory
+// :16:12: error: cannot return pointer to stack-allocated memory
+// :29:12: error: cannot return pointer to stack-allocated memory
+// :35:12: error: cannot return pointer to stack-allocated memory
+// :40:12: error: cannot return pointer to stack-allocated memory

--- a/test/cases/compile_errors/return_pointer_to_stack_allocated_memory_3.zig
+++ b/test/cases/compile_errors/return_pointer_to_stack_allocated_memory_3.zig
@@ -1,0 +1,41 @@
+// Test: Stack escape detection - Part 3: Slice escapes
+// This file tests returning slices to stack-allocated memory
+
+// Force runtime evaluation with this global
+var runtime_value: i32 = 42;
+
+// Direct slice return from stack array
+fn returnDirectSlice() []const u8 {
+    var buffer: [10]u8 = undefined;
+    buffer[0] = @intCast(runtime_value);
+    return buffer[0..5];
+}
+
+// Array to slice conversion
+fn returnArrayToSlice() []const u8 {
+    var arr = [_]u8{ 1, 2, 3, 4, @intCast(runtime_value) };
+    const slice: []const u8 = &arr;
+    return slice;
+}
+
+// Slice pointer extraction
+fn returnSlicePtr() [*]const u8 {
+    var buffer: [10]u8 = undefined;
+    buffer[0] = @intCast(runtime_value);
+    const slice = buffer[0..];
+    return slice.ptr;
+}
+
+pub fn main() void {
+    _ = returnDirectSlice();
+    _ = returnArrayToSlice();
+    _ = returnSlicePtr();
+}
+
+// error
+// backend=auto
+// target=native
+//
+// :11:18: error: cannot return pointer to stack-allocated memory
+// :18:12: error: cannot return slice of stack-allocated memory
+// :26:17: error: cannot return pointer to stack-allocated memory


### PR DESCRIPTION
Catch simple but common cases of returning pointers and slices to stack-allocated memory.

While not a complete solution to stack escape detection, this is still useful and has identified bugs in real-world projects.

Currently detects:

- Direct pointers to local variables
- Pointers to struct fields of stack-allocated structs
- Array-to-slice conversions of stack arrays

This prevents undefined behavior from dangling stack references that would otherwise only be caught at runtime (if at all).