### PR TITLE
zig fmt: fix extra whitespace in StructInit with multiline strings

### DIFF
--- a/lib/std/zig/Ast/Render.zig
+++ b/lib/std/zig/Ast/Render.zig
@@ -2056,7 +2056,8 @@ fn renderStructInit(
             const init_token = tree.firstToken(field_init);
             try renderToken(r, init_token - 3, .none); // .
             try renderIdentifier(r, init_token - 2, .space, .eagerly_unquote); // name
-            try renderToken(r, init_token - 1, .space); // =
+            const space_after_equal: Space = if (tree.nodeTag(field_init) == .multiline_string_literal) .none else .space;
+            try renderToken(r, init_token - 1, space_after_equal); // =
             try renderExpressionFixup(r, field_init, .comma_space);
         }
     }

--- a/lib/std/zig/parser_test.zig
+++ b/lib/std/zig/parser_test.zig
@@ -5719,6 +5719,16 @@ test "zig fmt: no space before newline before multiline string" {
         \\        ,
         \\    };
         \\    _ = s2;
+        \\    const s3 = .{ .text =
+        \\        \\hello
+        \\        \\world
+        \\    , .comment = "test" };
+        \\    _ = s3;
+        \\    const s4 = .{ .comment = "test", .text =
+        \\        \\hello
+        \\        \\world
+        \\    };
+        \\    _ = s4;
         \\}
         \\
     );

--- a/test/link/elf.zig
+++ b/test/link/elf.zig
@@ -480,7 +480,7 @@ fn testComdatElimination(b: *Build, opts: Options) *Step {
 fn testCommentString(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "comment-string", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes =
         \\pub fn main() void {}
     });
 
@@ -495,7 +495,7 @@ fn testCommentString(b: *Build, opts: Options) *Step {
 fn testCommentStringStaticLib(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "comment-string-static-lib", opts);
 
-    const lib = addStaticLibrary(b, opts, .{ .name = "lib", .zig_source_bytes = 
+    const lib = addStaticLibrary(b, opts, .{ .name = "lib", .zig_source_bytes =
         \\export fn foo() void {}
     });
 
@@ -866,7 +866,7 @@ fn testDsoUndef(b: *Build, opts: Options) *Step {
 fn testEmitRelocatable(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "emit-relocatable", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .zig_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .zig_source_bytes =
         \\const std = @import("std");
         \\extern var bar: i32;
         \\export fn foo() i32 {
@@ -878,7 +878,7 @@ fn testEmitRelocatable(b: *Build, opts: Options) *Step {
     });
     a_o.root_module.link_libc = true;
 
-    const b_o = addObject(b, opts, .{ .name = "b", .c_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .c_source_bytes =
         \\#include <stdio.h>
         \\int bar = 42;
         \\void printBar() {
@@ -891,7 +891,7 @@ fn testEmitRelocatable(b: *Build, opts: Options) *Step {
     c_o.root_module.addObject(a_o);
     c_o.root_module.addObject(b_o);
 
-    const exe = addExecutable(b, opts, .{ .name = "test", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "test", .zig_source_bytes =
         \\const std = @import("std");
         \\extern fn printFoo() void;
         \\extern fn printBar() void;
@@ -1925,7 +1925,7 @@ fn testInitArrayOrder(b: *Build, opts: Options) *Step {
     });
     g_o.root_module.link_libc = true;
 
-    const h_o = addObject(b, opts, .{ .name = "h", .c_source_bytes = 
+    const h_o = addObject(b, opts, .{ .name = "h", .c_source_bytes =
         \\#include <stdio.h>
         \\__attribute__((destructor)) void fini2() { printf("8"); }
     });
@@ -2447,7 +2447,7 @@ fn testLinkingZig(b: *Build, opts: Options) *Step {
 fn testLinksection(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "linksection", opts);
 
-    const obj = addObject(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const obj = addObject(b, opts, .{ .name = "main", .zig_source_bytes =
         \\export var test_global: u32 linksection(".TestGlobal") = undefined;
         \\export fn testFn() linksection(".TestFn") callconv(.c) void {
         \\    TestGenericFn("A").f();
@@ -2540,7 +2540,7 @@ fn testMergeStrings(b: *Build, opts: Options) *Step {
 fn testMergeStrings2(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "merge-strings2", opts);
 
-    const obj1 = addObject(b, opts, .{ .name = "a", .zig_source_bytes = 
+    const obj1 = addObject(b, opts, .{ .name = "a", .zig_source_bytes =
         \\const std = @import("std");
         \\export fn foo() void {
         \\    var arr: [5:0]u16 = [_:0]u16{ 1, 2, 3, 4, 5 };
@@ -2549,7 +2549,7 @@ fn testMergeStrings2(b: *Build, opts: Options) *Step {
         \\}
     });
 
-    const obj2 = addObject(b, opts, .{ .name = "b", .zig_source_bytes = 
+    const obj2 = addObject(b, opts, .{ .name = "b", .zig_source_bytes =
         \\const std = @import("std");
         \\extern fn foo() void;
         \\pub fn main() void {
@@ -2797,7 +2797,7 @@ fn testRelocatableEhFrame(b: *Build, opts: Options) *Step {
         ,
     });
     obj2.root_module.link_libcpp = true;
-    const obj3 = addObject(b, opts, .{ .name = "obj3", .cpp_source_bytes = 
+    const obj3 = addObject(b, opts, .{ .name = "obj3", .cpp_source_bytes =
         \\#include <iostream>
         \\#include <stdexcept>
         \\extern int try_again();
@@ -2909,7 +2909,7 @@ fn testRelocatableEhFrameComdatHeavy(b: *Build, opts: Options) *Step {
 fn testRelocatableMergeStrings(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "relocatable-merge-strings", opts);
 
-    const obj1 = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const obj1 = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.section .rodata.str1.1,"aMS",@progbits,1
         \\val1:
         \\.ascii "Hello \0"
@@ -3075,7 +3075,7 @@ fn testStrip(b: *Build, opts: Options) *Step {
 fn testThunks(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "thunks", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\void foo();
         \\__attribute__((section(".bar"))) void bar() {
         \\  return foo();

--- a/test/link/macho.zig
+++ b/test/link/macho.zig
@@ -111,7 +111,7 @@ pub fn testAll(b: *Build, build_opts: BuildOptions) *Step {
 fn testDeadStrip(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "dead-strip", opts);
 
-    const obj = addObject(b, opts, .{ .name = "a", .cpp_source_bytes = 
+    const obj = addObject(b, opts, .{ .name = "a", .cpp_source_bytes =
         \\#include <stdio.h>
         \\int two() { return 2; }
         \\int live_var1 = 1;
@@ -192,13 +192,13 @@ fn testDeadStrip(b: *Build, opts: Options) *Step {
 fn testDuplicateDefinitions(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "duplicate-definitions", opts);
 
-    const obj = addObject(b, opts, .{ .name = "a", .zig_source_bytes = 
+    const obj = addObject(b, opts, .{ .name = "a", .zig_source_bytes =
         \\var x: usize = 1;
         \\export fn strong() void { x += 1; }
         \\export fn weak() void { x += 1; }
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes =
         \\var x: usize = 1;
         \\export fn strong() void { x += 1; }
         \\comptime { @export(&weakImpl, .{ .name = "weak", .linkage = .weak }); }
@@ -223,7 +223,7 @@ fn testDuplicateDefinitions(b: *Build, opts: Options) *Step {
 fn testDeadStripDylibs(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "dead-strip-dylibs", opts);
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <objc/runtime.h>
         \\int main() {
         \\  if (objc_getClass("NSObject") == 0) {
@@ -272,7 +272,7 @@ fn testDeadStripDylibs(b: *Build, opts: Options) *Step {
 fn testDylib(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "dylib", opts);
 
-    const dylib = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes = 
+    const dylib = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes =
         \\#include<stdio.h>
         \\char world[] = "world";
         \\char* hello() {
@@ -286,7 +286,7 @@ fn testDylib(b: *Build, opts: Options) *Step {
     check.checkNotPresent("PIE");
     test_step.dependOn(&check.step);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include<stdio.h>
         \\char* hello();
         \\extern char world[];
@@ -347,7 +347,7 @@ fn testEmptyObject(b: *Build, opts: Options) *Step {
 
     const empty = addObject(b, opts, .{ .name = "empty", .c_source_bytes = "" });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int main() {
         \\  printf("Hello world!");
@@ -377,7 +377,7 @@ fn testEmptyZig(b: *Build, opts: Options) *Step {
 fn testEntryPoint(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "entry-point", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include<stdio.h>
         \\int non_main() {
         \\  printf("%d", 42);
@@ -599,7 +599,7 @@ fn testHeaderpad(b: *Build, opts: Options) *Step {
 fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "header-weak-flags", opts);
 
-    const obj1 = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const obj1 = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _x
         \\.weak_definition _x
         \\_x:
@@ -661,7 +661,7 @@ fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
     }
 
     {
-        const exe = addExecutable(b, opts, .{ .name = "main3", .asm_source_bytes = 
+        const exe = addExecutable(b, opts, .{ .name = "main3", .asm_source_bytes =
             \\.globl _main, _x
             \\_x:
             \\
@@ -686,7 +686,7 @@ fn testHeaderWeakFlags(b: *Build, opts: Options) *Step {
 fn testHelloC(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "hello-c", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int main() { 
         \\  printf("Hello world!\n");
@@ -710,7 +710,7 @@ fn testHelloC(b: *Build, opts: Options) *Step {
 fn testHelloZig(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "hello-zig", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes =
         \\const std = @import("std");
         \\pub fn main() void {
         \\    std.fs.File.stdout().writeAll("Hello world!\n") catch @panic("fail");
@@ -731,7 +731,7 @@ fn testLargeBss(b: *Build, opts: Options) *Step {
     // linker I tried misbehave in different ways. This only happened on arm64. I thought that
     // maybe S_GB_ZEROFILL section is an answer to this but it doesn't seem supported by dyld
     // anymore. When I get some free time I will re-investigate this.
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\char arr[0x1000000];
         \\int main() {
         \\  return arr[2000];
@@ -748,7 +748,7 @@ fn testLargeBss(b: *Build, opts: Options) *Step {
 fn testLayout(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "layout", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int main() {
         \\  printf("Hello world!");
@@ -938,7 +938,7 @@ fn testLinkingStaticLib(b: *Build, opts: Options) *Step {
 fn testLinksection(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "linksection", opts);
 
-    const obj = addObject(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const obj = addObject(b, opts, .{ .name = "main", .zig_source_bytes =
         \\export var test_global: u32 linksection("__DATA,__TestGlobal") = undefined;
         \\export fn testFn() linksection("__TEXT,__TestFn") callconv(.c) void {
         \\    TestGenericFn("A").f();
@@ -969,7 +969,7 @@ fn testLinksection(b: *Build, opts: Options) *Step {
 fn testMergeLiteralsX64(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "merge-literals-x64", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _q1
         \\.globl _s1
         \\
@@ -994,7 +994,7 @@ fn testMergeLiteralsX64(b: *Build, opts: Options) *Step {
         \\  .quad l._s1
     });
 
-    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes =
         \\.globl _q2
         \\.globl _s2
         \\.globl _s3
@@ -1024,7 +1024,7 @@ fn testMergeLiteralsX64(b: *Build, opts: Options) *Step {
         \\   .quad l._s3
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\extern double q1();
         \\extern double q2();
@@ -1085,7 +1085,7 @@ fn testMergeLiteralsX64(b: *Build, opts: Options) *Step {
 fn testMergeLiteralsArm64(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "merge-literals-arm64", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _q1
         \\.globl _s1
         \\
@@ -1110,7 +1110,7 @@ fn testMergeLiteralsArm64(b: *Build, opts: Options) *Step {
         \\  .quad l._s1
     });
 
-    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes =
         \\.globl _q2
         \\.globl _s2
         \\.globl _s3
@@ -1140,7 +1140,7 @@ fn testMergeLiteralsArm64(b: *Build, opts: Options) *Step {
         \\   .quad l._s3
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\extern double q1();
         \\extern double q2();
@@ -1205,7 +1205,7 @@ fn testMergeLiteralsArm64(b: *Build, opts: Options) *Step {
 fn testMergeLiteralsArm642(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "merge-literals-arm64-2", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _q1
         \\.globl _s1
         \\
@@ -1225,7 +1225,7 @@ fn testMergeLiteralsArm642(b: *Build, opts: Options) *Step {
         \\  .double 1.2345
     });
 
-    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes =
         \\.globl _q2
         \\.globl _s2
         \\.globl _s3
@@ -1248,7 +1248,7 @@ fn testMergeLiteralsArm642(b: *Build, opts: Options) *Step {
         \\  .double 1.2345
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\extern double q1();
         \\extern double q2();
@@ -1279,7 +1279,7 @@ fn testMergeLiteralsArm642(b: *Build, opts: Options) *Step {
 fn testMergeLiteralsAlignment(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "merge-literals-alignment", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _s1
         \\.globl _s2
         \\
@@ -1291,7 +1291,7 @@ fn testMergeLiteralsAlignment(b: *Build, opts: Options) *Step {
         \\  .asciz "str2"
     });
 
-    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .asm_source_bytes =
         \\.globl _s3
         \\.globl _s4
         \\
@@ -1303,7 +1303,7 @@ fn testMergeLiteralsAlignment(b: *Build, opts: Options) *Step {
         \\  .asciz "str2"
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <assert.h>
         \\#include <stdint.h>
         \\#include <stdio.h>
@@ -1358,7 +1358,7 @@ fn testMergeLiteralsAlignment(b: *Build, opts: Options) *Step {
 fn testMergeLiteralsObjc(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "merge-literals-objc", opts);
 
-    const main_o = addObject(b, opts, .{ .name = "main", .objc_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .objc_source_bytes =
         \\#import <Foundation/Foundation.h>;
         \\
         \\extern void foo();
@@ -1376,7 +1376,7 @@ fn testMergeLiteralsObjc(b: *Build, opts: Options) *Step {
         \\}
     });
 
-    const a_o = addObject(b, opts, .{ .name = "a", .objc_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .objc_source_bytes =
         \\#import <Foundation/Foundation.h>;
         \\
         \\void foo() {
@@ -1461,7 +1461,7 @@ fn testMhExecuteHeader(b: *Build, opts: Options) *Step {
 fn testNoDeadStrip(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "no-dead-strip", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "name", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "name", .c_source_bytes =
         \\__attribute__((used)) int bogus1 = 0;
         \\int bogus2 = 0;
         \\int foo = 42;
@@ -1545,7 +1545,7 @@ fn testNeededLibrary(b: *Build, opts: Options) *Step {
 fn testObjc(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "objc", opts);
 
-    const lib = addStaticLibrary(b, opts, .{ .name = "a", .objc_source_bytes = 
+    const lib = addStaticLibrary(b, opts, .{ .name = "a", .objc_source_bytes =
         \\#import <Foundation/Foundation.h>
         \\@interface Foo : NSObject
         \\@end
@@ -1602,7 +1602,7 @@ fn testObjcpp(b: *Build, opts: Options) *Step {
         );
     };
 
-    const foo_o = addObject(b, opts, .{ .name = "foo", .objcpp_source_bytes = 
+    const foo_o = addObject(b, opts, .{ .name = "foo", .objcpp_source_bytes =
         \\#import "Foo.h"
         \\@implementation Foo
         \\- (NSString *)name
@@ -1615,7 +1615,7 @@ fn testObjcpp(b: *Build, opts: Options) *Step {
     foo_o.root_module.addIncludePath(foo_h.dirname());
     foo_o.root_module.link_libcpp = true;
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .objcpp_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .objcpp_source_bytes =
         \\#import "Foo.h"
         \\#import <assert.h>
         \\#include <iostream>
@@ -1679,7 +1679,7 @@ fn testPagezeroSize(b: *Build, opts: Options) *Step {
 fn testReexportsZig(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "reexports-zig", opts);
 
-    const lib = addStaticLibrary(b, opts, .{ .name = "a", .zig_source_bytes = 
+    const lib = addStaticLibrary(b, opts, .{ .name = "a", .zig_source_bytes =
         \\const x: i32 = 42;
         \\export fn foo() i32 {
         \\    return x;
@@ -1689,7 +1689,7 @@ fn testReexportsZig(b: *Build, opts: Options) *Step {
         \\}
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\extern int foo();
         \\extern int bar();
         \\int main() {
@@ -1708,7 +1708,7 @@ fn testReexportsZig(b: *Build, opts: Options) *Step {
 fn testRelocatable(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "relocatable", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .cpp_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .cpp_source_bytes =
         \\#include <stdexcept>
         \\int try_me() {
         \\  throw std::runtime_error("Oh no!");
@@ -1716,14 +1716,14 @@ fn testRelocatable(b: *Build, opts: Options) *Step {
     });
     a_o.root_module.link_libcpp = true;
 
-    const b_o = addObject(b, opts, .{ .name = "b", .cpp_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .cpp_source_bytes =
         \\extern int try_me();
         \\int try_again() {
         \\  return try_me();
         \\}
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes =
         \\#include <iostream>
         \\#include <stdexcept>
         \\extern int try_again();
@@ -1776,7 +1776,7 @@ fn testRelocatable(b: *Build, opts: Options) *Step {
 fn testRelocatableZig(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "relocatable-zig", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .zig_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .zig_source_bytes =
         \\const std = @import("std");
         \\export var foo: i32 = 0;
         \\export fn incrFoo() void {
@@ -1785,7 +1785,7 @@ fn testRelocatableZig(b: *Build, opts: Options) *Step {
         \\}
     });
 
-    const b_o = addObject(b, opts, .{ .name = "b", .zig_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .zig_source_bytes =
         \\const std = @import("std");
         \\extern var foo: i32;
         \\export fn decrFoo() void {
@@ -1794,7 +1794,7 @@ fn testRelocatableZig(b: *Build, opts: Options) *Step {
         \\}
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .zig_source_bytes =
         \\const std = @import("std");
         \\extern var foo: i32;
         \\extern fn incrFoo() void;
@@ -1827,7 +1827,7 @@ fn testRelocatableZig(b: *Build, opts: Options) *Step {
 fn testSearchStrategy(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "search-strategy", opts);
 
-    const obj = addObject(b, opts, .{ .name = "a", .c_source_bytes = 
+    const obj = addObject(b, opts, .{ .name = "a", .c_source_bytes =
         \\#include<stdio.h>
         \\char world[] = "world";
         \\char* hello() {
@@ -1841,7 +1841,7 @@ fn testSearchStrategy(b: *Build, opts: Options) *Step {
     const dylib = addSharedLibrary(b, opts, .{ .name = "a" });
     dylib.root_module.addObject(obj);
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include<stdio.h>
         \\char* hello();
         \\extern char world[];
@@ -1975,7 +1975,7 @@ fn testSectionBoundarySymbols(b: *Build, opts: Options) *Step {
 fn testSectionBoundarySymbols2(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "section-boundary-symbols-2", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\struct pair { int a; int b;  };
         \\struct pair first __attribute__((section("__DATA,__pairs"))) = { 1, 2  };
@@ -2012,11 +2012,11 @@ fn testSectionBoundarySymbols2(b: *Build, opts: Options) *Step {
 fn testSegmentBoundarySymbols(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "segment-boundary-symbols", opts);
 
-    const obj1 = addObject(b, opts, .{ .name = "a", .cpp_source_bytes = 
+    const obj1 = addObject(b, opts, .{ .name = "a", .cpp_source_bytes =
         \\constexpr const char* MESSAGE __attribute__((used, section("__DATA_CONST_1,__message_ptr"))) = "codebase";
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\const char* interop();
         \\int main() {
@@ -2026,7 +2026,7 @@ fn testSegmentBoundarySymbols(b: *Build, opts: Options) *Step {
     });
 
     {
-        const obj2 = addObject(b, opts, .{ .name = "b", .cpp_source_bytes = 
+        const obj2 = addObject(b, opts, .{ .name = "b", .cpp_source_bytes =
             \\extern const char* message_pointer __asm("segment$start$__DATA_CONST_1");
             \\extern "C" const char* interop() {
             \\  return message_pointer;
@@ -2049,7 +2049,7 @@ fn testSegmentBoundarySymbols(b: *Build, opts: Options) *Step {
     }
 
     {
-        const obj2 = addObject(b, opts, .{ .name = "c", .cpp_source_bytes = 
+        const obj2 = addObject(b, opts, .{ .name = "c", .cpp_source_bytes =
             \\extern const char* message_pointer __asm("segment$start$__DATA_1");
             \\extern "C" const char* interop() {
             \\  return message_pointer;
@@ -2080,21 +2080,21 @@ fn testSegmentBoundarySymbols(b: *Build, opts: Options) *Step {
 fn testSymbolStabs(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "symbol-stabs", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .c_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .c_source_bytes =
         \\int foo = 42;
         \\int getFoo() {
         \\  return foo;
         \\}
     });
 
-    const b_o = addObject(b, opts, .{ .name = "b", .c_source_bytes = 
+    const b_o = addObject(b, opts, .{ .name = "b", .c_source_bytes =
         \\int bar = 24;
         \\int getBar() {
         \\  return bar;
         \\}
     });
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\extern int getFoo();
         \\extern int getBar();
@@ -2164,7 +2164,7 @@ fn testTbdv3(b: *Build, opts: Options) *Step {
         );
     };
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int getFoo();
         \\int main() {
@@ -2211,7 +2211,7 @@ fn testTentative(b: *Build, opts: Options) *Step {
 fn testThunks(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "thunks", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\void bar() {
         \\  printf("bar");
@@ -2243,14 +2243,14 @@ fn testThunks(b: *Build, opts: Options) *Step {
 fn testTls(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "tls", opts);
 
-    const dylib = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes = 
+    const dylib = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes =
         \\_Thread_local int a;
         \\int getA() {
         \\  return a;
         \\}
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include<stdio.h>
         \\extern _Thread_local int a;
         \\extern int getA();
@@ -2294,7 +2294,7 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
         );
     };
 
-    const bar_o = addObject(b, opts, .{ .name = "bar", .cpp_source_bytes = 
+    const bar_o = addObject(b, opts, .{ .name = "bar", .cpp_source_bytes =
         \\#include "foo.h"
         \\int bar() {
         \\  int v1 = Foo<int>::getVar();
@@ -2304,7 +2304,7 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
     bar_o.root_module.addIncludePath(foo_h.dirname());
     bar_o.root_module.link_libcpp = true;
 
-    const baz_o = addObject(b, opts, .{ .name = "baz", .cpp_source_bytes = 
+    const baz_o = addObject(b, opts, .{ .name = "baz", .cpp_source_bytes =
         \\#include "foo.h"
         \\int baz() {
         \\  int v1 = Foo<unsigned>::getVar();
@@ -2314,7 +2314,7 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
     baz_o.root_module.addIncludePath(foo_h.dirname());
     baz_o.root_module.link_libcpp = true;
 
-    const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes =
         \\extern int bar();
         \\extern int baz();
         \\int main() {
@@ -2342,7 +2342,7 @@ fn testTlsPointers(b: *Build, opts: Options) *Step {
 fn testTlsLargeTbss(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "tls-large-tbss", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\_Thread_local int x[0x8000];
         \\_Thread_local int y[0x8000];
@@ -2363,7 +2363,7 @@ fn testTlsLargeTbss(b: *Build, opts: Options) *Step {
 fn testTlsZig(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "tls-zig", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes =
         \\const std = @import("std");
         \\threadlocal var x: i32 = 0;
         \\threadlocal var y: i32 = -1;
@@ -2390,7 +2390,7 @@ fn testTlsZig(b: *Build, opts: Options) *Step {
 fn testTwoLevelNamespace(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "two-level-namespace", opts);
 
-    const liba = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes = 
+    const liba = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes =
         \\#include <stdio.h>
         \\int foo = 1;
         \\int* ptr_to_foo = &foo;
@@ -2411,7 +2411,7 @@ fn testTwoLevelNamespace(b: *Build, opts: Options) *Step {
         test_step.dependOn(&check.step);
     }
 
-    const libb = addSharedLibrary(b, opts, .{ .name = "b", .c_source_bytes = 
+    const libb = addSharedLibrary(b, opts, .{ .name = "b", .c_source_bytes =
         \\#include <stdio.h>
         \\int foo = 2;
         \\int* ptr_to_foo = &foo;
@@ -2432,7 +2432,7 @@ fn testTwoLevelNamespace(b: *Build, opts: Options) *Step {
         test_step.dependOn(&check.step);
     }
 
-    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int getFoo();
         \\extern int* ptr_to_foo;
@@ -2632,12 +2632,12 @@ fn testUndefinedFlag(b: *Build, opts: Options) *Step {
 fn testUnresolvedError(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "unresolved-error", opts);
 
-    const obj = addObject(b, opts, .{ .name = "a", .zig_source_bytes = 
+    const obj = addObject(b, opts, .{ .name = "a", .zig_source_bytes =
         \\extern fn foo() i32;
         \\export fn bar() i32 { return foo() + 1; }
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes =
         \\const std = @import("std");
         \\extern fn foo() i32;
         \\extern fn bar() i32;
@@ -2668,7 +2668,7 @@ fn testUnresolvedError(b: *Build, opts: Options) *Step {
 fn testUnresolvedError2(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "unresolved-error-2", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .zig_source_bytes =
         \\pub fn main() !void {
         \\    const msg_send_fn = @extern(
         \\        *const fn () callconv(.c) usize,
@@ -2740,7 +2740,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
         );
     };
 
-    const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes = 
+    const main_o = addObject(b, opts, .{ .name = "main", .cpp_source_bytes =
         \\#include "all.h"
         \\#include <cstdio>
         \\
@@ -2769,7 +2769,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
     main_o.root_module.addIncludePath(all_h.dirname());
     main_o.root_module.link_libcpp = true;
 
-    const simple_string_o = addObject(b, opts, .{ .name = "simple_string", .cpp_source_bytes = 
+    const simple_string_o = addObject(b, opts, .{ .name = "simple_string", .cpp_source_bytes =
         \\#include "all.h"
         \\#include <cstdio>
         \\#include <cstring>
@@ -2804,7 +2804,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
     simple_string_o.root_module.addIncludePath(all_h.dirname());
     simple_string_o.root_module.link_libcpp = true;
 
-    const simple_string_owner_o = addObject(b, opts, .{ .name = "simple_string_owner", .cpp_source_bytes = 
+    const simple_string_owner_o = addObject(b, opts, .{ .name = "simple_string_owner", .cpp_source_bytes =
         \\#include "all.h"
         \\
         \\SimpleStringOwner::SimpleStringOwner(const char* x) : string{ 10 } {
@@ -2851,7 +2851,7 @@ fn testUnwindInfo(b: *Build, opts: Options) *Step {
 fn testUnwindInfoNoSubsectionsArm64(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "unwind-info-no-subsections-arm64", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _foo
         \\.align 4
         \\_foo:
@@ -2891,7 +2891,7 @@ fn testUnwindInfoNoSubsectionsArm64(b: *Build, opts: Options) *Step {
         \\  .cfi_endproc
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int foo();
         \\int main() {
@@ -2911,7 +2911,7 @@ fn testUnwindInfoNoSubsectionsArm64(b: *Build, opts: Options) *Step {
 fn testUnwindInfoNoSubsectionsX64(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "unwind-info-no-subsections-x64", opts);
 
-    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes = 
+    const a_o = addObject(b, opts, .{ .name = "a", .asm_source_bytes =
         \\.globl _foo
         \\_foo:
         \\  .cfi_startproc
@@ -2943,7 +2943,7 @@ fn testUnwindInfoNoSubsectionsX64(b: *Build, opts: Options) *Step {
         \\  .cfi_endproc
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\int foo();
         \\int main() {
@@ -2964,7 +2964,7 @@ fn testUnwindInfoNoSubsectionsX64(b: *Build, opts: Options) *Step {
 fn testWeakBind(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "weak-bind", opts);
 
-    const lib = addSharedLibrary(b, opts, .{ .name = "foo", .asm_source_bytes = 
+    const lib = addSharedLibrary(b, opts, .{ .name = "foo", .asm_source_bytes =
         \\.globl _weak_dysym
         \\.weak_definition _weak_dysym
         \\_weak_dysym:
@@ -2998,7 +2998,7 @@ fn testWeakBind(b: *Build, opts: Options) *Step {
         test_step.dependOn(&check.step);
     }
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .asm_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .asm_source_bytes =
         \\.globl _main, _weak_external, _weak_external_for_gotpcrel, _weak_external_fn
         \\.weak_definition _weak_external, _weak_external_for_gotpcrel, _weak_external_fn, _weak_internal, _weak_internal_for_gotpcrel, _weak_internal_fn
         \\
@@ -3114,7 +3114,7 @@ fn testWeakFramework(b: *Build, opts: Options) *Step {
 fn testWeakLibrary(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "weak-library", opts);
 
-    const dylib = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes = 
+    const dylib = addSharedLibrary(b, opts, .{ .name = "a", .c_source_bytes =
         \\#include<stdio.h>
         \\int a = 42;
         \\const char* asStr() {
@@ -3124,7 +3124,7 @@ fn testWeakLibrary(b: *Build, opts: Options) *Step {
         \\}
     });
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include<stdio.h>
         \\extern int a;
         \\extern const char* asStr();
@@ -3157,7 +3157,7 @@ fn testWeakLibrary(b: *Build, opts: Options) *Step {
 fn testWeakRef(b: *Build, opts: Options) *Step {
     const test_step = addTestStep(b, "weak-ref", opts);
 
-    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes = 
+    const exe = addExecutable(b, opts, .{ .name = "main", .c_source_bytes =
         \\#include <stdio.h>
         \\#include <sys/_types/_fd_def.h>
         \\int main(int argc, char** argv) {


### PR DESCRIPTION
68d2f68ed introduced special handling for StructInit fields containing multiline strings to prevent inserting whitespace after =. However, this logic didn't handle cases without a trailing comma, which resulted in unwanted trailing whitespace.
```zig
test {
    _ = .{
        .field =
        \\this is fine
        ,
    };
    _ = .{ .field = 
        \\         ^ trailing whitespace here
    };
}

```