### PR TITLE
Reader.peekDelimiterInclusive: Fix handling of `stream` implementations that return 0

### DIFF
--- a/lib/std/Io/Reader.zig
+++ b/lib/std/Io/Reader.zig
@@ -795,13 +795,14 @@ pub fn takeDelimiterInclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
 pub fn peekDelimiterInclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
     const buffer = r.buffer[0..r.end];
     const seek = r.seek;
-    if (std.mem.indexOfScalarPos(u8, buffer, seek, delimiter)) |end| {
+    if (std.mem.indexOfScalarPos(u8, buffer, seek, delimiter)) |delimiter_index| {
         @branchHint(.likely);
-        return buffer[seek .. end + 1];
+        return buffer[seek .. delimiter_index + 1];
     }
     // TODO take a parameter for max search length rather than relying on buffer capacity
     try rebase(r, r.buffer.len);
     while (r.buffer.len - r.end != 0) {
+        const existing_buffered_len = r.end - r.seek;
         const end_cap = r.buffer[r.end..];
         var writer: Writer = .fixed(end_cap);
         const n = r.vtable.stream(r, &writer, .limited(end_cap.len)) catch |err| switch (err) {
@@ -809,8 +810,8 @@ pub fn peekDelimiterInclusive(r: *Reader, delimiter: u8) DelimiterError![]u8 {
             else => |e| return e,
         };
         r.end += n;
-        if (std.mem.indexOfScalarPos(u8, end_cap[0..n], 0, delimiter)) |end| {
-            return r.buffer[0 .. r.end - n + end + 1];
+        if (std.mem.indexOfScalarPos(u8, r.buffer[r.seek..r.end], existing_buffered_len, delimiter)) |delimiter_index| {
+            return r.buffer[r.seek .. delimiter_index + 1];
         }
     }
     return error.StreamTooLong;
@@ -1601,6 +1602,18 @@ test "readSliceShort with smaller buffer than Reader" {
     try testing.expectEqualStrings(str, &buf);
 }
 
+test "readSliceShort with indirect reader" {
+    var r: Reader = .fixed("HelloFren");
+    var ri_buf: [3]u8 = undefined;
+    var ri: std.testing.ReaderIndirect = .init(&r, &ri_buf);
+    var buf: [5]u8 = undefined;
+    try testing.expectEqual(5, try ri.interface.readSliceShort(&buf));
+    try testing.expectEqualStrings("Hello", buf[0..5]);
+    try testing.expectEqual(4, try ri.interface.readSliceShort(&buf));
+    try testing.expectEqualStrings("Fren", buf[0..4]);
+    try testing.expectEqual(0, try ri.interface.readSliceShort(&buf));
+}
+
 test readVec {
     var r: Reader = .fixed(std.ascii.letters);
     var flat_buffer: [52]u8 = undefined;
@@ -1696,6 +1709,25 @@ test "takeDelimiterInclusive when it rebases" {
         .{ .buffer = written_line },
     });
     const r = &tr.interface;
+    for (0..6) |_| {
+        try std.testing.expectEqualStrings(written_line, try r.takeDelimiterInclusive('\n'));
+    }
+}
+
+test "takeDelimiterInclusive on an indirect reader when it rebases" {
+    const written_line = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\n";
+    var buffer: [128]u8 = undefined;
+    var tr: std.testing.Reader = .init(&buffer, &.{
+        .{ .buffer = written_line },
+        .{ .buffer = written_line },
+        .{ .buffer = written_line },
+        .{ .buffer = written_line },
+        .{ .buffer = written_line },
+        .{ .buffer = written_line },
+    });
+    var indirect_buffer: [128]u8 = undefined;
+    var tri: std.testing.ReaderIndirect = .init(&tr.interface, &indirect_buffer);
+    const r = &tri.interface;
     for (0..6) |_| {
         try std.testing.expectEqualStrings(written_line, try r.takeDelimiterInclusive('\n'));
     }


### PR DESCRIPTION
Previously, the logic in peekDelimiterInclusive (when the delimiter was not found in the existing buffer) used the `n` returned from `r.vtable.stream` as the length of the slice to check, but it's valid for `vtable.stream` implementations to return 0 if they wrote to the buffer instead of `w`. In that scenario, the `indexOfScalarPos` would be given a 0-length slice so it would never be able to find the delimiter.

This commit changes the logic to assume that `r.vtable.stream` can both:
- return 0, and
- modify seek/end (i.e. it's also valid for a `vtable.stream` implementation to rebase)

Also introduces `std.testing.ReaderIndirect` which helps in being able to test against Reader implementations that return 0 from `stream`/`readVec`

Fixes #25428

---

Before this PR, the added `"takeDelimiterInclusive on an indirect reader when it rebases"` test would fail with `error.StreamTooLong` since it'd always be searching for the delimiter in a 0-length slice.

---

This is a very targeted fix. It does not address any of the following:

- https://github.com/ziglang/zig/issues/25132
- https://github.com/ziglang/zig/issues/24950
- https://github.com/ziglang/zig/commit/8023f3dcebff06cbf3563bdd09b07462ed43509f

It also assumes that the `stream` ambiguity described in https://github.com/ziglang/zig/issues/25170 should be resolved in the "writing to w cannot modify the buffer" way (i.e. this fix assumes that no implementation will try to write to both `buffer` and `w` in the same `stream` call).

(see also https://github.com/ziglang/zig/pull/25169 for some extra context around those issues)

---

The added `"readSliceShort with indirect reader"` test is just to verify the `std.testing.ReaderIndirect` implementation around rebasing within `stream` (without the rebase within stream, that test would enter an infinite loop).