### PR TITLE
forbid trivial local address returned from functions

### DIFF
--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -758,7 +758,8 @@ test "return undefined pointer from function, directly and by expired local" {
         /// Semantically equivalent to `returnUndefPointer`.
         fn returnStackPointer() *i32 {
             var stack_allocation: i32 = 1234;
-            return &stack_allocation;
+            const ptr = &stack_allocation; // defeats ast-check detection
+            return ptr;
         }
     };
 

--- a/test/cases/compile_errors/return_addr_of_local.zig
+++ b/test/cases/compile_errors/return_addr_of_local.zig
@@ -1,0 +1,9 @@
+export fn b() void {
+    var x: i32 = 1234;
+    return &x;
+}
+
+// error
+//
+// :3:13: error: returning address of expired local variable 'x'
+// :2:9: note: declared runtime-known here


### PR DESCRIPTION
closes #25312

## Upgrade Guide

```zig
fn foo() *i32 {
    var x: i32 = 1234;
    return &x;
}
```
```
test.zig:3:13: error: returning address of expired local variable 'x'
    return &x;
            ^
test.zig:2:9: note: declared runtime-known here
    var x: i32 = 1234;
        ^
```

:arrow_down: 

```zig
fn foo() *i32 {
    return undefined;
}
```