### PR TITLE
Change the return type of copy_file_range to isize on freebsd

### DIFF
--- a/lib/std/c/freebsd.zig
+++ b/lib/std/c/freebsd.zig
@@ -29,7 +29,7 @@ comptime {
 pub extern "c" fn ptrace(request: c_int, pid: pid_t, addr: caddr_t, data: c_int) c_int;
 
 pub extern "c" fn kinfo_getfile(pid: pid_t, cntp: *c_int) ?[*]kinfo_file;
-pub extern "c" fn copy_file_range(fd_in: fd_t, off_in: ?*off_t, fd_out: fd_t, off_out: ?*off_t, len: usize, flags: u32) usize;
+pub extern "c" fn copy_file_range(fd_in: fd_t, off_in: ?*off_t, fd_out: fd_t, off_out: ?*off_t, len: usize, flags: u32) isize;
 
 pub extern "c" fn sendfile(
     in_fd: fd_t,


### PR DESCRIPTION
[see this Ziggit thread](https://ziggit.dev/t/core-dump-on-freebsd-when-using-streamremaining/12333?u=rpkak)

What I think happens here is that `streamRemaining` uses `sendFile`, which tries to use `copy_file_range` but fails because the output is not seekable.

https://github.com/ziglang/zig/blob/07c3f9ef8e0a5a557dce70322334b0d1b49fe154/lib/std/os/freebsd.zig#L36-L50

Because `copy_file_range` returns `usize` (this is changed by this PR), `rc` is not `-1`, but `0xffffffffffffffff` on error. This is returned as success because `errno(rc)` compares `rc` with `-1`. `sendFile` changes `w.pos` to `0xffffffffffffffff` and the next time `streamRemaining` calls `sendFile`, `@intCast(file_reader.pos)` panics.

This is untested by me because I don't use freebsd, but the OP of the [Ziggit thread](https://ziggit.dev/t/core-dump-on-freebsd-when-using-streamremaining/12333?u=rpkak) tested this.

See also: [freebsd man page of `copy_file_range`](https://man.freebsd.org/cgi/man.cgi?query=copy_file_range&sektion=2&apropos=0&manpath=FreeBSD+16.0-CURRENT)