### PR TITLE
windows: workaround kernel race condition

### DIFF
--- a/lib/std/os/windows.zig
+++ b/lib/std/os/windows.zig
@@ -1912,6 +1912,7 @@ pub const CreateProcessError = error{
     NameTooLong,
     InvalidExe,
     SystemResources,
+    FileBusy,
     Unexpected,
 };
 
@@ -1982,6 +1983,7 @@ pub fn CreateProcessW(
             .INVALID_PARAMETER => unreachable,
             .INVALID_NAME => return error.InvalidName,
             .FILENAME_EXCED_RANGE => return error.NameTooLong,
+            .SHARING_VIOLATION => return error.FileBusy,
             // These are all the system errors that are mapped to ENOEXEC by
             // the undocumented _dosmaperr (old CRT) or __acrt_errno_map_os_error
             // (newer CRT) functions. Their code can be found in crt/src/dosmap.c (old SDK)


### PR DESCRIPTION
This was causing flaky CI failures.

Reproduced by running this program concurrently with CI workflows:
```zig
const std = @import("std");
pub fn main() !void {
    while (true) {
        var child: std.process.Child = .init(&.{"repro.exe"}, std.heap.page_allocator);
        _ = try child.spawnAndWait();
        const file = try std.fs.cwd().openFile("repro.exe", .{ .mode = .read_write });
        defer file.close();
    }
}
```