### PR TITLE
std.debug: fix incorrect FP unwinding on RISC-V and SPARC

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -993,6 +993,8 @@ const StackIterator = union(enum) {
 
     /// Offset of the saved return address wrt the frame pointer.
     const ra_offset = off: {
+        if (native_arch.isRISCV()) break :off -1 * @sizeOf(usize);
+        if (native_arch.isSPARC()) break :off 15 * @sizeOf(usize);
         if (native_arch.isPowerPC64()) break :off 2 * @sizeOf(usize);
         // On s390x, r14 is the link register and we need to grab it from its customary slot in the
         // register save area (ELF ABI s390x Supplement §1.2.2.2).


### PR DESCRIPTION
I broke this when porting this logic for the `std.debug` rework in https://github.com/ziglang/zig/pull/25227. The offset that I copied was actually being treated as relative to the address of the *saved* base pointer. I think it makes more sense to do what I did and just treat all offsets as relative to this frame's base.