### PR TITLE
tests length of zero allocation

### DIFF
--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -598,6 +598,8 @@ pub fn testAllocator(base_allocator: mem.Allocator) !void {
 
     // Zero-length allocation
     const empty = try allocator.alloc(u8, 0);
+    try testing.expect(empty.len == 0);
+    try testing.expect(empty.ptr == @as([*]u8, @ptrFromInt(std.math.maxInt(usize))));
     allocator.free(empty);
     // Allocation with zero-sized types
     const zero_bit_ptr = try allocator.create(u0);


### PR DESCRIPTION
Test code for zero length allocation was not checking the length of the returned slice was zero. Added a check for this.  Also added a check for the pointer based on examining how the current code works.