### PR TITLE
adds pointer to format string docs for debug.print

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -288,7 +288,8 @@ pub fn unlockStderrWriter() void {
 }
 
 /// Print to stderr, silently returning on failure. Intended for use in "printf
-/// debugging". Use `std.log` functions for proper logging.
+/// debugging". Use `std.log` functions for proper logging. See `Writer.print`
+/// for format string documentation.
 ///
 /// Uses a 64-byte buffer for formatted printing which is flushed before this
 /// function returns.


### PR DESCRIPTION
When using debug.print it took me a while to track down the format string documentation. This PR adds a breadcrumb to the docs to help others find this information.  