### PR TITLE
MemoryPool: Allocate only once for preheating & impl. proper resetting.

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -30,7 +30,7 @@ pub const GeneralPurposeAllocator = DebugAllocator;
 /// because it outperforms general purpose allocators.
 /// Functions that potentially allocate memory accept an `Allocator` parameter.
 pub fn MemoryPool(comptime Item: type) type {
-    return memory_pool.Extra(Item, .{ .alignment = null });
+    return memory_pool.Extra(Item, .{});
 }
 pub const memory_pool = @import("heap/memory_pool.zig");
 

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -1,4 +1,4 @@
-const std = @import("std");
+const std = @import("../std.zig");
 const Allocator = std.mem.Allocator;
 const Alignment = std.mem.Alignment;
 

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -1,7 +1,6 @@
-const std = @import("../std.zig");
+const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Alignment = std.mem.Alignment;
-const MemoryPool = std.heap.MemoryPool;
 
 /// Deprecated.
 pub fn Managed(comptime Item: type) type {
@@ -255,7 +254,7 @@ test "basic" {
     const a = std.testing.allocator;
 
     {
-        var pool: MemoryPool(u32) = .empty;
+        var pool: Extra(u32, .{}) = .empty;
         defer pool.deinit(a);
 
         const p1 = try pool.create(a);
@@ -299,7 +298,7 @@ test "initCapacity (success)" {
     const a = std.testing.allocator;
 
     {
-        var pool: MemoryPool(u32) = try .initCapacity(a, 4);
+        var pool: Extra(u32, .{}) = try .initCapacity(a, 4);
         defer pool.deinit(a);
 
         _ = try pool.create(a);
@@ -319,7 +318,7 @@ test "initCapacity (success)" {
 
 test "initCapacity (failure)" {
     const failer = std.testing.failing_allocator;
-    try std.testing.expectError(error.OutOfMemory, MemoryPool(u32).initCapacity(failer, 5));
+    try std.testing.expectError(error.OutOfMemory, Extra(u32, .{}).initCapacity(failer, 5));
     try std.testing.expectError(error.OutOfMemory, Managed(u32).initCapacity(failer, 5));
 }
 
@@ -358,7 +357,7 @@ test "greater than pointer default alignment" {
     const a = std.testing.allocator;
 
     {
-        var pool: MemoryPool(Foo) = .empty;
+        var pool: Extra(Foo, .{}) = .empty;
         defer pool.deinit(a);
 
         const foo: *Foo = try pool.create(a);
@@ -399,7 +398,7 @@ test "greater than pointer manual alignment" {
 
 test "reset" {
     const a = std.testing.allocator;
-    var pool: MemoryPool(u32) = .empty;
+    var pool: Extra(u32, .{ .growable = false }) = try .initCapacity(a, 3);
     defer pool.deinit(a);
 
     try std.testing.expect(pool.create(a) != error.OutOfMemory);

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -60,6 +60,8 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
 
         const Node = std.SinglyLinkedList.Node;
         const ItemPtr = *align(item_alignment.toByteUnits()) Item;
+        const Unit = [item_alignment.forward(item_size)]u8;
+        const unit_al_bytes = item_alignment.toByteUnits();
 
         /// A MemoryPool containing no elements.
         pub const empty: Pool = .{
@@ -94,11 +96,9 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
         /// This allows at least `num` active allocations before an
         /// `OutOfMemory` error might happen when calling `create()`.
         pub fn addCapacity(pool: *Pool, allocator: Allocator, num: usize) Allocator.Error!void {
-            var i: usize = 0;
-            while (i < num) : (i += 1) {
-                const memory = try pool.allocNew(allocator);
-                pool.free_list.prepend(@ptrCast(memory));
-            }
+            const raw_mem = try pool.allocNew(allocator, num);
+            const uni_slc = raw_mem[0..num];
+            for (uni_slc) |*unit| pool.free_list.prepend(@ptrCast(unit));
         }
 
         pub const ResetMode = std.heap.ArenaAllocator.ResetMode;
@@ -131,7 +131,7 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
             const ptr: ItemPtr = if (pool.free_list.popFirst()) |node|
                 @ptrCast(@alignCast(node))
             else if (pool_options.growable)
-                @ptrCast(try pool.allocNew(allocator))
+                @ptrCast(try pool.allocNew(allocator, 1))
             else
                 return error.OutOfMemory;
 
@@ -146,11 +146,11 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
             pool.free_list.prepend(@ptrCast(ptr));
         }
 
-        fn allocNew(pool: *Pool, allocator: Allocator) Allocator.Error!*align(item_alignment.toByteUnits()) [item_size]u8 {
+        fn allocNew(pool: *Pool, allocator: Allocator, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
             var arena = pool.arena_state.promote(allocator);
             defer pool.arena_state = arena.state;
-            const memory = try arena.allocator().alignedAlloc(u8, item_alignment, item_size);
-            return memory[0..item_size];
+            const memory = try arena.allocator().alignedAlloc(Unit, item_alignment, num);
+            return memory.ptr;
         }
     };
 }
@@ -175,6 +175,8 @@ pub fn ExtraManaged(comptime Item: type, comptime pool_options: Options) type {
         pub const item_alignment = Unmanaged.item_alignment;
 
         const ItemPtr = Unmanaged.ItemPtr;
+        const Unit = Unmanaged.Unit;
+        const unit_al_bytes = Unmanaged.unit_al_bytes;
 
         /// Creates a new memory pool.
         pub fn init(allocator: Allocator) Pool {
@@ -227,8 +229,9 @@ pub fn ExtraManaged(comptime Item: type, comptime pool_options: Options) type {
             return pool.unmanaged.destroy(ptr);
         }
 
-        fn allocNew(pool: *Pool) Allocator.Error!*align(item_alignment) [item_size]u8 {
-            return pool.unmanaged.allocNew(pool.allocator);
+        fn allocNew(pool: *Pool, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
+            const memory = try pool.arena.allocator().alignedAlloc(Unit, item_alignment, num);
+            return memory.ptr;
         }
     };
 }

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -1,5 +1,4 @@
-const std = @import("std");
-//const std = @import("../std.zig");
+const std = @import("../std.zig");
 const Allocator = std.mem.Allocator;
 const Alignment = std.mem.Alignment;
 const MemoryPool = std.heap.MemoryPool;
@@ -136,7 +135,7 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
                 .retain_capacity => .retain_capacity,
                 .retain_with_limit => |limit| ArenaResetMode{ .retain_with_limit = limit * item_size },
             };
-            self.free_list = null;
+            self.free_list = .{};
             if (!arena.reset(arena_mode)) return false;
             // When the backing arena allocator is being reset to
             // a capacity greater than 0, then its internals consists
@@ -249,10 +248,6 @@ pub fn ExtraManaged(comptime Item: type, comptime pool_options: Options) type {
         /// Only pass items to `ptr` that were previously created with `create()` of the same memory pool!
         pub fn destroy(self: *Pool, ptr: ItemPtr) void {
             return self.unmanaged.destroy(ptr);
-        }
-
-        fn allocNew(self: *Pool, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
-            return self.unmanaged.allocNew(self.allocator, num);
         }
     };
 }

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -126,19 +126,18 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
         ///
         /// NOTE: If `mode` is `free_all`, the function will always return `true`.
         pub fn reset(self: *Pool, allocator: Allocator, mode: ResetMode) bool {
+            self.free_list = .{};
             var arena = self.arena_state.promote(allocator);
-            defer self.arena_state = arena.state;
-
-            const ArenaResetMode = std.heap.ArenaAllocator.ResetMode;
-            const arena_mode = switch (mode) {
+            const arena_mode: std.heap.ArenaAllocator.ResetMode = switch (mode) {
                 .free_all => .free_all,
                 .retain_capacity => .retain_capacity,
-                .retain_with_limit => |limit| ArenaResetMode{ .retain_with_limit = limit * item_size },
+                .retain_with_limit => |limit| .{ .retain_with_limit = limit * item_size },
             };
-            self.free_list = .{};
-            if (!arena.reset(arena_mode)) return false;
+            const arena_result = arena.reset(arena_mode);
+            self.arena_state = arena.state;
+            if (!arena_result) return false;
             // When the backing arena allocator is being reset to
-            // a capacity greater than 0, then its internals consists
+            // a capacity greater than 0, then its internals consist
             // of a *single* buffer node of said capacity. This means,
             // we can safely pre-heat without causing additional allocations.
             const arena_capacity = arena.queryCapacity() / item_size;

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -101,7 +101,20 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
             for (uni_slc) |*unit| pool.free_list.prepend(@ptrCast(unit));
         }
 
-        pub const ResetMode = std.heap.ArenaAllocator.ResetMode;
+        pub const ResetMode = union(enum) {
+            /// Releases all allocated memory in the arena.
+            free_all,
+            /// This will pre-heat the memory pool for future allocations by allocating a
+            /// large enough buffer to accomodate the highest amount of actively allocated items
+            /// in the past. Preheating will speed up the allocation process by invoking the
+            /// backing allocator less often than before. If `reset()` is used in a loop, this
+            /// means if the highest amount of actively allocated items is never being surpassed,
+            /// no memory allocations are performed anymore.
+            retain_capacity,
+            /// This is the same as `retain_capacity`, but the memory will be shrunk to
+            /// only hold at most this value of items.
+            retain_with_limit: usize,
+        };
 
         /// Resets the memory pool and destroys all allocated items.
         /// This can be used to batch-destroy all objects without invalidating the memory pool.
@@ -113,16 +126,24 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
         ///
         /// NOTE: If `mode` is `free_all`, the function will always return `true`.
         pub fn reset(pool: *Pool, allocator: Allocator, mode: ResetMode) bool {
-            // TODO: Potentially store all allocated objects in a list as well, allowing to
-            //       just move them into the free list instead of actually releasing the memory.
-
             var arena = pool.arena_state.promote(allocator);
             defer pool.arena_state = arena.state;
 
-            const reset_successful = arena.reset(mode);
-            pool.free_list = .{};
-
-            return reset_successful;
+            const ArenaResetMode = std.heap.ArenaAllocator.ResetMode;
+            const arena_mode = switch (mode) {
+                .free_all => .free_all,
+                .retain_capacity => .retain_capacity,
+                .retain_with_limit => |limit| ArenaResetMode{ .retain_with_limit = limit * item_size },
+            };
+            pool.free_list = null;
+            if (!arena.reset(arena_mode)) return false;
+            // When the backing arena allocator is being reset to
+            // a capacity greater than 0, then its internals consists
+            // of a *single* buffer node of said capacity. This means,
+            // we can safely pre-heat without causing additional allocations.
+            const arena_capacity = pool.arena.queryCapacity() / item_size;
+            if (arena_capacity != 0) pool.addCapacity(arena_capacity) catch unreachable;
+            return true;
         }
 
         /// Creates a new item and adds it to the memory pool.
@@ -380,4 +401,26 @@ test "greater than pointer manual alignment" {
         const foo: *align(16) Foo = try pool.create();
         pool.destroy(foo);
     }
+}
+
+test "reset" {
+    const a = std.testing.allocator;
+    var pool: MemoryPool(u32) = .empty;
+    defer pool.deinit(a);
+
+    try std.testing.expect(pool.create(a) != error.OutOfMemory);
+    try std.testing.expect(pool.create(a) != error.OutOfMemory);
+    try std.testing.expect(pool.create(a) != error.OutOfMemory);
+    try std.testing.expect(pool.create(a) == error.OutOfMemory);
+
+    try std.testing.expect(pool.reset(.{ .retain_with_limit = 2 }));
+
+    try std.testing.expect(pool.create(a) != error.OutOfMemory);
+    try std.testing.expect(pool.create(a) != error.OutOfMemory);
+    try std.testing.expect(pool.create(a) == error.OutOfMemory);
+
+    try std.testing.expect(pool.reset(.{ .retain_with_limit = 1 }));
+
+    try std.testing.expect(pool.create(a) != error.OutOfMemory);
+    try std.testing.expect(pool.create(a) == error.OutOfMemory);
 }

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -140,8 +140,8 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
             // a capacity greater than 0, then its internals consist
             // of a *single* buffer node of said capacity. This means,
             // we can safely pre-heat without causing additional allocations.
-            const arena_capacity = arena.queryCapacity() / item_size;
-            if (arena_capacity != 0) self.addCapacity(arena_capacity) catch unreachable;
+            const num = arena.queryCapacity() / item_size;
+            if (num != 0) self.addCapacity(allocator, num) catch unreachable;
             return true;
         }
 

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -1,4 +1,5 @@
-const std = @import("../std.zig");
+const std = @import("std");
+//const std = @import("../std.zig");
 const Allocator = std.mem.Allocator;
 const Alignment = std.mem.Alignment;
 const MemoryPool = std.heap.MemoryPool;
@@ -80,9 +81,9 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
         }
 
         /// Destroys the memory pool and frees all allocated memory.
-        pub fn deinit(pool: *Pool, allocator: Allocator) void {
-            pool.arena_state.promote(allocator).deinit();
-            pool.* = undefined;
+        pub fn deinit(self: *Pool, allocator: Allocator) void {
+            self.arena_state.promote(allocator).deinit();
+            self.* = undefined;
         }
 
         pub fn toManaged(pool: Pool, allocator: Allocator) ExtraManaged(Item, pool_options) {
@@ -95,14 +96,14 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
         /// Pre-allocates `num` items and adds them to the memory pool.
         /// This allows at least `num` active allocations before an
         /// `OutOfMemory` error might happen when calling `create()`.
-        pub fn addCapacity(pool: *Pool, allocator: Allocator, num: usize) Allocator.Error!void {
-            const raw_mem = try pool.allocNew(allocator, num);
+        pub fn addCapacity(self: *Pool, allocator: Allocator, num: usize) Allocator.Error!void {
+            const raw_mem = try self.allocNew(allocator, num);
             const uni_slc = raw_mem[0..num];
-            for (uni_slc) |*unit| pool.free_list.prepend(@ptrCast(unit));
+            for (uni_slc) |*unit| self.free_list.prepend(@ptrCast(unit));
         }
 
         pub const ResetMode = union(enum) {
-            /// Releases all allocated memory in the arena.
+            /// Releases all allocated memory in the memory pool.
             free_all,
             /// This will pre-heat the memory pool for future allocations by allocating a
             /// large enough buffer to accomodate the highest amount of actively allocated items
@@ -125,9 +126,9 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
         /// be slower.
         ///
         /// NOTE: If `mode` is `free_all`, the function will always return `true`.
-        pub fn reset(pool: *Pool, allocator: Allocator, mode: ResetMode) bool {
-            var arena = pool.arena_state.promote(allocator);
-            defer pool.arena_state = arena.state;
+        pub fn reset(self: *Pool, allocator: Allocator, mode: ResetMode) bool {
+            var arena = self.arena_state.promote(allocator);
+            defer self.arena_state = arena.state;
 
             const ArenaResetMode = std.heap.ArenaAllocator.ResetMode;
             const arena_mode = switch (mode) {
@@ -135,24 +136,24 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
                 .retain_capacity => .retain_capacity,
                 .retain_with_limit => |limit| ArenaResetMode{ .retain_with_limit = limit * item_size },
             };
-            pool.free_list = null;
+            self.free_list = null;
             if (!arena.reset(arena_mode)) return false;
             // When the backing arena allocator is being reset to
             // a capacity greater than 0, then its internals consists
             // of a *single* buffer node of said capacity. This means,
             // we can safely pre-heat without causing additional allocations.
-            const arena_capacity = pool.arena.queryCapacity() / item_size;
-            if (arena_capacity != 0) pool.addCapacity(arena_capacity) catch unreachable;
+            const arena_capacity = arena.queryCapacity() / item_size;
+            if (arena_capacity != 0) self.addCapacity(arena_capacity) catch unreachable;
             return true;
         }
 
         /// Creates a new item and adds it to the memory pool.
         /// `allocator` may be `undefined` if pool is not `growable`.
-        pub fn create(pool: *Pool, allocator: Allocator) Allocator.Error!ItemPtr {
-            const ptr: ItemPtr = if (pool.free_list.popFirst()) |node|
+        pub fn create(self: *Pool, allocator: Allocator) Allocator.Error!ItemPtr {
+            const ptr: ItemPtr = if (self.free_list.popFirst()) |node|
                 @ptrCast(@alignCast(node))
             else if (pool_options.growable)
-                @ptrCast(try pool.allocNew(allocator, 1))
+                @ptrCast(try self.allocNew(allocator, 1))
             else
                 return error.OutOfMemory;
 
@@ -162,14 +163,14 @@ pub fn Extra(comptime Item: type, comptime pool_options: Options) type {
 
         /// Destroys a previously created item.
         /// Only pass items to `ptr` that were previously created with `create()` of the same memory pool!
-        pub fn destroy(pool: *Pool, ptr: ItemPtr) void {
+        pub fn destroy(self: *Pool, ptr: ItemPtr) void {
             ptr.* = undefined;
-            pool.free_list.prepend(@ptrCast(ptr));
+            self.free_list.prepend(@ptrCast(ptr));
         }
 
-        fn allocNew(pool: *Pool, allocator: Allocator, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
-            var arena = pool.arena_state.promote(allocator);
-            defer pool.arena_state = arena.state;
+        fn allocNew(self: *Pool, allocator: Allocator, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
+            var arena = self.arena_state.promote(allocator);
+            defer self.arena_state = arena.state;
             const memory = try arena.allocator().alignedAlloc(Unit, item_alignment, num);
             return memory.ptr;
         }
@@ -212,16 +213,16 @@ pub fn ExtraManaged(comptime Item: type, comptime pool_options: Options) type {
         }
 
         /// Destroys the memory pool and frees all allocated memory.
-        pub fn deinit(pool: *Pool) void {
-            pool.unmanaged.deinit(pool.allocator);
-            pool.* = undefined;
+        pub fn deinit(self: *Pool) void {
+            self.unmanaged.deinit(self.allocator);
+            self.* = undefined;
         }
 
         /// Pre-allocates `num` items and adds them to the memory pool.
         /// This allows at least `num` active allocations before an
         /// `OutOfMemory` error might happen when calling `create()`.
-        pub fn addCapacity(pool: *Pool, num: usize) Allocator.Error!void {
-            return pool.unmanaged.addCapacity(pool.allocator, num);
+        pub fn addCapacity(self: *Pool, num: usize) Allocator.Error!void {
+            return self.unmanaged.addCapacity(self.allocator, num);
         }
 
         pub const ResetMode = Unmanaged.ResetMode;
@@ -235,24 +236,23 @@ pub fn ExtraManaged(comptime Item: type, comptime pool_options: Options) type {
         /// be slower.
         ///
         /// NOTE: If `mode` is `free_all`, the function will always return `true`.
-        pub fn reset(pool: *Pool, mode: ResetMode) bool {
-            return pool.unmanaged.reset(pool.allocator, mode);
+        pub fn reset(self: *Pool, mode: ResetMode) bool {
+            return self.unmanaged.reset(self.allocator, mode);
         }
 
         /// Creates a new item and adds it to the memory pool.
-        pub fn create(pool: *Pool) Allocator.Error!ItemPtr {
-            return pool.unmanaged.create(pool.allocator);
+        pub fn create(self: *Pool) Allocator.Error!ItemPtr {
+            return self.unmanaged.create(self.allocator);
         }
 
         /// Destroys a previously created item.
         /// Only pass items to `ptr` that were previously created with `create()` of the same memory pool!
-        pub fn destroy(pool: *Pool, ptr: ItemPtr) void {
-            return pool.unmanaged.destroy(ptr);
+        pub fn destroy(self: *Pool, ptr: ItemPtr) void {
+            return self.unmanaged.destroy(ptr);
         }
 
-        fn allocNew(pool: *Pool, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
-            const memory = try pool.arena.allocator().alignedAlloc(Unit, item_alignment, num);
-            return memory.ptr;
+        fn allocNew(self: *Pool, num: usize) Allocator.Error![*]align(unit_al_bytes) Unit {
+            return self.unmanaged.allocNew(self.allocator, num);
         }
     };
 }

--- a/lib/std/heap/memory_pool.zig
+++ b/lib/std/heap/memory_pool.zig
@@ -408,13 +408,13 @@ test "reset" {
     try std.testing.expect(pool.create(a) != error.OutOfMemory);
     try std.testing.expect(pool.create(a) == error.OutOfMemory);
 
-    try std.testing.expect(pool.reset(.{ .retain_with_limit = 2 }));
+    try std.testing.expect(pool.reset(a, .{ .retain_with_limit = 2 }));
 
     try std.testing.expect(pool.create(a) != error.OutOfMemory);
     try std.testing.expect(pool.create(a) != error.OutOfMemory);
     try std.testing.expect(pool.create(a) == error.OutOfMemory);
 
-    try std.testing.expect(pool.reset(.{ .retain_with_limit = 1 }));
+    try std.testing.expect(pool.reset(a, .{ .retain_with_limit = 1 }));
 
     try std.testing.expect(pool.create(a) != error.OutOfMemory);
     try std.testing.expect(pool.create(a) == error.OutOfMemory);


### PR DESCRIPTION
Mempool calls the wrapped allocator N times when preheating it with N items.
I think it is more appropriate, if it only allocates one time. This should be faster and more importantly,
in case preheating fails (due to an allocation error), the state of the Mempool is easier to reason about.