### PR TITLE
std.Io.EventLoop: Add missing clobbers to context switching

### DIFF
--- a/lib/std/Io/EventLoop.zig
+++ b/lib/std/Io/EventLoop.zig
@@ -644,6 +644,7 @@ inline fn contextSwitch(message: *const SwitchMessage) *const SwitchMessage {
             : [received_message] "={x1}" (-> *const @FieldType(SwitchMessage, "contexts")),
             : [message_to_send] "{x1}" (&message.contexts),
             : .{
+              .x0 = true,
               .x1 = true,
               .x2 = true,
               .x3 = true,
@@ -745,6 +746,7 @@ inline fn contextSwitch(message: *const SwitchMessage) *const SwitchMessage {
               .rdx = true,
               .rbx = true,
               .rsi = true,
+              .rdi = true,
               .r8 = true,
               .r9 = true,
               .r10 = true,


### PR DESCRIPTION
This only shows in release mode, the compiler tries to preserve some value in rdi, but that gets replaced inside the fiber. This would not happen in the C calling convention, but in these normal Zig functions, it can happen.