### PR TITLE
`std.pie`: fix register constraint in `getDynamicSymbol()` for s390x

### DIFF
--- a/lib/std/pie.zig
+++ b/lib/std/pie.zig
@@ -177,7 +177,7 @@ inline fn getDynamicSymbol() [*]const elf.Dyn {
                 \\ jg 2f
                 \\ 1: .quad _DYNAMIC - .
                 \\ 2:
-                : [ret] "=r" (-> [*]const elf.Dyn),
+                : [ret] "=a" (-> [*]const elf.Dyn),
             ),
             // The compiler does not necessarily have any obligation to load the `l7` register (pointing
             // to the GOT), so do it ourselves just in case.

--- a/test/cases/pie_linux.zig
+++ b/test/cases/pie_linux.zig
@@ -6,5 +6,5 @@ pub fn main() void {}
 
 // run
 // backend=llvm
-// target=arm-linux,armeb-linux,thumb-linux,thumbeb-linux,aarch64-linux,aarch64_be-linux,loongarch64-linux,mips-linux,mipsel-linux,mips64-linux,mips64el-linux,powerpc-linux,powerpcle-linux,powerpc64-linux,powerpc64le-linux,riscv32-linux,riscv64-linux,x86-linux,x86_64-linux
+// target=arm-linux,armeb-linux,thumb-linux,thumbeb-linux,aarch64-linux,aarch64_be-linux,loongarch64-linux,mips-linux,mipsel-linux,mips64-linux,mips64el-linux,powerpc-linux,powerpcle-linux,powerpc64-linux,powerpc64le-linux,riscv32-linux,riscv64-linux,s390x-linux,x86-linux,x86_64-linux
 // pie=true


### PR DESCRIPTION
If the compiler happens to pick `ret = r0`, then this will assemble to `ag r0, 0` which is obviously not what we want. Using `a` instead of `r` will ensure that we get an appropriate address register, i.e. `r1` through `r15`.

Re-enable `pie_linux` for `s390x-linux` which was disabled in ed7ff0b693037078f451a7c6c1124611060f4892.