### PR TITLE
ast: Add comptime reason for error set merge

### DIFF
--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -765,6 +765,7 @@ pub const SimpleComptimeReason = enum(u32) {
     // Reasons other than `.type` are just more specific messages.
     type,
     array_sentinel,
+    merge_error_set,
     pointer_sentinel,
     slice_sentinel,
     array_length,
@@ -843,6 +844,7 @@ pub const SimpleComptimeReason = enum(u32) {
             .clobber              => "clobber must be comptime-known",
 
             .type                => "types must be comptime-known",
+            .merge_error_set     => "operand to error set merge (||) must be an error set",
             .array_sentinel      => "array sentinel value must be comptime-known",
             .pointer_sentinel    => "pointer sentinel value must be comptime-known",
             .slice_sentinel      => "slice sentinel value must be comptime-known",

--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -793,8 +793,8 @@ fn expr(gz: *GenZir, scope: *Scope, ri: ResultInfo, node: Ast.Node.Index) InnerE
                 else => unreachable,
             };
             const lhs_node, const rhs_node = tree.nodeData(node).node_and_node;
-            const lhs = try reachableTypeExpr(gz, scope, lhs_node, node);
-            const rhs = try reachableTypeExpr(gz, scope, rhs_node, node);
+            const lhs = try reachableExprComptime(gz, scope, coerced_type_ri, lhs_node, node, .merge_error_set);
+            const rhs = try reachableExprComptime(gz, scope, coerced_type_ri, rhs_node, node, .merge_error_set);
             const result = try gz.addPlNode(inst_tag, node, Zir.Inst.Bin{ .lhs = lhs, .rhs = rhs });
             return rvalue(gz, ri, result, node);
         },


### PR DESCRIPTION
This PR adds a better error message if a non-comptime operand is used with `||`. This would often happen when accidentally using `||` instead of `or`. Previously the error looked like this:

```
repro.zig:5:12: error: comptime call of extern function
    _ = foo() || b;
        ~~~^~
repro.zig:5:12: note: types must be comptime-known
```

Now a new notes is added:

```
repro.zig:5:12: error: comptime call of extern function
    _ = foo() || b;
        ~~~^~
repro.zig:5:12: note: operand to error set merge (||) must be an error set
```