### PR TITLE
`musl`: avoid `r0` as address register in s390x `__tls_get_offset`

### DIFF
--- a/lib/libc/musl/src/thread/s390x/__tls_get_offset.s
+++ b/lib/libc/musl/src/thread/s390x/__tls_get_offset.s
@@ -1,17 +1,17 @@
 	.global __tls_get_offset
 	.type __tls_get_offset,%function
 __tls_get_offset:
-	ear   %r0, %a0
-	sllg  %r0, %r0, 32
-	ear   %r0, %a1
+	ear   %r3, %a0
+	sllg  %r3, %r3, 32
+	ear   %r3, %a1
 
 	la    %r1, 0(%r2, %r12)
 
-	lg    %r3, 0(%r1)
-	sllg  %r4, %r3, 3
-	lg    %r5, 8(%r0)
+	lg    %r0, 0(%r1)
+	sllg  %r4, %r0, 3
+	lg    %r5, 8(%r3)
 	lg    %r2, 0(%r4, %r5)
 	ag    %r2, 8(%r1)
-	sgr   %r2, %r0
+	sgr   %r2, %r3
 
 	br    %r14


### PR DESCRIPTION
https://www.openwall.com/lists/musl/2025/10/12/4

See also 7b92d5f4052be651e9bc5cd4ad78a69ccbee865d...