### PR TITLE
Fix deficiencies in meta.hasUniqueRepresentation

### DIFF
--- a/lib/compiler/build_runner.zig
+++ b/lib/compiler/build_runner.zig
@@ -79,7 +79,7 @@ pub fn main() !void {
         .zig_lib_directory = zig_lib_directory,
         .host = .{
             .query = .{},
-            .result = try std.zig.system.resolveTargetQuery(.{}),
+            .result = try std.zig.system.resolveTargetQuery(.{}, arena),
         },
         .time_report = false,
     };

--- a/lib/std/Build.zig
+++ b/lib/std/Build.zig
@@ -2668,8 +2668,8 @@ pub fn resolveTargetQuery(b: *Build, query: Target.Query) ResolvedTarget {
     }
     return .{
         .query = query,
-        .result = std.zig.system.resolveTargetQuery(query) catch
-            @panic("unable to resolve target query"),
+        .result = std.zig.system.resolveTargetQuery(query, b.allocator) catch |err|
+            std.debug.panic("unable to resolve target query: {t}", .{err}),
     };
 }
 

--- a/lib/std/Build/WebServer.zig
+++ b/lib/std/Build/WebServer.zig
@@ -662,7 +662,7 @@ fn buildClientWasm(ws: *WebServer, arena: Allocator, optimize: std.builtin.Optim
         .target = &(std.zig.system.resolveTargetQuery(std.Build.parseTargetQuery(.{
             .arch_os_abi = arch_os_abi,
             .cpu_features = cpu_features,
-        }) catch unreachable) catch unreachable),
+        }) catch unreachable, arena) catch unreachable),
         .output_mode = .Exe,
     });
     return base_path.join(arena, bin_name);

--- a/lib/std/Target/Query.zig
+++ b/lib/std/Target/Query.zig
@@ -648,7 +648,8 @@ test parse {
             .arch_os_abi = "x86_64-linux-gnu",
             .cpu_features = "x86_64-sse-sse2-avx-cx8",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+
+        const target = try std.zig.system.resolveTargetQuery(query, undefined);
 
         try std.testing.expect(target.os.tag == .linux);
         try std.testing.expect(target.abi == .gnu);
@@ -673,7 +674,8 @@ test parse {
             .arch_os_abi = "arm-linux-musleabihf",
             .cpu_features = "generic+v8a",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+
+        const target = try std.zig.system.resolveTargetQuery(query, undefined);
 
         try std.testing.expect(target.os.tag == .linux);
         try std.testing.expect(target.abi == .musleabihf);
@@ -690,7 +692,7 @@ test parse {
             .arch_os_abi = "aarch64-linux.3.10...4.4.1-gnu.2.27",
             .cpu_features = "generic+v8a",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, undefined);
 
         try std.testing.expect(target.cpu.arch == .aarch64);
         try std.testing.expect(target.os.tag == .linux);
@@ -713,7 +715,7 @@ test parse {
         const query = try Query.parse(.{
             .arch_os_abi = "aarch64-linux.3.10...4.4.1-android.30",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, undefined);
 
         try std.testing.expect(target.cpu.arch == .aarch64);
         try std.testing.expect(target.os.tag == .linux);
@@ -734,7 +736,7 @@ test parse {
         const query = try Query.parse(.{
             .arch_os_abi = "x86-windows.xp...win8-msvc",
         });
-        const target = try std.zig.system.resolveTargetQuery(query);
+        const target = try std.zig.system.resolveTargetQuery(query, undefined);
 
         try std.testing.expect(target.cpu.arch == .x86);
         try std.testing.expect(target.os.tag == .windows);

--- a/lib/std/hash.zig
+++ b/lib/std/hash.zig
@@ -2,7 +2,7 @@ pub const Adler32 = @import("hash/Adler32.zig");
 
 const auto_hash = @import("hash/auto_hash.zig");
 pub const autoHash = auto_hash.autoHash;
-pub const autoHashStrat = auto_hash.hash;
+pub const autoHashStrat = auto_hash.autoHashStrat;
 pub const Strategy = auto_hash.HashStrategy;
 
 // pub for polynomials + generic crc32 construction

--- a/lib/std/zig.zig
+++ b/lib/std/zig.zig
@@ -620,8 +620,8 @@ pub fn putAstErrorsIntoBundle(
     try wip_errors.addZirErrorMessages(zir, tree, tree.source, path);
 }
 
-pub fn resolveTargetQueryOrFatal(target_query: std.Target.Query) std.Target {
-    return std.zig.system.resolveTargetQuery(target_query) catch |err|
+pub fn resolveTargetQueryOrFatal(target_query: std.Target.Query, arena: Allocator) std.Target {
+    return std.zig.system.resolveTargetQuery(target_query, arena) catch |err|
         std.process.fatal("unable to resolve target: {s}", .{@errorName(err)});
 }
 

--- a/src/Builtin.zig
+++ b/src/Builtin.zig
@@ -23,17 +23,12 @@ wasi_exec_model: std.builtin.WasiExecModel,
 /// of the resulting file contents.
 pub fn hash(opts: @This()) [std.Build.Cache.bin_digest_len]u8 {
     var h: Cache.Hasher = Cache.hasher_init;
-    inline for (@typeInfo(@This()).@"struct".fields) |f| {
-        if (comptime std.mem.eql(u8, f.name, "target")) {
+    inline for (@typeInfo(@This()).@"struct".fields) |field| {
+        if (comptime field.type == std.Target) {
             // This needs special handling.
-            std.hash.autoHash(&h, opts.target.cpu);
-            std.hash.autoHash(&h, opts.target.os.tag);
-            std.hash.autoHash(&h, opts.target.os.versionRange());
-            std.hash.autoHash(&h, opts.target.abi);
-            std.hash.autoHash(&h, opts.target.ofmt);
-            std.hash.autoHash(&h, opts.target.dynamic_linker);
+            @field(opts, field.name).hash(&h);
         } else {
-            std.hash.autoHash(&h, @field(opts, f.name));
+            std.hash.autoHash(&h, @field(opts, field.name));
         }
     }
     return h.finalResult();

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -5384,7 +5384,7 @@ fn workerDocsWasmFallible(comp: *Compilation, prog_node: std.Progress.Node) SubU
                 //.simd128,
                 // .tail_call, not supported by Safari
             }),
-        }) catch unreachable,
+        }, undefined) catch unreachable,
 
         .is_native_os = false,
         .is_native_abi = false,

--- a/src/print_env.zig
+++ b/src/print_env.zig
@@ -39,7 +39,7 @@ pub fn cmdEnv(
     const zig_std_dir = try dirs.zig_lib.join(arena, &.{"std"});
     const global_cache_dir = dirs.global_cache.path orelse "";
 
-    const host = try std.zig.system.resolveTargetQuery(.{});
+    const host = try std.zig.system.resolveTargetQuery(.{}, arena);
     const triple = try host.zigTriple(arena);
 
     var serializer: std.zon.Serializer = .{ .writer = out };

--- a/test/src/Cases.zig
+++ b/test/src/Cases.zig
@@ -455,8 +455,8 @@ pub fn lowerToBuildSteps(
     parent_step: *std.Build.Step,
     options: CaseTestOptions,
 ) void {
-    const host = std.zig.system.resolveTargetQuery(.{}) catch |err|
-        std.debug.panic("unable to detect native host: {s}\n", .{@errorName(err)});
+    const host = b.resolveTargetQuery(.{}).result;
+
     const cases_dir_path = b.build_root.join(b.allocator, &.{ "test", "cases" }) catch @panic("OOM");
 
     for (self.cases.items) |case| {
@@ -972,10 +972,10 @@ const TestManifest = struct {
     }
 };
 
-fn resolveTargetQuery(query: std.Target.Query) std.Build.ResolvedTarget {
+fn resolveTargetQuery(ctx: *Cases, query: std.Target.Query) std.Build.ResolvedTarget {
     return .{
         .query = query,
-        .target = std.zig.system.resolveTargetQuery(query) catch
+        .target = std.zig.system.resolveTargetQuery(query, ctx.arena) catch
             @panic("unable to resolve target query"),
     };
 }

--- a/tools/doctest.zig
+++ b/tools/doctest.zig
@@ -123,7 +123,7 @@ fn printOutput(
     var env_map = try process.getEnvMap(arena);
     try env_map.put("CLICOLOR_FORCE", "1");
 
-    const host = try std.zig.system.resolveTargetQuery(.{});
+    const host = try std.zig.system.resolveTargetQuery(.{}, arena);
     const obj_ext = builtin.object_format.fileExt(builtin.cpu.arch);
     const print = std.debug.print;
 
@@ -238,7 +238,7 @@ fn printOutput(
             const target_query = try std.Target.Query.parse(.{
                 .arch_os_abi = code.target_str orelse "native",
             });
-            const target = try std.zig.system.resolveTargetQuery(target_query);
+            const target = try std.zig.system.resolveTargetQuery(target_query, arena);
 
             const path_to_exe = try std.fmt.allocPrint(arena, "./{s}{s}", .{
                 code_name, target.exeFileExt(),
@@ -318,6 +318,7 @@ fn printOutput(
                 });
                 const target = try std.zig.system.resolveTargetQuery(
                     target_query,
+                    arena,
                 );
                 switch (getExternalExecutor(&host, &target, .{
                     .link_libc = code.link_libc,

--- a/tools/fetch_them_macos_headers.zig
+++ b/tools/fetch_them_macos_headers.zig
@@ -86,7 +86,7 @@ pub fn main() anyerror!void {
     }
 
     const sysroot_path = sysroot orelse blk: {
-        const target = try std.zig.system.resolveTargetQuery(.{});
+        const target = try std.zig.system.resolveTargetQuery(.{}, arena);
         break :blk std.zig.system.darwin.getSdk(allocator, &target) orelse
             fatal("no SDK found; you can provide one explicitly with '--sysroot' flag", .{});
     };

--- a/tools/generate_c_size_and_align_checks.zig
+++ b/tools/generate_c_size_and_align_checks.zig
@@ -40,7 +40,11 @@ pub fn main() !void {
     }
 
     const query = try std.Target.Query.parse(.{ .arch_os_abi = args[1] });
-    const target = try std.zig.system.resolveTargetQuery(query);
+
+    var target_buffer: [128]u8 = undefined;
+    var fba: std.heap.FixedBufferAllocator = .init(&target_buffer);
+
+    const target = try std.zig.system.resolveTargetQuery(query, fba.allocator());
 
     var buffer: [2000]u8 = undefined;
     var stdout_writer = std.fs.File.stdout().writerStreaming(&buffer);

--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -86,7 +86,7 @@ pub fn main() !void {
     else
         null;
 
-    const host = try std.zig.system.resolveTargetQuery(.{});
+    const host = try std.zig.system.resolveTargetQuery(.{}, arena);
 
     const debug_log_verbose = debug_zcu or debug_dwarf or debug_link;
 
@@ -683,7 +683,7 @@ const Case = struct {
                         },
                     }) catch fatal("line {d}: invalid target query '{s}'", .{ line_n, query });
 
-                    const resolved = try std.zig.system.resolveTargetQuery(parsed_query);
+                    const resolved = try std.zig.system.resolveTargetQuery(parsed_query, arena);
 
                     try targets.append(arena, .{
                         .query = query,


### PR DESCRIPTION
Fix several errors in hasUniqueRepresentation, both false negatives and false positives. Additionally, improve documentation surrounding the function, and split its ever-growing unit test into multiple seperate tests.

- False positives resolved
  - Error sets when the backing int of the error set does not have a unique representation
  - Enums tagged by non-unique types
  - Function types
  - ~~Pointers to comptime-only types~~
- False negatives resolved
  - Packed unions
  - Vectors on targets where the scalar types are bitpacked

While fixing this, I ran into several notable edge cases, so I would recommend any reviewers read the comments I left in hasUniqueRepresentation

~~One of the false positives in question was pointers to comptime-only types. Their representation is not defined, but to solve this, it was necessary to introduce a function to determine whether a type is comptime-only. Since this is a widely-applicable function, I made it public in meta.isComptimeOnly.~~
^ This has been rolled back, as determining whether a type is comptime-known takes up a massive of eval branch quota such that building any sizable project, including the compiler or even the build system, is impossible when checking this in hasUniqueRepresentation

Some rules of thumb for how hasUniqueRepresentation works now:
  - False negatives can be returned, but never false positives
  - ~~Comptime-only types always return false~~
  - Types with a well-defined layout never return a false negative or a
    false positive
  - Types with no well-defined layout may return true if the type
    provably has a unique representation, but may also return a false
    negative
    
PS: While working on this, I ran into some bugs in `std.hash.autoHash` which ended up incorrectly hashing slices, optional slices, and other types which should not be able to be hashed without specifying a strategy. To resolve this, I ended up refactoring `std/hash/auto_hash.zig` and fixing some uses of the API which should have been compile errors.
    
PPS: Also while working on this, I ran into a stale reference bug in `std.zig.resolveTargetQuery` that was causing the CI and behavior tests to fail. To fix this, an additional allocator parameter had to be added to the function. Then, I had to correct every reference of the function within the codebase, hence the all-over-the-place changes.