### PR TITLE
`std.{c,posix}`: add `getgid` and `getegid`

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -10713,7 +10713,9 @@ pub extern "c" fn setresuid(ruid: uid_t, euid: uid_t, suid: uid_t) c_int;
 pub extern "c" fn setresgid(rgid: gid_t, egid: gid_t, sgid: gid_t) c_int;
 pub extern "c" fn setpgid(pid: pid_t, pgid: pid_t) c_int;
 pub extern "c" fn getuid() uid_t;
+pub extern "c" fn getgid() gid_t;
 pub extern "c" fn geteuid() uid_t;
+pub extern "c" fn getegid() gid_t;
 pub extern "c" fn getresuid(ruid: *uid_t, euid: *uid_t, suid: *uid_t) c_int;
 pub extern "c" fn getresgid(rgid: *gid_t, egid: *gid_t, sgid: *gid_t) c_int;
 

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -3557,6 +3557,14 @@ pub fn geteuid() uid_t {
     return system.geteuid();
 }
 
+pub fn getgid() gid_t {
+    return system.getgid();
+}
+
+pub fn getegid() gid_t {
+    return system.getegid();
+}
+
 /// Test whether a file descriptor refers to a terminal.
 pub fn isatty(handle: fd_t) bool {
     if (native_os == .windows) {

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -314,6 +314,12 @@ test "getuid" {
     _ = posix.geteuid();
 }
 
+test "getgid" {
+    if (native_os == .windows or native_os == .wasi) return error.SkipZigTest;
+    _ = posix.getgid();
+    _ = posix.getegid();
+}
+
 test "sigaltstack" {
     if (native_os == .windows or native_os == .wasi) return error.SkipZigTest;
 


### PR DESCRIPTION
Both of these functions are part of POSIX and should exist on all supported platforms.