### PR TITLE
Sema: correct AIR semantics around array concat optimization

### DIFF
--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -92,6 +92,12 @@ test "array init with concat" {
     try expect(std.mem.eql(u8, &i, "abcd"));
 }
 
+test "array concat zero length pointers" {
+    var x: *const [0]u8 = &.{};
+    _ = &x;
+    _ = @as([]const u8, "") ++ x;
+}
+
 test "array init with mult" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO


### PR DESCRIPTION
closes #24953

<details>

<summary>New AIR</summary>

```zig
export fn a(x: *const [0]u8) void {
    _ = @as([]const u8, "") ++ x;
}
```
->
```
  %0!= arg(*const [0]u8, 0)
  %1!= dbg_stmt(2:5)
  %4!= alloc(*[0]u8)
  %5!= ret(@.void_value)
```
---

```zig
export fn b(x: *const [1]u8) void {
    _ = @as([]const u8, "") ++ x;
}
```
->
```
  %0 = arg(*const [1]u8, 0)
  %1!= dbg_stmt(2:5)
  %4 = alloc(*[1]u8)
  %5!= bitcast([*]u8, %4)
  %6 = array_to_slice([]u8, %4!)
  %7!= memcpy(%6!, %0!)
  %8!= bitcast(*const [1]u8, %4)
  %9!= ret(@.void_value)
```

---

```zig
export fn c(x: *const [0]u8) void {
    _ = @as([]const u8, "1") ++ x;
}
```
->
```
  %0!= arg(*const [0]u8, 0)
  %1!= dbg_stmt(2:5)
  %4 = alloc(*[1]u8)
  %5 = array_to_slice([]u8, %4!)
  %6 = slice_ptr([*]u8, <[]const u8, "1"[0..1]>)
  %7!= memcpy(%5!, %6!)
  %8!= bitcast(*const [1]u8, %4)
  %9!= ret(@.void_value)
```

---

```zig
export fn d(x: *const [0]u8) void {
    _ = "1" ++ x;
}
```
->
```
  %0!= arg(*const [0]u8, 0)
  %1!= dbg_stmt(2:5)
  %4 = alloc(*[1:0]u8)
  %5 = array_to_slice([]u8, %4)
  %6!= memcpy(%5!, <*const [1:0]u8, "1">)
  %7 = ptr_elem_ptr(*u8, %4!, @.one_usize)
  %8!= store(%7!, @.zero_u8)
  %9!= bitcast(*const [1:0]u8, %4)
  %10!= ret(@.void_value)
```

</details>

cc @jacobly0, perhaps you could double check my AIR? 