### PR TITLE
std.crypto.tls: fix readIndirect returning 0 for application_data

### DIFF
--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -1277,7 +1277,7 @@ fn readIndirect(c: *Client) Reader.Error!usize {
         },
         .application_data => {
             r.end += cleartext.len;
-            return 0;
+            return cleartext.len;
         },
         else => return failRead(c, error.TlsUnexpectedMessage),
     }


### PR DESCRIPTION
The readIndirect function was incorrectly returning 0 when processing application_data, even though it had successfully read and decrypted data into the buffer.

Fixes #25428

Reported by @Southporter -- Thanks!