### PR TITLE
Docs: Fixed missing example output for float_mode_exe.zig

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -1120,6 +1120,10 @@
       otherwise the optimizer figures out all the values at compile-time,
       which operates in strict mode.</p>
       {#code|float_mode_exe.zig#}
+	  {#shell_samp#}$ zig build-exe float_mode_exe.zig -O ReleaseFast
+$ ./float_mode_exe
+optimized = 0.001
+strict = 0.0009765625{#end_shell_samp#}
 
       {#see_also|@setFloatMode|Division by Zero#}
       {#header_close#}

--- a/doc/langref/float_mode_exe.zig
+++ b/doc/langref/float_mode_exe.zig
@@ -9,5 +9,8 @@ pub fn main() void {
     print("strict = {}\n", .{foo_strict(x)});
 }
 
-// exe=succeed
-// optimize=ReleaseFast
+// syntax
+// This file requires the object file of float_mode_obj.zig
+// Currently the automatic generation of the langref runs each file independently
+// and does therefore not support this use case
+// The output for this snippet is written into the langref manually as a workaround

--- a/doc/langref/float_mode_exe.zig
+++ b/doc/langref/float_mode_exe.zig
@@ -9,4 +9,5 @@ pub fn main() void {
     print("strict = {}\n", .{foo_strict(x)});
 }
 
-// syntax
+// exe=succeed
+// optimize=ReleaseFast


### PR DESCRIPTION
I just stumbled across this while reading the docs. Basically the build instructions and output of the example are missing.
Took me a while to figure out how to fix it, but I think this should be it?
I didn't render it myself because I don't know how yet so please double-check before merging!