### PR TITLE
Change the macho linker gc_sections option to respect rdynamic flag

### DIFF
--- a/src/link/MachO.zig
+++ b/src/link/MachO.zig
@@ -172,6 +172,7 @@ pub fn createEmpty(
     const optimize_mode = comp.root_mod.optimize_mode;
     const output_mode = comp.config.output_mode;
     const link_mode = comp.config.link_mode;
+    const export_symbols = comp.config.rdynamic;
 
     const allow_shlib_undefined = options.allow_shlib_undefined orelse false;
 
@@ -185,7 +186,7 @@ pub fn createEmpty(
                 try std.fmt.allocPrint(arena, "{s}_zcu.o", .{fs.path.stem(emit.sub_path)})
             else
                 null,
-            .gc_sections = options.gc_sections orelse (optimize_mode != .Debug),
+            .gc_sections = options.gc_sections orelse (!export_symbols and optimize_mode != .Debug),
             .print_gc_sections = options.print_gc_sections,
             .stack_size = options.stack_size orelse 16777216,
             .allow_shlib_undefined = allow_shlib_undefined,


### PR DESCRIPTION
# Fix #17554
When initializing the gc_sections flag in the MachO linker, check the config's rdynamic setting. Don't eliminate dead code in non-debug builds when rdynamic is set (Unless gc_sections itself is explicitly set).

I tested locally on a c file such as this:
```c
int example(int a, int b) { return a + b; }

int main() { return 0; }
```

Cross-compiling for macos like so:
```bash
~/repos/zig/stage3/bin/zig cc -O3 -rdynamic main.c -o main --target=aarch64-macos-none
```

Using `llvm-objdump -S main`, I can confirm that:
- the `example` function is eliminated in `-O3`
- the `example` function is  present in `-O3 -rdynamic`.

This is my first open source contribution, let me know if anything needs to be fixed!