### PR TITLE
std.posix: added missing posix error ENXIO

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -836,7 +836,7 @@ pub const ReadError = error{
     LockViolation,
 
     /// The device is not available or the address is not found.
-    NoSuchDeviceOrAddress,
+    DeviceOrAddressNotFound,
 } || UnexpectedError;
 
 /// Returns the number of bytes that were read, which can be less than
@@ -904,7 +904,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.NoSuchDeviceOrAddress,
+            .NXIO => return error.DeviceOrAddressNotFound,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -968,7 +968,7 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.NoSuchDeviceOrAddress,
+            .NXIO => return error.DeviceOrAddressNotFound,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -1016,7 +1016,7 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.NoSuchDeviceOrAddress,
+            .NXIO => return error.DeviceOrAddressNotFound,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
             .NOTCAPABLE => return error.AccessDenied,
@@ -1049,7 +1049,7 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.NoSuchDeviceOrAddress,
+            .NXIO => return error.DeviceOrAddressNotFound,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
             else => |err| return unexpectedErrno(err),
@@ -1195,7 +1195,7 @@ pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
             .TIMEDOUT => return error.ConnectionTimedOut,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
-            .NXIO => return error.NoSuchDeviceOrAddress,
+            .NXIO => return error.DeviceOrAddressNotFound,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -6238,7 +6238,7 @@ pub const SendError = error{
     ConnectionRefused,
 
     /// The device is not available or the address is not found.
-    NoSuchDeviceOrAddress,
+    DeviceOrAddressNotFound,
 } || UnexpectedError;
 
 pub const SendMsgError = SendError || error{
@@ -6430,7 +6430,7 @@ pub fn sendto(
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTCONN => return error.SocketNotConnected,
             .NETDOWN => return error.NetworkSubsystemFailed,
-            .NXIO => return error.NoSuchDeviceOrAddress,
+            .NXIO => return error.DeviceOrAddressNotFound,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -968,6 +968,7 @@ pub fn readv(fd: fd_t, iov: []const iovec) ReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
+            .NXIO => return error.NoSuchDeviceOrAddress,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -1015,7 +1016,7 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.Unseekable,
+            .NXIO => return error.NoSuchDeviceOrAddress,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
             .NOTCAPABLE => return error.AccessDenied,
@@ -1048,7 +1049,7 @@ pub fn pread(fd: fd_t, buf: []u8, offset: u64) PReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.Unseekable,
+            .NXIO => return error.NoSuchDeviceOrAddress,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
             else => |err| return unexpectedErrno(err),
@@ -1192,9 +1193,9 @@ pub fn preadv(fd: fd_t, iov: []const iovec, offset: u64) PReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
-            .NXIO => return error.Unseekable,
             .SPIPE => return error.Unseekable,
             .OVERFLOW => return error.Unseekable,
+            .NXIO => return error.NoSuchDeviceOrAddress,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -834,6 +834,9 @@ pub const ReadError = error{
 
     /// Unable to read file due to lock.
     LockViolation,
+
+    /// The device is not available or the address is not found.
+    NoSuchDeviceOrAddress,
 } || UnexpectedError;
 
 /// Returns the number of bytes that were read, which can be less than
@@ -901,6 +904,7 @@ pub fn read(fd: fd_t, buf: []u8) ReadError!usize {
             .NOTCONN => return error.SocketNotConnected,
             .CONNRESET => return error.ConnectionResetByPeer,
             .TIMEDOUT => return error.ConnectionTimedOut,
+            .NXIO => return error.NoSuchDeviceOrAddress,
             else => |err| return unexpectedErrno(err),
         }
     }
@@ -6231,6 +6235,9 @@ pub const SendError = error{
 
     /// The destination address is not listening.
     ConnectionRefused,
+
+    /// The device is not available or the address is not found.
+    NoSuchDeviceOrAddress,
 } || UnexpectedError;
 
 pub const SendMsgError = SendError || error{
@@ -6422,6 +6429,7 @@ pub fn sendto(
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTCONN => return error.SocketNotConnected,
             .NETDOWN => return error.NetworkSubsystemFailed,
+            .NXIO => return error.NoSuchDeviceOrAddress,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -926,6 +926,7 @@ fn glibcVerFromRPath(rpath: []const u8) !std.SemanticVersion {
         error.Unexpected,
         error.FileSystem,
         error.ProcessNotFound,
+        error.NoSuchDeviceOrAddress,
         => |e| return e,
     };
 }
@@ -1239,6 +1240,7 @@ fn detectAbiAndDynamicLinker(
         error.UnexpectedEndOfFile,
         error.NameTooLong,
         error.StaticElfFile,
+        error.NoSuchDeviceOrAddress,
         // Finally, we fall back on the standard path.
         => |e| {
             std.log.warn("Encountered error: {s}, falling back to default ABI and dynamic linker.", .{@errorName(e)});

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1284,6 +1284,7 @@ fn preadAtLeast(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usi
             error.AccessDenied => return error.Unexpected,
             error.ProcessNotFound => return error.ProcessNotFound,
             error.LockViolation => return error.UnableToReadElfFile,
+            error.NoSuchDeviceOrAddress => return error.NoSuchDeviceOrAddress,
         };
         if (len == 0) return error.UnexpectedEndOfFile;
         i += len;

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -517,6 +517,7 @@ pub const AbiAndDynamicLinkerFromFileError = error{
     NameTooLong,
     ProcessNotFound,
     StaticElfFile,
+    NoSuchDeviceOrAddress,
 };
 
 pub fn abiAndDynamicLinkerFromFile(

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -517,7 +517,7 @@ pub const AbiAndDynamicLinkerFromFileError = error{
     NameTooLong,
     ProcessNotFound,
     StaticElfFile,
-    NoSuchDeviceOrAddress,
+    DeviceOrAddressNotFound,
 };
 
 pub fn abiAndDynamicLinkerFromFile(
@@ -926,7 +926,7 @@ fn glibcVerFromRPath(rpath: []const u8) !std.SemanticVersion {
         error.Unexpected,
         error.FileSystem,
         error.ProcessNotFound,
-        error.NoSuchDeviceOrAddress,
+        error.DeviceOrAddressNotFound,
         => |e| return e,
     };
 }
@@ -1183,7 +1183,7 @@ fn detectAbiAndDynamicLinker(
                 error.UnexpectedEndOfFile,
                 error.UnableToReadElfFile,
                 error.ProcessNotFound,
-                error.NoSuchDeviceOrAddress,
+                error.DeviceOrAddressNotFound,
                 => return defaultAbiAndDynamicLinker(cpu, os, query),
 
                 else => |e| return e,
@@ -1240,7 +1240,7 @@ fn detectAbiAndDynamicLinker(
         error.UnexpectedEndOfFile,
         error.NameTooLong,
         error.StaticElfFile,
-        error.NoSuchDeviceOrAddress,
+        error.DeviceOrAddressNotFound,
         // Finally, we fall back on the standard path.
         => |e| {
             std.log.warn("Encountered error: {s}, falling back to default ABI and dynamic linker.", .{@errorName(e)});
@@ -1288,7 +1288,7 @@ fn preadAtLeast(file: fs.File, buf: []u8, offset: u64, min_read_len: usize) !usi
             error.AccessDenied => return error.Unexpected,
             error.ProcessNotFound => return error.ProcessNotFound,
             error.LockViolation => return error.UnableToReadElfFile,
-            error.NoSuchDeviceOrAddress => return error.NoSuchDeviceOrAddress,
+            error.DeviceOrAddressNotFound => return error.DeviceOrAddressNotFound,
         };
         if (len == 0) return error.UnexpectedEndOfFile;
         i += len;

--- a/lib/std/zig/system.zig
+++ b/lib/std/zig/system.zig
@@ -1181,6 +1181,7 @@ fn detectAbiAndDynamicLinker(
                 error.UnexpectedEndOfFile,
                 error.UnableToReadElfFile,
                 error.ProcessNotFound,
+                error.NoSuchDeviceOrAddress,
                 => return defaultAbiAndDynamicLinker(cpu, os, query),
 
                 else => |e| return e,


### PR DESCRIPTION
Per POSIX, ENXIO (“No such device or address”) may occur with read(), write(), open()/openat(), send(), and sendto() (e.g., device removed or request outside device capabilities).
read() and sendto() (and some dependencies) were missing this mapping; this PR adds it.

fixes #23383 