### PR TITLE
os.linux.timeval: use same field names as std.c

### DIFF
--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -8429,8 +8429,8 @@ pub const POSIX_FADV = switch (native_arch) {
 };
 
 pub const timeval = extern struct {
-    tv_sec: isize,
-    tv_usec: i64,
+    sec: isize,
+    usec: i64,
 };
 
 pub const timezone = extern struct {


### PR DESCRIPTION
Otherwise, the field names in std.posix.timeval vary by target os. I think this was an accidental change during the work of #25610