### PR TITLE
switch generic asn.1 der reader/writer to Io.Reader/Writer

### DIFF
--- a/lib/std/crypto/codecs.zig
+++ b/lib/std/crypto/codecs.zig
@@ -1,3 +1,8 @@
 pub const asn1 = @import("codecs/asn1.zig");
 pub const base64 = @import("codecs/base64_hex_ct.zig").base64;
 pub const hex = @import("codecs/base64_hex_ct.zig").hex;
+
+test {
+    _ = @import("codecs/asn1.zig");
+    _ = @import("codecs/base64_hex_ct.zig");
+}

--- a/lib/std/crypto/codecs/asn1.zig
+++ b/lib/std/crypto/codecs/asn1.zig
@@ -90,7 +90,7 @@ pub const Tag = struct {
         };
     }
 
-    pub fn encode(self: Tag, writer: *std.Io.Writer) @TypeOf(writer).Error!void {
+    pub fn encode(self: Tag, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         var tag1 = FirstTag{
             .number = undefined,
             .constructed = self.constructed,
@@ -98,7 +98,7 @@ pub const Tag = struct {
         };
 
         var buffer: [3]u8 = undefined;
-        var writer2: std.Io.Writer = .init(&buffer);
+        var writer2: std.Io.Writer = .fixed(&buffer);
 
         switch (@intFromEnum(self.number)) {
             0...std.math.maxInt(u5) => |n| {
@@ -183,7 +183,7 @@ pub const Element = struct {
         }
     };
 
-    pub const DecodeError = error{ InvalidLength, EndOfStream };
+    pub const DecodeError = error{InvalidLength} || std.Io.Reader.Error;
 
     /// Safely decode a DER/BER/CER element at `index`:
     /// - Ensures length uses shortest form

--- a/lib/std/crypto/codecs/asn1.zig
+++ b/lib/std/crypto/codecs/asn1.zig
@@ -183,7 +183,7 @@ pub const Element = struct {
         }
     };
 
-    pub const DecodeError = error{InvalidLength} || std.Io.Reader.Error;
+    pub const DecodeError = error{ InvalidLength, EndOfStream, ReadFailed };
 
     /// Safely decode a DER/BER/CER element at `index`:
     /// - Ensures length uses shortest form

--- a/lib/std/crypto/codecs/asn1/Oid.zig
+++ b/lib/std/crypto/codecs/asn1/Oid.zig
@@ -47,7 +47,7 @@ test fromDot {
     }
 }
 
-pub fn toDot(self: Oid, writer: anytype) @TypeOf(writer).Error!void {
+pub fn toDot(self: Oid, writer: anytype) std.Io.Writer.Error!void {
     const encoded = self.encoded;
     const first = @divTrunc(encoded[0], 40);
     const second = encoded[0] - first * 40;
@@ -81,7 +81,7 @@ test toDot {
     for (test_cases) |t| {
         var stream: std.Io.Writer = .fixed(&buf);
         try toDot(Oid{ .encoded = t.encoded }, &stream);
-        try std.testing.expectEqualStrings(t.dot_notation, stream.written());
+        try std.testing.expectEqualStrings(t.dot_notation, stream.buffered());
     }
 }
 

--- a/lib/std/crypto/codecs/asn1/der/Encoder.zig
+++ b/lib/std/crypto/codecs/asn1/der/Encoder.zig
@@ -117,8 +117,8 @@ pub fn tagBytes(self: *Encoder, tag_: Tag, bytes: []const u8) !void {
 }
 
 /// Warning: This writer writes backwards. `fn print` will NOT work as expected.
-pub fn writer(self: *Encoder) ArrayListReverse.Writer {
-    return self.buffer.writer();
+pub fn writer(self: *Encoder) *std.Io.Writer {
+    return &self.buffer.writer;
 }
 
 fn int(self: *Encoder, comptime T: type, value: T) !void {


### PR DESCRIPTION
Followup to #25036 to finish moving the asn.1 der encoder & decoder to the `Io.Reader`/`Io.Writer` interfaces. It looks like the tests for those types were not being imported, so CI wasn't catching these compile errors.

Fixes #25408