### PR TITLE
`std.Target`: bump min-max versions for OpenBSD from 7.6-7.7 to 7.7-7.8

### DIFF
--- a/lib/std/Target.zig
+++ b/lib/std/Target.zig
@@ -554,8 +554,8 @@ pub const Os = struct {
                 },
                 .openbsd => .{
                     .semver = .{
-                        .min = .{ .major = 7, .minor = 6, .patch = 0 },
-                        .max = .{ .major = 7, .minor = 7, .patch = 0 },
+                        .min = .{ .major = 7, .minor = 7, .patch = 0 },
+                        .max = .{ .major = 7, .minor = 8, .patch = 0 },
                     },
                 },
 


### PR DESCRIPTION
https://cdn.openbsd.org/pub/OpenBSD/7.8/ANNOUNCEMENT