### PR TITLE
copy_file_range: limit len to prevent EOVERFLOW

### DIFF
--- a/lib/std/fs/File.zig
+++ b/lib/std/fs/File.zig
@@ -1926,9 +1926,11 @@ pub const Writer = struct {
                 return sendFileBuffered(io_w, file_reader, reader_buffered);
             var off_in: i64 = undefined;
             var off_out: i64 = undefined;
+            var len: usize = @intFromEnum(limit);
             const off_in_ptr: ?*i64 = switch (file_reader.mode) {
                 .positional_reading, .streaming_reading => return error.Unimplemented,
                 .positional => p: {
+                    len = @min(len, std.math.maxInt(usize) - file_reader.pos);
                     off_in = @intCast(file_reader.pos);
                     break :p &off_in;
                 },
@@ -1938,13 +1940,14 @@ pub const Writer = struct {
             const off_out_ptr: ?*i64 = switch (w.mode) {
                 .positional_reading, .streaming_reading => return error.Unimplemented,
                 .positional => p: {
+                    len = @min(len, std.math.maxInt(usize) - w.pos);
                     off_out = @intCast(w.pos);
                     break :p &off_out;
                 },
                 .streaming => null,
                 .failure => return error.WriteFailed,
             };
-            const n = copy_file_range(in_fd, off_in_ptr, out_fd, off_out_ptr, @intFromEnum(limit), 0) catch |err| {
+            const n = copy_file_range(in_fd, off_in_ptr, out_fd, off_out_ptr, len, 0) catch |err| {
                 w.copy_file_range_err = err;
                 return 0;
             };


### PR DESCRIPTION
```
EOVERFLOW The requested source or destination range is too large to represent in the specified data types.
```

This error occurs if `limit` is `.unlimited` (`std.math.maxInt(usize)`) and the `pos` field of the reader/writer is not `0`.

<details><summary>Example 1 (uses preadv after copy_file_range)</summary>


```zig
const std = @import("std");

pub fn main() !void {
    const path_from = std.os.argv[1];
    const path_to = std.os.argv[2];
    const from = try std.fs.cwd().openFile(std.mem.span(path_from), .{});
    defer from.close();
    const to = try std.fs.cwd().createFile(std.mem.span(path_to), .{});
    defer to.close();
    var buf: [4096]u8 = undefined;
    var reader = from.reader(&.{});
    var writer = to.writer(&buf);
    defer writer.interface.flush() catch {};

    _ = try reader.interface.streamRemaining(&writer.interface);
}
```


```
$ zig build-exe test.zig
$ ./test test.zig out
```


strace before this PR:


```strace
openat(AT_FDCWD, "test.zig", O_RDONLY|O_NOCTTY|O_CLOEXEC) = 3
openat(AT_FDCWD, "out", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 4
copy_file_range(3, [0], 4, [0], 18446744073709551615, 0) = 535
copy_file_range(3, [535], 4, [535], 18446744073709551615, 0) = -1 EOVERFLOW (Value too large for defined data type)
preadv(3, [{iov_base="", iov_len=4096}], 1, 535) = 0
close(4)                                = 0
close(3)                                = 0
```

strace with this PR:


```strace
openat(AT_FDCWD, "test.zig", O_RDONLY|O_NOCTTY|O_CLOEXEC) = 3
openat(AT_FDCWD, "out", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 4
copy_file_range(3, [0], 4, [0], 18446744073709551615, 0) = 535
copy_file_range(3, [535], 4, [535], 18446744073709551080, 0) = 0
close(4)                                = 0
close(3)                                = 0
```

</details> 

<details><summary>Example 2 (uses preadv/pwritev instead of copy_file_range)</summary>

```zig
const std = @import("std");

pub fn main() !void {
    const path_from = std.os.argv[1];
    const path_to = std.os.argv[2];
    const from = try std.fs.cwd().openFile(std.mem.span(path_from), .{});
    defer from.close();
    const to = try std.fs.cwd().createFile(std.mem.span(path_to), .{});
    defer to.close();
    var buf: [4096]u8 = undefined;
    var reader = from.reader(&.{});
    var writer = to.writer(&buf);
    defer writer.interface.flush() catch {};

    // Change the seek position of writer or reader (or both)
    try reader.interface.discardAll(1);

    _ = try reader.interface.streamRemaining(&writer.interface);
}
```

```
$ zig build-exe test.zig
$ ./test test.zig out
```


strace before this PR:

```strace
openat(AT_FDCWD, "test.zig", O_RDONLY|O_NOCTTY|O_CLOEXEC) = 3
openat(AT_FDCWD, "out", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 4
statx(3, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_TYPE|STATX_MODE|STATX_ATIME|STATX_MTIME|STATX_CTIME, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=638, ...}) = 0
copy_file_range(3, [1], 4, [0], 18446744073709551615, 0) = -1 EOVERFLOW (Value too large for defined data type)
preadv(3, [{iov_base="onst std = @import(\"std\");\n\npub "..., iov_len=4096}], 1, 1) = 637
preadv(3, [{iov_base="", iov_len=3459}], 1, 638) = 0
pwritev(4, [{iov_base="onst std = @import(\"std\");\n\npub "..., iov_len=637}], 1, 0) = 637
close(4)                                = 0
close(3)                                = 0
```

strace with this PR:

```strace
openat(AT_FDCWD, "test.zig", O_RDONLY|O_NOCTTY|O_CLOEXEC) = 3
openat(AT_FDCWD, "out", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 4
statx(3, "", AT_STATX_SYNC_AS_STAT|AT_EMPTY_PATH, STATX_TYPE|STATX_MODE|STATX_ATIME|STATX_MTIME|STATX_CTIME, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=638, ...}) = 0
copy_file_range(3, [1], 4, [0], 18446744073709551614, 0) = 637
close(4)                                = 0
close(3)                                = 0
```

</details> 