### PR TITLE
Sema: fix SIGSEGV when accessing undefined struct fields at comptime

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -27502,7 +27502,12 @@ fn structFieldVal(
                 if ((try sema.typeHasOnePossibleValue(field_ty))) |opv| {
                     return Air.internedToRef(opv.toIntern());
                 }
-                return Air.internedToRef((try struct_val.fieldValue(pt, field_index)).toIntern());
+                const field_value = try struct_val.fieldValue(pt, field_index);
+                // Check if the field itself is undefined
+                if (field_value.isUndef(zcu) and block.isComptime()) {
+                    return sema.failWithUseOfUndef(block, field_name_src, null);
+                }
+                return Air.internedToRef(field_value.toIntern());
             }
 
             try field_ty.resolveLayout(pt);


### PR DESCRIPTION
When an allocator with `.ptr = undefined` was used to call vtable methods at comptime (e.g., ArrayList.append with a comptime_allocator), the compiler would crash with SIGSEGV instead of reporting a proper error.

Fixes #25214