### PR TITLE
MachO: emit absolute path in N_OSO stabs

### DIFF
--- a/src/link/MachO/relocatable.zig
+++ b/src/link/MachO/relocatable.zig
@@ -191,7 +191,7 @@ pub fn flushStaticLib(macho_file: *MachO, comp: *Compilation, module_obj_path: ?
                     pos = mem.alignForward(usize, pos, 2);
                     state.file_off = pos;
                     pos += @sizeOf(Archive.ar_hdr);
-                    pos += mem.alignForward(usize, o.path.basename().len + 1, ptr_width);
+                    pos += mem.alignForward(usize, std.fs.path.basename(o.path).len + 1, ptr_width);
                     pos += try macho_file.cast(usize, state.size);
                 },
                 else => unreachable,


### PR DESCRIPTION
This path being relative is unconventional and causes issues for us if the output artifact is ever used from a different cwd than the one it was built from. The behavior implemented by this commit of always emitting these paths as absolute was actually the behavior in 0.14.x, but it regressed in 0.15.1 due to internal reworks to path handling which led to relative paths being more common in the compiler internals.

Resolves: #25433

---

As well as testing the repro in #25433, I validated the output by looking at `nm -a zig-out/lib/librepro.dylib`.
Before:
`0000000068e8ee28 - 00 0001   OSO .zig-cache/o/13d349047a1695f9fa77834919794ddf/librepro_zcu.o`
After:
`0000000068e8ee50 - 00 0001   OSO /Users/mlugg/repro/.zig-cache/o/bc93e92b842c169ecffbcb97eea62dcf/librepro_zcu.o`