### PR TITLE
ed25519: fast s canonical check for verification

### DIFF
--- a/lib/std/crypto/25519/scalar.zig
+++ b/lib/std/crypto/25519/scalar.zig
@@ -25,10 +25,10 @@ pub fn rejectNonCanonical(s: CompressedScalar) NonCanonicalError!void {
     var n: u8 = 1;
     var i: usize = 31;
     while (true) : (i -= 1) {
-        const xs = @as(u16, s[i]);
-        const xfield_order_s = @as(u16, field_order_s[i]);
-        c |= @as(u8, @intCast(((xs -% xfield_order_s) >> 8) & n));
-        n &= @as(u8, @intCast(((xs ^ xfield_order_s) -% 1) >> 8));
+        const xs: u16 = s[i];
+        const xfield_order_s: u16 = field_order_s[i];
+        c |= @intCast(((xs -% xfield_order_s) >> 8) & n);
+        n &= @intCast(((xs ^ xfield_order_s) -% 1) >> 8);
         if (i == 0) break;
     }
     if (c == 0) {


### PR DESCRIPTION
This should introduce no breaking changes; since we still do full rejection this doesn't do the `[0, 2^253)` fail-fast mistake previous implementations did.

https://zig.godbolt.org/z/r81aWq3cM

https://gist.github.com/Rexicon226/6d87daeaa840d9bea014691635e93aa4
```
slow: 48
fast: 27
```
(in terms of cycles for checking the scalar)

cc @jedisct1 