### PR TITLE
Update posix.zig

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -47,6 +47,7 @@ else switch (native_os) {
     .linux => linux,
     .plan9 => std.os.plan9,
     else => struct {
+        pub const ucontext_t = void;
         pub const pid_t = void;
         pub const pollfd = void;
         pub const fd_t = void;
@@ -74,18 +75,13 @@ pub const HOST_NAME_MAX = system.HOST_NAME_MAX;
 pub const HW = system.HW;
 pub const IFNAMESIZE = system.IFNAMESIZE;
 pub const IOV_MAX = system.IOV_MAX;
-pub const IP = system.IP;
-pub const IPV6 = system.IPV6;
 pub const IPPROTO = system.IPPROTO;
-pub const IPTOS = system.IPTOS;
 pub const KERN = system.KERN;
 pub const Kevent = system.Kevent;
 pub const MADV = system.MADV;
 pub const MAP = system.MAP;
 pub const MAX_ADDR_LEN = system.MAX_ADDR_LEN;
-pub const MCL = system.MCL;
 pub const MFD = system.MFD;
-pub const MLOCK = system.MLOCK;
 pub const MREMAP = system.MREMAP;
 pub const MSF = system.MSF;
 pub const MSG = system.MSG;
@@ -97,12 +93,12 @@ pub const POLL = system.POLL;
 pub const POSIX_FADV = system.POSIX_FADV;
 pub const PR = system.PR;
 pub const PROT = system.PROT;
+pub const REG = system.REG;
 pub const RLIM = system.RLIM;
 pub const RR = system.RR;
 pub const S = system.S;
 pub const SA = system.SA;
 pub const SC = system.SC;
-pub const SCM = system.SCM;
 pub const SEEK = system.SEEK;
 pub const SHUT = system.SHUT;
 pub const SIG = system.SIG;
@@ -135,10 +131,8 @@ pub const fd_t = system.fd_t;
 pub const file_obj = system.file_obj;
 pub const gid_t = system.gid_t;
 pub const ifreq = system.ifreq;
-pub const in_pktinfo = system.in_pktinfo;
-pub const in6_pktinfo = system.in6_pktinfo;
 pub const ino_t = system.ino_t;
-pub const linger = system.linger;
+pub const mcontext_t = system.mcontext_t;
 pub const mode_t = system.mode_t;
 pub const msghdr = system.msghdr;
 pub const msghdr_const = system.msghdr_const;
@@ -167,6 +161,7 @@ pub const timespec = system.timespec;
 pub const timestamp_t = system.timestamp_t;
 pub const timeval = system.timeval;
 pub const timezone = system.timezone;
+pub const ucontext_t = system.ucontext_t;
 pub const uid_t = system.uid_t;
 pub const user_desc = system.user_desc;
 pub const utsname = system.utsname;
@@ -493,7 +488,7 @@ fn fchmodat2(dirfd: fd_t, path: []const u8, mode: mode_t, flags: u32) FChmodAtEr
         return error.OperationNotSupported;
 
     var procfs_buf: ["/proc/self/fd/-2147483648\x00".len]u8 = undefined;
-    const proc_path = std.fmt.bufPrintSentinel(procfs_buf[0..], "/proc/self/fd/{d}", .{pathfd}, 0) catch unreachable;
+    const proc_path = std.fmt.bufPrintZ(procfs_buf[0..], "/proc/self/fd/{d}", .{pathfd}) catch unreachable;
     while (true) {
         const res = system.chmod(proc_path, mode);
         switch (errno(res)) {
@@ -674,8 +669,8 @@ fn getRandomBytesDevURandom(buf: []u8) !void {
     }
 
     const file: fs.File = .{ .handle = fd };
-    var file_reader = file.readerStreaming(&.{});
-    file_reader.interface.readSliceAll(buf) catch return error.Unexpected;
+    const stream = file.deprecatedReader();
+    stream.readNoEof(buf) catch return error.Unexpected;
 }
 
 /// Causes abnormal process termination.
@@ -688,7 +683,7 @@ pub fn abort() noreturn {
     // even when linking libc on Windows we use our own abort implementation.
     // See https://github.com/ziglang/zig/issues/2071 for more details.
     if (native_os == .windows) {
-        if (builtin.mode == .Debug and windows.peb().BeingDebugged != 0) {
+        if (builtin.mode == .Debug) {
             @breakpoint();
         }
         windows.kernel32.ExitProcess(3);
@@ -1624,7 +1619,7 @@ pub const OpenError = error{
     InvalidUtf8,
 
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
 
     /// On Windows, `\\server` or `\\server\share` was not found.
@@ -1647,7 +1642,7 @@ pub const OpenError = error{
 } || UnexpectedError;
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// See also `openZ`.
@@ -1662,7 +1657,7 @@ pub fn open(file_path: []const u8, flags: O, perm: mode_t) OpenError!fd_t {
 }
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// See also `open`.
@@ -1710,7 +1705,7 @@ pub fn openZ(file_path: [*:0]const u8, flags: O, perm: mode_t) OpenError!fd_t {
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
 /// `file_path` is relative to the open directory handle `dir_fd`.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// See also `openatZ`.
@@ -1833,7 +1828,7 @@ fn openOptionsFromFlagsWasi(oflag: O) OpenError!WasiOpenOptions {
 
 /// Open and possibly create a file. Keeps trying if it gets interrupted.
 /// `file_path` is relative to the open directory handle `dir_fd`.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// See also `openat`.
@@ -2137,7 +2132,7 @@ pub const SymLinkError = error{
     InvalidUtf8,
 
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
 
     BadPathName,
@@ -2146,7 +2141,7 @@ pub const SymLinkError = error{
 /// Creates a symbolic link named `sym_link_path` which contains the string `target_path`.
 /// A symbolic link (also known as a soft link) may point to an existing file or to a nonexistent
 /// one; the latter case is known as a dangling link.
-/// On Windows, both paths should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, both paths should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, both paths should be encoded as valid UTF-8.
 /// On other platforms, both paths are an opaque sequence of bytes with no particular encoding.
 /// If `sym_link_path` exists, it will not be overwritten.
@@ -2198,7 +2193,7 @@ pub fn symlinkZ(target_path: [*:0]const u8, sym_link_path: [*:0]const u8) SymLin
 /// `target_path` **relative** to `newdirfd` directory handle.
 /// A symbolic link (also known as a soft link) may point to an existing file or to a nonexistent
 /// one; the latter case is known as a dangling link.
-/// On Windows, both paths should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, both paths should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, both paths should be encoded as valid UTF-8.
 /// On other platforms, both paths are an opaque sequence of bytes with no particular encoding.
 /// If `sym_link_path` exists, it will not be overwritten.
@@ -2446,7 +2441,7 @@ pub const UnlinkError = error{
     InvalidUtf8,
 
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
 
     /// On Windows, file paths cannot contain these characters:
@@ -2458,7 +2453,7 @@ pub const UnlinkError = error{
 } || UnexpectedError;
 
 /// Delete a name and possibly the file it refers to.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// See also `unlinkZ`.
@@ -2522,7 +2517,7 @@ pub const UnlinkatError = UnlinkError || error{
 };
 
 /// Delete a file name and possibly the file it refers to, based on an open directory handle.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// Asserts that the path parameter has no null bytes.
@@ -2637,7 +2632,7 @@ pub const RenameError = error{
     /// WASI-only; file paths must be valid UTF-8.
     InvalidUtf8,
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
     BadPathName,
     NoDevice,
@@ -2654,7 +2649,7 @@ pub const RenameError = error{
 } || UnexpectedError;
 
 /// Change the name or location of a file.
-/// On Windows, both paths should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, both paths should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, both paths should be encoded as valid UTF-8.
 /// On other platforms, both paths are an opaque sequence of bytes with no particular encoding.
 pub fn rename(old_path: []const u8, new_path: []const u8) RenameError!void {
@@ -2716,7 +2711,7 @@ pub fn renameW(old_path: [*:0]const u16, new_path: [*:0]const u16) RenameError!v
 }
 
 /// Change the name or location of a file based on an open directory handle.
-/// On Windows, both paths should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, both paths should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, both paths should be encoded as valid UTF-8.
 /// On other platforms, both paths are an opaque sequence of bytes with no particular encoding.
 pub fn renameat(
@@ -2824,7 +2819,7 @@ pub fn renameatZ(
 }
 
 /// Same as `renameat` but Windows-only and the path parameters are
-/// [WTF-16](https://wtf-8.codeberg.page/#potentially-ill-formed-utf-16) encoded.
+/// [WTF-16](https://simonsapin.github.io/wtf-8/#potentially-ill-formed-utf-16) encoded.
 pub fn renameatW(
     old_dir_fd: fd_t,
     old_path_w: []const u16,
@@ -2844,19 +2839,15 @@ pub fn renameatW(
     };
     defer windows.CloseHandle(src_fd);
 
+    var need_fallback = true;
     var rc: windows.NTSTATUS = undefined;
-    // FileRenameInformationEx has varying levels of support:
-    // - FILE_RENAME_INFORMATION_EX requires >= win10_rs1
-    //   (INVALID_INFO_CLASS is returned if not supported)
-    // - Requires the NTFS filesystem
-    //   (on filesystems like FAT32, INVALID_PARAMETER is returned)
-    // - FILE_RENAME_POSIX_SEMANTICS requires >= win10_rs1
-    // - FILE_RENAME_IGNORE_READONLY_ATTRIBUTE requires >= win10_rs5
-    //   (NOT_SUPPORTED is returned if a flag is unsupported)
-    //
-    // The strategy here is just to try using FileRenameInformationEx and fall back to
-    // FileRenameInformation if the return value lets us know that some aspect of it is not supported.
-    const need_fallback = need_fallback: {
+    // FILE_RENAME_INFORMATION_EX and FILE_RENAME_POSIX_SEMANTICS require >= win10_rs1,
+    // but FILE_RENAME_IGNORE_READONLY_ATTRIBUTE requires >= win10_rs5. We check >= rs5 here
+    // so that we only use POSIX_SEMANTICS when we know IGNORE_READONLY_ATTRIBUTE will also be
+    // supported in order to avoid either (1) using a redundant call that we can know in advance will return
+    // STATUS_NOT_SUPPORTED or (2) only setting IGNORE_READONLY_ATTRIBUTE when >= rs5
+    // and therefore having different behavior when the Windows version is >= rs1 but < rs5.
+    if (builtin.target.os.isAtLeast(.windows, .win10_rs5) orelse false) {
         const struct_buf_len = @sizeOf(windows.FILE_RENAME_INFORMATION_EX) + (max_path_bytes - 1);
         var rename_info_buf: [struct_buf_len]u8 align(@alignOf(windows.FILE_RENAME_INFORMATION_EX)) = undefined;
         const struct_len = @sizeOf(windows.FILE_RENAME_INFORMATION_EX) - 1 + new_path_w.len * 2;
@@ -2883,17 +2874,12 @@ pub fn renameatW(
         );
         switch (rc) {
             .SUCCESS => return,
-            // The filesystem does not support FileDispositionInformationEx
-            .INVALID_PARAMETER,
-            // The operating system does not support FileDispositionInformationEx
-            .INVALID_INFO_CLASS,
-            // The operating system does not support one of the flags
-            .NOT_SUPPORTED,
-            => break :need_fallback true,
+            // INVALID_PARAMETER here means that the filesystem does not support FileRenameInformationEx
+            .INVALID_PARAMETER => {},
             // For all other statuses, fall down to the switch below to handle them.
-            else => break :need_fallback false,
+            else => need_fallback = false,
         }
-    };
+    }
 
     if (need_fallback) {
         const struct_buf_len = @sizeOf(windows.FILE_RENAME_INFORMATION) + (max_path_bytes - 1);
@@ -2912,13 +2898,14 @@ pub fn renameatW(
         };
         @memcpy((&rename_info.FileName).ptr, new_path_w);
 
-        rc = windows.ntdll.NtSetInformationFile(
-            src_fd,
-            &io_status_block,
-            rename_info,
-            @intCast(struct_len), // already checked for error.NameTooLong
-            .FileRenameInformation,
-        );
+        rc =
+            windows.ntdll.NtSetInformationFile(
+                src_fd,
+                &io_status_block,
+                rename_info,
+                @intCast(struct_len), // already checked for error.NameTooLong
+                .FileRenameInformation,
+            );
     }
 
     switch (rc) {
@@ -2938,7 +2925,7 @@ pub fn renameatW(
     }
 }
 
-/// On Windows, `sub_dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `sub_dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `sub_dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `sub_dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn mkdirat(dir_fd: fd_t, sub_dir_path: []const u8, mode: mode_t) MakeDirError!void {
@@ -3048,7 +3035,7 @@ pub const MakeDirError = error{
     /// WASI-only; file paths must be valid UTF-8.
     InvalidUtf8,
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
     BadPathName,
     NoDevice,
@@ -3058,7 +3045,7 @@ pub const MakeDirError = error{
 
 /// Create a directory.
 /// `mode` is ignored on Windows and WASI.
-/// On Windows, `dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn mkdir(dir_path: []const u8, mode: mode_t) MakeDirError!void {
@@ -3074,7 +3061,7 @@ pub fn mkdir(dir_path: []const u8, mode: mode_t) MakeDirError!void {
 }
 
 /// Same as `mkdir` but the parameter is null-terminated.
-/// On Windows, `dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn mkdirZ(dir_path: [*:0]const u8, mode: mode_t) MakeDirError!void {
@@ -3140,7 +3127,7 @@ pub const DeleteDirError = error{
     /// WASI-only; file paths must be valid UTF-8.
     InvalidUtf8,
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
     BadPathName,
     /// On Windows, `\\server` or `\\server\share` was not found.
@@ -3148,7 +3135,7 @@ pub const DeleteDirError = error{
 } || UnexpectedError;
 
 /// Deletes an empty directory.
-/// On Windows, `dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn rmdir(dir_path: []const u8) DeleteDirError!void {
@@ -3168,7 +3155,7 @@ pub fn rmdir(dir_path: []const u8) DeleteDirError!void {
 }
 
 /// Same as `rmdir` except the parameter is null-terminated.
-/// On Windows, `dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn rmdirZ(dir_path: [*:0]const u8) DeleteDirError!void {
@@ -3221,12 +3208,12 @@ pub const ChangeCurDirError = error{
     /// WASI-only; file paths must be valid UTF-8.
     InvalidUtf8,
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
 } || UnexpectedError;
 
 /// Changes the current working directory of the calling process.
-/// On Windows, `dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn chdir(dir_path: []const u8) ChangeCurDirError!void {
@@ -3246,7 +3233,7 @@ pub fn chdir(dir_path: []const u8) ChangeCurDirError!void {
 }
 
 /// Same as `chdir` except the parameter is null-terminated.
-/// On Windows, `dir_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `dir_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `dir_path` should be encoded as valid UTF-8.
 /// On other platforms, `dir_path` is an opaque sequence of bytes with no particular encoding.
 pub fn chdirZ(dir_path: [*:0]const u8) ChangeCurDirError!void {
@@ -3323,7 +3310,7 @@ pub const ReadLinkError = error{
     /// WASI-only; file paths must be valid UTF-8.
     InvalidUtf8,
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
     BadPathName,
     /// Windows-only. This error may occur if the opened reparse point is
@@ -3334,11 +3321,11 @@ pub const ReadLinkError = error{
 } || UnexpectedError;
 
 /// Read value of a symbolic link.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// The return value is a slice of `out_buffer` from index 0.
-/// On Windows, the result is encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, the result is encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, the result is encoded as UTF-8.
 /// On other platforms, the result is an opaque sequence of bytes with no particular encoding.
 pub fn readlink(file_path: []const u8, out_buffer: []u8) ReadLinkError![]u8 {
@@ -3354,7 +3341,7 @@ pub fn readlink(file_path: []const u8, out_buffer: []u8) ReadLinkError![]u8 {
 }
 
 /// Windows-only. Same as `readlink` except `file_path` is WTF16 LE encoded.
-/// The result is encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// The result is encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// See also `readlinkZ`.
 pub fn readlinkW(file_path: []const u16, out_buffer: []u8) ReadLinkError![]u8 {
     return windows.ReadLink(fs.cwd().fd, file_path, out_buffer);
@@ -3389,11 +3376,11 @@ pub fn readlinkZ(file_path: [*:0]const u8, out_buffer: []u8) ReadLinkError![]u8 
 }
 
 /// Similar to `readlink` except reads value of a symbolink link **relative** to `dirfd` directory handle.
-/// On Windows, `file_path` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `file_path` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, `file_path` should be encoded as valid UTF-8.
 /// On other platforms, `file_path` is an opaque sequence of bytes with no particular encoding.
 /// The return value is a slice of `out_buffer` from index 0.
-/// On Windows, the result is encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, the result is encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// On WASI, the result is encoded as UTF-8.
 /// On other platforms, the result is an opaque sequence of bytes with no particular encoding.
 /// See also `readlinkatWasi`, `realinkatZ` and `realinkatW`.
@@ -3431,7 +3418,7 @@ pub fn readlinkatWasi(dirfd: fd_t, file_path: []const u8, out_buffer: []u8) Read
 }
 
 /// Windows-only. Same as `readlinkat` except `file_path` is null-terminated, WTF16 LE encoded.
-/// The result is encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// The result is encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// See also `readlinkat`.
 pub fn readlinkatW(dirfd: fd_t, file_path: []const u16, out_buffer: []u8) ReadLinkError![]u8 {
     return windows.ReadLink(dirfd, file_path, out_buffer);
@@ -3557,14 +3544,6 @@ pub fn geteuid() uid_t {
     return system.geteuid();
 }
 
-pub fn getgid() gid_t {
-    return system.getgid();
-}
-
-pub fn getegid() gid_t {
-    return system.getegid();
-}
-
 /// Test whether a file descriptor refers to a terminal.
 pub fn isatty(handle: fd_t) bool {
     if (native_os == .windows) {
@@ -3676,46 +3655,6 @@ pub fn socket(domain: u32, socket_type: u32, protocol: u32) SocketError!socket_t
                 try setSockFlags(fd, socket_type);
             }
             return fd;
-        },
-        .ACCES => return error.AccessDenied,
-        .AFNOSUPPORT => return error.AddressFamilyNotSupported,
-        .INVAL => return error.ProtocolFamilyNotAvailable,
-        .MFILE => return error.ProcessFdQuotaExceeded,
-        .NFILE => return error.SystemFdQuotaExceeded,
-        .NOBUFS => return error.SystemResources,
-        .NOMEM => return error.SystemResources,
-        .PROTONOSUPPORT => return error.ProtocolNotSupported,
-        .PROTOTYPE => return error.SocketTypeNotSupported,
-        else => |err| return unexpectedErrno(err),
-    }
-}
-
-pub fn socketpair(domain: u32, socket_type: u32, protocol: u32) SocketError![2]socket_t {
-    // Note to the future: we could provide a shim here for e.g. windows which
-    // creates a listening socket, then creates a second socket and connects it
-    // to the listening socket, and then returns the two.
-    if (@TypeOf(system.socketpair) == void)
-        @compileError("socketpair() not supported by this OS");
-
-    // I'm not really sure if haiku supports flags here.  I'm following the
-    // existing filter here from pipe2(), because it sure seems like it
-    // supports flags there too, but haiku can be hard to understand.
-    const have_sock_flags = !builtin.target.os.tag.isDarwin() and native_os != .haiku;
-    const filtered_sock_type = if (!have_sock_flags)
-        socket_type & ~@as(u32, SOCK.NONBLOCK | SOCK.CLOEXEC)
-    else
-        socket_type;
-    var socks: [2]socket_t = undefined;
-    const rc = system.socketpair(domain, filtered_sock_type, protocol, &socks);
-    switch (errno(rc)) {
-        .SUCCESS => {
-            errdefer close(socks[0]);
-            errdefer close(socks[1]);
-            if (!have_sock_flags) {
-                try setSockFlags(socks[0], socket_type);
-                try setSockFlags(socks[1], socket_type);
-            }
-            return socks;
         },
         .ACCES => return error.AccessDenied,
         .AFNOSUPPORT => return error.AddressFamilyNotSupported,
@@ -4344,9 +4283,6 @@ pub const ConnectError = error{
 
     /// Socket is non-blocking and already has a pending connection in progress.
     ConnectionPending,
-
-    /// Socket was already connected
-    AlreadyConnected,
 } || UnexpectedError;
 
 /// Initiate a connection on a socket.
@@ -4367,7 +4303,7 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
             => return error.NetworkUnreachable,
             .WSAEFAULT => unreachable,
             .WSAEINVAL => unreachable,
-            .WSAEISCONN => return error.AlreadyConnected,
+            .WSAEISCONN => unreachable,
             .WSAENOTSOCK => unreachable,
             .WSAEWOULDBLOCK => return error.WouldBlock,
             .WSAEACCES => unreachable,
@@ -4393,7 +4329,7 @@ pub fn connect(sock: socket_t, sock_addr: *const sockaddr, len: socklen_t) Conne
             .CONNRESET => return error.ConnectionResetByPeer,
             .FAULT => unreachable, // The socket structure address is outside the user's address space.
             .INTR => continue,
-            .ISCONN => return error.AlreadyConnected, // The socket is already connected.
+            .ISCONN => unreachable, // The socket is already connected.
             .HOSTUNREACH => return error.NetworkUnreachable,
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.
@@ -4453,7 +4389,7 @@ pub fn getsockoptError(sockfd: fd_t) ConnectError!void {
             .BADF => unreachable, // sockfd is not a valid open file descriptor.
             .CONNREFUSED => return error.ConnectionRefused,
             .FAULT => unreachable, // The socket structure address is outside the user's address space.
-            .ISCONN => return error.AlreadyConnected, // The socket is already connected.
+            .ISCONN => unreachable, // The socket is already connected.
             .HOSTUNREACH => return error.NetworkUnreachable,
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.
@@ -4809,76 +4745,6 @@ pub fn fanotify_markZ(
     }
 }
 
-pub const MlockError = error{
-    PermissionDenied,
-    LockedMemoryLimitExceeded,
-    SystemResources,
-} || UnexpectedError;
-
-pub fn mlock(memory: []align(page_size_min) const u8) MlockError!void {
-    if (@TypeOf(system.mlock) == void)
-        @compileError("mlock not supported on this OS");
-    return switch (errno(system.mlock(memory.ptr, memory.len))) {
-        .SUCCESS => {},
-        .INVAL => unreachable, // unaligned, negative, runs off end of addrspace
-        .PERM => error.PermissionDenied,
-        .NOMEM => error.LockedMemoryLimitExceeded,
-        .AGAIN => error.SystemResources,
-        else => |err| unexpectedErrno(err),
-    };
-}
-
-pub fn mlock2(memory: []align(page_size_min) const u8, flags: MLOCK) MlockError!void {
-    if (@TypeOf(system.mlock2) == void)
-        @compileError("mlock2 not supported on this OS");
-    return switch (errno(system.mlock2(memory.ptr, memory.len, flags))) {
-        .SUCCESS => {},
-        .INVAL => unreachable, // bad memory or bad flags
-        .PERM => error.PermissionDenied,
-        .NOMEM => error.LockedMemoryLimitExceeded,
-        .AGAIN => error.SystemResources,
-        else => |err| unexpectedErrno(err),
-    };
-}
-
-pub fn munlock(memory: []align(page_size_min) const u8) MlockError!void {
-    if (@TypeOf(system.munlock) == void)
-        @compileError("munlock not supported on this OS");
-    return switch (errno(system.munlock(memory.ptr, memory.len))) {
-        .SUCCESS => {},
-        .INVAL => unreachable, // unaligned or runs off end of addr space
-        .PERM => return error.PermissionDenied,
-        .NOMEM => return error.LockedMemoryLimitExceeded,
-        .AGAIN => return error.SystemResources,
-        else => |err| unexpectedErrno(err),
-    };
-}
-
-pub fn mlockall(flags: MCL) MlockError!void {
-    if (@TypeOf(system.mlockall) == void)
-        @compileError("mlockall not supported on this OS");
-    return switch (errno(system.mlockall(flags))) {
-        .SUCCESS => {},
-        .INVAL => unreachable, // bad flags
-        .PERM => error.PermissionDenied,
-        .NOMEM => error.LockedMemoryLimitExceeded,
-        .AGAIN => error.SystemResources,
-        else => |err| unexpectedErrno(err),
-    };
-}
-
-pub fn munlockall() MlockError!void {
-    if (@TypeOf(system.munlockall) == void)
-        @compileError("munlockall not supported on this OS");
-    return switch (errno(system.munlockall())) {
-        .SUCCESS => {},
-        .PERM => error.PermissionDenied,
-        .NOMEM => error.LockedMemoryLimitExceeded,
-        .AGAIN => error.SystemResources,
-        else => |err| unexpectedErrno(err),
-    };
-}
-
 pub const MProtectError = error{
     /// The memory cannot be given the specified access.  This can happen, for example, if you
     /// mmap(2)  a  file  to  which  you have read-only access, then ask mprotect() to mark it
@@ -5007,9 +4873,7 @@ pub fn munmap(memory: []align(page_size_min) const u8) void {
         .SUCCESS => return,
         .INVAL => unreachable, // Invalid parameters.
         .NOMEM => unreachable, // Attempted to unmap a region in the middle of an existing mapping.
-        else => |e| if (unexpected_error_tracing) {
-            std.debug.panic("unexpected errno: {d} ({t})", .{ @intFromEnum(e), e });
-        } else unreachable,
+        else => unreachable,
     }
 }
 
@@ -5076,13 +4940,13 @@ pub const AccessError = error{
     /// WASI-only; file paths must be valid UTF-8.
     InvalidUtf8,
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
 } || UnexpectedError;
 
 /// check user's permissions for a file
 ///
-/// * On Windows, asserts `path` is valid [WTF-8](https://wtf-8.codeberg.page/).
+/// * On Windows, asserts `path` is valid [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// * On WASI, invalid UTF-8 passed to `path` causes `error.InvalidUtf8`.
 /// * On other platforms, `path` is an opaque sequence of bytes with no particular encoding.
 ///
@@ -5133,7 +4997,7 @@ pub fn accessZ(path: [*:0]const u8, mode: u32) AccessError!void {
 
 /// Check user's permissions for a file, based on an open directory handle.
 ///
-/// * On Windows, asserts `path` is valid [WTF-8](https://wtf-8.codeberg.page/).
+/// * On Windows, asserts `path` is valid [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// * On WASI, invalid UTF-8 passed to `path` causes `error.InvalidUtf8`.
 /// * On other platforms, `path` is an opaque sequence of bytes with no particular encoding.
 ///
@@ -5355,19 +5219,13 @@ pub fn sysctl(
     }
 }
 
-pub const SysCtlByNameError = error{
-    PermissionDenied,
-    SystemResources,
-    UnknownName,
-} || UnexpectedError;
-
 pub fn sysctlbynameZ(
     name: [*:0]const u8,
     oldp: ?*anyopaque,
     oldlenp: ?*usize,
     newp: ?*anyopaque,
     newlen: usize,
-) SysCtlByNameError!void {
+) SysCtlError!void {
     if (native_os == .wasi) {
         @compileError("sysctl not supported on WASI");
     }
@@ -5653,7 +5511,7 @@ pub const RealPathError = error{
     PipeBusy,
 
     /// Windows-only; file paths provided by the user must be valid WTF-8.
-    /// https://wtf-8.codeberg.page/
+    /// https://simonsapin.github.io/wtf-8/
     InvalidWtf8,
 
     /// On Windows, `\\server` or `\\server\share` was not found.
@@ -5678,7 +5536,7 @@ pub const RealPathError = error{
 /// Expands all symbolic links and resolves references to `.`, `..`, and
 /// extra `/` characters in `pathname`.
 ///
-/// On Windows, `pathname` should be encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// On Windows, `pathname` should be encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 ///
 /// On other platforms, `pathname` is an opaque sequence of bytes with no particular encoding.
 ///
@@ -5686,18 +5544,14 @@ pub const RealPathError = error{
 ///
 /// See also `realpathZ` and `realpathW`.
 ///
-/// * On Windows, the result is encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// * On Windows, the result is encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 /// * On other platforms, the result is an opaque sequence of bytes with no particular encoding.
 ///
 /// Calling this function is usually a bug.
 pub fn realpath(pathname: []const u8, out_buffer: *[max_path_bytes]u8) RealPathError![]u8 {
     if (native_os == .windows) {
-        var pathname_w = try windows.sliceToPrefixedFileW(null, pathname);
-
-        const wide_slice = try realpathW2(pathname_w.span(), &pathname_w.data);
-
-        const end_index = std.unicode.wtf16LeToWtf8(out_buffer, wide_slice);
-        return out_buffer[0..end_index];
+        const pathname_w = try windows.sliceToPrefixedFileW(null, pathname);
+        return realpathW(pathname_w.span(), out_buffer);
     } else if (native_os == .wasi and !builtin.link_libc) {
         @compileError("WASI does not support os.realpath");
     }
@@ -5710,12 +5564,8 @@ pub fn realpath(pathname: []const u8, out_buffer: *[max_path_bytes]u8) RealPathE
 /// Calling this function is usually a bug.
 pub fn realpathZ(pathname: [*:0]const u8, out_buffer: *[max_path_bytes]u8) RealPathError![]u8 {
     if (native_os == .windows) {
-        var pathname_w = try windows.cStrToPrefixedFileW(null, pathname);
-
-        const wide_slice = try realpathW2(pathname_w.span(), &pathname_w.data);
-
-        const end_index = std.unicode.wtf16LeToWtf8(out_buffer, wide_slice);
-        return out_buffer[0..end_index];
+        const pathname_w = try windows.cStrToPrefixedFileW(null, pathname);
+        return realpathW(pathname_w.span(), out_buffer);
     } else if (native_os == .wasi and !builtin.link_libc) {
         return realpath(mem.sliceTo(pathname, 0), out_buffer);
     }
@@ -5759,24 +5609,34 @@ pub fn realpathZ(pathname: [*:0]const u8, out_buffer: *[max_path_bytes]u8) RealP
     return mem.sliceTo(result_path, 0);
 }
 
-/// Deprecated: use `realpathW2`.
-///
 /// Same as `realpath` except `pathname` is WTF16LE-encoded.
 ///
-/// The result is encoded as [WTF-8](https://wtf-8.codeberg.page/).
+/// The result is encoded as [WTF-8](https://simonsapin.github.io/wtf-8/).
 ///
 /// Calling this function is usually a bug.
 pub fn realpathW(pathname: []const u16, out_buffer: *[max_path_bytes]u8) RealPathError![]u8 {
-    return fs.cwd().realpathW(pathname, out_buffer);
-}
+    const w = windows;
 
-/// Same as `realpath` except `pathname` is WTF16LE-encoded.
-///
-/// The result is encoded as WTF16LE.
-///
-/// Calling this function is usually a bug.
-pub fn realpathW2(pathname: []const u16, out_buffer: *[std.os.windows.PATH_MAX_WIDE]u16) RealPathError![]u16 {
-    return fs.cwd().realpathW2(pathname, out_buffer);
+    const dir = fs.cwd().fd;
+    const access_mask = w.GENERIC_READ | w.SYNCHRONIZE;
+    const share_access = w.FILE_SHARE_READ | w.FILE_SHARE_WRITE | w.FILE_SHARE_DELETE;
+    const creation = w.FILE_OPEN;
+    const h_file = blk: {
+        const res = w.OpenFile(pathname, .{
+            .dir = dir,
+            .access_mask = access_mask,
+            .share_access = share_access,
+            .creation = creation,
+            .filter = .any,
+        }) catch |err| switch (err) {
+            error.WouldBlock => unreachable,
+            else => |e| return e,
+        };
+        break :blk res;
+    };
+    defer w.CloseHandle(h_file);
+
+    return std.os.getFdPath(h_file, out_buffer);
 }
 
 /// Spurious wakeups are possible and no precision of timing is guaranteed.
@@ -6382,65 +6242,70 @@ pub fn sendto(
     dest_addr: ?*const sockaddr,
     addrlen: socklen_t,
 ) SendToError!usize {
-    if (native_os == .windows) {
-        switch (windows.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen)) {
-            windows.ws2_32.SOCKET_ERROR => switch (windows.ws2_32.WSAGetLastError()) {
-                .WSAEACCES => return error.AccessDenied,
-                .WSAEADDRNOTAVAIL => return error.AddressNotAvailable,
-                .WSAECONNRESET => return error.ConnectionResetByPeer,
-                .WSAEMSGSIZE => return error.MessageTooBig,
-                .WSAENOBUFS => return error.SystemResources,
-                .WSAENOTSOCK => return error.FileDescriptorNotASocket,
-                .WSAEAFNOSUPPORT => return error.AddressFamilyNotSupported,
-                .WSAEDESTADDRREQ => unreachable, // A destination address is required.
-                .WSAEFAULT => unreachable, // The lpBuffers, lpTo, lpOverlapped, lpNumberOfBytesSent, or lpCompletionRoutine parameters are not part of the user address space, or the lpTo parameter is too small.
-                .WSAEHOSTUNREACH => return error.NetworkUnreachable,
-                // TODO: WSAEINPROGRESS, WSAEINTR
-                .WSAEINVAL => unreachable,
-                .WSAENETDOWN => return error.NetworkSubsystemFailed,
-                .WSAENETRESET => return error.ConnectionResetByPeer,
-                .WSAENETUNREACH => return error.NetworkUnreachable,
-                .WSAENOTCONN => return error.SocketNotConnected,
-                .WSAESHUTDOWN => unreachable, // The socket has been shut down; it is not possible to WSASendTo on a socket after shutdown has been invoked with how set to SD_SEND or SD_BOTH.
-                .WSAEWOULDBLOCK => return error.WouldBlock,
-                .WSANOTINITIALISED => unreachable, // A successful WSAStartup call must occur before using this function.
-                else => |err| return windows.unexpectedWSAError(err),
-            },
-            else => |rc| return @intCast(rc),
-        }
-    }
     while (true) {
-        const rc = system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
-        switch (errno(rc)) {
-            .SUCCESS => return @intCast(rc),
+        if (native_os == .windows) {
+            const rc = windows.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
+            if (rc == windows.ws2_32.SOCKET_ERROR) {
+                switch (windows.ws2_32.WSAGetLastError()) {
+                    .WSAEACCES => return error.AccessDenied,
+                    .WSAEADDRNOTAVAIL => return error.AddressNotAvailable,
+                    .WSAECONNRESET => return error.ConnectionResetByPeer,
+                    .WSAEMSGSIZE => return error.MessageTooBig,
+                    .WSAENOBUFS => return error.SystemResources,
+                    .WSAENOTSOCK => return error.FileDescriptorNotASocket,
+                    .WSAEAFNOSUPPORT => return error.AddressFamilyNotSupported,
+                    .WSAEDESTADDRREQ => unreachable, // A destination address is required.
+                    .WSAEFAULT => unreachable, // The lpBuffers, lpTo, lpOverlapped, lpNumberOfBytesSent, or lpCompletionRoutine parameters are not part of the user address space, or the lpTo parameter is too small.
+                    .WSAEHOSTUNREACH => return error.NetworkUnreachable,
+                    .WSAEINPROGRESS => return error.BlockingOperationInProgress,
+                    .WSAEINTR => continue,
+                    .WSAEINVAL => unreachable,
+                    .WSAENETDOWN => return error.NetworkSubsystemFailed,
+                    .WSAENETRESET => return error.ConnectionResetByPeer,
+                    .WSAENETUNREACH => return error.NetworkUnreachable,
+                    .WSAENOTCONN => return error.SocketNotConnected,
+                    .WSAESHUTDOWN => unreachable, // The socket has been shut down; it is not possible to WSASendTo on a socket after shutdown has been invoked with how set to SD_SEND or SD_BOTH.
+                    .WSAEWOULDBLOCK => return error.WouldBlock,
+                    .WSANOTINITIALISED => unreachable, // A successful WSAStartup call must occur before using this function.
+                    // TODO: test all errors
+                    else => |err| return windows.unexpectedWSAError(err),
+                }
+            } else {
+                return @intCast(rc);
+            }
+        } else {
+            const rc = system.sendto(sockfd, buf.ptr, buf.len, flags, dest_addr, addrlen);
+            switch (errno(rc)) {
+                .SUCCESS => return @intCast(rc),
 
-            .ACCES => return error.AccessDenied,
-            .AGAIN => return error.WouldBlock,
-            .ALREADY => return error.FastOpenAlreadyInProgress,
-            .BADF => unreachable, // always a race condition
-            .CONNREFUSED => return error.ConnectionRefused,
-            .CONNRESET => return error.ConnectionResetByPeer,
-            .DESTADDRREQ => unreachable, // The socket is not connection-mode, and no peer address is set.
-            .FAULT => unreachable, // An invalid user space address was specified for an argument.
-            .INTR => continue,
-            .INVAL => return error.UnreachableAddress,
-            .ISCONN => unreachable, // connection-mode socket was connected already but a recipient was specified
-            .MSGSIZE => return error.MessageTooBig,
-            .NOBUFS => return error.SystemResources,
-            .NOMEM => return error.SystemResources,
-            .NOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.
-            .OPNOTSUPP => unreachable, // Some bit in the flags argument is inappropriate for the socket type.
-            .PIPE => return error.BrokenPipe,
-            .AFNOSUPPORT => return error.AddressFamilyNotSupported,
-            .LOOP => return error.SymLinkLoop,
-            .NAMETOOLONG => return error.NameTooLong,
-            .NOENT => return error.FileNotFound,
-            .NOTDIR => return error.NotDir,
-            .HOSTUNREACH => return error.NetworkUnreachable,
-            .NETUNREACH => return error.NetworkUnreachable,
-            .NOTCONN => return error.SocketNotConnected,
-            .NETDOWN => return error.NetworkSubsystemFailed,
-            else => |err| return unexpectedErrno(err),
+                .ACCES => return error.AccessDenied,
+                .AGAIN => return error.WouldBlock,
+                .ALREADY => return error.FastOpenAlreadyInProgress,
+                .BADF => unreachable, // always a race condition
+                .CONNREFUSED => return error.ConnectionRefused,
+                .CONNRESET => return error.ConnectionResetByPeer,
+                .DESTADDRREQ => unreachable, // The socket is not connection-mode, and no peer address is set.
+                .FAULT => unreachable, // An invalid user space address was specified for an argument.
+                .INTR => continue,
+                .INVAL => return error.UnreachableAddress,
+                .ISCONN => unreachable, // connection-mode socket was connected already but a recipient was specified
+                .MSGSIZE => return error.MessageTooBig,
+                .NOBUFS => return error.SystemResources,
+                .NOMEM => return error.SystemResources,
+                .NOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.
+                .OPNOTSUPP => unreachable, // Some bit in the flags argument is inappropriate for the socket type.
+                .PIPE => return error.BrokenPipe,
+                .AFNOSUPPORT => return error.AddressFamilyNotSupported,
+                .LOOP => return error.SymLinkLoop,
+                .NAMETOOLONG => return error.NameTooLong,
+                .NOENT => return error.FileNotFound,
+                .NOTDIR => return error.NotDir,
+                .HOSTUNREACH => return error.NetworkUnreachable,
+                .NETUNREACH => return error.NetworkUnreachable,
+                .NOTCONN => return error.SocketNotConnected,
+                .NETDOWN => return error.NetworkSubsystemFailed,
+                else => |err| return unexpectedErrno(err),
+            }
         }
     }
 }
@@ -6639,7 +6504,7 @@ pub fn ppoll(fds: []pollfd, timeout: ?*const timespec, mask: ?*const sigset_t) P
     }
 }
 
-pub const RecvFromError = error{
+pub const RecvError = error{
     /// The socket is marked nonblocking and the requested operation would block, and
     /// there is no global event loop configured.
     WouldBlock,
@@ -6651,11 +6516,26 @@ pub const RecvFromError = error{
     /// Could not allocate kernel memory.
     SystemResources,
 
+    ///The connection was reset by the peer
     ConnectionResetByPeer,
+
+    ///Operation now in progress.A blocking operation is currently executing.
+    BlockingOperationInProgress,
+
+    ///Connection timed out
     ConnectionTimedOut,
 
     /// The socket has not been bound.
     SocketNotBound,
+
+    ///Software caused connection abort. An established connection was aborted by the software in your host computer, possibly due to a data transmission time-out or protocol error.
+    ConnectionAborted,
+
+    /// The file descriptor sockfd does not refer to a socket.
+    FileDescriptorNotASocket,
+
+    /// The socket is not of a type that supports the recv() operation.
+    OperationNotSupported,
 
     /// The UDP message was too big for the buffer and part of it has been discarded
     MessageTooBig,
@@ -6666,12 +6546,63 @@ pub const RecvFromError = error{
     /// The socket is not connected (connection-oriented sockets only).
     SocketNotConnected,
 
-    /// The other end closed the socket unexpectedly or a read is executed on a shut down socket
-    BrokenPipe,
+    /// Already connected
+    AlreadyConnected,
 } || UnexpectedError;
 
-pub fn recv(sock: socket_t, buf: []u8, flags: u32) RecvFromError!usize {
-    return recvfrom(sock, buf, flags, null, null);
+pub const RecvFromError = RecvError || error{
+    /// The passed address didn't have the correct address family in its sa_family field.
+    AddressFamilyNotSupported,
+
+    /// The socket is not connected (connection-oriented sockets only).
+    AddressNotAvailable,
+
+    /// The destination address is not reachable by the bound address.
+    UnreachableAddress,
+} || UnexpectedError;
+
+/// Receive messages from a socket.
+/// The `recv` call may be used only when the socket is in a connected state (so that the intended
+/// recipient  is  known).   The  only  difference  between `recv` and `read` is the presence of
+/// flags.  With a zero flags argument, `recv` is equivalent to  `read`.   Also,  the  following
+/// call
+///
+///     recv(sockfd, buf, flags);
+///
+/// is equivalent to
+///
+///     recvfrom(sockfd, buf, flags, NULL, NULL);
+///
+/// If  recvfrom()  is used on a connection-mode (`SOCK.STREAM`, `SOCK.SEQPACKET`) socket, the arguments
+/// `src_addr` and `addrlen` are asserted to be `null` and `null` respectively, and asserted
+/// that the socket was actually connected.
+/// Otherwise, the address of the source is given by `src_addr` with `addrlen` specifying  its  size.
+///
+/// If the message is too long to pass atomically through the underlying protocol,
+/// `RecvError.MessageTooBig` is returned, and the message is not transmitted.
+///
+/// When the message does not fit into the recv buffer of the socket,  `recv`  normally  blocks,
+/// unless the socket has been placed in nonblocking I/O mode.  In nonblocking mode it would fail
+/// with `RecvError.WouldBlock`.  The `select` call may be used to determine when it is
+/// possible to receive more data.
+pub fn recv(
+    /// The file descriptor of the sending socket.
+    sock: socket_t,
+    buf: []u8,
+    flags: u32,
+) RecvError!usize {
+    return recvfrom(sock, buf, flags, null, null) catch |err| switch (err) {
+        error.AddressFamilyNotSupported => unreachable,
+        error.SymLinkLoop => unreachable,
+        error.NameTooLong => unreachable,
+        error.FileNotFound => unreachable,
+        error.NotDir => unreachable,
+        error.NetworkUnreachable => unreachable,
+        error.AddressNotAvailable => unreachable,
+        error.SocketNotConnected => unreachable,
+        error.UnreachableAddress => unreachable,
+        else => |e| return e,
+    };
 }
 
 /// If `sockfd` is opened in non blocking mode, the function will
@@ -6684,90 +6615,50 @@ pub fn recvfrom(
     addrlen: ?*socklen_t,
 ) RecvFromError!usize {
     while (true) {
-        const rc = system.recvfrom(sockfd, buf.ptr, buf.len, flags, src_addr, addrlen);
         if (native_os == .windows) {
+            const rc = windows.recvfrom(sockfd, buf.ptr, buf.len, flags, src_addr, addrlen);
             if (rc == windows.ws2_32.SOCKET_ERROR) {
                 switch (windows.ws2_32.WSAGetLastError()) {
                     .WSANOTINITIALISED => unreachable,
-                    .WSAECONNRESET => return error.ConnectionResetByPeer,
-                    .WSAEINVAL => return error.SocketNotBound,
-                    .WSAEMSGSIZE => return error.MessageTooBig,
                     .WSAENETDOWN => return error.NetworkSubsystemFailed,
-                    .WSAENOTCONN => return error.SocketNotConnected,
+                    .WSAEFAULT => unreachable, // The lpBuffers, lpTo, lpOverlapped, lpNumberOfBytesSent, or lpCompletionRoutine parameters are not part of the user address space, or the lpTo parameter is too small.
+                    .WSAEINTR => continue,
+                    .WSAEINPROGRESS => return error.BlockingOperationInProgress,
+                    .WSAEINVAL => return error.SocketNotBound,
+                    .WSAEISCONN => return error.AlreadyConnected,
+                    .WSAENETRESET => return error.ConnectionResetByPeer,
+                    .WSAENOTSOCK => return error.FileDescriptorNotASocket,
+                    .WSAEOPNOTSUPP => return error.OperationNotSupported,
+                    .WSAESHUTDOWN => unreachable, // The socket has been shut down; it is not possible to WSASendTo on a socket after shutdown has been invoked with how set to SD_SEND or SD_BOTH.
                     .WSAEWOULDBLOCK => return error.WouldBlock,
+                    .WSAEMSGSIZE => return error.MessageTooBig,
                     .WSAETIMEDOUT => return error.ConnectionTimedOut,
-                    // TODO: handle more errors
+                    .WSAECONNRESET => return error.ConnectionResetByPeer,
+                    .WSAENOTCONN => return error.SocketNotConnected,
+                    .WSAECONNABORTED => return error.ConnectionAborted,
+                    // TODO: test all errors
                     else => |err| return windows.unexpectedWSAError(err),
                 }
             } else {
                 return @intCast(rc);
             }
         } else {
+            const rc = system.recvfrom(sockfd, buf.ptr, buf.len, flags, src_addr, addrlen);
             switch (errno(rc)) {
                 .SUCCESS => return @intCast(rc),
                 .BADF => unreachable, // always a race condition
                 .FAULT => unreachable,
-                .INVAL => unreachable,
+                .INVAL => return error.SocketNotBound,
                 .NOTCONN => return error.SocketNotConnected,
-                .NOTSOCK => unreachable,
+                .NOTSOCK => return error.FileDescriptorNotASocket,
                 .INTR => continue,
                 .AGAIN => return error.WouldBlock,
                 .NOMEM => return error.SystemResources,
                 .CONNREFUSED => return error.ConnectionRefused,
                 .CONNRESET => return error.ConnectionResetByPeer,
                 .TIMEDOUT => return error.ConnectionTimedOut,
-                .PIPE => return error.BrokenPipe,
                 else => |err| return unexpectedErrno(err),
             }
-        }
-    }
-}
-
-pub const RecvMsgError = RecvFromError || error{
-    /// Reception of SCM_RIGHTS fds via ancillary data in msg.control would
-    /// exceed some system limit (generally this is retryable by trying to
-    /// receive fewer fds or closing some existing fds)
-    SystemFdQuotaExceeded,
-
-    /// Reception of SCM_RIGHTS fds via ancillary data in msg.control would
-    /// exceed some process limit (generally this is retryable by trying to
-    /// receive fewer fds, closing some existing fds, or changing the ulimit)
-    ProcessFdQuotaExceeded,
-};
-
-/// If `sockfd` is opened in non blocking mode, the function will
-/// return error.WouldBlock when EAGAIN is received.
-pub fn recvmsg(
-    /// The file descriptor of the sending socket.
-    sockfd: socket_t,
-    /// Message header and iovecs
-    msg: *msghdr,
-    flags: u32,
-) RecvMsgError!usize {
-    if (@TypeOf(system.recvmsg) == void)
-        @compileError("recvmsg() not supported on this OS");
-    while (true) {
-        const rc = system.recvmsg(sockfd, msg, flags);
-        switch (errno(rc)) {
-            .SUCCESS => return @intCast(rc),
-            .AGAIN => return error.WouldBlock,
-            .BADF => unreachable, // always a race condition
-            .NFILE => return error.SystemFdQuotaExceeded,
-            .MFILE => return error.ProcessFdQuotaExceeded,
-            .INTR => continue,
-            .FAULT => unreachable, // An invalid user space address was specified for an argument.
-            .INVAL => unreachable, // Invalid argument passed.
-            .ISCONN => unreachable, // connection-mode socket was connected already but a recipient was specified
-            .NOBUFS => return error.SystemResources,
-            .NOMEM => return error.SystemResources,
-            .NOTCONN => return error.SocketNotConnected,
-            .NOTSOCK => unreachable, // The file descriptor sockfd does not refer to a socket.
-            .MSGSIZE => return error.MessageTooBig,
-            .PIPE => return error.BrokenPipe,
-            .OPNOTSUPP => unreachable, // Some bit in the flags argument is inappropriate for the socket type.
-            .CONNRESET => return error.ConnectionResetByPeer,
-            .NETDOWN => return error.NetworkSubsystemFailed,
-            else => |err| return unexpectedErrno(err),
         }
     }
 }
@@ -7021,7 +6912,7 @@ pub const SetSidError = error{
 pub fn setsid() SetSidError!pid_t {
     const rc = system.setsid();
     switch (errno(rc)) {
-        .SUCCESS => return @intCast(rc),
+        .SUCCESS => return rc,
         .PERM => return error.PermissionDenied,
         else => |err| return unexpectedErrno(err),
     }
@@ -7398,33 +7289,18 @@ pub fn timerfd_gettime(fd: i32) TimerFdGetError!system.itimerspec {
 }
 
 pub const PtraceError = error{
-    DeadLock,
     DeviceBusy,
     InputOutput,
-    NameTooLong,
-    OperationNotSupported,
-    OutOfMemory,
     ProcessNotFound,
     PermissionDenied,
 } || UnexpectedError;
 
-pub fn ptrace(request: u32, pid: pid_t, addr: usize, data: usize) PtraceError!void {
-    return switch (native_os) {
-        .windows,
-        .wasi,
-        .emscripten,
-        .haiku,
-        .solaris,
-        .illumos,
-        .plan9,
-        => @compileError("ptrace unsupported by target OS"),
+pub fn ptrace(request: u32, pid: pid_t, addr: usize, signal: usize) PtraceError!void {
+    if (native_os == .windows or native_os == .wasi)
+        @compileError("Unsupported OS");
 
-        .linux => switch (errno(if (builtin.link_libc) std.c.ptrace(
-            @intCast(request),
-            pid,
-            @ptrFromInt(addr),
-            @ptrFromInt(data),
-        ) else linux.ptrace(request, pid, addr, data, 0))) {
+    return switch (native_os) {
+        .linux => switch (errno(linux.ptrace(request, pid, addr, signal, 0))) {
             .SUCCESS => {},
             .SRCH => error.ProcessNotFound,
             .FAULT => unreachable,
@@ -7436,24 +7312,10 @@ pub fn ptrace(request: u32, pid: pid_t, addr: usize, data: usize) PtraceError!vo
         },
 
         .macos, .ios, .tvos, .watchos, .visionos => switch (errno(std.c.ptrace(
-            @enumFromInt(request),
-            pid,
-            @ptrFromInt(addr),
-            @intCast(data),
-        ))) {
-            .SUCCESS => {},
-            .SRCH => error.ProcessNotFound,
-            .INVAL => unreachable,
-            .PERM => error.PermissionDenied,
-            .BUSY => error.DeviceBusy,
-            else => |err| return unexpectedErrno(err),
-        },
-
-        .dragonfly => switch (errno(std.c.ptrace(
             @intCast(request),
             pid,
             @ptrFromInt(addr),
-            @intCast(data),
+            @intCast(signal),
         ))) {
             .SUCCESS => {},
             .SRCH => error.ProcessNotFound,
@@ -7463,53 +7325,14 @@ pub fn ptrace(request: u32, pid: pid_t, addr: usize, data: usize) PtraceError!vo
             else => |err| return unexpectedErrno(err),
         },
 
-        .freebsd => switch (errno(std.c.ptrace(
-            @intCast(request),
-            pid,
-            @ptrFromInt(addr),
-            @intCast(data),
-        ))) {
+        else => switch (errno(system.ptrace(request, pid, addr, signal))) {
             .SUCCESS => {},
             .SRCH => error.ProcessNotFound,
             .INVAL => unreachable,
             .PERM => error.PermissionDenied,
             .BUSY => error.DeviceBusy,
-            .NOENT, .NOMEM => error.OutOfMemory,
-            .NAMETOOLONG => error.NameTooLong,
             else => |err| return unexpectedErrno(err),
         },
-
-        .netbsd => switch (errno(std.c.ptrace(
-            @intCast(request),
-            pid,
-            @ptrFromInt(addr),
-            @intCast(data),
-        ))) {
-            .SUCCESS => {},
-            .SRCH => error.ProcessNotFound,
-            .INVAL => unreachable,
-            .PERM => error.PermissionDenied,
-            .BUSY => error.DeviceBusy,
-            .DEADLK => error.DeadLock,
-            else => |err| return unexpectedErrno(err),
-        },
-
-        .openbsd => switch (errno(std.c.ptrace(
-            @intCast(request),
-            pid,
-            @ptrFromInt(addr),
-            @intCast(data),
-        ))) {
-            .SUCCESS => {},
-            .SRCH => error.ProcessNotFound,
-            .INVAL => unreachable,
-            .PERM => error.PermissionDenied,
-            .BUSY => error.DeviceBusy,
-            .NOTSUP => error.OperationNotSupported,
-            else => |err| return unexpectedErrno(err),
-        },
-
-        else => @compileError("std.posix.ptrace unimplemented for target OS"),
     };
 }
 
@@ -7602,7 +7425,7 @@ pub const UnexpectedError = error{
 pub fn unexpectedErrno(err: E) UnexpectedError {
     if (unexpected_error_tracing) {
         std.debug.print("unexpected errno: {d}\n", .{@intFromEnum(err)});
-        std.debug.dumpCurrentStackTrace(.{});
+        std.debug.dumpCurrentStackTrace(null);
     }
     return error.Unexpected;
 }


### PR DESCRIPTION
recvfrom() uses Windows system calls, consistent with sendto(), the error return types have been updated, and the retry method for sendto() has been corrected.