### PR TITLE
std: Skip element comparisons if `mem.order` args point to same memory

### DIFF
--- a/lib/std/ascii.zig
+++ b/lib/std/ascii.zig
@@ -420,13 +420,15 @@ test indexOfIgnoreCase {
 
 /// Returns the lexicographical order of two slices. O(n).
 pub fn orderIgnoreCase(lhs: []const u8, rhs: []const u8) std.math.Order {
-    const n = @min(lhs.len, rhs.len);
-    var i: usize = 0;
-    while (i < n) : (i += 1) {
-        switch (std.math.order(toLower(lhs[i]), toLower(rhs[i]))) {
-            .eq => continue,
-            .lt => return .lt,
-            .gt => return .gt,
+    if (lhs.ptr != rhs.ptr) {
+        const n = @min(lhs.len, rhs.len);
+        var i: usize = 0;
+        while (i < n) : (i += 1) {
+            switch (std.math.order(toLower(lhs[i]), toLower(rhs[i]))) {
+                .eq => continue,
+                .lt => return .lt,
+                .gt => return .gt,
+            }
         }
     }
     return std.math.order(lhs.len, rhs.len);


### PR DESCRIPTION
This optimization is used in `mem.eql`, but was missing from `order`, `orderZ`, and `ascii.orderIgnoreCase`.