### PR TITLE
std.crypto.aead.aes_gcm: add support for nonce length other than 96 bits

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -29,6 +29,8 @@ pub const aead = struct {
     pub const aes_gcm = struct {
         pub const Aes128Gcm = @import("crypto/aes_gcm.zig").Aes128Gcm;
         pub const Aes256Gcm = @import("crypto/aes_gcm.zig").Aes256Gcm;
+        pub const Aes256GcmNonceLength = @import("crypto/aes_gcm.zig").Aes128GcmNonceLength;
+        pub const Aes128GcmNonceLength = @import("crypto/aes_gcm.zig").Aes256GcmNonceLength;
     };
 
     pub const aes_gcm_siv = struct {
@@ -273,6 +275,8 @@ test {
 
     _ = aead.aes_gcm.Aes128Gcm;
     _ = aead.aes_gcm.Aes256Gcm;
+    _ = aead.aes_gcm.Aes128GcmNonceLength(16);
+    _ = aead.aes_gcm.Aes256GcmNonceLength(16);
 
     _ = aead.aes_gcm_siv.Aes128GcmSiv;
     _ = aead.aes_gcm_siv.Aes256GcmSiv;

--- a/lib/std/crypto/aes_gcm.zig
+++ b/lib/std/crypto/aes_gcm.zig
@@ -10,6 +10,12 @@ const AuthenticationError = crypto.errors.AuthenticationError;
 
 pub const Aes128Gcm = AesGcm(crypto.core.aes.Aes128, 12);
 pub const Aes256Gcm = AesGcm(crypto.core.aes.Aes256, 12);
+pub fn Aes128GcmNonceLength(comptime n: usize) type {
+    return AesGcm(crypto.core.aes.Aes128, n);
+}
+pub fn Aes256GcmNonceLength(comptime n: usize) type {
+    return AesGcm(crypto.core.aes.Aes256, n);
+}
 
 fn AesGcm(comptime Aes: anytype, comptime n: usize) type {
     debug.assert(Aes.block.block_length == 16);


### PR DESCRIPTION
This PR add support for arbitrary nonce size between 1 and 16 bytes. 
Even if the nonce length is recommended to be of 96 bits, other programs such as gocryptfs use other nonce length.


<details>
 <summary>Program used to generate test data</summary>

```go
package main

import (
	"crypto/aes"
	"crypto/cipher"
	"fmt"
)

func main() {
	key := make([]byte, 32)
	for i := 0; i < 32; i++ {
		key[i] = 0x69
	}
	plaintext := []byte("Test with message")
	add := []byte("Test with associated data")

	block, err := aes.NewCipher(key)
	if err != nil {
		panic(err.Error())
	}
	nonce := make([]byte, 16)
	for i := 0; i < 16; i++ {
		nonce[i] = 0x42
	}
	aesgcm, err := cipher.NewGCMWithNonceSize(block, 16)
	if err != nil {
		panic(err.Error())
	}
	ciphertext := aesgcm.Seal(nil, nonce, plaintext, add)
	fmt.Printf("ciphertext: %x, tag: %x\n", ciphertext[0:len(ciphertext)-16], ciphertext[len(ciphertext)-16:])
}
```
</details>