### PR TITLE
Lld: fix implib emit path

### DIFF
--- a/src/link/Lld.zig
+++ b/src/link/Lld.zig
@@ -505,7 +505,7 @@ fn coffLink(lld: *Lld, arena: Allocator) !void {
         try argv.append(try allocPrint(arena, "-OUT:{s}", .{full_out_path}));
 
         if (comp.emit_implib) |raw_emit_path| {
-            const path = try comp.resolveEmitPathFlush(arena, .temp, raw_emit_path);
+            const path = try comp.resolveEmitPathFlush(arena, .artifact, raw_emit_path);
             try argv.append(try allocPrint(arena, "-IMPLIB:{f}", .{path}));
         }
 


### PR DESCRIPTION
Resolves: https://github.com/ziglang/zig/issues/24993

---

The actual issue was that we were trying to emit implibs in the wrong place. As well as causing #24993, this also caused direct CLI invocations (`zig cc`, `zig build-exe`) to not emit the expected implib `foo.lib` alongside the output `foo.dll`.