### PR TITLE
drop support for powerpc64 ELF v1

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -2463,9 +2463,9 @@ pub const DynamicLinker = struct {
                         => init("/lib/ld.so.1"),
                         else => none,
                     },
-                    // TODO: ELFv2 ABI (`/lib64/ld64.so.2`) opt-in support.
-                    .powerpc64 => if (abi == .gnu) init("/lib64/ld64.so.1") else none,
-                    .powerpc64le => if (abi == .gnu) init("/lib64/ld64.so.2") else none,
+                    .powerpc64,
+                    .powerpc64le,
+                    => if (abi == .gnu) init("/lib64/ld64.so.2") else none,
 
                     .riscv32,
                     .riscv64,

--- a/src/target.zig
+++ b/src/target.zig
@@ -631,14 +631,6 @@ pub fn isDynamicAMDGCNFeature(target: *const std.Target, feature: std.Target.Cpu
 }
 
 pub fn llvmMachineAbi(target: *const std.Target) ?[:0]const u8 {
-    // LLD does not support ELFv1. Rather than having LLVM produce ELFv1 code and then linking it
-    // into a broken ELFv2 binary, just force LLVM to use ELFv2 as well. This will break when glibc
-    // is linked as glibc only supports ELFv2 for little endian, but there's nothing we can do about
-    // that. With this hack, `powerpc64-linux-none` will at least work.
-    //
-    // Once our self-hosted linker can handle both ABIs, this hack should go away.
-    if (target.cpu.arch == .powerpc64) return "elfv2";
-
     return switch (target.cpu.arch) {
         .arm, .armeb, .thumb, .thumbeb => "aapcs",
         .loongarch64 => switch (target.abi) {
@@ -656,15 +648,7 @@ pub fn llvmMachineAbi(target: *const std.Target) ?[:0]const u8 {
             .gnuabin32, .muslabin32 => "n32",
             else => "n64",
         },
-        .powerpc64 => switch (target.os.tag) {
-            .freebsd => if (target.os.version_range.semver.isAtLeast(.{ .major = 13, .minor = 0, .patch = 0 }) orelse false)
-                "elfv2"
-            else
-                "elfv1",
-            .openbsd => "elfv2",
-            else => if (target.abi.isMusl()) "elfv2" else "elfv1",
-        },
-        .powerpc64le => "elfv2",
+        .powerpc64, .powerpc64le => "elfv2", // We do not support ELFv1.
         .riscv64, .riscv64be => if (target.cpu.has(.riscv, .e))
             "lp64e"
         else if (target.cpu.has(.riscv, .d))

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -801,7 +801,7 @@ const test_targets = blk: {
             .link_libc = true,
             .extra_target = true,
         },
-        // Requires ELFv1 linker support.
+        // glibc's build-many-glibcs.py currently only builds this target for ELFv1.
         // .{
         //     .target = .{
         //         .cpu_arch = .powerpc64,


### PR DESCRIPTION
* ELF v1 on powerpc64 is only barely kept on life support in a couple of Linux distros. I don't anticipate that this will last much longer.
* Most of the Linux world has moved to powerpc64le which requires ELF v2.
* Some Linux distros have even started supporting powerpc64 with ELF v2.
* The BSD world has long since moved to ELF v2.
* We have no actual linking support for ELF v1.
* ELF v1 had confused DWARF register mappings which is becoming a problem in our DWARF code in std.debug.

It's clear that ELF v1 is on its way out, and we never fully supported it anyway. So let's not waste any time or energy on it going forward.

closes #5927