### PR TITLE
disallow switch case capture discards

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -801,7 +801,7 @@ fn expectEqualDeepInner(comptime T: type, expected: T, actual: T) error{TestExpe
             }
         },
 
-        .array => |_| {
+        .array => {
             if (expected.len != actual.len) {
                 print("Array len not the same, expected {d}, found {d}\n", .{ expected.len, actual.len });
                 return error.TestExpectedEqual;

--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -11338,7 +11338,9 @@ fn zirSwitchBlock(sema: *Sema, block: *Block, inst: Zir.Inst.Index, operand_is_r
                 });
             }
             try sema.validateRuntimeValue(block, operand_src, maybe_ptr);
-            const operand_alloc = if (extra.data.bits.any_non_inline_capture) a: {
+            const operand_alloc = if (extra.data.bits.any_non_inline_capture or
+                extra.data.bits.any_has_tag_capture)
+            a: {
                 const operand_ptr_ty = try pt.singleMutPtrType(sema.typeOf(maybe_ptr));
                 const operand_alloc = try block.addTy(.alloc, operand_ptr_ty);
                 _ = try block.addBinOp(.store, operand_alloc, maybe_ptr);

--- a/test/behavior/switch_loop.zig
+++ b/test/behavior/switch_loop.zig
@@ -273,3 +273,30 @@ test "switch loop on non-exhaustive enum" {
     try S.doTheTest();
     try comptime S.doTheTest();
 }
+
+test "switch loop with discarded tag capture" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
+
+    const S = struct {
+        const U = union(enum) {
+            a: u32,
+            b: u32,
+            c: u32,
+        };
+
+        fn doTheTest() void {
+            const a: U = .{ .a = 10 };
+            blk: switch (a) {
+                inline .b => |_, tag| {
+                    _ = tag;
+                    continue :blk .{ .c = 20 };
+                },
+                else => {},
+            }
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}

--- a/test/cases/compile_errors/switch_loop_discarded_capture.zig
+++ b/test/cases/compile_errors/switch_loop_discarded_capture.zig
@@ -1,0 +1,16 @@
+export fn foo() void {
+    const S = struct {
+        fn doTheTest() void {
+            blk: switch (@as(u8, 'a')) {
+                '1' => |_| continue :blk '1',
+                else => {},
+            }
+        }
+    };
+    S.doTheTest();
+    comptime S.doTheTest();
+}
+
+// error
+//
+// :5:25: error: discard of capture; omit it instead


### PR DESCRIPTION
fixes: #24789 (by disallowing it)
also fixes another bug that I noticed, which remains allowed but Actually Works now.

Previously Zig allowed you to write something like,
```zig
switch (x) {
    .y => |_| {
```

This seems a bit strange because in other cases, such as when capturing the tag in a switch case,
```zig
switch (x) {
    .y => |_, _| {
```
this produces an error.

The only usecase I can think of for the previous behaviour is if you wanted to assert that all union payloads are able to coerce,
```zig
const X = union(enum) { y: u8, z: f32 };

switch (x) {
    .y, .z => |_| {
```

This will compile-error with the `|_|` and pass without it.

I don't believe this usecase is strong enough to keep the current behaviour; it was never used in the Zig codebase and I cannot find a single usage of this behaviour in the real world, searching through Sourcegraph.

To be clear, this PR does *not* remove the ability to do,
```zig
switch (x) {
    .y => |_, tag| {
```