### PR TITLE
std.fs.Dir: Add `walkSelectively` to provide more control over directory walking

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -260,7 +260,7 @@ pub fn build(b: *std.Build) !void {
         };
         const git_describe = mem.trim(u8, git_describe_untrimmed, " \n\r");
 
-        switch (mem.count(u8, git_describe, "-")) {
+        switch (mem.countScalar(u8, git_describe, '-')) {
             0 => {
                 // Tagged release version (e.g. 0.10.0).
                 if (!mem.eql(u8, git_describe, version_string)) {

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -732,16 +732,14 @@ pub const SelectiveWalker = struct {
         });
     }
 
-    pub fn depth(self: *SelectiveWalker) usize {
-        return self.stack.items.len;
-    }
-
     pub fn deinit(self: *SelectiveWalker) void {
         self.name_buffer.deinit(self.allocator);
         self.stack.deinit(self.allocator);
     }
 
     /// Leaves the current directory, continuing walking one level up.
+    /// If the current entry is a directory entry, then the "current directory"
+    /// will pertain to that entry if `enter` is called before `leave`.
     pub fn leave(self: *SelectiveWalker) void {
         var item = self.stack.pop().?;
         if (self.stack.items.len != 0) {
@@ -789,6 +787,13 @@ pub const Walker = struct {
         basename: [:0]const u8,
         path: [:0]const u8,
         kind: Dir.Entry.Kind,
+
+        /// Returns the depth of the entry relative to the initial directory.
+        /// Returns 1 for a direct child of the initial directory, 2 for an entry
+        /// within a direct child of the initial directory, etc.
+        pub fn depth(self: Walker.Entry) usize {
+            return mem.countScalar(u8, self.path, fs.path.sep) + 1;
+        }
     };
 
     const StackItem = struct {

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -732,6 +732,10 @@ pub const SelectiveWalker = struct {
         });
     }
 
+    pub fn depth(self: *SelectiveWalker) usize {
+        return self.stack.items.len;
+    }
+
     pub fn deinit(self: *SelectiveWalker) void {
         self.name_buffer.deinit(self.allocator);
         self.stack.deinit(self.allocator);

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -663,10 +663,119 @@ fn iterateImpl(self: Dir, first_iter_start_value: bool) Iterator {
     }
 }
 
-pub const Walker = struct {
-    stack: std.ArrayListUnmanaged(StackItem),
+pub const SelectiveWalker = struct {
+    stack: std.ArrayListUnmanaged(Walker.StackItem),
     name_buffer: std.ArrayListUnmanaged(u8),
     allocator: Allocator,
+
+    /// After each call to this function, and on deinit(), the memory returned
+    /// from this function becomes invalid. A copy must be made in order to keep
+    /// a reference to the path.
+    pub fn next(self: *SelectiveWalker) !?Walker.Entry {
+        while (self.stack.items.len > 0) {
+            const top = &self.stack.items[self.stack.items.len - 1];
+            var dirname_len = top.dirname_len;
+            if (top.iter.next() catch |err| {
+                // If we get an error, then we want the user to be able to continue
+                // walking if they want, which means that we need to pop the directory
+                // that errored from the stack. Otherwise, all future `next` calls would
+                // likely just fail with the same error.
+                var item = self.stack.pop().?;
+                if (self.stack.items.len != 0) {
+                    item.iter.dir.close();
+                }
+                return err;
+            }) |entry| {
+                self.name_buffer.shrinkRetainingCapacity(dirname_len);
+                if (self.name_buffer.items.len != 0) {
+                    try self.name_buffer.append(self.allocator, fs.path.sep);
+                    dirname_len += 1;
+                }
+                try self.name_buffer.ensureUnusedCapacity(self.allocator, entry.name.len + 1);
+                self.name_buffer.appendSliceAssumeCapacity(entry.name);
+                self.name_buffer.appendAssumeCapacity(0);
+                const walker_entry: Walker.Entry = .{
+                    .dir = top.iter.dir,
+                    .basename = self.name_buffer.items[dirname_len .. self.name_buffer.items.len - 1 :0],
+                    .path = self.name_buffer.items[0 .. self.name_buffer.items.len - 1 :0],
+                    .kind = entry.kind,
+                };
+                return walker_entry;
+            } else {
+                var item = self.stack.pop().?;
+                if (self.stack.items.len != 0) {
+                    item.iter.dir.close();
+                }
+            }
+        }
+        return null;
+    }
+
+    /// Traverses into the directory, continuing walking one level down.
+    pub fn enter(self: *SelectiveWalker, entry: Walker.Entry) !void {
+        if (entry.kind != .directory) {
+            @branchHint(.cold);
+            return;
+        }
+
+        var new_dir = entry.dir.openDir(entry.basename, .{ .iterate = true }) catch |err| {
+            switch (err) {
+                error.NameTooLong => unreachable,
+                else => |e| return e,
+            }
+        };
+        errdefer new_dir.close();
+
+        try self.stack.append(self.allocator, .{
+            .iter = new_dir.iterateAssumeFirstIteration(),
+            .dirname_len = self.name_buffer.items.len - 1,
+        });
+    }
+
+    pub fn deinit(self: *SelectiveWalker) void {
+        self.name_buffer.deinit(self.allocator);
+        self.stack.deinit(self.allocator);
+    }
+
+    /// Leaves the current directory, continuing walking one level up.
+    pub fn leave(self: *SelectiveWalker) void {
+        var item = self.stack.pop().?;
+        if (self.stack.items.len != 0) {
+            @branchHint(.likely);
+            item.iter.dir.close();
+        }
+    }
+};
+
+/// Recursively iterates over a directory, but requires the user to
+/// opt-in to recursing into each directory entry.
+///
+/// `self` must have been opened with `OpenOptions{.iterate = true}`.
+///
+/// `Walker.deinit` releases allocated memory and directory handles.
+///
+/// The order of returned file system entries is undefined.
+///
+/// `self` will not be closed after walking it.
+///
+/// See also `walk`.
+pub fn walkSelectively(self: Dir, allocator: Allocator) !SelectiveWalker {
+    var stack: std.ArrayListUnmanaged(Walker.StackItem) = .empty;
+
+    try stack.append(allocator, .{
+        .iter = self.iterate(),
+        .dirname_len = 0,
+    });
+
+    return .{
+        .stack = stack,
+        .name_buffer = .{},
+        .allocator = allocator,
+    };
+}
+
+pub const Walker = struct {
+    inner: SelectiveWalker,
 
     pub const Entry = struct {
         /// The containing directory. This can be used to operate directly on `basename`
@@ -687,72 +796,22 @@ pub const Walker = struct {
     /// from this function becomes invalid. A copy must be made in order to keep
     /// a reference to the path.
     pub fn next(self: *Walker) !?Walker.Entry {
-        const gpa = self.allocator;
-        while (self.stack.items.len != 0) {
-            // `top` and `containing` become invalid after appending to `self.stack`
-            var top = &self.stack.items[self.stack.items.len - 1];
-            var containing = top;
-            var dirname_len = top.dirname_len;
-            if (top.iter.next() catch |err| {
-                // If we get an error, then we want the user to be able to continue
-                // walking if they want, which means that we need to pop the directory
-                // that errored from the stack. Otherwise, all future `next` calls would
-                // likely just fail with the same error.
-                var item = self.stack.pop().?;
-                if (self.stack.items.len != 0) {
-                    item.iter.dir.close();
-                }
-                return err;
-            }) |base| {
-                self.name_buffer.shrinkRetainingCapacity(dirname_len);
-                if (self.name_buffer.items.len != 0) {
-                    try self.name_buffer.append(gpa, fs.path.sep);
-                    dirname_len += 1;
-                }
-                try self.name_buffer.ensureUnusedCapacity(gpa, base.name.len + 1);
-                self.name_buffer.appendSliceAssumeCapacity(base.name);
-                self.name_buffer.appendAssumeCapacity(0);
-                if (base.kind == .directory) {
-                    var new_dir = top.iter.dir.openDir(base.name, .{ .iterate = true }) catch |err| switch (err) {
-                        error.NameTooLong => unreachable, // no path sep in base.name
-                        else => |e| return e,
-                    };
-                    {
-                        errdefer new_dir.close();
-                        try self.stack.append(gpa, .{
-                            .iter = new_dir.iterateAssumeFirstIteration(),
-                            .dirname_len = self.name_buffer.items.len - 1,
-                        });
-                        top = &self.stack.items[self.stack.items.len - 1];
-                        containing = &self.stack.items[self.stack.items.len - 2];
-                    }
-                }
-                return .{
-                    .dir = containing.iter.dir,
-                    .basename = self.name_buffer.items[dirname_len .. self.name_buffer.items.len - 1 :0],
-                    .path = self.name_buffer.items[0 .. self.name_buffer.items.len - 1 :0],
-                    .kind = base.kind,
-                };
-            } else {
-                var item = self.stack.pop().?;
-                if (self.stack.items.len != 0) {
-                    item.iter.dir.close();
-                }
-            }
+        const entry = try self.inner.next();
+        if (entry != null and entry.?.kind == .directory) {
+            try self.inner.enter(entry.?);
         }
-        return null;
+        return entry;
     }
 
     pub fn deinit(self: *Walker) void {
-        const gpa = self.allocator;
-        // Close any remaining directories except the initial one (which is always at index 0)
-        if (self.stack.items.len > 1) {
-            for (self.stack.items[1..]) |*item| {
-                item.iter.dir.close();
-            }
-        }
-        self.stack.deinit(gpa);
-        self.name_buffer.deinit(gpa);
+        self.inner.deinit();
+    }
+
+    /// Leaves the current directory, continuing walking one level up.
+    /// If the current entry is a directory entry, then the "current directory"
+    /// is the directory pertaining to the current entry.
+    pub fn leave(self: *Walker) void {
+        self.inner.leave();
     }
 };
 
@@ -765,18 +824,11 @@ pub const Walker = struct {
 /// The order of returned file system entries is undefined.
 ///
 /// `self` will not be closed after walking it.
+///
+/// See also `walkSelectively`.
 pub fn walk(self: Dir, allocator: Allocator) Allocator.Error!Walker {
-    var stack: std.ArrayListUnmanaged(Walker.StackItem) = .empty;
-
-    try stack.append(allocator, .{
-        .iter = self.iterate(),
-        .dirname_len = 0,
-    });
-
     return .{
-        .stack = stack,
-        .name_buffer = .{},
-        .allocator = allocator,
+        .inner = try walkSelectively(self, allocator),
     };
 }
 

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1851,10 +1851,6 @@ test "selective walker, skip entries that start with ." {
     var num_walked: usize = 0;
     while (try walker.next()) |entry| {
         if (entry.basename[0] == '.') continue;
-        if (entry.kind == .directory) {
-            try walker.enter(entry);
-        }
-
         testing.expect(expected_basenames.has(entry.basename)) catch |err| {
             std.debug.print("found unexpected basename: {f}\n", .{std.ascii.hexEscape(entry.basename, .lower)});
             return err;
@@ -1865,9 +1861,14 @@ test "selective walker, skip entries that start with ." {
         };
 
         testing.expectEqual(expected_paths.get(entry.path).?, walker.depth()) catch |err| {
-            std.debug.print("path reported unexpected depth: {f}, {d}", .{ std.ascii.hexEscape(entry.path, .lower), walker.depth() });
+            std.debug.print("path reported unexpected depth: {f}, {d}, expected {d}\n", .{ std.ascii.hexEscape(entry.path, .lower), walker.depth(), expected_paths.get(entry.path).? });
             return err;
         };
+
+        if (entry.kind == .directory) {
+            try walker.enter(entry);
+        }
+
         // make sure that the entry.dir is the containing dir
         var entry_dir = try entry.dir.openDir(entry.basename, .{});
         defer entry_dir.close();

--- a/lib/std/fs/test.zig
+++ b/lib/std/fs/test.zig
@@ -1823,13 +1823,13 @@ test "selective walker, skip entries that start with ." {
 
     // iteration order of walker is undefined, so need lookup maps to check against
 
-    const expected_paths = std.StaticStringMap(void).initComptime(.{
-        .{"dir1"},
-        .{"dir1" ++ fs.path.sep_str ++ "foo"},
-        .{"a"},
-        .{"a" ++ fs.path.sep_str ++ "b"},
-        .{"a" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c"},
-        .{"a" ++ fs.path.sep_str ++ "baz"},
+    const expected_paths = std.StaticStringMap(usize).initComptime(.{
+        .{ "dir1", 1 },
+        .{ "dir1" ++ fs.path.sep_str ++ "foo", 2 },
+        .{ "a", 1 },
+        .{ "a" ++ fs.path.sep_str ++ "b", 2 },
+        .{ "a" ++ fs.path.sep_str ++ "b" ++ fs.path.sep_str ++ "c", 3 },
+        .{ "a" ++ fs.path.sep_str ++ "baz", 2 },
     });
 
     const expected_basenames = std.StaticStringMap(void).initComptime(.{
@@ -1861,6 +1861,11 @@ test "selective walker, skip entries that start with ." {
         };
         testing.expect(expected_paths.has(entry.path)) catch |err| {
             std.debug.print("found unexpected path: {f}\n", .{std.ascii.hexEscape(entry.path, .lower)});
+            return err;
+        };
+
+        testing.expectEqual(expected_paths.get(entry.path).?, walker.depth()) catch |err| {
+            std.debug.print("path reported unexpected depth: {f}, {d}", .{ std.ascii.hexEscape(entry.path, .lower), walker.depth() });
             return err;
         };
         // make sure that the entry.dir is the containing dir

--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -1704,6 +1704,26 @@ test count {
     try testing.expect(count(u8, "owowowu", "owowu") == 1);
 }
 
+/// Returns the number of needles inside the haystack
+pub fn countScalar(comptime T: type, haystack: []const T, needle: T) usize {
+    var i: usize = 0;
+    var found: usize = 0;
+
+    while (findScalarPos(T, haystack, i, needle)) |idx| {
+        i = idx + 1;
+        found += 1;
+    }
+
+    return found;
+}
+
+test countScalar {
+    try testing.expectEqual(0, countScalar(u8, "", 'h'));
+    try testing.expectEqual(1, countScalar(u8, "h", 'h'));
+    try testing.expectEqual(2, countScalar(u8, "hh", 'h'));
+    try testing.expectEqual(3, countScalar(u8, "   abcabc   abc", 'b'));
+}
+
 /// Returns true if the haystack contains expected_count or more needles
 /// needle.len must be > 0
 /// does not count overlapping needles

--- a/tools/update_mingw.zig
+++ b/tools/update_mingw.zig
@@ -118,7 +118,7 @@ pub fn main() !void {
             switch (entry.kind) {
                 .directory => {
                     switch (walker.depth()) {
-                        1 => if (def_dirs.get(entry.basename)) {
+                        1 => if (def_dirs.has(entry.basename)) {
                             try walker.enter(entry);
                             continue;
                         },

--- a/tools/update_mingw.zig
+++ b/tools/update_mingw.zig
@@ -118,11 +118,9 @@ pub fn main() !void {
             switch (entry.kind) {
                 .directory => {
                     switch (walker.depth()) {
-                        1 => for (def_dirs) |p| {
-                            if (std.mem.eql(u8, entry.basename, p)) {
-                                try walker.enter(entry);
-                                continue;
-                            }
+                        1 => if (def_dirs.get(entry.basename)) {
+                            try walker.enter(entry);
+                            continue;
                         },
                         else => {
                             // The top-level directory was already validated
@@ -174,14 +172,14 @@ const def_exts = [_][]const u8{
     ".def.in",
 };
 
-const def_dirs = [_][]const u8{
-    "lib32" ++ std.fs.path.sep_str,
-    "lib64" ++ std.fs.path.sep_str,
-    "libarm32" ++ std.fs.path.sep_str,
-    "libarm64" ++ std.fs.path.sep_str,
-    "lib-common" ++ std.fs.path.sep_str,
-    "def-include" ++ std.fs.path.sep_str,
-};
+const def_dirs = std.StaticStringMap(void).initComptime(.{
+    .{"lib32"},
+    .{"lib64"},
+    .{"libarm32"},
+    .{"libarm64"},
+    .{"lib-common"},
+    .{"def-include"},
+});
 
 const blacklisted_defs = [_][]const u8{
     "crtdll.def.in",

--- a/tools/update_mingw.zig
+++ b/tools/update_mingw.zig
@@ -117,7 +117,7 @@ pub fn main() !void {
         while (try walker.next()) |entry| {
             switch (entry.kind) {
                 .directory => {
-                    switch (walker.depth()) {
+                    switch (entry.depth()) {
                         1 => if (def_dirs.has(entry.basename)) {
                             try walker.enter(entry);
                             continue;


### PR DESCRIPTION
**[Release notes are here](https://github.com/ziglang/zig/pull/25320#issuecomment-3367584918)**

Closes #25321

---

First of all I'd really like to thank the zig community for such a welcoming environment and I wish I'm not stepping out of boundaries by suggesting this improvement.

This doesn't come out of the blue, as I've had a few interactions through the fantastic [ziggit](https://ziggit.dev/t/while-loop-continue-bug/12112/16) community and I've been encouraged to step forward with this, that I've been using in my personal project.

The background for that is that I understand not always all directories are meant to be visited by the walker - and in my measured tests, skipping an entire directory or parts of it yield significant performance improvement. Even the mere act of skipping opening the directory instead of popping out of it after stepping into yield benefits ([10% less syscalls](https://github.com/hkupty/todo-zen/commit/27a74d003335b43b9e17cb6e3221766b58b17ebe) on my local tests).

Since I understand there's a difference between specialized code I write for my tool and general code that exists in the std library, I think this approach of having it take a mode (`.manual` or `.automatic`) would yield the best of both worlds, balancing flexibility and control.

I'm completely fine if this is not the best approach to solve the problem or if it's decided that we should take a different approach, and I'd be OK with refactoring to conform to any standards I might've missed. And thanks a lot for the language, it's been very joyful and inspiring to use it! 