### PR TITLE
fix(std): don't add the default `_start` and `panic` in homebrew targets

### DIFF
--- a/lib/std/debug.zig
+++ b/lib/std/debug.zig
@@ -481,7 +481,7 @@ pub fn defaultPanic(
     if (use_trap_panic) @trap();
 
     switch (builtin.os.tag) {
-        .freestanding, .other => {
+        .freestanding, .other, .@"3ds", .vita => {
             @trap();
         },
         .uefi => {

--- a/lib/std/start.zig
+++ b/lib/std/start.zig
@@ -91,8 +91,9 @@ comptime {
                 // Only call main when defined. For WebAssembly it's allowed to pass `-fno-entry` in which
                 // case it's not required to provide an entrypoint such as main.
                 if (!@hasDecl(root, start_sym_name) and @hasDecl(root, "main")) @export(&wasm_freestanding_start, .{ .name = start_sym_name });
-            } else if (native_os != .other and native_os != .freestanding) {
-                if (!@hasDecl(root, start_sym_name)) @export(&_start, .{ .name = start_sym_name });
+            } else switch (native_os) {
+                .other, .freestanding, .@"3ds", .vita => {},
+                else => if (!@hasDecl(root, start_sym_name)) @export(&_start, .{ .name = start_sym_name }),
             }
         }
     }


### PR DESCRIPTION
The targets are not posixy to be in that codepath and they're basically unusable unless someone explicitly adds yet another decl (`_start`) in their root file.

Related: https://github.com/ziglang/zig/issues/10392