### PR TITLE
`musl`: add missing fenv C dummy functions for `loongarch64-linux-muslsf`

### DIFF
--- a/lib/libc/musl/src/fenv/loongarch64/fenv-sf.c
+++ b/lib/libc/musl/src/fenv/loongarch64/fenv-sf.c
@@ -1,0 +1,3 @@
+#ifdef __loongarch_soft_float
+#include "../fenv.c"
+#endif

--- a/src/libs/musl.zig
+++ b/src/libs/musl.zig
@@ -627,6 +627,7 @@ const src_files = [_][]const u8{
     "musl/src/fenv/hexagon/fenv.S",
     "musl/src/fenv/i386/fenv.s",
     "musl/src/fenv/loongarch64/fenv.S",
+    "musl/src/fenv/loongarch64/fenv-sf.c",
     "musl/src/fenv/m68k/fenv.c",
     "musl/src/fenv/mips64/fenv.S",
     "musl/src/fenv/mips64/fenv-sf.c",


### PR DESCRIPTION
https://www.openwall.com/lists/musl/2025/09/27/1

closes #25367