### PR TITLE
zon: add Formatter

### DIFF
--- a/lib/std/zon.zig
+++ b/lib/std/zon.zig
@@ -37,9 +37,50 @@
 //! ZON does not have syntax for pointers, but the parsers will allocate as needed to match the
 //! given Zig types. Similarly, the serializer will traverse pointers.
 
+const std = @import("std");
+
 pub const parse = @import("zon/parse.zig");
 pub const stringify = @import("zon/stringify.zig");
 pub const Serializer = @import("zon/Serializer.zig");
+
+/// Returns a formatter that formats the given value using stringify.
+pub fn fmt(value: anytype, options: stringify.SerializeOptions) Formatter(@TypeOf(value)) {
+    return Formatter(@TypeOf(value)){ .value = value, .options = options };
+}
+
+test fmt {
+    const expectFmt = std.testing.expectFmt;
+    try expectFmt("123", "{f}", .{fmt(@as(u32, 123), .{})});
+    try expectFmt(
+        \\.{
+        \\    .num = 927,
+        \\    .msg = "hello",
+        \\    .sub = .{ .mybool = true },
+        \\}
+    , "{f}", .{fmt(struct {
+        num: u32,
+        msg: []const u8,
+        sub: struct {
+            mybool: bool,
+        },
+    }{
+        .num = 927,
+        .msg = "hello",
+        .sub = .{ .mybool = true },
+    }, .{})});
+}
+
+/// Formats the given value using stringify.
+pub fn Formatter(comptime T: type) type {
+    return struct {
+        value: T,
+        options: stringify.SerializeOptions,
+
+        pub fn format(self: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
+            try stringify.serialize(self.value, self.options, writer);
+        }
+    };
+}
 
 test {
     _ = parse;


### PR DESCRIPTION
Add `zon.Formatter` & `zon.fmt` for pretty printing:

```zig
const Thing = struct {
    num: u32,
    msg: []const u8,
    sub: struct {
	mybool: bool,
    },
};

const thing: Thing = .{
    .num = 927,
    .msg = "hello",
    .sub = .{ .mybool = true },
};

std.debug.print("{f}", .{std.zon.fmt(thing, .{})});

// outputs:
//
// .{
//     .num = 927,
//     .msg = "hello",
//     .sub = .{ .mybool = true },
// }
```