### PR TITLE
llvm backend: fix uefi data layout

### DIFF
--- a/src/codegen/llvm.zig
+++ b/src/codegen/llvm.zig
@@ -332,13 +332,13 @@ pub fn dataLayout(target: *const std.Target) []const u8 {
         .hexagon => "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048",
         .lanai => "E-m:e-p:32:32-i64:64-a:0:32-n32-S64",
         .aarch64 => if (target.ofmt == .macho)
-            if (target.os.tag == .windows)
+            if (target.os.tag == .windows or target.os.tag == .uefi)
                 "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
             else if (target.abi == .ilp32)
                 "e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
             else
                 "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
-        else if (target.os.tag == .windows)
+        else if (target.os.tag == .windows or target.os.tag == .uefi)
             "e-m:w-p270:32:32-p271:32:32-p272:64:64-p:64:64-i32:32-i64:64-i128:128-n32:64-S128-Fn32"
         else
             "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
@@ -353,7 +353,7 @@ pub fn dataLayout(target: *const std.Target) []const u8 {
             "E-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
         .thumb => if (target.ofmt == .macho)
             "e-m:o-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
-        else if (target.os.tag == .windows)
+        else if (target.os.tag == .windows or target.os.tag == .uefi)
             "e-m:w-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
         else
             "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
@@ -419,7 +419,7 @@ pub fn dataLayout(target: *const std.Target) []const u8 {
             "E-m:l-p1:32:32-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
         else
             "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64",
-        .x86 => if (target.os.tag == .windows) switch (target.abi) {
+        .x86 => if (target.os.tag == .windows or target.os.tag == .uefi) switch (target.abi) {
             .cygnus => "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32",
             .gnu => if (target.ofmt == .coff)
                 "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:32-n8:16:32-a:0:32-S32"
@@ -449,7 +449,7 @@ pub fn dataLayout(target: *const std.Target) []const u8 {
             "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
         else switch (target.abi) {
             .gnux32, .muslx32 => "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
-            else => if (target.os.tag == .windows and target.ofmt == .coff)
+            else => if ((target.os.tag == .windows or target.os.tag == .uefi) and target.ofmt == .coff)
                 "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
             else
                 "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",


### PR DESCRIPTION
The old logic was falling through to the default case, which made no sense for UEFI, causing an assertion in LLVM to fail. This should fix it for both x86 and x86-64. Whoever is reviewing this should double check the one I chose for x86, but I'm pretty confident I've got them right. The changes definitely cover the test case in #25578 for both x86 and x86_64.

Closes #25578