### PR TITLE
Faster std.mem.swap

### DIFF
--- a/lib/std/mem.zig
+++ b/lib/std/mem.zig
@@ -3633,10 +3633,12 @@ test indexOfMinMax {
 }
 
 /// Exchanges contents of two memory locations.
-pub fn swap(comptime T: type, a: *T, b: *T) void {
-    const tmp = a.*;
-    a.* = b.*;
-    b.* = tmp;
+pub fn swap(comptime T: type, noalias a: *T, noalias b: *T) void {
+    for (asBytes(a), asBytes(b)) |*x, *y| {
+        const tmp = x.*;
+        x.* = y.*;
+        y.* = tmp;
+    }
 }
 
 inline fn reverseVector(comptime N: usize, comptime T: type, a: []T) [N]T {


### PR DESCRIPTION
Compiler Explorer shows an auto-vectorized copy in the first link with `-OReleaseSafe` and `-OReleaseFast`, and a byte-wise copy in the second link with `-OReleaseSmall`. I am about to go to school, so I do not have time to benchmark this right now.

Closes #25334

https://godbolt.org/z/7MGWEP1fj
https://godbolt.org/z/fqPozr8n5