### PR TITLE
std.c: add MSG support for dragonfly

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -5825,6 +5825,22 @@ pub const MSG = switch (native_os) {
         pub const WAITFORONE = 0x1000;
         pub const CMSG_CLOFORK = 0x2000;
     },
+    .dragonfly => struct {
+        pub const OOB = 0x0001;
+        pub const PEEK = 0x0002;
+        pub const DONTROUTE = 0x0004;
+        pub const EOR = 0x0008;
+        pub const TRUNC = 0x0010;
+        pub const CTRUNC = 0x0020;
+        pub const WAITALL = 0x0040;
+        pub const DONTWAIT = 0x0080;
+        pub const NOSIGNAL = 0x0400;
+        pub const SYNC = 0x0800;
+        pub const CMSG_CLOEXEC = 0x1000;
+        pub const CMSG_CLOFORK = 0x2000;
+        pub const FBLOCKING = 0x10000;
+        pub const FNONBLOCKING = 0x20000;
+    },
     else => void,
 };
 pub const SOCK = switch (native_os) {


### PR DESCRIPTION
Contributes to #24997 

There might be other issues, but at the very least, this defines the ``MSG`` struct for dragonfly.

Based on

https://gitweb.dragonflybsd.org/?p=dragonfly.git;a=blob_plain;f=sys/sys/socket.h;hb=HEAD