### PR TITLE
http.Client: change casing of managed headers to title-case

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -985,36 +985,36 @@ pub const Request = struct {
         try w.writeAll(@tagName(r.version));
         try w.writeAll("\r\n");
 
-        if (try emitOverridableHeader("host: ", r.headers.host, w)) {
-            try w.writeAll("host: ");
+        if (try emitOverridableHeader("Host: ", r.headers.host, w)) {
+            try w.writeAll("Host: ");
             try uri.writeToStream(w, .{ .authority = true });
             try w.writeAll("\r\n");
         }
 
-        if (try emitOverridableHeader("authorization: ", r.headers.authorization, w)) {
+        if (try emitOverridableHeader("Authorization: ", r.headers.authorization, w)) {
             if (uri.user != null or uri.password != null) {
-                try w.writeAll("authorization: ");
+                try w.writeAll("Authorization: ");
                 try basic_authorization.write(uri, w);
                 try w.writeAll("\r\n");
             }
         }
 
-        if (try emitOverridableHeader("user-agent: ", r.headers.user_agent, w)) {
-            try w.writeAll("user-agent: zig/");
+        if (try emitOverridableHeader("User-Agent: ", r.headers.user_agent, w)) {
+            try w.writeAll("User-Agent: zig/");
             try w.writeAll(builtin.zig_version_string);
             try w.writeAll(" (std.http)\r\n");
         }
 
-        if (try emitOverridableHeader("connection: ", r.headers.connection, w)) {
+        if (try emitOverridableHeader("Connection: ", r.headers.connection, w)) {
             if (r.keep_alive) {
-                try w.writeAll("connection: keep-alive\r\n");
+                try w.writeAll("Connection: keep-alive\r\n");
             } else {
-                try w.writeAll("connection: close\r\n");
+                try w.writeAll("Connection: close\r\n");
             }
         }
 
-        if (try emitOverridableHeader("accept-encoding: ", r.headers.accept_encoding, w)) {
-            try w.writeAll("accept-encoding: ");
+        if (try emitOverridableHeader("Accept-Encoding: ", r.headers.accept_encoding, w)) {
+            try w.writeAll("Accept-Encoding: ");
             for (r.accept_encoding, 0..) |enabled, i| {
                 if (!enabled) continue;
                 const tag: http.ContentEncoding = @enumFromInt(i);
@@ -1029,12 +1029,12 @@ pub const Request = struct {
         }
 
         switch (r.transfer_encoding) {
-            .chunked => try w.writeAll("transfer-encoding: chunked\r\n"),
-            .content_length => |len| try w.print("content-length: {d}\r\n", .{len}),
+            .chunked => try w.writeAll("Transfer-Encoding: chunked\r\n"),
+            .content_length => |len| try w.print("Content-Length: {d}\r\n", .{len}),
             .none => {},
         }
 
-        if (try emitOverridableHeader("content-type: ", r.headers.content_type, w)) {
+        if (try emitOverridableHeader("Content-Type: ", r.headers.content_type, w)) {
             // The default is to omit content-type if not provided because
             // "application/octet-stream" is redundant.
         }
@@ -1055,7 +1055,7 @@ pub const Request = struct {
             } orelse break :proxy;
 
             const authorization = proxy.authorization orelse break :proxy;
-            try w.writeAll("proxy-authorization: ");
+            try w.writeAll("Proxy-Authorization: ");
             try w.writeAll(authorization);
             try w.writeAll("\r\n");
         }


### PR DESCRIPTION
:warning: **Heads up,** because my OS only provides LLVM version 20, and the buildscript that installs LLVM from git is failing me on my computer, **I wasn't able to build Zig** and therefore test the changes in this PR.

---

The HTTP client currently emits header names in lower-case, such as `host`, `content-type`, and so on. This differs to most HTTP clients, which titlecases header names instead.

For example, using this snippet:
```zig
var client: std.http.Client = .{ .allocator = std.testing.allocator };
_ = try client.fetch(.{
    .location = .{ .url = "http://localhost:8080/path/to/resource" },
});
```

We get this:
```
GET /path/to/resource HTTP/1.1
host: localhost:8080
user-agent: zig/0.15.1 (std.http)
connection: keep-alive
accept-encoding: gzip, deflate
```

Compare this to Python's urllib3:
```
GET /path/to/resource HTTP/1.1
Host: 127.0.0.1:8080
Accept-Encoding: identity
User-Agent: python-urllib3/2.5.0
```

Or curl:
```
GET /path/to/resource HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: curl/8.16.0
Accept: */*
```

Or Firefox:
```
GET /path/to/resource HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate, br, zstd
DNT: 1
Sec-GPC: 1
Connection: keep-alive
Upgrade-Insecure-Requests: 1
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: none
Sec-Fetch-User: ?1
Priority: u=0, i
```

In the real world, some HTTP servers have different (assumedly unfavorable) behavior when receiving requests that deviate from the norm. For example, one HTTP server I queried closed the connection when it received a `host` header, but not the `Host` header.

A workaround here for some requests could be to omit the default header and manually insert your own:

```zig
_ = try client.fetch(.{
    .location = .{ .url = "http://localhost:8080/path/to/resource" },
    .headers = .{
        .host = .omit,
        // ...and so on
    },
    .extra_headers = &.{
        .{ .name = "Host", .value = "localhost:8080" },
        // ...and so on
    },
});
```

Beyond dropping the benefit of letting http.Client manage these headers for me, I could only assume this would break the moment it handles a redirect to a different domain.

This change moves the HTTP client closer towards most other clients by title-casing these headers.