### PR TITLE
simplify swapRemove

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -279,8 +279,10 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         /// This may not preserve item order. Use `orderedRemove` if you need to preserve order.
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            defer self.items[i] = self.pop() orelse unreachable;
-            return self.items[i];
+            const item = self.items[i];
+            self.items[i] = self.getLast();
+            self.items.len -= 1;
+            return item;
         }
 
         /// Append the slice of items to the list. Allocates more
@@ -954,8 +956,10 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
         /// This operation is O(1).
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            defer self.items[i] = self.pop() orelse unreachable;
-            return self.items[i];
+            const item = self.items[i];
+            self.items[i] = self.getLast();
+            self.items.len -= 1;
+            return item;
         }
 
         /// Append the slice of items to the list. Allocates more

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -279,7 +279,6 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         /// This may not preserve item order. Use `orderedRemove` if you need to preserve order.
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            assert(i < self.items.len);
             defer self.items[i] = self.pop() orelse unreachable;
             return self.items[i];
         }
@@ -955,7 +954,6 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
         /// This operation is O(1).
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            assert(i < self.items.len);
             defer self.items[i] = self.pop() orelse unreachable;
             return self.items[i];
         }

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -277,14 +277,11 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         /// The empty slot is filled from the end of the list.
         /// This operation is O(1).
         /// This may not preserve item order. Use `orderedRemove` if you need to preserve order.
-        /// Asserts that the list is not empty.
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            if (self.items.len - 1 == i) return self.pop().?;
-
-            const old_item = self.items[i];
-            self.items[i] = self.pop().?;
-            return old_item;
+            assert(i < self.items.len);
+            defer self.items[i] = self.pop() orelse unreachable;
+            return self.items[i];
         }
 
         /// Append the slice of items to the list. Allocates more
@@ -956,14 +953,11 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
         /// The empty slot is filled from the end of the list.
         /// Invalidates pointers to last element.
         /// This operation is O(1).
-        /// Asserts that the list is not empty.
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            if (self.items.len - 1 == i) return self.pop().?;
-
-            const old_item = self.items[i];
-            self.items[i] = self.pop().?;
-            return old_item;
+            assert(i < self.items.len);
+            defer self.items[i] = self.pop() orelse unreachable;
+            return self.items[i];
         }
 
         /// Append the slice of items to the list. Allocates more

--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -279,10 +279,11 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         /// This may not preserve item order. Use `orderedRemove` if you need to preserve order.
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            const item = self.items[i];
-            self.items[i] = self.getLast();
+            const val = self.items[i];
+            self.items[i] = self.items[self.items.len - 1];
+            self.items[self.items.len - 1] = undefined;
             self.items.len -= 1;
-            return item;
+            return val;
         }
 
         /// Append the slice of items to the list. Allocates more
@@ -520,6 +521,7 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         pub fn pop(self: *Self) ?T {
             if (self.items.len == 0) return null;
             const val = self.items[self.items.len - 1];
+            self.items[self.items.len - 1] = undefined;
             self.items.len -= 1;
             return val;
         }
@@ -542,8 +544,7 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         /// Returns the last element from the list.
         /// Asserts that the list is not empty.
         pub fn getLast(self: Self) T {
-            const val = self.items[self.items.len - 1];
-            return val;
+            return self.items[self.items.len - 1];
         }
 
         /// Returns the last element from the list, or `null` if list is empty.
@@ -956,10 +957,11 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
         /// This operation is O(1).
         /// Asserts that the index is in bounds.
         pub fn swapRemove(self: *Self, i: usize) T {
-            const item = self.items[i];
-            self.items[i] = self.getLast();
+            const val = self.items[i];
+            self.items[i] = self.items[self.items.len - 1];
+            self.items[self.items.len - 1] = undefined;
             self.items.len -= 1;
-            return item;
+            return val;
         }
 
         /// Append the slice of items to the list. Allocates more
@@ -1323,6 +1325,7 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
         pub fn pop(self: *Self) ?T {
             if (self.items.len == 0) return null;
             const val = self.items[self.items.len - 1];
+            self.items[self.items.len - 1] = undefined;
             self.items.len -= 1;
             return val;
         }
@@ -1344,8 +1347,7 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
         /// Return the last element from the list.
         /// Asserts that the list is not empty.
         pub fn getLast(self: Self) T {
-            const val = self.items[self.items.len - 1];
-            return val;
+            return self.items[self.items.len - 1];
         }
 
         /// Return the last element from the list, or


### PR DESCRIPTION
The existing implementation needlessly special-cased removal of the last item, even though it is handled perfectly fine by the rest of the code.

Additionally:
- added the documented but non-existent assert that "index is in bounds",
- removed the documented assertion that "list is not empty", as that is already implied by the previous assertion.

If my usage of `defer` or `orelse unreachable` is confusing, I'll happily change them to a three-line solution, and `.?`.

The correctness of this simplification relies on the left-to-right evaluation order of the operands of assignment.