### PR TITLE
InternPool: use sequential string indices instead of byte offsets

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3684,6 +3684,7 @@ const Header = extern struct {
             items_len: u32,
             extra_len: u32,
             limbs_len: u32,
+            strings_len: u32,
             string_bytes_len: u32,
             tracked_insts_len: u32,
             files_len: u32,
@@ -3732,7 +3733,8 @@ pub fn saveState(comp: *Compilation) !void {
                 .items_len = @intCast(local.mutate.items.len),
                 .extra_len = @intCast(local.mutate.extra.len),
                 .limbs_len = @intCast(local.mutate.limbs.len),
-                .string_bytes_len = @intCast(local.mutate.strings.len),
+                .strings_len = @intCast(local.mutate.strings.len),
+                .string_bytes_len = @intCast(local.mutate.string_bytes.len),
                 .tracked_insts_len = @intCast(local.mutate.tracked_insts.len),
                 .files_len = @intCast(local.mutate.files.len),
             },
@@ -3775,8 +3777,11 @@ pub fn saveState(comp: *Compilation) !void {
                 addBuf(&bufs, @ptrCast(local.shared.items.view().items(.data)[0..pt_header.intern_pool.items_len]));
                 addBuf(&bufs, @ptrCast(local.shared.items.view().items(.tag)[0..pt_header.intern_pool.items_len]));
             }
+            if (pt_header.intern_pool.strings_len > 0) {
+                addBuf(&bufs, @ptrCast(local.shared.strings.view().items(.@"0")[0..pt_header.intern_pool.strings_len]));
+            }
             if (pt_header.intern_pool.string_bytes_len > 0) {
-                addBuf(&bufs, local.shared.strings.view().items(.@"0")[0..pt_header.intern_pool.string_bytes_len]);
+                addBuf(&bufs, local.shared.string_bytes.view().items(.@"0")[0..pt_header.intern_pool.string_bytes_len]);
             }
             if (pt_header.intern_pool.tracked_insts_len > 0) {
                 addBuf(&bufs, @ptrCast(local.shared.tracked_insts.view().items(.@"0")[0..pt_header.intern_pool.tracked_insts_len]));

--- a/src/Zcu.zig
+++ b/src/Zcu.zig
@@ -1115,8 +1115,8 @@ pub const File = struct {
     pub fn internFullyQualifiedName(file: File, pt: Zcu.PerThread) !InternPool.NullTerminatedString {
         const gpa = pt.zcu.gpa;
         const ip = &pt.zcu.intern_pool;
-        const strings = ip.getLocal(pt.tid).getMutableStrings(gpa);
-        var w: Writer = .fixed((try strings.addManyAsSlice(file.fullyQualifiedNameLen()))[0]);
+        const string_bytes = ip.getLocal(pt.tid).getMutableStringBytes(gpa);
+        var w: Writer = .fixed((try string_bytes.addManyAsSlice(file.fullyQualifiedNameLen()))[0]);
         file.renderFullyQualifiedName(&w) catch unreachable;
         assert(w.end == w.buffer.len);
         return ip.getOrPutTrailingString(gpa, pt.tid, @intCast(w.end), .no_embedded_nulls);

--- a/src/Zcu/PerThread.zig
+++ b/src/Zcu/PerThread.zig
@@ -2460,10 +2460,10 @@ fn updateEmbedFileInner(
 
     // The loaded bytes of the file, including a sentinel 0 byte.
     const ip_str: InternPool.String = str: {
-        const strings = ip.getLocal(tid).getMutableStrings(gpa);
-        const old_len = strings.mutate.len;
-        errdefer strings.shrinkRetainingCapacity(old_len);
-        const bytes = (try strings.addManyAsSlice(size_plus_one))[0];
+        const string_bytes = ip.getLocal(tid).getMutableStringBytes(gpa);
+        const old_len = string_bytes.mutate.len;
+        errdefer string_bytes.shrinkRetainingCapacity(old_len);
+        const bytes = (try string_bytes.addManyAsSlice(size_plus_one))[0];
         var fr = file.reader(&.{});
         fr.size = stat.size;
         fr.interface.readSliceAll(bytes[0..size]) catch |err| switch (err) {


### PR DESCRIPTION
Building the compiler with `-Ddev=cbe`:
```
Benchmark 1 (58 runs): master/bin/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          2.09s  ± 7.58ms    2.07s  … 2.12s           2 ( 3%)        0%
  peak_rss            609MB ± 5.82MB     589MB …  619MB          1 ( 2%)        0%
  cpu_cycles         22.0G  ± 60.0M     21.9G  … 22.1G           0 ( 0%)        0%
  instructions       47.6G  ± 5.30M     47.6G  … 47.6G           2 ( 3%)        0%
  cache_references   2.15G  ± 10.5M     2.12G  … 2.17G           0 ( 0%)        0%
  cache_misses        106M  ± 1.61M      103M  …  110M           0 ( 0%)        0%
  branch_misses       114M  ±  605K      113M  …  116M           1 ( 2%)        0%
Benchmark 2 (58 runs): 25384/bin/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          2.09s  ± 8.01ms    2.07s  … 2.11s           0 ( 0%)          -  0.2% ±  0.1%
  peak_rss            613MB ± 6.55MB     598MB …  625MB          0 ( 0%)          +  0.6% ±  0.4%
  cpu_cycles         22.0G  ± 66.3M     21.9G  … 22.2G           0 ( 0%)          +  0.3% ±  0.1%
  instructions       47.7G  ± 5.07M     47.7G  … 47.7G           1 ( 2%)          +  0.2% ±  0.0%
  cache_references   2.12G  ± 10.2M     2.10G  … 2.14G           0 ( 0%)        ⚡-  1.2% ±  0.2%
  cache_misses        106M  ± 1.43M      102M  …  109M           0 ( 0%)          -  0.5% ±  0.5%
  branch_misses       113M  ±  555K      112M  …  115M           1 ( 2%)          -  0.2% ±  0.2%
Benchmark 3 (58 runs): 25464/bin/zig build-exe ...
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          2.09s  ± 7.19ms    2.08s  … 2.11s           1 ( 2%)          +  0.0% ±  0.1%
  peak_rss            608MB ± 6.32MB     588MB …  618MB          3 ( 5%)          -  0.2% ±  0.4%
  cpu_cycles         22.0G  ± 49.4M     21.9G  … 22.1G           1 ( 2%)          +  0.1% ±  0.1%
  instructions       47.6G  ± 3.29M     47.6G  … 47.6G           1 ( 2%)          +  0.0% ±  0.0%
  cache_references   2.12G  ± 8.34M     2.10G  … 2.15G           2 ( 3%)        ⚡-  1.3% ±  0.2%
  cache_misses        106M  ± 1.56M      102M  …  109M           0 ( 0%)          -  0.1% ±  0.5%
  branch_misses       113M  ±  636K      112M  …  114M           0 ( 0%)          -  0.5% ±  0.2%
```
Where #25384 is not a measurable enough speedup to be worth the extra complexity, especially for something that needs to be backported into 0.15.2.

Supercedes #25384
Closes #22867
Closes #25297
Closes #25339