### PR TITLE
std.Uri: test file URIs without an authority field

### DIFF
--- a/lib/std/Uri.zig
+++ b/lib/std/Uri.zig
@@ -586,6 +586,11 @@ test "file" {
     try std.testing.expectEqualStrings("file", parsed3.scheme);
     try std.testing.expectEqualStrings("localhost", parsed3.host.?.percent_encoded);
     try std.testing.expectEqualStrings("/an/absolute/path/to/another/thing/", parsed3.path.percent_encoded);
+
+    const parsed4 = try parse("file:/an/absolute/path");
+    try std.testing.expectEqualStrings("file", parsed4.scheme);
+    try std.testing.expectEqual(@as(?Component, null), parsed4.host);
+    try std.testing.expectEqualStrings("/an/absolute/path", parsed4.path.percent_encoded);
 }
 
 test "scheme" {


### PR DESCRIPTION
Some environments (such as KDE) form file URIs without an authority field (e.g. file:/etc/fstab). Also test this case for completeness.