### PR TITLE
ArrayHashMapWithAllocator: add `sortUnstable` fn alongside `sort`

### DIFF
--- a/lib/std/array_hash_map.zig
+++ b/lib/std/array_hash_map.zig
@@ -460,8 +460,17 @@ pub fn ArrayHashMapWithAllocator(
         /// Sorts the entries and then rebuilds the index.
         /// `sort_ctx` must have this method:
         /// `fn lessThan(ctx: @TypeOf(ctx), a_index: usize, b_index: usize) bool`
+        /// Uses a stable sorting algorithm.
         pub fn sort(self: *Self, sort_ctx: anytype) void {
             return self.unmanaged.sortContext(sort_ctx, self.ctx);
+        }
+
+        /// Sorts the entries and then rebuilds the index.
+        /// `sort_ctx` must have this method:
+        /// `fn lessThan(ctx: @TypeOf(ctx), a_index: usize, b_index: usize) bool`
+        /// Uses an unstable sorting algorithm.
+        pub fn sortUnstable(self: *Self, sort_ctx: anytype) void {
+            return self.unmanaged.sortUnstableContext(sort_ctx, self.ctx);
         }
 
         /// Shrinks the underlying `Entry` array to `new_len` elements and


### PR DESCRIPTION
This wrapper in the "managed" version was missing for no apparent reason. It's useful in scenarios where stable sort is not necessary (i.e. you are sorting on the keys so you know there won't be any equal elements)

`ReleaseFast` results for `sortUnstable` vs `sort` in a real use case (bulk of the runtime is sorting 7272 elements by their keys in a `StringArrayHashMap`):

```
Benchmark 1 (446 runs): ./test-unstable
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          11.1ms ±  918us    9.61ms … 15.3ms          2 ( 0%)        0%
  peak_rss           6.38MB ± 31.7KB    6.26MB … 6.42MB         75 (17%)        0%
  cpu_cycles         13.7M  ±  151K     13.5M  … 14.6M          24 ( 5%)        0%
  instructions       35.2M  ±  576      35.2M  … 35.2M           4 ( 1%)        0%
  cache_references    802K  ± 10.0K      740K  …  849K          11 ( 2%)        0%
  cache_misses       88.0K  ± 1.49K     77.0K  … 95.0K          13 ( 3%)        0%
  branch_misses       140K  ±  545       139K  …  143K          17 ( 4%)        0%
Benchmark 2 (106 runs): ./test-stable
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          47.1ms ± 1.64ms    45.1ms … 57.1ms          3 ( 3%)        💩+324.1% ±  2.1%
  peak_rss           6.37MB ± 41.4KB    6.26MB … 6.42MB         19 (18%)          -  0.2% ±  0.1%
  cpu_cycles          160M  ±  668K      159M  …  163M           2 ( 2%)        💩+1071.5% ±  0.5%
  instructions        271M  ±  563       271M  …  271M           1 ( 1%)        💩+669.8% ±  0.0%
  cache_references   14.6M  ±  267K     14.1M  … 15.4M           1 ( 1%)        💩+1717.2% ±  3.1%
  cache_misses       1.12M  ±  186K      770K  … 1.65M           3 ( 3%)        💩+1171.6% ± 19.5%
  branch_misses      90.8K  ±  899      89.7K  … 94.7K           4 ( 4%)        ⚡- 34.9% ±  0.1%
```