### PR TITLE
cmake: disable ccache on unix platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ if(NOT CMAKE_INSTALL_PREFIX)
       "Directory to install zig to" FORCE)
 endif()
 
+if (UNIX)
+    # Ccache temporarily stores its output in the XDG Runtime Directory
+    # which is the size of 10% of physical RAM, in most cases this will 
+    # use up the entire space during stage 2 compilation and cause
+    # other applications to be starved of resources.
+    set(ENV{CCACHE_DISABLE} "true")
+endif()
+
 # CMake recognizes the CMAKE_PREFIX_PATH environment variable for some things,
 # and also the CMAKE_PREFIX_PATH cache variable for other things. However, it
 # does not relate these two things, i.e. if the environment variable is set,


### PR DESCRIPTION
Ccache temporarily stores its output in the XDG Runtime Directory which is the size of 10% of physical RAM, in most cases this will use up the entire space during stage 2 compilation and cause other applications to be starved of resources.

Since Zig only has so few C and C++ files and some C files that are generated there is no benefit to using ccache and it may even negatively impact it because stage2 will be freshly cached every time zig is changed.

It might make sense to add a message to inform the user that ccache is disabled.