### PR TITLE
fix(std): Correct hash_map max_load_percentage comparison

### DIFF
--- a/lib/std/hash_map.zig
+++ b/lib/std/hash_map.zig
@@ -508,7 +508,7 @@ pub fn HashMapUnmanaged(
     comptime Context: type,
     comptime max_load_percentage: u64,
 ) type {
-    if (max_load_percentage <= 0 or max_load_percentage >= 100)
+    if (max_load_percentage == 0 or max_load_percentage >= 100)
         @compileError("max_load_percentage must be between 0 and 100.");
     return struct {
         const Self = @This();


### PR DESCRIPTION
since max_load_percentage is unsigned it will never be less then zero