### PR TITLE
Update descriptions of -f[no-]error-tracing to match the actual behavior

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -538,8 +538,8 @@ const usage_build_generic =
     \\  -funwind-tables           Always produce unwind table entries for all functions
     \\  -fasync-unwind-tables     Always produce asynchronous unwind table entries for all functions
     \\  -fno-unwind-tables        Never produce unwind table entries
-    \\  -ferror-tracing           Enable error tracing in ReleaseFast mode
-    \\  -fno-error-tracing        Disable error tracing in Debug and ReleaseSafe mode
+    \\  -ferror-tracing           Enable error tracing in release builds
+    \\  -fno-error-tracing        Disable error tracing in debug builds
     \\  -fsingle-threaded         Code assumes there is only one thread
     \\  -fno-single-threaded      Code may not assume there is only one thread
     \\  -fstrip                   Omit debug symbols


### PR DESCRIPTION
Before https://github.com/ziglang/zig/pull/18160, error tracing defaulted to true in ReleaseSafe, but that is no longer the case. These option descriptions were never updated accordingly.

I chose to use the same wording as `-fvalgrind`/`-fno-valgrind`:

https://github.com/ziglang/zig/blob/3b365a1f9b277dd2cf7f7dac51e71647e164ff3c/src/main.zig#L511-L512