### PR TITLE
Gcd deserves to be simpler and faster.

### DIFF
--- a/lib/std/math/gcd.zig
+++ b/lib/std/math/gcd.zig
@@ -9,42 +9,26 @@ pub fn gcd(a: anytype, b: anytype) @TypeOf(a, b) {
         comptime_int => std.math.IntFittingRange(@min(a, b), @max(a, b)),
         else => |T| T,
     };
+
     if (@typeInfo(N) != .int or @typeInfo(N).int.signedness != .unsigned) {
         @compileError("`a` and `b` must be usigned integers");
     }
 
-    // using an optimised form of Stein's algorithm:
-    // https://en.wikipedia.org/wiki/Binary_GCD_algorithm
-    std.debug.assert(a != 0 or b != 0);
-
-    if (a == 0) return b;
-    if (b == 0) return a;
-
+    // Euclidean algorithm.
     var x: N = a;
     var y: N = b;
 
-    const xz = @ctz(x);
-    const yz = @ctz(y);
-    const shift = @min(xz, yz);
-    x >>= @intCast(xz);
-    y >>= @intCast(yz);
-
-    var diff = y -% x;
-    while (diff != 0) : (diff = y -% x) {
-        // ctz is invariant under negation, we
-        // put it here to ease data dependencies,
-        // makes the CPU happy.
-        const zeros = @ctz(diff);
-        if (x > y) diff = -%diff;
-        y = @min(x, y);
-        x = diff >> @intCast(zeros);
+    while (x != 0) {
+        const r = y % x;
+        y = x;
+        x = r;
     }
-    return y << @intCast(shift);
+
+    return y;
 }
 
 test gcd {
     const expectEqual = std.testing.expectEqual;
-
     try expectEqual(gcd(0, 5), 5);
     try expectEqual(gcd(5, 0), 5);
     try expectEqual(gcd(8, 12), 4);


### PR DESCRIPTION
The current implementation uses Stein's algorithm.

This algorithm is outdated, because modern cpu's are smart at optimizing the modulo operation, i.e. the "tricks" that are applied in the algorithm explicitly (i.e. shifting, comparing count of trailing zeros), are usually done by the cpu already and should be avoided if possible.

My local benchmarks indicate that simply using the Euclidean algorithm is almost 2x faster than using Stein's algorithm for random `u64` inputs.

Warmup iterations: 500k.
Timed iterations: 5kk.

Some random run 1:
```
Time needed (.none): 3262ms   // cost of generating random u64s.
Time needed (.euclid): 4517ms // +~1.3sec
Time needed (.steins): 6206ms // +~2.9sec
```

Some random run 2:
```
Time needed (.none): 3171ms
Time needed (.euclid): 3935ms // +~0.76
Time needed (.steins): 4832ms // +~1.66
```

On a side note: both algorithms require `~1.44 * n` steps of iterations in the worst case (`n` is bits of smallest number).
It is possible to reduce this to `~0.79 *n` steps in the worst case. This algorithm outperforms the Euclidean algorithm by almost 2x speed for worst case inputs, but for random inputs it is a bit worse because it has one additional branch. If interested, I can also add this algorithm -- called "Ring" -- in the gcd file.