### PR TITLE
stage2-wasm: pass behavior test, disable one not passing before

### DIFF
--- a/src/dev.zig
+++ b/src/dev.zig
@@ -201,6 +201,7 @@ pub const Env = enum {
             .wasm => switch (feature) {
                 .stdio_listen,
                 .incremental,
+                .legalize,
                 .wasm_backend,
                 .wasm_linker,
                 => true,

--- a/src/link/Wasm/Flush.zig
+++ b/src/link/Wasm/Flush.zig
@@ -1853,7 +1853,6 @@ fn emitTagNameFunction(
 ) !void {
     const comp = wasm.base.comp;
     const gpa = comp.gpa;
-    const diags = &comp.link_diags;
     const zcu = comp.zcu.?;
     const ip = &zcu.intern_pool;
     const enum_type = ip.loadEnumType(enum_type_ip);
@@ -1884,52 +1883,74 @@ fn emitTagNameFunction(
         appendReservedUleb32(code, 0);
     } else {
         const int_info = Zcu.Type.intInfo(.fromInterned(enum_type.tag_ty), zcu);
-        const outer_block_type: std.wasm.BlockType = switch (int_info.bits) {
-            0...32 => .i32,
-            33...64 => .i64,
-            else => return diags.fail("wasm linker does not yet implement @tagName for sparse enums with more than 64 bit integer tag types", .{}),
-        };
+        const is_big_int = int_info.bits > 64;
 
         code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.local_get));
         appendReservedUleb32(code, 0);
 
         // Outer block that computes table offset.
+        // use i32 block type since we're computing a table offset
         code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.block));
-        code.appendAssumeCapacity(@intFromEnum(outer_block_type));
+        code.appendAssumeCapacity(@intFromEnum(std.wasm.BlockType.i32));
 
         for (tag_values, 0..) |tag_value, tag_index| {
             // block for this if case
             code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.block));
             code.appendAssumeCapacity(@intFromEnum(std.wasm.BlockType.empty));
 
-            // Tag value whose name should be returned.
-            code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.local_get));
-            appendReservedUleb32(code, 1);
-
             const val: Zcu.Value = .fromInterned(tag_value);
-            switch (outer_block_type) {
-                .i32 => {
+            if (is_big_int) {
+                var val_space: Zcu.Value.BigIntSpace = undefined;
+                const val_bigint = val.toBigInt(&val_space, zcu);
+                const num_limbs = (int_info.bits + 63) / 64;
+
+                const limbs = try gpa.alloc(u64, num_limbs);
+                defer gpa.free(limbs);
+                val_bigint.writeTwosComplement(@ptrCast(limbs), .little);
+
+                try code.ensureUnusedCapacity(gpa, 7 * 5 + 6 + 1 * 6 + 20 * num_limbs);
+
+                for (0..num_limbs) |limb_index| {
+                    // load the limb from memory (local 1 is pointer)
+                    code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.local_get));
+                    appendReservedUleb32(code, 1);
+
+                    code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.i64_load));
+                    appendReservedUleb32(code, @ctz(@as(u32, 8))); // alignment for i64
+                    appendReservedUleb32(code, @intCast(limb_index * 8));
+
+                    appendReservedI64Const(code, limbs[limb_index]);
+                    code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.i64_ne));
+
+                    // if not equal, break out of current case block
+                    code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.br_if));
+                    appendReservedUleb32(code, 0);
+                }
+            } else {
+                // Tag value whose name should be returned.
+                code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.local_get));
+                appendReservedUleb32(code, 1);
+
+                if (int_info.bits <= 32) {
                     const x: u32 = switch (int_info.signedness) {
                         .signed => @bitCast(@as(i32, @intCast(val.toSignedInt(zcu)))),
                         .unsigned => @intCast(val.toUnsignedInt(zcu)),
                     };
                     appendReservedI32Const(code, x);
                     code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.i32_ne));
-                },
-                .i64 => {
+                } else {
                     const x: u64 = switch (int_info.signedness) {
                         .signed => @bitCast(val.toSignedInt(zcu)),
                         .unsigned => val.toUnsignedInt(zcu),
                     };
                     appendReservedI64Const(code, x);
                     code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.i64_ne));
-                },
-                else => unreachable,
-            }
+                }
 
-            // if they're not equal, break out of current branch
-            code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.br_if));
-            appendReservedUleb32(code, 0);
+                // if they're not equal, break out of current branch
+                code.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.br_if));
+                appendReservedUleb32(code, 0);
+            }
 
             // Put the table offset of the result on the stack.
             appendReservedI32Const(code, @intCast(tag_index * slice_abi_size));
@@ -1962,7 +1983,7 @@ fn appendReservedI32Const(bytes: *ArrayList(u8), val: u32) void {
     bytes.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.i32_const));
     var w: std.Io.Writer = .fromArrayList(bytes);
     defer bytes.* = w.toArrayList();
-    return w.writeSleb128(val) catch |err| switch (err) {
+    return w.writeSleb128(@as(i32, @bitCast(val))) catch |err| switch (err) {
         error.WriteFailed => unreachable,
     };
 }
@@ -1972,7 +1993,7 @@ fn appendReservedI64Const(bytes: *ArrayList(u8), val: u64) void {
     bytes.appendAssumeCapacity(@intFromEnum(std.wasm.Opcode.i64_const));
     var w: std.Io.Writer = .fromArrayList(bytes);
     defer bytes.* = w.toArrayList();
-    return w.writeSleb128(val) catch |err| switch (err) {
+    return w.writeSleb128(@as(i64, @bitCast(val))) catch |err| switch (err) {
         error.WriteFailed => unreachable,
     };
 }

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1084,6 +1084,102 @@ test "tag name with large enum values" {
     try expect(mem.eql(u8, @tagName(kdf), "argon2id"));
 }
 
+test "@tagName with exotic integer enum types" {
+    if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_c) return error.SkipZigTest;
+
+    const S = struct {
+        fn testEnumSigned(comptime T: type) !void {
+            {
+                const E1 = enum(T) {
+                    a = -125,
+                    b = 125,
+                    c = std.math.minInt(T),
+                    d = std.math.maxInt(T),
+                };
+
+                var e: E1 = .a;
+                try expect(mem.eql(u8, @tagName(e), "a"));
+                e = .b;
+                try expect(mem.eql(u8, @tagName(e), "b"));
+                e = .c;
+                try expect(mem.eql(u8, @tagName(e), "c"));
+                e = .d;
+                try expect(mem.eql(u8, @tagName(e), "d"));
+            }
+            {
+                const E2 = enum(T) {
+                    a = -125,
+                    b = 125,
+                    c = std.math.minInt(T),
+                    d = std.math.maxInt(T),
+                    _,
+                };
+
+                var e: E2 = .a;
+                try expect(mem.eql(u8, @tagName(e), "a"));
+                e = .b;
+                try expect(mem.eql(u8, @tagName(e), "b"));
+                e = .c;
+                try expect(mem.eql(u8, @tagName(e), "c"));
+                e = .d;
+                try expect(mem.eql(u8, @tagName(e), "d"));
+            }
+        }
+
+        fn testEnumUnsigned(comptime T: type) !void {
+            {
+                const E1 = enum(T) {
+                    a = std.math.maxInt(T) - 125,
+                    b = 125,
+                    c = std.math.minInt(T),
+                    d = std.math.maxInt(T),
+                };
+
+                var e: E1 = .a;
+                try expect(mem.eql(u8, @tagName(e), "a"));
+                e = .b;
+                try expect(mem.eql(u8, @tagName(e), "b"));
+                e = .c;
+                try expect(mem.eql(u8, @tagName(e), "c"));
+                e = .d;
+                try expect(mem.eql(u8, @tagName(e), "d"));
+            }
+            {
+                const E2 = enum(T) {
+                    a = std.math.maxInt(T) - 125,
+                    b = 125,
+                    c = std.math.minInt(T),
+                    d = std.math.maxInt(T),
+                    _,
+                };
+
+                var e: E2 = .a;
+                try expect(mem.eql(u8, @tagName(e), "a"));
+                e = .b;
+                try expect(mem.eql(u8, @tagName(e), "b"));
+                e = .c;
+                try expect(mem.eql(u8, @tagName(e), "c"));
+                e = .d;
+                try expect(mem.eql(u8, @tagName(e), "d"));
+            }
+        }
+
+        fn doTheTest() !void {
+            try testEnumSigned(i33);
+            try testEnumSigned(i95);
+            try testEnumSigned(i127);
+
+            try testEnumUnsigned(u33);
+            try testEnumUnsigned(u95);
+            try testEnumUnsigned(u127);
+        }
+    };
+
+    try S.doTheTest();
+    try comptime S.doTheTest();
+}
+
 test "@tagName in callconv(.c) function" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest;

--- a/test/behavior/field_parent_ptr.zig
+++ b/test/behavior/field_parent_ptr.zig
@@ -1033,6 +1033,7 @@ test "@fieldParentPtr packed struct first zero-bit field" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const C = packed struct {
         a: u0 = 0,
@@ -1139,6 +1140,7 @@ test "@fieldParentPtr packed struct middle zero-bit field" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const C = packed struct {
         a: f32 = 3.14,
@@ -1245,6 +1247,7 @@ test "@fieldParentPtr packed struct last zero-bit field" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const C = packed struct {
         a: f32 = 3.14,

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -749,6 +749,7 @@ test "packed struct with fp fields" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = packed struct {
         data0: f32,

--- a/test/behavior/vector.zig
+++ b/test/behavior/vector.zig
@@ -9,6 +9,7 @@ const expectEqual = std.testing.expectEqual;
 test "implicit cast vector to array - bool" {
     if (builtin.cpu.arch == .aarch64_be and builtin.zig_backend == .stage2_llvm) return error.SkipZigTest;
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {
@@ -32,6 +33,7 @@ test "implicit cast vector to array - bool" {
 
 test "implicit cast array to vector - bool" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
+    if (builtin.zig_backend == .stage2_wasm) return error.SkipZigTest;
 
     const S = struct {
         fn doTheTest() !void {

--- a/test/tests.zig
+++ b/test/tests.zig
@@ -1366,18 +1366,16 @@ const test_targets = blk: {
 
         // WASI Targets
 
-        // Disabled due to no active maintainer (feel free to fix the failures
-        // and then re-enable at any time). The failures occur due to backend
-        // miscompilation of different AIR from the frontend.
-        //.{
-        //    .target = .{
-        //        .cpu_arch = .wasm32,
-        //        .os_tag = .wasi,
-        //        .abi = .none,
-        //    },
-        //    .use_llvm = false,
-        //    .use_lld = false,
-        //},
+        .{
+            .target = .{
+                .cpu_arch = .wasm32,
+                .os_tag = .wasi,
+                .abi = .none,
+            },
+            .skip_modules = &.{ "compiler-rt", "std" },
+            .use_llvm = false,
+            .use_lld = false,
+        },
         .{
             .target = .{
                 .cpu_arch = .wasm32,


### PR DESCRIPTION
Implemented `@tagName` for >64 bits. Fixed a bug in loading enums or packed structs (use signed load instruction for proper sign extension).
