### PR TITLE
fix(std.Build.Step.Run): properly cache input directories.

### DIFF
--- a/test/standalone/dirname/build.zig
+++ b/test/standalone/dirname/build.zig
@@ -81,7 +81,7 @@ fn addTestRun(
     args: []const []const u8,
 ) void {
     const run = test_step.owner.addRunArtifact(exe);
-    run.addDirectoryArg(dirname);
+    run.addPathArg(dirname);
     run.addArgs(args);
     run.expectExitCode(0);
     test_step.dependOn(&run.step);


### PR DESCRIPTION
It applies the same logic `std.Build.Step.WriteFile` uses. However some run steps want the cache directory as an argument thus *breaking* things.

Closes #20935