### PR TITLE
skip certificate which is not part of the chain

### DIFF
--- a/lib/std/crypto/tls/Client.zig
+++ b/lib/std/crypto/tls/Client.zig
@@ -637,7 +637,14 @@ pub fn init(input: *Reader, output: *Writer, options: Options) InitError!Client 
                                 // certificate_verify message later.
                                 try main_cert_pub_key.init(subject.pub_key_algo, subject.pubKey());
                             } else {
-                                try prev_cert.verify(subject, now_sec);
+                                prev_cert.verify(subject, now_sec) catch |err| switch (err) {
+                                    error.CertificateIssuerMismatch => {
+                                        // Skip certificate which is not part of the chain
+                                        cert_index += 1;
+                                        continue;
+                                    },
+                                    else => |e| return e,
+                                };
                             }
 
                             switch (options.ca) {


### PR DESCRIPTION
Fixes: #25606

Browsers and curl ignore extra irrelevant certificates in the chain.

This fix skips certificate which is not part of the chain. Remaining certificates still form an unbroken chain of signatures with the last one trusted by root CA.

Some other domain which also have extra certificates in the chain:
 - jhu.edu
 - last.fm
 - terra.com.br