### PR TITLE
`Build.Step.Options`: add `comptime_float` support

### DIFF
--- a/lib/std/Build/Step/Options.zig
+++ b/lib/std/Build/Step/Options.zig
@@ -230,6 +230,7 @@ fn printType(
         .int,
         .comptime_int,
         .float,
+        .comptime_float,
         .null,
         => {
             if (name) |some| {
@@ -590,6 +591,7 @@ test Options {
     options.addOption(?usize, "option2", null);
     options.addOption(?usize, "option3", 3);
     options.addOption(comptime_int, "option4", 4);
+    options.addOption(comptime_float, "option5", 5.01);
     options.addOption([]const u8, "string", "zigisthebest");
     options.addOption(?[]const u8, "optional_string", null);
     options.addOption([2][2]u16, "nested_array", nested_array);
@@ -614,6 +616,7 @@ test Options {
         \\pub const option2: ?usize = null;
         \\pub const option3: ?usize = 3;
         \\pub const option4: comptime_int = 4;
+        \\pub const option5: comptime_float = 5.01;
         \\pub const string: []const u8 = "zigisthebest";
         \\pub const optional_string: ?[]const u8 = null;
         \\pub const nested_array: [2][2]u16 = [2][2]u16 {


### PR DESCRIPTION
It seems to me this was simply forgotten.
Or there is some other reason I neither know nor can observe why this code wouldn't work for `comptime_float`.

For a more comprehensive fix of/addition to `Build.Step.Options`, https://github.com/ziglang/zig/pull/24057 is the place to look.