### PR TITLE
fix typo in std.debug.ElfFile

### DIFF
--- a/lib/std/debug/ElfFile.zig
+++ b/lib/std/debug/ElfFile.zig
@@ -375,7 +375,7 @@ fn loadSeparateDebugFile(arena: Allocator, main_loaded: *LoadInnerResult, opt_cr
         "debug_line",
     })) |name| {
         const s = @field(Section.Id, name);
-        if (main_loaded.sections.get(s) == null and result.sections.get(s) != null) {
+        if (main_loaded.sections.get(s) == null and result.sections.get(s) == null) {
             break false;
         }
     } else true;


### PR DESCRIPTION
Fixes #25667 

Fix typo that makes loading separate debug file impossible.
