### PR TITLE
x86_64: generate better constant memcpy code

### DIFF
--- a/src/target.zig
+++ b/src/target.zig
@@ -375,11 +375,7 @@ pub fn canBuildLibCompilerRt(target: *const std.Target) enum { no, yes, llvm_onl
         else => {},
     }
     return switch (zigBackend(target, false)) {
-        .stage2_aarch64 => .yes,
-        .stage2_x86_64 => switch (target.ofmt) {
-            .elf, .macho => .yes,
-            else => .llvm_only,
-        },
+        .stage2_aarch64, .stage2_x86_64 => .yes,
         else => .llvm_only,
     };
 }

--- a/test/behavior/x86_64/build.zig
+++ b/test/behavior/x86_64/build.zig
@@ -5,6 +5,7 @@ pub fn build(b: *std.Build) void {
         "test-filter",
         "Skip tests that do not match any filter",
     ) orelse &[0][]const u8{};
+    const strip = b.option(bool, "strip", "Omit debug information");
 
     const compiler_rt_lib = b.addLibrary(.{
         .linkage = .static,
@@ -171,6 +172,7 @@ pub fn build(b: *std.Build) void {
             const test_mod = b.createModule(.{
                 .root_source_file = b.path(path),
                 .target = target,
+                .strip = strip,
             });
             const test_exe = b.addTest(.{
                 .name = std.fs.path.stem(path),

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1176,6 +1176,7 @@ const test_targets = blk: {
                 .abi = .musl,
             },
             .link_libc = true,
+            .use_llvm = true,
             .use_lld = false,
         },
 


### PR DESCRIPTION
`rep movsb` isn't usually a great idea here. This commit makes the logic which tentatively existed in `genInlineMemcpy` apply in more cases, and in particular applies it to the "new" backend logic. All copies of 128 bytes or fewer will now attempt this path first, where---provided there is an SSE register and/or a general-purpose register available---we will lower the operation using a sequence of 32, 16, 8, 4, 2, and 1 byte copy operations.

The feedback I got on this diff was "Push it to master and if it miscomps I'll revert it" so don't blame me when it explodes