### PR TITLE
error.SocketNotListening is needed as part of std.Io.net.AcceptError

### DIFF
--- a/lib/std/Io/net.zig
+++ b/lib/std/Io/net.zig
@@ -1336,6 +1336,8 @@ pub const Server = struct {
         /// Firewall rules forbid connection.
         BlockedByFirewall,
         ProtocolFailure,
+        /// Socket is not listening for connections.
+        SocketNotListening,
     } || Io.UnexpectedError || Io.Cancelable;
 
     /// Blocks until a client connects to the server.


### PR DESCRIPTION
because std.posix.AcceptError now points to std.Io.net and std.posix.accept can return it.