### PR TITLE
InternPool: Rework the way strings are represented

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3676,6 +3676,7 @@ const Header = extern struct {
             items_len: u32,
             extra_len: u32,
             limbs_len: u32,
+            strings_len: u32,
             string_bytes_len: u32,
             tracked_insts_len: u32,
             files_len: u32,
@@ -3724,7 +3725,8 @@ pub fn saveState(comp: *Compilation) !void {
                 .items_len = @intCast(local.mutate.items.len),
                 .extra_len = @intCast(local.mutate.extra.len),
                 .limbs_len = @intCast(local.mutate.limbs.len),
-                .string_bytes_len = @intCast(local.mutate.strings.len),
+                .strings_len = @intCast(local.mutate.strings.len),
+                .string_bytes_len = @intCast(local.mutate.string_bytes.len),
                 .tracked_insts_len = @intCast(local.mutate.tracked_insts.len),
                 .files_len = @intCast(local.mutate.files.len),
             },
@@ -3767,8 +3769,11 @@ pub fn saveState(comp: *Compilation) !void {
                 addBuf(&bufs, @ptrCast(local.shared.items.view().items(.data)[0..pt_header.intern_pool.items_len]));
                 addBuf(&bufs, @ptrCast(local.shared.items.view().items(.tag)[0..pt_header.intern_pool.items_len]));
             }
+            if (pt_header.intern_pool.strings_len > 0) {
+                addBuf(&bufs, @ptrCast(local.shared.strings.view().items(.@"0")[0..pt_header.intern_pool.strings_len]));
+            }
             if (pt_header.intern_pool.string_bytes_len > 0) {
-                addBuf(&bufs, local.shared.strings.view().items(.@"0")[0..pt_header.intern_pool.string_bytes_len]);
+                addBuf(&bufs, local.shared.string_bytes.view().items(.@"0")[0..pt_header.intern_pool.string_bytes_len]);
             }
             if (pt_header.intern_pool.tracked_insts_len > 0) {
                 addBuf(&bufs, @ptrCast(local.shared.tracked_insts.view().items(.@"0")[0..pt_header.intern_pool.tracked_insts_len]));

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3771,6 +3771,7 @@ pub fn saveState(comp: *Compilation) !void {
             }
             if (pt_header.intern_pool.strings_len > 0) {
                 addBuf(&bufs, @ptrCast(local.shared.strings.view().items(.@"0")[0..pt_header.intern_pool.strings_len]));
+                addBuf(&bufs, @ptrCast(local.shared.strings.view().items(.@"1")[0..pt_header.intern_pool.strings_len]));
             }
             if (pt_header.intern_pool.string_bytes_len > 0) {
                 addBuf(&bufs, local.shared.string_bytes.view().items(.@"0")[0..pt_header.intern_pool.string_bytes_len]);

--- a/src/InternPool.zig
+++ b/src/InternPool.zig
@@ -1432,10 +1432,8 @@ const Local = struct {
     }
 
     /// For a given pair of `s: String, ip: *const InternPool`, `s.unwrap(ip).index`
-    /// refers to an index into this array. The corresponding value is an offset into
-    /// `string_bytes`. This allows for up to `@bitSizeOf(String) - ip.tid_shift_32`
-    /// unique to be stored and up to 4 GiB of string bytes to be stored, although this
-    /// last part could change in the future depending on future needs.
+    /// refers to an index into this array. The corresponding value is an both an offset into
+    /// `string_bytes` and a length.
     pub fn getMutableStrings(local: *Local, gpa: Allocator) Strings.Mutable {
         return .{
             .gpa = gpa,

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1115,8 +1115,8 @@ pub const File = struct {
     pub fn internFullyQualifiedName(file: File, pt: Zcu.PerThread) !InternPool.NullTerminatedString {
         const gpa = pt.zcu.gpa;
         const ip = &pt.zcu.intern_pool;
-        const strings = ip.getLocal(pt.tid).getMutableStrings(gpa);
-        var w: Writer = .fixed((try strings.addManyAsSlice(file.fullyQualifiedNameLen()))[0]);
+        const string_bytes = ip.getLocal(pt.tid).getMutableStringBytes(gpa);
+        var w: Writer = .fixed((try string_bytes.addManyAsSlice(file.fullyQualifiedNameLen()))[0]);
         file.renderFullyQualifiedName(&w) catch unreachable;
         assert(w.end == w.buffer.len);
         return ip.getOrPutTrailingString(gpa, pt.tid, @intCast(w.end), .no_embedded_nulls);

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2459,10 +2459,10 @@ fn updateEmbedFileInner(
 
     // The loaded bytes of the file, including a sentinel 0 byte.
     const ip_str: InternPool.String = str: {
-        const strings = ip.getLocal(tid).getMutableStrings(gpa);
-        const old_len = strings.mutate.len;
-        errdefer strings.shrinkRetainingCapacity(old_len);
-        const bytes = (try strings.addManyAsSlice(size_plus_one))[0];
+        const string_bytes = ip.getLocal(tid).getMutableStringBytes(gpa);
+        const old_len = string_bytes.mutate.len;
+        errdefer string_bytes.shrinkRetainingCapacity(old_len);
+        const bytes = (try string_bytes.addManyAsSlice(size_plus_one))[0];
         var fr = file.reader(&.{});
         fr.size = stat.size;
         fr.interface.readSliceAll(bytes[0..size]) catch |err| switch (err) {


### PR DESCRIPTION
Marked as a draft due to a shower thought I had about a potential way to reduce the performance impact of these changes. I still need to look into that idea, but I'm opening this PR regardless so people know that I'm working on it. I'll write a more in-depth description once this PR is ready for review. 

Anyway, the goal of this PR is to make some changes to the internal representation of `InternPool.String` to make it harder crash the compiler when dealing with large amounts of string data, particularly when building with a large number of parallel jobs.

Current perf (stage3 is master, stage4 is this branch):
```
gabeu@gu /t/state> sudo nice -n-20 sudo -u gabeu -- poop './stage3 build-exe hello-world.zig -fno-emit-bin --zig-lib-dir /home/gabeu/devel/zig/lib' './stage4 build-exe hello-world.zig -fno-emit-bin --zig-lib-dir /home/gabeu/devel/zig/lib' -d 30000
Benchmark 1 (70 runs): ./stage3 build-exe hello-world.zig -fno-emit-bin --zig-lib-dir /home/gabeu/devel/zig/lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           429ms ± 4.40ms     423ms …  449ms          4 ( 6%)        0%
  peak_rss            112MB ±  163KB     112MB …  113MB          0 ( 0%)        0%
  cpu_cycles          655M  ± 4.85M      649M  …  673M          11 (16%)        0%
  instructions        934M  ± 57.8K      934M  …  934M           0 ( 0%)        0%
  cache_references   93.0M  ±  282K     92.4M  … 94.0M           1 ( 1%)        0%
  cache_misses       13.7M  ±  178K     13.4M  … 14.4M           3 ( 4%)        0%
  branch_misses      3.03M  ± 11.1K     3.01M  … 3.07M           4 ( 6%)        0%
Benchmark 2 (70 runs): ./stage4 build-exe hello-world.zig -fno-emit-bin --zig-lib-dir /home/gabeu/devel/zig/lib
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           433ms ± 4.94ms     424ms …  445ms          0 ( 0%)          +  1.0% ±  0.4%
  peak_rss            114MB ±  173KB     113MB …  114MB          0 ( 0%)        💩+  1.1% ±  0.0%
  cpu_cycles          662M  ± 7.23M      653M  …  679M           0 ( 0%)          +  1.0% ±  0.3%
  instructions        934M  ± 59.4K      934M  …  934M           0 ( 0%)          -  0.0% ±  0.0%
  cache_references   91.5M  ±  382K     90.8M  … 92.8M           3 ( 4%)        ⚡-  1.6% ±  0.1%
  cache_misses       13.9M  ±  254K     13.5M  … 14.7M           1 ( 1%)        💩+  1.8% ±  0.5%
  branch_misses      3.04M  ± 15.8K     3.02M  … 3.08M           2 ( 3%)          +  0.5% ±  0.1%

```

Regardless of what ends up going forward...

Fixes #22867
Fixes #25297
Fixes #25339