### PR TITLE
Sema: Fix compilation timeout in analyzeAs with nested cast builtins

### DIFF
--- a/src/Sema.zig
+++ b/src/Sema.zig
@@ -9641,6 +9641,21 @@ fn zirAsShiftOperand(sema: *Sema, block: *Block, inst: Zir.Inst.Index) CompileEr
     return sema.analyzeAs(block, src, extra.dest_type, extra.operand, true);
 }
 
+fn validateCastDestType(
+    sema: *Sema,
+    block: *Block,
+    dest_ty: Type,
+    src: LazySrcLoc,
+) CompileError!void {
+    const pt = sema.pt;
+    const zcu = pt.zcu;
+    switch (dest_ty.zigTypeTag(zcu)) {
+        .@"opaque" => return sema.fail(block, src, "cannot cast to opaque type '{f}'", .{dest_ty.fmt(pt)}),
+        .noreturn => return sema.fail(block, src, "cannot cast to noreturn", .{}),
+        else => {},
+    }
+}
+
 fn analyzeAs(
     sema: *Sema,
     block: *Block,
@@ -9651,13 +9666,48 @@ fn analyzeAs(
 ) CompileError!Air.Inst.Ref {
     const pt = sema.pt;
     const zcu = pt.zcu;
+
+    // Optimize nested cast builtins to prevent redundant coercion and circular dependencies.
+    if (zir_operand.toIndex()) |operand_index| {
+        const operand_tag = sema.code.instructions.items(.tag)[@intFromEnum(operand_index)];
+        switch (operand_tag) {
+            // These builtins perform their own type-directed casting
+            .int_cast, .float_cast, .ptr_cast, .truncate => {
+                // Resolve dest_ty first so inner cast can use it as type context
+                const dest_ty = try sema.resolveTypeOrPoison(block, src, zir_dest_type) orelse {
+                    return sema.resolveInst(zir_operand);
+                };
+
+                try sema.validateCastDestType(block, dest_ty, src);
+
+                // Now analyze inner cast with dest_ty already resolved
+                const operand = try sema.resolveInst(zir_operand);
+
+                // If inner cast already produced the correct type, skip redundant coercion
+                if (sema.typeOf(operand).eql(dest_ty, zcu)) {
+                    return operand;
+                }
+
+                // Otherwise perform outer coercion (handles vectors/arrays and other edge cases)
+                const is_ret = if (zir_dest_type.toIndex()) |ptr_index|
+                    sema.code.instructions.items(.tag)[@intFromEnum(ptr_index)] == .ret_type
+                else
+                    false;
+                return sema.coerceExtra(block, dest_ty, operand, src, .{
+                    .is_ret = is_ret,
+                    .no_cast_to_comptime_int = no_cast_to_comptime_int
+                }) catch |err| switch (err) {
+                    error.NotCoercible => unreachable,
+                    else => |e| return e,
+                };
+            },
+            else => {},
+        }
+    }
+
     const operand = try sema.resolveInst(zir_operand);
     const dest_ty = try sema.resolveTypeOrPoison(block, src, zir_dest_type) orelse return operand;
-    switch (dest_ty.zigTypeTag(zcu)) {
-        .@"opaque" => return sema.fail(block, src, "cannot cast to opaque type '{f}'", .{dest_ty.fmt(pt)}),
-        .noreturn => return sema.fail(block, src, "cannot cast to noreturn", .{}),
-        else => {},
-    }
+    try sema.validateCastDestType(block, dest_ty, src);
 
     const is_ret = if (zir_dest_type.toIndex()) |ptr_index|
         sema.code.instructions.items(.tag)[@intFromEnum(ptr_index)] == .ret_type


### PR DESCRIPTION
## Summary

Fixes a circular dependency issue in `Sema.analyzeAs()` where `@as` coercion with nested cast builtins (`@intCast`, `@floatCast`, `@ptrCast`, `@truncate`) causes infinite recursion/timeout during compilation in specific control flow patterns.

## Problematic Pattern

The bug manifests when the following elements are combined:
- Loop constructs
- Short-circuit boolean operations (OR/AND)
- Optional unwrapping
- `@as(DestType, @intCast(value))` pattern

**Example from the wild** (from [Bun's codebase](https://github.com/oven-sh/bun/blob/d1cfb2ad5e2e9aa49dab63ac2872b41c8f24dd8b/src/install/updatePackageJSONAndInstall.zig#L722)):

```zig
while (lockfile.buffers.resolutions.items.len > i) {
    const pkg_id: u32 = @truncate(lockfile.buffers.resolutions.items[i].tag.to);
    if (workspace_package_ids.items.len > 0 and
        !workspace_package_ids.items[@as(usize, @intCast(pkg_id))])
    {
        break;
    }
    i += 1;
}
```

This pattern causes compilation to timeout indefinitely.

**Minimal reproduction**:

```zig
fn testPattern() void {
    comptime {
        var pid: u32 = 1;
        const arr = [_]bool{ true, false, true };
        var opt: ?[]const bool = &arr;

        var i: usize = 0;
        while (i < 3) : (i += 1) {
            if (opt == null or (opt.?)[@as(usize, @intCast(pid))] == false) {
                break;
            }
        }
    }
}
```

## Root Cause

The original implementation in `Sema.analyzeAs()` resolves the operand **before** the destination type:

```zig
const operand = try sema.resolveInst(zir_operand);
const dest_ty = try sema.resolveTypeOrPoison(block, src, zir_dest_type) orelse {
    return operand;
};
```

When the operand is a type-directed cast builtin like `@intCast`, this creates a circular dependency:
1. `@as` tries to resolve `@intCast(pid)` without knowing the destination type
2. `@intCast` recursively analyzes itself without type context
3. In complex control flow (loops + short-circuits + optionals), this triggers infinite recursion

## Fix

The fix adds an optimization path that detects when the operand is a cast builtin and **resolves the destination type FIRST**:

```zig
if (zir_operand.toIndex()) |operand_index| {
    const operand_tag = sema.code.instructions.items(.tag)[@intFromEnum(operand_index)];
    switch (operand_tag) {
        .int_cast, .float_cast, .ptr_cast, .truncate => {
            // Resolve dest_ty FIRST so inner cast has type context
            const dest_ty = try sema.resolveTypeOrPoison(block, src, zir_dest_type) orelse {
                return sema.resolveInst(zir_operand);
            };

            // ... validation ...

            // Now analyze inner cast with dest_ty already resolved
            const operand = try sema.resolveInst(zir_operand);

            // Skip redundant coercion if types already match
            if (sema.typeOf(operand).eql(dest_ty, zcu)) {
                return operand;
            }

            // Perform outer coercion for edge cases
            return sema.coerceExtra(block, dest_ty, operand, src, ...);
        },
        else => {},
    }
}
```

This breaks the circular dependency while preserving correct type coercion semantics.

## Testing

Verified the fix by:
1. Building the Zig compiler from source (bootstrap build)
2. Successfully compiling [Bun](https://github.com/oven-sh/bun) with the fixed compiler
   - The compilation previously timed out indefinitely at `updatePackageJSONAndInstall.zig:722`
   - With the fix, Bun compiles successfully
3. Tested minimal reproduction case compiles without timeout

## Related

- Affects: Bun and potentially other codebases using similar patterns
- Related to: Type system circular dependency resolution