### PR TITLE
fix fedora build + atomic crash bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,8 @@ if(ZIG_STATIC_ZSTD)
         list(REMOVE_ITEM LLVM_LIBRARIES "-lzstd")
     endif()
 
-    find_library(ZSTD NAMES libzstd.a libzstdstatic.a zstd NAMES_PER_DIR)
+    find_library(ZSTD NAMES libzstd.a libzstdstatic.a zstd NAMES_PER_DIR
+        PATHS /usr/lib64 /usr/lib/x86_64-linux-gnu)
     list(APPEND LLVM_LIBRARIES "${ZSTD}")
 endif()
 


### PR DESCRIPTION
cmake can't find zstd on fedora because it's in /usr/lib64 not the ubuntu path.
also atomicPtrAlignment segfaults when you pass packed structs that don't have 
a backing int - just check for it first.

closes #24506 #25310