### PR TITLE
translate-c: demote structs with opaque fields to opaque

### DIFF
--- a/lib/compiler/translate-c/Translator.zig
+++ b/lib/compiler/translate-c/Translator.zig
@@ -527,6 +527,13 @@ fn transRecordDecl(t: *Translator, scope: *Scope, record_qt: QualType) Error!voi
                 break :init ZigTag.opaque_literal.init();
             }
 
+            // Demote record to opaque if it contains an opaque field
+            if (t.typeWasDemotedToOpaque(field.qt)) {
+                try t.opaque_demotes.put(t.gpa, base.qt, {});
+                try t.warn(scope, field_loc, "{s} demoted to opaque type - has opaque field", .{container_kind_name});
+                break :init ZigTag.opaque_literal.init();
+            }
+
             var field_name = field.name.lookup(t.comp);
             if (field.name_tok == 0) {
                 field_name = try std.fmt.allocPrint(t.arena, "unnamed_{d}", .{unnamed_field_count});


### PR DESCRIPTION
Uses the same logic as demoting structs with bitfields. I also noticed that `Translator.alignmentForField` panics when given a bitfield, which could be replicated for opaque fields, but I figured the repeated call to `Translator.typeWasDemotedToOpaque` was not preferable.

Fixes ziglang/translate-c#182