### PR TITLE
Reduce usage of expectEqual in behavior tests

### DIFF
--- a/test/behavior/align.zig
+++ b/test/behavior/align.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const expect = std.testing.expect;
+const assert = std.debug.assert;
 const builtin = @import("builtin");
 const native_arch = builtin.target.cpu.arch;
-const assert = std.debug.assert;
 
 var foo: u8 align(4) = 100;
 
@@ -556,7 +556,7 @@ test "function pointer @intFromPtr/@ptrFromInt roundtrip" {
     const nothing_int: usize = @intFromPtr(nothing_ptr);
     const nothing_ptr2: *const fn () callconv(.c) void = @ptrFromInt(nothing_int);
 
-    try std.testing.expectEqual(nothing_ptr, nothing_ptr2);
+    try std.testing.expect(nothing_ptr == nothing_ptr2);
 }
 
 test "function pointer align mask" {

--- a/test/behavior/array.zig
+++ b/test/behavior/array.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const testing = std.testing;
 const mem = std.mem;
 const assert = std.debug.assert;
 const expect = testing.expect;
 const expectEqual = testing.expectEqual;
+const builtin = @import("builtin");
 
 test "array to slice" {
     const a: u32 align(4) = 3;
@@ -745,7 +745,7 @@ test "runtime side-effects in comptime-known array init" {
         },
     };
     try expectEqual([4]u4{ 1, 2, 4, 8 }, init);
-    try expectEqual(@as(u4, std.math.maxInt(u4)), side_effects);
+    try expect(@as(u4, std.math.maxInt(u4)) == side_effects);
 }
 
 test "slice initialized through reference to anonymous array init provides result types" {
@@ -791,10 +791,10 @@ test "many-item pointer initialized through reference to anonymous array init pr
         @truncate(my_u32),
         @truncate(my_u64),
     };
-    try expectEqual(123, foo[0]);
-    try expectEqual(456, foo[1]);
-    try expectEqual(123, foo[2]);
-    try expectEqual(456, foo[3]);
+    try expect(123 == foo[0]);
+    try expect(456 == foo[1]);
+    try expect(123 == foo[2]);
+    try expect(456 == foo[3]);
 }
 
 test "many-item sentinel-terminated pointer initialized through reference to anonymous array init provides result types" {
@@ -810,11 +810,11 @@ test "many-item sentinel-terminated pointer initialized through reference to ano
         @truncate(my_u32),
         @truncate(my_u64),
     };
-    try expectEqual(123, foo[0]);
-    try expectEqual(456, foo[1]);
-    try expectEqual(123, foo[2]);
-    try expectEqual(456, foo[3]);
-    try expectEqual(999, foo[4]);
+    try expect(123 == foo[0]);
+    try expect(456 == foo[1]);
+    try expect(123 == foo[2]);
+    try expect(456 == foo[3]);
+    try expect(999 == foo[4]);
 }
 
 test "pointer to array initialized through reference to anonymous array init provides result types" {
@@ -1020,10 +1020,10 @@ test "@splat array with sentinel" {
         fn doTheTest(comptime T: type, x: T, comptime s: T) !void {
             const arr: [10:s]T = @splat(x);
             for (arr) |elem| {
-                try expectEqual(x, elem);
+                try expect(x == elem);
             }
             const ptr: [*]const T = &arr;
-            try expectEqual(s, ptr[10]); // sentinel correct
+            try expect(s == ptr[10]); // sentinel correct
         }
     };
 

--- a/test/behavior/asm.zig
+++ b/test/behavior/asm.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 const is_x86_64_linux = builtin.cpu.arch == .x86_64 and builtin.os.tag == .linux;
 
@@ -159,7 +158,7 @@ test "rw constraint (x86_64)" {
         : [a] "+r" (res),
         : [b] "r" (@as(i32, 13)),
         : .{ .flags = true });
-    try expectEqual(@as(i32, 18), res);
+    try expect(@as(i32, 18) == res);
 }
 
 test "asm modifiers (AArch64)" {
@@ -173,5 +172,5 @@ test "asm modifiers (AArch64)" {
         : [ret] "=r" (-> u32),
         : [in] "r" (x),
     );
-    try expectEqual(2 * x, double);
+    try expect(2 * x == double);
 }

--- a/test/behavior/bit_shifting.zig
+++ b/test/behavior/bit_shifting.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
 const builtin = @import("builtin");
 
 fn ShardedTable(comptime Key: type, comptime mask_bit_count: comptime_int, comptime V: type) type {
@@ -172,7 +171,7 @@ test "Saturating Shift Left" {
             inline while (true) : (rhs += 1) {
                 comptime var lhs: T = std.math.minInt(T);
                 inline while (true) : (lhs += 1) {
-                    try expectEqual(lhs <<| rhs, shlSat(lhs, rhs));
+                    try expect(lhs <<| rhs == shlSat(lhs, rhs));
                     if (lhs == std.math.maxInt(T)) break;
                 }
                 if (rhs == @bitSizeOf(T) - 1) break;
@@ -187,12 +186,12 @@ test "Saturating Shift Left" {
     try S.testType(u4);
     try S.testType(i4);
 
-    try expectEqual(0xfffffffffffffff0fffffffffffffff0, S.shlSat(@as(u128, 0x0fffffffffffffff0fffffffffffffff), 4));
-    try expectEqual(0xffffffffffffffffffffffffffffffff, S.shlSat(@as(u128, 0x0fffffffffffffff0fffffffffffffff), 5));
-    try expectEqual(-0x80000000000000000000000000000000, S.shlSat(@as(i128, -0x0fffffffffffffff0fffffffffffffff), 5));
+    try expect(0xfffffffffffffff0fffffffffffffff0 == S.shlSat(@as(u128, 0x0fffffffffffffff0fffffffffffffff), 4));
+    try expect(0xffffffffffffffffffffffffffffffff == S.shlSat(@as(u128, 0x0fffffffffffffff0fffffffffffffff), 5));
+    try expect(-0x80000000000000000000000000000000 == S.shlSat(@as(i128, -0x0fffffffffffffff0fffffffffffffff), 5));
 
-    try expectEqual(51146728248377216718956089012931236753385031969422887335676427626502090568823039920051095192592252455482604439493126109519019633529459266458258243583, S.shlSat(@as(i495, 0x2fe6bc5448c55ce18252e2c9d44777505dfe63ff249a8027a6626c7d8dd9893fd5731e51474727be556f757facb586a4e04bbc0148c6c7ad692302f46fbd), 0x31));
-    try expectEqual(-57896044618658097711785492504343953926634992332820282019728792003956564819968, S.shlSat(@as(i256, -0x53d4148cee74ea43477a65b3daa7b8fdadcbf4508e793f4af113b8d8da5a7eb6), 0x91));
-    try expectEqual(170141183460469231731687303715884105727, S.shlSat(@as(i128, 0x2fe6bc5448c55ce18252e2c9d4477750), 0x31));
-    try expectEqual(0, S.shlSat(@as(i128, 0), 127));
+    try expect(51146728248377216718956089012931236753385031969422887335676427626502090568823039920051095192592252455482604439493126109519019633529459266458258243583 == S.shlSat(@as(i495, 0x2fe6bc5448c55ce18252e2c9d44777505dfe63ff249a8027a6626c7d8dd9893fd5731e51474727be556f757facb586a4e04bbc0148c6c7ad692302f46fbd), 0x31));
+    try expect(-57896044618658097711785492504343953926634992332820282019728792003956564819968 == S.shlSat(@as(i256, -0x53d4148cee74ea43477a65b3daa7b8fdadcbf4508e793f4af113b8d8da5a7eb6), 0x91));
+    try expect(170141183460469231731687303715884105727 == S.shlSat(@as(i128, 0x2fe6bc5448c55ce18252e2c9d4477750), 0x31));
+    try expect(0 == S.shlSat(@as(i128, 0), 127));
 }

--- a/test/behavior/bitcast.zig
+++ b/test/behavior/bitcast.zig
@@ -359,7 +359,7 @@ test "comptime @bitCast packed struct to int and back" {
     // S -> Int
     var s: S = .{};
     _ = &s;
-    try expectEqual(@as(Int, @bitCast(s)), comptime @as(Int, @bitCast(S{})));
+    try expect(@as(Int, @bitCast(s)) == comptime @as(Int, @bitCast(S{})));
 
     // Int -> S
     var i: Int = 0;
@@ -430,43 +430,43 @@ test "bitcast nan float does not modify signaling bit" {
 
     // 16 bit
     const snan_f16_const = math.snan(f16);
-    try expectEqual(snan_u16, @as(u16, @bitCast(snan_f16_const)));
-    try expectEqual(snan_u16, bitCastWrapper16(snan_f16_const));
+    try expect(snan_u16 == @as(u16, @bitCast(snan_f16_const)));
+    try expect(snan_u16 == bitCastWrapper16(snan_f16_const));
 
     var snan_f16_var = math.snan(f16);
     _ = &snan_f16_var;
-    try expectEqual(snan_u16, @as(u16, @bitCast(snan_f16_var)));
-    try expectEqual(snan_u16, bitCastWrapper16(snan_f16_var));
+    try expect(snan_u16 == @as(u16, @bitCast(snan_f16_var)));
+    try expect(snan_u16 == bitCastWrapper16(snan_f16_var));
 
     // 32 bit
     const snan_f32_const = math.snan(f32);
-    try expectEqual(snan_u32, @as(u32, @bitCast(snan_f32_const)));
-    try expectEqual(snan_u32, bitCastWrapper32(snan_f32_const));
+    try expect(snan_u32 == @as(u32, @bitCast(snan_f32_const)));
+    try expect(snan_u32 == bitCastWrapper32(snan_f32_const));
 
     var snan_f32_var = math.snan(f32);
     _ = &snan_f32_var;
-    try expectEqual(snan_u32, @as(u32, @bitCast(snan_f32_var)));
-    try expectEqual(snan_u32, bitCastWrapper32(snan_f32_var));
+    try expect(snan_u32 == @as(u32, @bitCast(snan_f32_var)));
+    try expect(snan_u32 == bitCastWrapper32(snan_f32_var));
 
     // 64 bit
     const snan_f64_const = math.snan(f64);
-    try expectEqual(snan_u64, @as(u64, @bitCast(snan_f64_const)));
-    try expectEqual(snan_u64, bitCastWrapper64(snan_f64_const));
+    try expect(snan_u64 == @as(u64, @bitCast(snan_f64_const)));
+    try expect(snan_u64 == bitCastWrapper64(snan_f64_const));
 
     var snan_f64_var = math.snan(f64);
     _ = &snan_f64_var;
-    try expectEqual(snan_u64, @as(u64, @bitCast(snan_f64_var)));
-    try expectEqual(snan_u64, bitCastWrapper64(snan_f64_var));
+    try expect(snan_u64 == @as(u64, @bitCast(snan_f64_var)));
+    try expect(snan_u64 == bitCastWrapper64(snan_f64_var));
 
     // 128 bit
     const snan_f128_const = math.snan(f128);
-    try expectEqual(snan_u128, @as(u128, @bitCast(snan_f128_const)));
-    try expectEqual(snan_u128, bitCastWrapper128(snan_f128_const));
+    try expect(snan_u128 == @as(u128, @bitCast(snan_f128_const)));
+    try expect(snan_u128 == bitCastWrapper128(snan_f128_const));
 
     var snan_f128_var = math.snan(f128);
     _ = &snan_f128_var;
-    try expectEqual(snan_u128, @as(u128, @bitCast(snan_f128_var)));
-    try expectEqual(snan_u128, bitCastWrapper128(snan_f128_var));
+    try expect(snan_u128 == @as(u128, @bitCast(snan_f128_var)));
+    try expect(snan_u128 == bitCastWrapper128(snan_f128_var));
 }
 
 test "@bitCast of packed struct of bools all true" {

--- a/test/behavior/bool.zig
+++ b/test/behavior/bool.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "bool literals" {
     try expect(true);
@@ -14,22 +13,22 @@ test "cast bool to int" {
 
     const t = true;
     const f = false;
-    try expectEqual(@as(u32, 1), @intFromBool(t));
-    try expectEqual(@as(u32, 0), @intFromBool(f));
-    try expectEqual(-1, @as(i1, @bitCast(@intFromBool(t))));
-    try expectEqual(0, @as(i1, @bitCast(@intFromBool(f))));
-    try expectEqual(u1, @TypeOf(@intFromBool(t)));
-    try expectEqual(u1, @TypeOf(@intFromBool(f)));
+    try expect(@as(u32, 1) == @intFromBool(t));
+    try expect(@as(u32, 0) == @intFromBool(f));
+    try expect(-1 == @as(i1, @bitCast(@intFromBool(t))));
+    try expect(0 == @as(i1, @bitCast(@intFromBool(f))));
+    try expect(u1 == @TypeOf(@intFromBool(t)));
+    try expect(u1 == @TypeOf(@intFromBool(f)));
     try nonConstCastIntFromBool(t, f);
 }
 
 fn nonConstCastIntFromBool(t: bool, f: bool) !void {
-    try expectEqual(@as(u32, 1), @intFromBool(t));
-    try expectEqual(@as(u32, 0), @intFromBool(f));
-    try expectEqual(@as(i1, -1), @as(i1, @bitCast(@intFromBool(t))));
-    try expectEqual(@as(i1, 0), @as(i1, @bitCast(@intFromBool(f))));
-    try expectEqual(u1, @TypeOf(@intFromBool(t)));
-    try expectEqual(u1, @TypeOf(@intFromBool(f)));
+    try expect(@as(u32, 1) == @intFromBool(t));
+    try expect(@as(u32, 0) == @intFromBool(f));
+    try expect(@as(i1, -1) == @as(i1, @bitCast(@intFromBool(t))));
+    try expect(@as(i1, 0) == @as(i1, @bitCast(@intFromBool(f))));
+    try expect(u1 == @TypeOf(@intFromBool(t)));
+    try expect(u1 == @TypeOf(@intFromBool(f)));
 }
 
 test "bool cmp" {

--- a/test/behavior/builtin_functions_returning_void_or_noreturn.zig
+++ b/test/behavior/builtin_functions_returning_void_or_noreturn.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const testing = std.testing;
+const builtin = @import("builtin");
 
 var x: u8 = 1;
 
@@ -12,15 +12,15 @@ test {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     var val: u8 = undefined;
-    try testing.expectEqual({}, @atomicStore(u8, &val, 0, .unordered));
-    try testing.expectEqual(void, @TypeOf(@breakpoint()));
-    try testing.expectEqual({}, @export(&x, .{ .name = "x" }));
-    try testing.expectEqual({}, @memcpy(@as([*]u8, @ptrFromInt(1))[0..0], @as([*]u8, @ptrFromInt(1))[0..0]));
-    try testing.expectEqual({}, @memmove(@as([*]u8, @ptrFromInt(1))[0..0], @as([*]u8, @ptrFromInt(1))[0..0]));
-    try testing.expectEqual({}, @memset(@as([*]u8, @ptrFromInt(1))[0..0], undefined));
-    try testing.expectEqual(noreturn, @TypeOf(if (true) @panic("") else {}));
-    try testing.expectEqual({}, @prefetch(&val, .{}));
-    try testing.expectEqual({}, @setEvalBranchQuota(0));
-    try testing.expectEqual({}, @setFloatMode(.optimized));
-    try testing.expectEqual({}, @setRuntimeSafety(true));
+    try testing.expect({} == @atomicStore(u8, &val, 0, .unordered));
+    try testing.expect(void == @TypeOf(@breakpoint()));
+    try testing.expect({} == @export(&x, .{ .name = "x" }));
+    try testing.expect({} == @memcpy(@as([*]u8, @ptrFromInt(1))[0..0], @as([*]u8, @ptrFromInt(1))[0..0]));
+    try testing.expect({} == @memmove(@as([*]u8, @ptrFromInt(1))[0..0], @as([*]u8, @ptrFromInt(1))[0..0]));
+    try testing.expect({} == @memset(@as([*]u8, @ptrFromInt(1))[0..0], undefined));
+    try testing.expect(noreturn == @TypeOf(if (true) @panic("") else {}));
+    try testing.expect({} == @prefetch(&val, .{}));
+    try testing.expect({} == @setEvalBranchQuota(0));
+    try testing.expect({} == @setFloatMode(.optimized));
+    try testing.expect({} == @setRuntimeSafety(true));
 }

--- a/test/behavior/call.zig
+++ b/test/behavior/call.zig
@@ -1,8 +1,7 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "super basic invocations" {
     const foo = struct {
@@ -431,8 +430,8 @@ test "method call as parameter type" {
             return u64;
         }
     };
-    try expectEqual(@as(u64, 123), S.foo(S{}, 123));
-    try expectEqual(@as(u64, 500), S.foo(S{}, 500));
+    try expect(@as(u64, 123) == S.foo(S{}, 123));
+    try expect(@as(u64, 500) == S.foo(S{}, 500));
 }
 
 test "non-anytype generic parameters provide result type" {
@@ -441,11 +440,11 @@ test "non-anytype generic parameters provide result type" {
 
     const S = struct {
         fn f(comptime T: type, y: T) !void {
-            try expectEqual(@as(T, 123), y);
+            try expect(@as(T, 123) == y);
         }
 
         fn g(x: anytype, y: @TypeOf(x)) !void {
-            try expectEqual(@as(@TypeOf(x), 0x222), y);
+            try expect(@as(@TypeOf(x), 0x222) == y);
         }
     };
 
@@ -605,10 +604,10 @@ test "call with union with zero sized field is not memorized incorrectly" {
         }
     };
     const s1 = U.S(U{ .T = u32 }).tag();
-    try std.testing.expectEqual(u32, s1);
+    try std.testing.expect(u32 == s1);
 
     const s2 = U.S(U{ .T = u64 }).tag();
-    try std.testing.expectEqual(u64, s2);
+    try std.testing.expect(u64 == s2);
 }
 
 test "function call with cast to anyopaque pointer" {

--- a/test/behavior/cast.zig
+++ b/test/behavior/cast.zig
@@ -1,4 +1,3 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
@@ -6,6 +5,8 @@ const expectEqual = std.testing.expectEqual;
 const expectEqualSlices = std.testing.expectEqualSlices;
 const mem = std.mem;
 const maxInt = std.math.maxInt;
+const builtin = @import("builtin");
+
 const native_endian = builtin.target.cpu.arch.endian();
 
 test "int to ptr cast" {
@@ -1867,8 +1868,8 @@ test "peer type resolution: float and comptime-known fixed-width integer" {
 
     const T = @TypeOf(r1);
 
-    try expectEqual(@as(T, 100.0), r1);
-    try expectEqual(@as(T, 1.234), r2);
+    try expect(@as(T, 100.0) == r1);
+    try expect(@as(T, 1.234) == r2);
 }
 
 test "peer type resolution: same array type with sentinel" {
@@ -2007,8 +2008,8 @@ test "peer type resolution: C pointer and @TypeOf(null)" {
 
     const T = @TypeOf(r1);
 
-    try expectEqual(@as(T, 0x1000), r1);
-    try expectEqual(@as(T, null), r2);
+    try expect(@as(T, 0x1000) == r1);
+    try expect(@as(T, null) == r2);
 }
 
 test "peer type resolution: three-way resolution combines error set and optional" {
@@ -2095,8 +2096,8 @@ test "peer type resolution: optional fixed-width int and comptime_int" {
 
     const T = @TypeOf(r1);
 
-    try expectEqual(@as(T, 42), r1);
-    try expectEqual(@as(T, 50), r2);
+    try expect(@as(T, 42) == r1);
+    try expect(@as(T, 50) == r2);
 }
 
 test "peer type resolution: array and tuple" {
@@ -2345,11 +2346,11 @@ test "peer type resolution: tuples with comptime fields" {
     const r1 = if (t) a else b;
     const r2 = if (t) b else a;
 
-    try expectEqual(@as(u32, 1), r1[0]);
-    try expectEqual(@as(i16, 2), r1[1]);
+    try expect(@as(u32, 1) == r1[0]);
+    try expect(@as(i16, 2) == r1[1]);
 
-    try expectEqual(@as(u32, 3), r2[0]);
-    try expectEqual(@as(i16, 4), r2[1]);
+    try expect(@as(u32, 3) == r2[0]);
+    try expect(@as(i16, 4) == r2[1]);
 }
 
 test "peer type resolution: C pointer and many pointer" {
@@ -2742,7 +2743,7 @@ test "numeric coercions with undefined" {
     var to: f32 = from;
     to = @floatFromInt(from);
     to = 42.0;
-    try expectEqual(@as(f32, 42.0), to);
+    try expect(@as(f32, 42.0) == to);
 }
 
 test "15-bit int to float" {
@@ -2824,7 +2825,7 @@ test "bitcast vector" {
 
     const zerox32: u8x32 = [_]u8{0} ** 32;
     const bigsum: u32x8 = @bitCast(zerox32);
-    try std.testing.expectEqual(0, @reduce(.Add, bigsum));
+    try std.testing.expect(0 == @reduce(.Add, bigsum));
 }
 
 test "peer type resolution: slice of sentinel-terminated array" {

--- a/test/behavior/cast_int.zig
+++ b/test/behavior/cast_int.zig
@@ -1,8 +1,7 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
 const maxInt = std.math.maxInt;
+const builtin = @import("builtin");
 
 test "@intCast i32 to u7" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -45,11 +44,11 @@ test "coerce non byte-sized integers accross 32bits boundary" {
         _ = &w;
         const d: u21 = @truncate(w);
         const e: u60 = d;
-        try expectEqual(@as(u32, 6417), a);
-        try expectEqual(@as(u64, 6417), b);
-        try expectEqual(@as(u64, 6417), c);
-        try expectEqual(@as(u21, 0x145678), d);
-        try expectEqual(@as(u60, 0x145678), e);
+        try expect(@as(u32, 6417) == a);
+        try expect(@as(u64, 6417) == b);
+        try expect(@as(u64, 6417) == c);
+        try expect(@as(u21, 0x145678) == d);
+        try expect(@as(u60, 0x145678) == e);
     }
 
     {
@@ -62,11 +61,11 @@ test "coerce non byte-sized integers accross 32bits boundary" {
         _ = &w;
         const d: u10 = @truncate(w);
         const e: u60 = d;
-        try expectEqual(@as(u32, 234), a);
-        try expectEqual(@as(u64, 234), b);
-        try expectEqual(@as(u64, 234), c);
-        try expectEqual(@as(u21, 0x278), d);
-        try expectEqual(@as(u60, 0x278), e);
+        try expect(@as(u32, 234) == a);
+        try expect(@as(u64, 234) == b);
+        try expect(@as(u64, 234) == c);
+        try expect(@as(u21, 0x278) == d);
+        try expect(@as(u60, 0x278) == e);
     }
     {
         var v: u7 = 11;
@@ -78,11 +77,11 @@ test "coerce non byte-sized integers accross 32bits boundary" {
         _ = &w;
         const d: u7 = @truncate(w);
         const e: u60 = d;
-        try expectEqual(@as(u32, 11), a);
-        try expectEqual(@as(u64, 11), b);
-        try expectEqual(@as(u64, 11), c);
-        try expectEqual(@as(u21, 0x78), d);
-        try expectEqual(@as(u60, 0x78), e);
+        try expect(@as(u32, 11) == a);
+        try expect(@as(u64, 11) == b);
+        try expect(@as(u64, 11) == c);
+        try expect(@as(u21, 0x78) == d);
+        try expect(@as(u60, 0x78) == e);
     }
 
     {
@@ -95,11 +94,11 @@ test "coerce non byte-sized integers accross 32bits boundary" {
         _ = &w;
         const d: i21 = @intCast(w);
         const e: i60 = d;
-        try expectEqual(@as(i32, -6417), a);
-        try expectEqual(@as(i64, -6417), b);
-        try expectEqual(@as(i64, -6417), c);
-        try expectEqual(@as(i21, -12345), d);
-        try expectEqual(@as(i60, -12345), e);
+        try expect(@as(i32, -6417) == a);
+        try expect(@as(i64, -6417) == b);
+        try expect(@as(i64, -6417) == c);
+        try expect(@as(i21, -12345) == d);
+        try expect(@as(i60, -12345) == e);
     }
 
     {
@@ -112,11 +111,11 @@ test "coerce non byte-sized integers accross 32bits boundary" {
         _ = &w;
         const d: i10 = @intCast(w);
         const e: i60 = d;
-        try expectEqual(@as(i32, -234), a);
-        try expectEqual(@as(i64, -234), b);
-        try expectEqual(@as(i64, -234), c);
-        try expectEqual(@as(i10, -456), d);
-        try expectEqual(@as(i60, -456), e);
+        try expect(@as(i32, -234) == a);
+        try expect(@as(i64, -234) == b);
+        try expect(@as(i64, -234) == c);
+        try expect(@as(i10, -456) == d);
+        try expect(@as(i60, -456) == e);
     }
     {
         var v: i7 = -11;
@@ -128,11 +127,11 @@ test "coerce non byte-sized integers accross 32bits boundary" {
         _ = &w;
         const d: i7 = @intCast(w);
         const e: i60 = d;
-        try expectEqual(@as(i32, -11), a);
-        try expectEqual(@as(i64, -11), b);
-        try expectEqual(@as(i64, -11), c);
-        try expectEqual(@as(i7, -42), d);
-        try expectEqual(@as(i60, -42), e);
+        try expect(@as(i32, -11) == a);
+        try expect(@as(i64, -11) == b);
+        try expect(@as(i64, -11) == c);
+        try expect(@as(i7, -42) == d);
+        try expect(@as(i60, -42) == e);
     }
 }
 

--- a/test/behavior/comptime_memory.zig
+++ b/test/behavior/comptime_memory.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const builtin = @import("builtin");
-const endian = builtin.cpu.arch.endian();
 const testing = @import("std").testing;
+const builtin = @import("builtin");
+
+const endian = builtin.cpu.arch.endian();
 const ptr_size = @sizeOf(usize);
 
 test "type pun signed and unsigned as single pointer" {
@@ -9,7 +10,7 @@ test "type pun signed and unsigned as single pointer" {
         var x: u32 = 0;
         const y = @as(*i32, @ptrCast(&x));
         y.* = -1;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFF), x);
+        try testing.expect(@as(u32, 0xFFFFFFFF) == x);
     }
 }
 
@@ -18,7 +19,7 @@ test "type pun signed and unsigned as many pointer" {
         var x: u32 = 0;
         const y = @as([*]i32, @ptrCast(&x));
         y[0] = -1;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFF), x);
+        try testing.expect(@as(u32, 0xFFFFFFFF) == x);
     }
 }
 
@@ -27,7 +28,7 @@ test "type pun signed and unsigned as array pointer" {
         var x: u32 = 0;
         const y = @as(*[1]i32, @ptrCast(&x));
         y[0] = -1;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFF), x);
+        try testing.expect(@as(u32, 0xFFFFFFFF) == x);
     }
 }
 
@@ -37,7 +38,7 @@ test "type pun signed and unsigned as offset many pointer" {
         var y: [*]i32 = @ptrCast(&x[10]);
         y -= 10;
         y[10] = -1;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFF), x[10]);
+        try testing.expect(@as(u32, 0xFFFFFFFF) == x[10]);
     }
 }
 
@@ -47,7 +48,7 @@ test "type pun signed and unsigned as array pointer with pointer arithemtic" {
         const y = @as([*]i32, @ptrCast(&x[10])) - 10;
         const z: *[15]i32 = y[0..15];
         z[10] = -1;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFF), x[10]);
+        try testing.expect(@as(u32, 0xFFFFFFFF) == x[10]);
     }
 }
 
@@ -56,9 +57,9 @@ test "type pun value and struct" {
         const StructOfU32 = extern struct { x: u32 };
         var inst: StructOfU32 = .{ .x = 0 };
         @as(*i32, @ptrCast(&inst.x)).* = -1;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFF), inst.x);
+        try testing.expect(@as(u32, 0xFFFFFFFF) == inst.x);
         @as(*i32, @ptrCast(&inst)).* = -2;
-        try testing.expectEqual(@as(u32, 0xFFFFFFFE), inst.x);
+        try testing.expect(@as(u32, 0xFFFFFFFE) == inst.x);
     }
 }
 
@@ -75,15 +76,15 @@ test "type pun endianness" {
         const arrayPtr = @as(*align(1) u32, @ptrCast(&inst.x));
         inst.x[0] = 0xFE;
         inst.x[2] = 0xBE;
-        try testing.expectEqual(bigToNativeEndian(u32, 0xFE00BE00), structPtr.*);
-        try testing.expectEqual(bigToNativeEndian(u32, 0xFE00BE00), arrayPtr.*);
+        try testing.expect(bigToNativeEndian(u32, 0xFE00BE00) == structPtr.*);
+        try testing.expect(bigToNativeEndian(u32, 0xFE00BE00) == arrayPtr.*);
         structPtr.* = bigToNativeEndian(u32, 0xDEADF00D);
-        try testing.expectEqual(bigToNativeEndian(u32, 0xDEADF00D), structPtr.*);
-        try testing.expectEqual(bigToNativeEndian(u32, 0xDEADF00D), arrayPtr.*);
-        try testing.expectEqual(@as(u8, 0xDE), inst.x[0]);
-        try testing.expectEqual(@as(u8, 0xAD), inst.x[1]);
-        try testing.expectEqual(@as(u8, 0xF0), inst.x[2]);
-        try testing.expectEqual(@as(u8, 0x0D), inst.x[3]);
+        try testing.expect(bigToNativeEndian(u32, 0xDEADF00D) == structPtr.*);
+        try testing.expect(bigToNativeEndian(u32, 0xDEADF00D) == arrayPtr.*);
+        try testing.expect(@as(u8, 0xDE) == inst.x[0]);
+        try testing.expect(@as(u8, 0xAD) == inst.x[1]);
+        try testing.expect(@as(u8, 0xF0) == inst.x[2]);
+        try testing.expect(@as(u8, 0x0D) == inst.x[3]);
     }
 }
 
@@ -129,33 +130,33 @@ fn doTypePunBitsTest(as_bits: *Bits) !void {
     const as_u32 = @as(*align(1) u32, @ptrCast(as_bits));
     const as_bytes = @as(*[4]u8, @ptrCast(as_bits));
     as_u32.* = bigToNativeEndian(u32, 0xB0A7DEED);
-    try testing.expectEqual(@as(u1, 0x00), as_bits.p0);
-    try testing.expectEqual(@as(u4, 0x08), as_bits.p1);
-    try testing.expectEqual(@as(u3, 0x05), as_bits.p2);
-    try testing.expectEqual(@as(u2, 0x03), as_bits.p3);
-    try testing.expectEqual(@as(u6, 0x29), as_bits.p4);
-    try testing.expectEqual(@as(u8, 0xDE), as_bits.p5);
-    try testing.expectEqual(@as(u7, 0x6D), as_bits.p6);
-    try testing.expectEqual(@as(u1, 0x01), as_bits.p7);
+    try testing.expect(@as(u1, 0x00) == as_bits.p0);
+    try testing.expect(@as(u4, 0x08) == as_bits.p1);
+    try testing.expect(@as(u3, 0x05) == as_bits.p2);
+    try testing.expect(@as(u2, 0x03) == as_bits.p3);
+    try testing.expect(@as(u6, 0x29) == as_bits.p4);
+    try testing.expect(@as(u8, 0xDE) == as_bits.p5);
+    try testing.expect(@as(u7, 0x6D) == as_bits.p6);
+    try testing.expect(@as(u1, 0x01) == as_bits.p7);
 
     as_bits.p6 = 0x2D;
     as_bits.p1 = 0x0F;
-    try testing.expectEqual(bigToNativeEndian(u32, 0xBEA7DEAD), as_u32.*);
+    try testing.expect(bigToNativeEndian(u32, 0xBEA7DEAD) == as_u32.*);
 
     // clobbering one bit doesn't clobber the word
     as_bits.p7 = undefined;
-    try testing.expectEqual(@as(u7, 0x2D), as_bits.p6);
+    try testing.expect(@as(u7, 0x2D) == as_bits.p6);
     // even when read as a whole
     const u = as_u32.*;
     _ = u; // u is undefined
-    try testing.expectEqual(@as(u7, 0x2D), as_bits.p6);
+    try testing.expect(@as(u7, 0x2D) == as_bits.p6);
     // or if a field which shares the byte is modified
     as_bits.p6 = 0x6D;
-    try testing.expectEqual(@as(u7, 0x6D), as_bits.p6);
+    try testing.expect(@as(u7, 0x6D) == as_bits.p6);
 
     // but overwriting the undefined will clear it
     as_bytes[3] = 0xAF;
-    try testing.expectEqual(bigToNativeEndian(u32, 0xBEA7DEAF), as_u32.*);
+    try testing.expect(bigToNativeEndian(u32, 0xBEA7DEAF) == as_u32.*);
 }
 
 test "type pun bits" {
@@ -186,8 +187,8 @@ test "basic pointer preservation" {
 
     comptime {
         const lazy_address = @intFromPtr(&imports.global_u32);
-        try testing.expectEqual(@intFromPtr(&imports.global_u32), lazy_address);
-        try testing.expectEqual(&imports.global_u32, @as(*u32, @ptrFromInt(lazy_address)));
+        try testing.expect(@intFromPtr(&imports.global_u32) == lazy_address);
+        try testing.expect(&imports.global_u32 == @as(*u32, @ptrFromInt(lazy_address)));
     }
 }
 
@@ -205,13 +206,13 @@ test "byte copy preserves linker value" {
         var i: usize = 0;
         while (i < ptr_size) : (i += 1) {
             pResult[i] = pSource[i];
-            try testing.expectEqual(pSource[i], pResult[i]);
+            try testing.expect(pSource[i] == pResult[i]);
         }
-        try testing.expectEqual(&imports.global_u32, result);
+        try testing.expect(&imports.global_u32 == result);
         break :blk result;
     };
 
-    try testing.expectEqual(&imports.global_u32, ct_value);
+    try testing.expect(&imports.global_u32 == ct_value);
 }
 
 test "unordered byte copy preserves linker value" {
@@ -229,13 +230,13 @@ test "unordered byte copy preserves linker value" {
         const shuffled_indices = [_]usize{ 4, 5, 2, 6, 1, 3, 0, 7 };
         for (shuffled_indices) |i| {
             pResult[i] = pSource[i];
-            try testing.expectEqual(pSource[i], pResult[i]);
+            try testing.expect(pSource[i] == pResult[i]);
         }
-        try testing.expectEqual(&imports.global_u32, result);
+        try testing.expect(&imports.global_u32 == result);
         break :blk result;
     };
 
-    try testing.expectEqual(&imports.global_u32, ct_value);
+    try testing.expect(&imports.global_u32 == ct_value);
 }
 
 test "shuffle chunks of linker value" {
@@ -247,13 +248,13 @@ test "shuffle chunks of linker value" {
     const lazy_address = @intFromPtr(&imports.global_u32);
     const shuffled1_rt = shuffle(lazy_address, Bits, ShuffledBits);
     const unshuffled1_rt = shuffle(shuffled1_rt, ShuffledBits, Bits);
-    try testing.expectEqual(lazy_address, unshuffled1_rt);
+    try testing.expect(lazy_address == unshuffled1_rt);
     const shuffled1_ct = comptime shuffle(lazy_address, Bits, ShuffledBits);
     const shuffled1_ct_2 = comptime shuffle(lazy_address, Bits, ShuffledBits);
-    try comptime testing.expectEqual(shuffled1_ct, shuffled1_ct_2);
+    try comptime testing.expect(shuffled1_ct == shuffled1_ct_2);
     const unshuffled1_ct = comptime shuffle(shuffled1_ct, ShuffledBits, Bits);
-    try comptime testing.expectEqual(lazy_address, unshuffled1_ct);
-    try testing.expectEqual(shuffled1_ct, shuffled1_rt);
+    try comptime testing.expect(lazy_address == unshuffled1_ct);
+    try testing.expect(shuffled1_ct == shuffled1_rt);
 }
 
 test "dance on linker values" {
@@ -283,7 +284,7 @@ test "dance on linker values" {
             rebuilt_bytes[i] = arr_bytes[1][i];
         }
 
-        try testing.expectEqual(&imports.global_u32, @as(*u32, @ptrFromInt(@as(usize, @bitCast(rebuilt_bytes)))));
+        try testing.expect(&imports.global_u32 == @as(*u32, @ptrFromInt(@as(usize, @bitCast(rebuilt_bytes)))));
     }
 }
 
@@ -300,7 +301,7 @@ test "offset array ptr by element size" {
         const buf: [*]align(@alignOf(VirtualStruct)) u8 = @ptrCast(&arr);
 
         const second_element: *VirtualStruct = @ptrCast(buf + 2 * @sizeOf(VirtualStruct));
-        try testing.expectEqual(bigToNativeEndian(u32, 0x02060a0e), second_element.x);
+        try testing.expect(bigToNativeEndian(u32, 0x02060a0e) == second_element.x);
     }
 }
 
@@ -317,15 +318,15 @@ test "offset instance by field size" {
         var ptr = @intFromPtr(&inst);
         ptr -= 4;
         ptr += @offsetOf(VirtualStruct, "x");
-        try testing.expectEqual(@as(u32, 0), @as([*]u32, @ptrFromInt(ptr))[1]);
+        try testing.expect(@as(u32, 0) == @as([*]u32, @ptrFromInt(ptr))[1]);
         ptr -= @offsetOf(VirtualStruct, "x");
         ptr += @offsetOf(VirtualStruct, "y");
-        try testing.expectEqual(@as(u32, 1), @as([*]u32, @ptrFromInt(ptr))[1]);
+        try testing.expect(@as(u32, 1) == @as([*]u32, @ptrFromInt(ptr))[1]);
         ptr = ptr - @offsetOf(VirtualStruct, "y") + @offsetOf(VirtualStruct, "z");
-        try testing.expectEqual(@as(u32, 2), @as([*]u32, @ptrFromInt(ptr))[1]);
+        try testing.expect(@as(u32, 2) == @as([*]u32, @ptrFromInt(ptr))[1]);
         ptr = @intFromPtr(&inst.z) - 4 - @offsetOf(VirtualStruct, "z");
         ptr += @offsetOf(VirtualStruct, "w");
-        try testing.expectEqual(@as(u32, 3), @as(*u32, @ptrFromInt(ptr + 4)).*);
+        try testing.expect(@as(u32, 3) == @as(*u32, @ptrFromInt(ptr + 4)).*);
     }
 }
 
@@ -352,7 +353,7 @@ test "offset field ptr by enclosing array element size" {
             var j: usize = 0;
             while (j < 4) : (j += 1) {
                 const base = ptr + j * @sizeOf(VirtualStruct);
-                try testing.expectEqual(@as(u8, @intCast(i * 4 + j)), base[0]);
+                try testing.expect(@as(u8, @intCast(i * 4 + j)) == base[0]);
             }
         }
     }
@@ -392,8 +393,8 @@ test "bitcast packed union to integer" {
         const cast_a: u2 = @bitCast(a);
         const cast_b: u2 = @bitCast(b);
 
-        try testing.expectEqual(@as(u2, 3), cast_a);
-        try testing.expectEqual(@as(u2, 2), cast_b);
+        try testing.expect(@as(u2, 3) == cast_a);
+        try testing.expect(@as(u2, 2) == cast_b);
     }
 }
 
@@ -409,7 +410,7 @@ test "dereference undefined pointer to zero-bit type" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     const p0: *void = undefined;
-    try testing.expectEqual({}, p0.*);
+    try testing.expect({} == p0.*);
 
     const p1: *[0]u32 = undefined;
     try testing.expect(p1.*.len == 0);
@@ -419,7 +420,7 @@ test "type pun extern struct" {
     const S = extern struct { f: u8 };
     comptime var s = S{ .f = 123 };
     @as(*u8, @ptrCast(&s)).* = 72;
-    try testing.expectEqual(@as(u8, 72), s.f);
+    try testing.expect(@as(u8, 72) == s.f);
 }
 
 test "type pun @ptrFromInt" {

--- a/test/behavior/defer.zig
+++ b/test/behavior/defer.zig
@@ -1,8 +1,7 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;
+const builtin = @import("builtin");
 
 test "break and continue inside loop inside defer expression" {
     testBreakContInDefer(10);
@@ -115,7 +114,7 @@ test "errdefer with payload" {
     const S = struct {
         fn foo() !i32 {
             errdefer |a| {
-                expectEqual(error.One, a) catch @panic("test failure");
+                expect(error.One == a) catch @panic("test failure");
             }
             return error.One;
         }
@@ -138,8 +137,8 @@ test "reference to errdefer payload" {
             errdefer |a| {
                 const ptr = &a;
                 const ptr2 = &ptr;
-                expectEqual(error.One, ptr2.*.*) catch @panic("test failure");
-                expectEqual(error.One, ptr.*) catch @panic("test failure");
+                expect(error.One == ptr2.*.*) catch @panic("test failure");
+                expect(error.One == ptr.*) catch @panic("test failure");
             }
             return error.One;
         }

--- a/test/behavior/enum.zig
+++ b/test/behavior/enum.zig
@@ -1,9 +1,9 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
 const assert = std.debug.assert;
 const mem = std.mem;
 const Tag = std.meta.Tag;
+const builtin = @import("builtin");
 
 const Number = enum { Zero, One, Two, Three, Four };
 
@@ -1251,20 +1251,20 @@ test "auto-numbered enum with signed tag type" {
 
     const E = enum(i32) { a, b };
 
-    try std.testing.expectEqual(@as(i32, 0), @intFromEnum(E.a));
-    try std.testing.expectEqual(@as(i32, 1), @intFromEnum(E.b));
-    try std.testing.expectEqual(E.a, @as(E, @enumFromInt(0)));
-    try std.testing.expectEqual(E.b, @as(E, @enumFromInt(1)));
-    try std.testing.expectEqual(E.a, @as(E, @enumFromInt(@as(i32, 0))));
-    try std.testing.expectEqual(E.b, @as(E, @enumFromInt(@as(i32, 1))));
-    try std.testing.expectEqual(E.a, @as(E, @enumFromInt(@as(u32, 0))));
-    try std.testing.expectEqual(E.b, @as(E, @enumFromInt(@as(u32, 1))));
+    try std.testing.expect(@as(i32, 0) == @intFromEnum(E.a));
+    try std.testing.expect(@as(i32, 1) == @intFromEnum(E.b));
+    try std.testing.expect(E.a == @as(E, @enumFromInt(0)));
+    try std.testing.expect(E.b == @as(E, @enumFromInt(1)));
+    try std.testing.expect(E.a == @as(E, @enumFromInt(@as(i32, 0))));
+    try std.testing.expect(E.b == @as(E, @enumFromInt(@as(i32, 1))));
+    try std.testing.expect(E.a == @as(E, @enumFromInt(@as(u32, 0))));
+    try std.testing.expect(E.b == @as(E, @enumFromInt(@as(u32, 1))));
     try std.testing.expectEqualStrings("a", @tagName(E.a));
     try std.testing.expectEqualStrings("b", @tagName(E.b));
 }
 
 test "lazy initialized field" {
-    try std.testing.expectEqual(@as(u8, @alignOf(struct {})), getLazyInitialized(.a));
+    try std.testing.expect(@as(u8, @alignOf(struct {})) == getLazyInitialized(.a));
 }
 
 fn getLazyInitialized(param: enum(u8) {

--- a/test/behavior/error.zig
+++ b/test/behavior/error.zig
@@ -1,9 +1,8 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
 const mem = std.mem;
+const builtin = @import("builtin");
 
 /// A more basic implementation of std.testing.expectError which
 /// does not require formatter/printing support
@@ -1066,7 +1065,7 @@ test "result location initialization of error union with OPV payload" {
 
     var c: anyerror!S = .{ .x = 0 };
     _ = &c;
-    try expectEqual(0, (c catch return error.TestFailed).x);
+    try expect(0 == (c catch return error.TestFailed).x);
 }
 
 test "return error union with i65" {

--- a/test/behavior/eval.zig
+++ b/test/behavior/eval.zig
@@ -1,8 +1,8 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "compile time recursion" {
     try expect(some_data.len == 21);
@@ -862,7 +862,7 @@ test "comptime assign int to optional int" {
         var x: ?i32 = null;
         x = 2;
         x.? *= 10;
-        try expectEqual(20, x.?);
+        try expect(20 == x.?);
     }
 }
 
@@ -1688,9 +1688,9 @@ test "@inComptime" {
             return @inComptime();
         }
     };
-    try expectEqual(false, @inComptime());
-    try expectEqual(false, S.inComptime());
-    try expectEqual(true, comptime S.inComptime());
+    try expect(false == @inComptime());
+    try expect(false == S.inComptime());
+    try expect(true == comptime S.inComptime());
 }
 
 // comptime partial array assign

--- a/test/behavior/fn.zig
+++ b/test/behavior/fn.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const testing = std.testing;
 const assert = std.debug.assert;
 const expect = testing.expect;
-const expectEqual = testing.expectEqual;
+const builtin = @import("builtin");
 
 test "params" {
     try expect(testParamsAdd(22, 11) == 33);
@@ -400,7 +399,7 @@ test "function with inferred error set but returning no error" {
     };
 
     const return_ty = @typeInfo(@TypeOf(S.foo)).@"fn".return_type.?;
-    try expectEqual(0, @typeInfo(@typeInfo(return_ty).error_union.error_set).error_set.?.len);
+    try expect(0 == @typeInfo(@typeInfo(return_ty).error_union.error_set).error_set.?.len);
 }
 
 test "import passed byref to function in return type" {
@@ -564,8 +563,8 @@ test "pass and return comptime-only types" {
         }
     };
 
-    try expectEqual(null, S.returnNull(null));
-    try expectEqual(@as(u0, 0), S.returnUndefined(undefined));
+    try expect(null == S.returnNull(null));
+    try expect(@as(u0, 0) == S.returnUndefined(undefined));
 }
 
 test "pointer to alias behaves same as pointer to function" {
@@ -602,8 +601,8 @@ test "inline function with comptime-known comptime-only return type called at ru
     var a: i32 = 0;
     const b: i32 = 111;
     const T = S.foo(&a, &b);
-    try expectEqual(111, a);
-    try expectEqual(f32, T);
+    try expect(111 == a);
+    try expect(f32 == T);
 }
 
 test "address of function parameter is consistent" {

--- a/test/behavior/for.zig
+++ b/test/behavior/for.zig
@@ -1,8 +1,8 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const mem = std.mem;
+const builtin = @import("builtin");
 
 test "continue in for loop" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -465,11 +465,11 @@ test "ref counter that starts at zero" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
 
     for ([_]usize{ 0, 1, 2 }, 0..) |i, j| {
-        try expectEqual(i, j);
+        try expect(i == j);
         try expectEqual((&i).*, (&j).*);
     }
     inline for (.{ 0, 1, 2 }, 0..) |i, j| {
-        try expectEqual(i, j);
+        try expect(i == j);
         try expectEqual((&i).*, (&j).*);
     }
 }
@@ -484,7 +484,7 @@ test "inferred alloc ptr of for loop" {
         const opt = for (0..1) |_| {
             if (cond) break cond;
         } else null;
-        try expectEqual(@as(?bool, null), opt);
+        try expect(@as(?bool, null) == opt);
     }
     {
         var cond = true;
@@ -492,7 +492,7 @@ test "inferred alloc ptr of for loop" {
         const opt = for (0..1) |_| {
             if (cond) break cond;
         } else null;
-        try expectEqual(@as(?bool, true), opt);
+        try expect(@as(?bool, true) == opt);
     }
 }
 

--- a/test/behavior/generics.zig
+++ b/test/behavior/generics.zig
@@ -1,8 +1,7 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const testing = std.testing;
 const expect = testing.expect;
-const expectEqual = testing.expectEqual;
+const builtin = @import("builtin");
 
 test "one param, explicit comptime" {
     var x: usize = 0;
@@ -577,7 +576,7 @@ test "call generic function that uses capture from function declaration's scope"
 
     const S = StructCapture(f64);
     const s = S.foo(123);
-    try expectEqual(123.0, s[0]);
+    try expect(123.0 == s[0]);
 }
 
 comptime {

--- a/test/behavior/globals.zig
+++ b/test/behavior/globals.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 var pos = [2]f32{ 0.0, 0.0 };
 test "store to global array" {
@@ -179,7 +179,7 @@ test "function pointer field call on global extern struct, conditional on global
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     if (callbacks_loaded) {
-        try std.testing.expectEqual(42, callbacks.key_callback(42));
+        try std.testing.expect(42 == callbacks.key_callback(42));
     }
 }
 
@@ -194,5 +194,5 @@ test "function pointer field call on global extern struct" {
     };
 
     callbacks = Callbacks{ .key_callback = S.keyCallback };
-    try std.testing.expectEqual(42, callbacks.key_callback(42));
+    try std.testing.expect(42 == callbacks.key_callback(42));
 }

--- a/test/behavior/if.zig
+++ b/test/behavior/if.zig
@@ -1,7 +1,6 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "if statements" {
     shouldBeEqual(1, 1);
@@ -187,7 +186,7 @@ test "if value shouldn't be load-elided if used later (structs)" {
     a.x = 2;
     b.x = 3;
 
-    try std.testing.expectEqual(c.x, 1);
+    try std.testing.expect(c.x == 1);
 }
 
 test "if value shouldn't be load-elided if used later (optionals)" {
@@ -201,7 +200,7 @@ test "if value shouldn't be load-elided if used later (optionals)" {
     a = 2;
     b = 3;
 
-    try std.testing.expectEqual(c, 1);
+    try std.testing.expect(c == 1);
 }
 
 test "variable type inferred from if expression" {

--- a/test/behavior/import.zig
+++ b/test/behavior/import.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
+
 const a_namespace = @import("import/a_namespace.zig");
 
 test "call fn via namespace lookup" {

--- a/test/behavior/math.zig
+++ b/test/behavior/math.zig
@@ -1,4 +1,3 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
@@ -8,6 +7,7 @@ const maxInt = std.math.maxInt;
 const minInt = std.math.minInt;
 const mem = std.mem;
 const math = std.math;
+const builtin = @import("builtin");
 
 test "assignment operators" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -692,7 +692,7 @@ test "negation wrapping" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
     if (builtin.zig_backend == .stage2_riscv64) return error.SkipZigTest;
 
-    try expectEqual(@as(u1, 1), negateWrap(u1, 1));
+    try expect(@as(u1, 1) == negateWrap(u1, 1));
 }
 
 fn negateWrap(comptime T: type, x: T) T {
@@ -1390,14 +1390,14 @@ test "shift left/right on u0 operand" {
             var x: u0 = 0;
             var y: u0 = 0;
             _ = .{ &x, &y };
-            try expectEqual(@as(u0, 0), x << 0);
-            try expectEqual(@as(u0, 0), x >> 0);
-            try expectEqual(@as(u0, 0), x << y);
-            try expectEqual(@as(u0, 0), x >> y);
-            try expectEqual(@as(u0, 0), @shlExact(x, 0));
-            try expectEqual(@as(u0, 0), @shrExact(x, 0));
-            try expectEqual(@as(u0, 0), @shlExact(x, y));
-            try expectEqual(@as(u0, 0), @shrExact(x, y));
+            try expect(@as(u0, 0) == x << 0);
+            try expect(@as(u0, 0) == x >> 0);
+            try expect(@as(u0, 0) == x << y);
+            try expect(@as(u0, 0) == x >> y);
+            try expect(@as(u0, 0) == @shlExact(x, 0));
+            try expect(@as(u0, 0) == @shrExact(x, 0));
+            try expect(@as(u0, 0) == @shlExact(x, y));
+            try expect(@as(u0, 0) == @shrExact(x, y));
         }
     };
     try S.doTheTest();
@@ -1757,7 +1757,7 @@ test "@clz works on both vector and scalar inputs" {
     _ = &y;
     const a = @clz(x);
     const b = @clz(y);
-    try std.testing.expectEqual(@as(u6, 31), a);
+    try std.testing.expect(@as(u6, 31) == a);
     try std.testing.expectEqual([_]u6{ 31, 31, 31, 31 }, b);
 }
 

--- a/test/behavior/maximum_minimum.zig
+++ b/test/behavior/maximum_minimum.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const mem = std.mem;
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "@max" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -125,16 +125,16 @@ test "@min/max for floats" {
             var x: T = -3.14;
             var y: T = 5.27;
             _ = .{ &x, &y };
-            try expectEqual(x, @min(x, y));
-            try expectEqual(x, @min(y, x));
-            try expectEqual(y, @max(x, y));
-            try expectEqual(y, @max(y, x));
+            try expect(x == @min(x, y));
+            try expect(x == @min(y, x));
+            try expect(y == @max(x, y));
+            try expect(y == @max(y, x));
 
             if (T != comptime_float) {
                 var nan: T = std.math.nan(T);
                 _ = &nan;
-                try expectEqual(y, @max(nan, y));
-                try expectEqual(y, @max(y, nan));
+                try expect(y == @max(nan, y));
+                try expect(y == @max(y, nan));
             }
         }
     };
@@ -159,8 +159,8 @@ test "@min/@max more than two arguments" {
     const x: u32 = 30;
     const y: u32 = 10;
     const z: u32 = 20;
-    try expectEqual(@as(u32, 10), @min(x, y, z));
-    try expectEqual(@as(u32, 30), @max(x, y, z));
+    try expect(@as(u32, 10) == @min(x, y, z));
+    try expect(@as(u32, 30) == @max(x, y, z));
 }
 
 test "@min/@max more than two vector arguments" {
@@ -187,10 +187,10 @@ test "@min/@max notices bounds" {
     _ = .{ &x, &z };
     const min = @min(x, y, z);
     const max = @max(x, y, z);
-    try expectEqual(x, min);
-    try expectEqual(u5, @TypeOf(min));
-    try expectEqual(z, max);
-    try expectEqual(u32, @TypeOf(max));
+    try expect(x == min);
+    try expect(u5 == @TypeOf(min));
+    try expect(z == max);
+    try expect(u32 == @TypeOf(max));
 }
 
 test "@min/@max notices vector bounds" {
@@ -219,10 +219,10 @@ test "@min/@max on comptime_int" {
     const min = @min(1, 2, -2, -1);
     const max = @max(1, 2, -2, -1);
 
-    try expectEqual(comptime_int, @TypeOf(min));
-    try expectEqual(comptime_int, @TypeOf(max));
-    try expectEqual(-2, min);
-    try expectEqual(2, max);
+    try expect(comptime_int == @TypeOf(min));
+    try expect(comptime_int == @TypeOf(max));
+    try expect(-2 == min);
+    try expect(2 == max);
 }
 
 test "@min/@max notices bounds from types" {
@@ -240,8 +240,8 @@ test "@min/@max notices bounds from types" {
     comptime assert(@TypeOf(min) == u8);
     comptime assert(@TypeOf(max) == u32);
 
-    try expectEqual(z, min);
-    try expectEqual(y, max);
+    try expect(z == min);
+    try expect(y == max);
 }
 
 test "@min/@max notices bounds from vector types" {
@@ -303,8 +303,8 @@ test "@min/@max notices bounds from vector types when element of comptime-known 
     comptime assert(@TypeOf(min) == @Vector(2, u16));
     comptime assert(@TypeOf(max) == @Vector(2, u32));
 
-    try expectEqual(@as(u16, 10), min[0]);
-    try expectEqual(@as(u32, 1_000_000), max[0]);
+    try expect(@as(u16, 10) == min[0]);
+    try expect(@as(u32, 1_000_000) == max[0]);
     // Cannot assert values at index 1 as one was undefined
 }
 
@@ -321,8 +321,8 @@ test "@min/@max of signed and unsigned runtime integers" {
     comptime assert(@TypeOf(min) == i32);
     comptime assert(@TypeOf(max) == u31);
 
-    try expectEqual(x, @min(x, y));
-    try expectEqual(y, @max(x, y));
+    try expect(x == @min(x, y));
+    try expect(y == @max(x, y));
 }
 
 test "@min resulting in u0" {

--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -1,10 +1,10 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const testing = std.testing;
 const assert = std.debug.assert;
 const expect = testing.expect;
 const expectEqual = testing.expectEqual;
 const expectEqualStrings = std.testing.expectEqualStrings;
+const builtin = @import("builtin");
 
 test "passing an optional integer as a parameter" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -515,7 +515,7 @@ test "orelse on C pointer" {
     // TODO https://github.com/ziglang/zig/issues/6597
     const foo: [*c]const u8 = "hey";
     const d = foo orelse @compileError("bad");
-    try expectEqual([*c]const u8, @TypeOf(d));
+    try expect([*c]const u8 == @TypeOf(d));
 }
 
 test "alignment of wrapping an optional payload" {
@@ -651,7 +651,7 @@ test "result location initialization of optional with OPV payload" {
 
     var c: ?S = .{ .x = 0 };
     _ = &c;
-    try expectEqual(0, (c orelse return error.TestFailed).x);
+    try expect(0 == (c orelse return error.TestFailed).x);
 }
 
 test "global comptime only optional" {

--- a/test/behavior/packed-struct.zig
+++ b/test/behavior/packed-struct.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
 
 test "flags in packed structs" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -31,8 +30,8 @@ test "flags in packed structs" {
         _: u9,
     };
 
-    try expectEqual(@sizeOf(u24), @sizeOf(Flags1));
-    try expectEqual(24, @bitSizeOf(Flags1));
+    try expect(@sizeOf(u24) == @sizeOf(Flags1));
+    try expect(24 == @bitSizeOf(Flags1));
 
     const Flags2 = packed struct {
         // byte 0
@@ -58,8 +57,8 @@ test "flags in packed structs" {
         _: u10,
     };
 
-    try expectEqual(@sizeOf(u25), @sizeOf(Flags2));
-    try expectEqual(25, @bitSizeOf(Flags2));
+    try expect(@sizeOf(u25) == @sizeOf(Flags2));
+    try expect(25 == @bitSizeOf(Flags2));
 
     const Flags3 = packed struct {
         // byte 0
@@ -86,8 +85,8 @@ test "flags in packed structs" {
         _: u16, // it works, if the padding is 8-based
     };
 
-    try expectEqual(@sizeOf(u32), @sizeOf(Flags3));
-    try expectEqual(32, @bitSizeOf(Flags3));
+    try expect(@sizeOf(u32) == @sizeOf(Flags3));
+    try expect(32 == @bitSizeOf(Flags3));
 }
 
 test "consistent size of packed structs" {
@@ -99,11 +98,11 @@ test "consistent size of packed structs" {
     const register_size_bits = 32;
     const register_size_bytes = @sizeOf(u32);
 
-    try expectEqual(register_size_bits, @bitSizeOf(TxData1));
-    try expectEqual(register_size_bytes, @sizeOf(TxData1));
+    try expect(register_size_bits == @bitSizeOf(TxData1));
+    try expect(register_size_bytes == @sizeOf(TxData1));
 
-    try expectEqual(register_size_bits, @bitSizeOf(TxData2));
-    try expectEqual(register_size_bytes, @sizeOf(TxData2));
+    try expect(register_size_bits == @bitSizeOf(TxData2));
+    try expect(register_size_bytes == @sizeOf(TxData2));
 
     const TxData4 = packed struct { a: u32, b: u24 };
     const TxData6 = packed struct { a: u24, b: u32 };
@@ -111,11 +110,11 @@ test "consistent size of packed structs" {
     const expectedBitSize = 56;
     const expectedByteSize = @sizeOf(u56);
 
-    try expectEqual(expectedBitSize, @bitSizeOf(TxData4));
-    try expectEqual(expectedByteSize, @sizeOf(TxData4));
+    try expect(expectedBitSize == @bitSizeOf(TxData4));
+    try expect(expectedByteSize == @sizeOf(TxData4));
 
-    try expectEqual(expectedBitSize, @bitSizeOf(TxData6));
-    try expectEqual(expectedByteSize, @sizeOf(TxData6));
+    try expect(expectedBitSize == @bitSizeOf(TxData6));
+    try expect(expectedByteSize == @sizeOf(TxData6));
 }
 
 test "correct sizeOf and offsets in packed structs" {
@@ -136,50 +135,50 @@ test "correct sizeOf and offsets in packed structs" {
         u10_a: u10,
         u10_b: u10,
     };
-    try expectEqual(0, @offsetOf(PStruct, "bool_a"));
-    try expectEqual(0, @bitOffsetOf(PStruct, "bool_a"));
-    try expectEqual(0, @offsetOf(PStruct, "bool_b"));
-    try expectEqual(1, @bitOffsetOf(PStruct, "bool_b"));
-    try expectEqual(0, @offsetOf(PStruct, "bool_c"));
-    try expectEqual(2, @bitOffsetOf(PStruct, "bool_c"));
-    try expectEqual(0, @offsetOf(PStruct, "bool_d"));
-    try expectEqual(3, @bitOffsetOf(PStruct, "bool_d"));
-    try expectEqual(0, @offsetOf(PStruct, "bool_e"));
-    try expectEqual(4, @bitOffsetOf(PStruct, "bool_e"));
-    try expectEqual(0, @offsetOf(PStruct, "bool_f"));
-    try expectEqual(5, @bitOffsetOf(PStruct, "bool_f"));
-    try expectEqual(0, @offsetOf(PStruct, "u1_a"));
-    try expectEqual(6, @bitOffsetOf(PStruct, "u1_a"));
-    try expectEqual(0, @offsetOf(PStruct, "bool_g"));
-    try expectEqual(7, @bitOffsetOf(PStruct, "bool_g"));
-    try expectEqual(1, @offsetOf(PStruct, "u1_b"));
-    try expectEqual(8, @bitOffsetOf(PStruct, "u1_b"));
-    try expectEqual(1, @offsetOf(PStruct, "u3_a"));
-    try expectEqual(9, @bitOffsetOf(PStruct, "u3_a"));
-    try expectEqual(1, @offsetOf(PStruct, "u10_a"));
-    try expectEqual(12, @bitOffsetOf(PStruct, "u10_a"));
-    try expectEqual(2, @offsetOf(PStruct, "u10_b"));
-    try expectEqual(22, @bitOffsetOf(PStruct, "u10_b"));
-    try expectEqual(4, @sizeOf(PStruct));
+    try expect(0 == @offsetOf(PStruct, "bool_a"));
+    try expect(0 == @bitOffsetOf(PStruct, "bool_a"));
+    try expect(0 == @offsetOf(PStruct, "bool_b"));
+    try expect(1 == @bitOffsetOf(PStruct, "bool_b"));
+    try expect(0 == @offsetOf(PStruct, "bool_c"));
+    try expect(2 == @bitOffsetOf(PStruct, "bool_c"));
+    try expect(0 == @offsetOf(PStruct, "bool_d"));
+    try expect(3 == @bitOffsetOf(PStruct, "bool_d"));
+    try expect(0 == @offsetOf(PStruct, "bool_e"));
+    try expect(4 == @bitOffsetOf(PStruct, "bool_e"));
+    try expect(0 == @offsetOf(PStruct, "bool_f"));
+    try expect(5 == @bitOffsetOf(PStruct, "bool_f"));
+    try expect(0 == @offsetOf(PStruct, "u1_a"));
+    try expect(6 == @bitOffsetOf(PStruct, "u1_a"));
+    try expect(0 == @offsetOf(PStruct, "bool_g"));
+    try expect(7 == @bitOffsetOf(PStruct, "bool_g"));
+    try expect(1 == @offsetOf(PStruct, "u1_b"));
+    try expect(8 == @bitOffsetOf(PStruct, "u1_b"));
+    try expect(1 == @offsetOf(PStruct, "u3_a"));
+    try expect(9 == @bitOffsetOf(PStruct, "u3_a"));
+    try expect(1 == @offsetOf(PStruct, "u10_a"));
+    try expect(12 == @bitOffsetOf(PStruct, "u10_a"));
+    try expect(2 == @offsetOf(PStruct, "u10_b"));
+    try expect(22 == @bitOffsetOf(PStruct, "u10_b"));
+    try expect(4 == @sizeOf(PStruct));
 
     const s1 = @as(PStruct, @bitCast(@as(u32, 0x12345678)));
-    try expectEqual(false, s1.bool_a);
-    try expectEqual(false, s1.bool_b);
-    try expectEqual(false, s1.bool_c);
-    try expectEqual(true, s1.bool_d);
-    try expectEqual(true, s1.bool_e);
-    try expectEqual(true, s1.bool_f);
-    try expectEqual(1, s1.u1_a);
-    try expectEqual(false, s1.bool_g);
-    try expectEqual(0, s1.u1_b);
-    try expectEqual(3, s1.u3_a);
-    try expectEqual(0b1101000101, s1.u10_a);
-    try expectEqual(0b0001001000, s1.u10_b);
+    try expect(false == s1.bool_a);
+    try expect(false == s1.bool_b);
+    try expect(false == s1.bool_c);
+    try expect(true == s1.bool_d);
+    try expect(true == s1.bool_e);
+    try expect(true == s1.bool_f);
+    try expect(1 == s1.u1_a);
+    try expect(false == s1.bool_g);
+    try expect(0 == s1.u1_b);
+    try expect(3 == s1.u3_a);
+    try expect(0b1101000101 == s1.u10_a);
+    try expect(0b0001001000 == s1.u10_b);
 
     const s2 = @as(packed struct { x: u1, y: u7, z: u24 }, @bitCast(@as(u32, 0xd5c71ff4)));
-    try expectEqual(0, s2.x);
-    try expectEqual(0b1111010, s2.y);
-    try expectEqual(0xd5c71f, s2.z);
+    try expect(0 == s2.x);
+    try expect(0b1111010 == s2.y);
+    try expect(0xd5c71f == s2.z);
 }
 
 test "nested packed structs" {
@@ -193,19 +192,19 @@ test "nested packed structs" {
     const S3 = packed struct { x: S1, y: S2 };
     const S3Padded = packed struct { s3: S3, pad: u16 };
 
-    try expectEqual(48, @bitSizeOf(S3));
-    try expectEqual(@sizeOf(u48), @sizeOf(S3));
+    try expect(48 == @bitSizeOf(S3));
+    try expect(@sizeOf(u48) == @sizeOf(S3));
 
-    try expectEqual(3, @offsetOf(S3, "y"));
-    try expectEqual(24, @bitOffsetOf(S3, "y"));
+    try expect(3 == @offsetOf(S3, "y"));
+    try expect(24 == @bitOffsetOf(S3, "y"));
 
     const s3 = @as(S3Padded, @bitCast(@as(u64, 0xe952d5c71ff4))).s3;
-    try expectEqual(0xf4, s3.x.a);
-    try expectEqual(0x1f, s3.x.b);
-    try expectEqual(0xc7, s3.x.c);
-    try expectEqual(0xd5, s3.y.d);
-    try expectEqual(0x52, s3.y.e);
-    try expectEqual(0xe9, s3.y.f);
+    try expect(0xf4 == s3.x.a);
+    try expect(0x1f == s3.x.b);
+    try expect(0xc7 == s3.x.c);
+    try expect(0xd5 == s3.y.d);
+    try expect(0x52 == s3.y.e);
+    try expect(0xe9 == s3.y.f);
 
     const S4 = packed struct { a: i32, b: i8 };
     const S5 = packed struct { a: i32, b: i8, c: S4 };
@@ -213,15 +212,15 @@ test "nested packed structs" {
 
     const expectedBitSize = 80;
     const expectedByteSize = @sizeOf(u80);
-    try expectEqual(expectedBitSize, @bitSizeOf(S5));
-    try expectEqual(expectedByteSize, @sizeOf(S5));
-    try expectEqual(expectedBitSize, @bitSizeOf(S6));
-    try expectEqual(expectedByteSize, @sizeOf(S6));
+    try expect(expectedBitSize == @bitSizeOf(S5));
+    try expect(expectedByteSize == @sizeOf(S5));
+    try expect(expectedBitSize == @bitSizeOf(S6));
+    try expect(expectedByteSize == @sizeOf(S6));
 
-    try expectEqual(5, @offsetOf(S5, "c"));
-    try expectEqual(40, @bitOffsetOf(S5, "c"));
-    try expectEqual(9, @offsetOf(S6, "c"));
-    try expectEqual(72, @bitOffsetOf(S6, "c"));
+    try expect(5 == @offsetOf(S5, "c"));
+    try expect(40 == @bitOffsetOf(S5, "c"));
+    try expect(9 == @offsetOf(S6, "c"));
+    try expect(72 == @bitOffsetOf(S6, "c"));
 }
 
 test "regular in irregular packed struct" {
@@ -240,8 +239,8 @@ test "regular in irregular packed struct" {
     foo.bar.a = 235;
     foo.bar.b = 42;
 
-    try expectEqual(235, foo.bar.a);
-    try expectEqual(42, foo.bar.b);
+    try expect(235 == foo.bar.a);
+    try expect(42 == foo.bar.b);
 }
 
 test "nested packed struct unaligned" {
@@ -430,12 +429,12 @@ test "nested packed struct field pointers" {
     const ptr_p0_c = &S2.s.p0.c;
     const ptr_p1_a = &S2.s.p1.a;
     const ptr_p1_b = &S2.s.p1.b;
-    try expectEqual(1, ptr_base.*);
-    try expectEqual(2, ptr_p0_a.*);
-    try expectEqual(3, ptr_p0_b.*);
-    try expectEqual(4, ptr_p0_c.*);
-    try expectEqual(5, ptr_p1_a.*);
-    try expectEqual(6, ptr_p1_b.*);
+    try expect(1 == ptr_base.*);
+    try expect(2 == ptr_p0_a.*);
+    try expect(3 == ptr_p0_b.*);
+    try expect(4 == ptr_p0_c.*);
+    try expect(5 == ptr_p1_a.*);
+    try expect(6 == ptr_p1_b.*);
 }
 
 test "load pointer from packed struct" {
@@ -661,15 +660,15 @@ test "nested packed struct field access test" {
         .y = 2.0,
     };
 
-    try std.testing.expectEqual(vec2.x, 1.0);
-    try std.testing.expectEqual(vec2.y, 2.0);
+    try std.testing.expect(vec2.x == 1.0);
+    try std.testing.expect(vec2.y == 2.0);
 
     var vec2_o: Vec2 = undefined;
     const vec2_o_ptr: *Vec2 = &vec2_o;
     vec2_o_ptr.* = vec2;
 
-    try std.testing.expectEqual(vec2_o.x, 1.0);
-    try std.testing.expectEqual(vec2_o.y, 2.0);
+    try std.testing.expect(vec2_o.x == 1.0);
+    try std.testing.expect(vec2_o.y == 2.0);
 
     const nested_vec2 = NestedVec2{
         .nested = Vec2{
@@ -678,15 +677,15 @@ test "nested packed struct field access test" {
         },
     };
 
-    try std.testing.expectEqual(nested_vec2.nested.x, 1.0);
-    try std.testing.expectEqual(nested_vec2.nested.y, 2.0);
+    try std.testing.expect(nested_vec2.nested.x == 1.0);
+    try std.testing.expect(nested_vec2.nested.y == 2.0);
 
     var nested_o: NestedVec2 = undefined;
     const nested_o_ptr: *NestedVec2 = &nested_o;
     nested_o_ptr.* = nested_vec2;
 
-    try std.testing.expectEqual(nested_o.nested.x, 1.0);
-    try std.testing.expectEqual(nested_o.nested.y, 2.0);
+    try std.testing.expect(nested_o.nested.x == 1.0);
+    try std.testing.expect(nested_o.nested.y == 2.0);
 
     const vec3 = Vec3{
         .x = 1.0,
@@ -694,17 +693,17 @@ test "nested packed struct field access test" {
         .z = 3.0,
     };
 
-    try std.testing.expectEqual(vec3.x, 1.0);
-    try std.testing.expectEqual(vec3.y, 2.0);
-    try std.testing.expectEqual(vec3.z, 3.0);
+    try std.testing.expect(vec3.x == 1.0);
+    try std.testing.expect(vec3.y == 2.0);
+    try std.testing.expect(vec3.z == 3.0);
 
     var vec3_o: Vec3 = undefined;
     const vec3_o_ptr: *Vec3 = &vec3_o;
     vec3_o_ptr.* = vec3;
 
-    try std.testing.expectEqual(vec3_o.x, 1.0);
-    try std.testing.expectEqual(vec3_o.y, 2.0);
-    try std.testing.expectEqual(vec3_o.z, 3.0);
+    try std.testing.expect(vec3_o.x == 1.0);
+    try std.testing.expect(vec3_o.y == 2.0);
+    try std.testing.expect(vec3_o.z == 3.0);
 
     const nested_vec3 = NestedVec3{
         .nested = Vec3{
@@ -714,17 +713,17 @@ test "nested packed struct field access test" {
         },
     };
 
-    try std.testing.expectEqual(nested_vec3.nested.x, 1.0);
-    try std.testing.expectEqual(nested_vec3.nested.y, 2.0);
-    try std.testing.expectEqual(nested_vec3.nested.z, 3.0);
+    try std.testing.expect(nested_vec3.nested.x == 1.0);
+    try std.testing.expect(nested_vec3.nested.y == 2.0);
+    try std.testing.expect(nested_vec3.nested.z == 3.0);
 
     var nested_vec3_o: NestedVec3 = undefined;
     const nested_vec3_o_ptr: *NestedVec3 = &nested_vec3_o;
     nested_vec3_o_ptr.* = nested_vec3;
 
-    try std.testing.expectEqual(nested_vec3_o.nested.x, 1.0);
-    try std.testing.expectEqual(nested_vec3_o.nested.y, 2.0);
-    try std.testing.expectEqual(nested_vec3_o.nested.z, 3.0);
+    try std.testing.expect(nested_vec3_o.nested.x == 1.0);
+    try std.testing.expect(nested_vec3_o.nested.y == 2.0);
+    try std.testing.expect(nested_vec3_o.nested.z == 3.0);
 
     const hld = packed struct {
         c: u64,
@@ -947,7 +946,7 @@ test "store undefined to packed result location" {
     var x: u4 = 0;
     _ = &x;
     const s = packed struct { x: u4, y: u4 }{ .x = x, .y = if (x > 0) x else undefined };
-    try expectEqual(x, s.x);
+    try expect(x == s.x);
 }
 
 // Originally reported at https://github.com/ziglang/zig/issues/9914
@@ -1001,12 +1000,12 @@ test "modify nested packed struct aligned field" {
 
     var opts = Options{};
     opts.pretty_print.indent += 1;
-    try std.testing.expectEqual(0b00000000100100000, @as(u17, @bitCast(opts)));
+    try std.testing.expect(0b00000000100100000 == @as(u17, @bitCast(opts)));
     try std.testing.expect(!opts.foo);
     try std.testing.expect(!opts.bar);
     try std.testing.expect(!opts.pretty_print.enabled);
-    try std.testing.expectEqual(4, opts.pretty_print.num_spaces);
-    try std.testing.expectEqual(1, opts.pretty_print.indent);
+    try std.testing.expect(4 == opts.pretty_print.num_spaces);
+    try std.testing.expect(1 == opts.pretty_print.indent);
     try std.testing.expect(!opts.baz);
 }
 
@@ -1038,7 +1037,7 @@ test "assigning packed struct inside another packed struct" {
     S.mem.padding = 0;
     S.t(val);
 
-    try expectEqual(val, S.mem.inner);
+    try expect(val == S.mem.inner);
     try expect(S.mem.padding == 0);
 }
 
@@ -1342,8 +1341,8 @@ test "packed struct store of comparison result" {
 
     var A: S1 = .{ .val1 = 1, .val2 = 1 };
     A.val2 += 1;
-    try expectEqual(1, A.val1);
-    try expectEqual(2, A.val2);
+    try expect(1 == A.val1);
+    try expect(2 == A.val2);
     try expect((A.val2 & 1) != 1);
     const result1: S2 = .{ .a = (A.val2 & 1) != 1, .b = (A.val1 & 1) != 1 };
     try expect(result1.a);

--- a/test/behavior/packed-union.zig
+++ b/test/behavior/packed-union.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const assert = std.debug.assert;
-const expectEqual = std.testing.expectEqual;
+const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 test "flags in packed union" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -32,18 +32,18 @@ fn testFlagsInPackedUnion() !void {
     };
     var test_bits: FlagBits = .{};
 
-    try expectEqual(false, test_bits.enable_1);
-    try expectEqual(true, test_bits.other_flags.flags.enable_1);
+    try expect(false == test_bits.enable_1);
+    try expect(true == test_bits.other_flags.flags.enable_1);
 
     test_bits.enable_1 = true;
 
-    try expectEqual(true, test_bits.enable_1);
-    try expectEqual(true, test_bits.other_flags.flags.enable_1);
+    try expect(true == test_bits.enable_1);
+    try expect(true == test_bits.other_flags.flags.enable_1);
 
     test_bits.other_flags.flags.enable_1 = false;
 
-    try expectEqual(true, test_bits.enable_1);
-    try expectEqual(false, test_bits.other_flags.flags.enable_1);
+    try expect(true == test_bits.enable_1);
+    try expect(false == test_bits.other_flags.flags.enable_1);
 }
 
 test "flags in packed union at offset" {
@@ -86,20 +86,20 @@ fn testFlagsInPackedUnionAtOffset() !void {
     };
     var test_bits: FlagBits = .{ .adv_flags = .{ .adv = .{ .flags = .{} } } };
 
-    try expectEqual(@as(u8, 0), test_bits.adv_flags.pad);
-    try expectEqual(true, test_bits.adv_flags.adv.flags.enable_1);
-    try expectEqual(false, test_bits.adv_flags.adv.flags.enable_2);
+    try expect(@as(u8, 0) == test_bits.adv_flags.pad);
+    try expect(true == test_bits.adv_flags.adv.flags.enable_1);
+    try expect(false == test_bits.adv_flags.adv.flags.enable_2);
 
     test_bits.adv_flags.adv.flags.enable_1 = false;
     test_bits.adv_flags.adv.flags.enable_2 = true;
-    try expectEqual(@as(u8, 0), test_bits.adv_flags.pad);
-    try expectEqual(false, test_bits.adv_flags.adv.flags.enable_1);
-    try expectEqual(true, test_bits.adv_flags.adv.flags.enable_2);
+    try expect(@as(u8, 0) == test_bits.adv_flags.pad);
+    try expect(false == test_bits.adv_flags.adv.flags.enable_1);
+    try expect(true == test_bits.adv_flags.adv.flags.enable_2);
 
     test_bits.adv_flags.adv.bits = 12;
-    try expectEqual(@as(u8, 0), test_bits.adv_flags.pad);
-    try expectEqual(false, test_bits.adv_flags.adv.flags.enable_1);
-    try expectEqual(false, test_bits.adv_flags.adv.flags.enable_2);
+    try expect(@as(u8, 0) == test_bits.adv_flags.pad);
+    try expect(false == test_bits.adv_flags.adv.flags.enable_1);
+    try expect(false == test_bits.adv_flags.adv.flags.enable_2);
 }
 
 // Originally reported at https://github.com/ziglang/zig/issues/16581
@@ -135,7 +135,7 @@ fn testPackedUnionInPackedStruct() !void {
         }
     };
 
-    try std.testing.expectEqual(RequestType.read, Request.init(.{ .key = 3 }).active_type);
+    try std.testing.expect(RequestType.read == Request.init(.{ .key = 3 }).active_type);
 }
 
 test "packed union initialized with a runtime value" {

--- a/test/behavior/packed_struct_explicit_backing_int.zig
+++ b/test/behavior/packed_struct_explicit_backing_int.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const assert = std.debug.assert;
-const expectEqual = std.testing.expectEqual;
+const expect = std.testing.expect;
+const builtin = @import("builtin");
+
 const native_endian = builtin.cpu.arch.endian();
 
 test "packed struct explicit backing integer" {
@@ -15,20 +16,20 @@ test "packed struct explicit backing integer" {
     const S3 = packed struct { x: S1, y: S2 };
     const S3Padded = packed struct(u64) { s3: S3, pad: u16 };
 
-    try expectEqual(48, @bitSizeOf(S3));
-    try expectEqual(@sizeOf(u48), @sizeOf(S3));
+    try expect(48 == @bitSizeOf(S3));
+    try expect(@sizeOf(u48) == @sizeOf(S3));
 
-    try expectEqual(3, @offsetOf(S3, "y"));
-    try expectEqual(24, @bitOffsetOf(S3, "y"));
+    try expect(3 == @offsetOf(S3, "y"));
+    try expect(24 == @bitOffsetOf(S3, "y"));
 
     if (native_endian == .little) {
         const s3 = @as(S3Padded, @bitCast(@as(u64, 0xe952d5c71ff4))).s3;
-        try expectEqual(@as(u8, 0xf4), s3.x.a);
-        try expectEqual(@as(u8, 0x1f), s3.x.b);
-        try expectEqual(@as(u8, 0xc7), s3.x.c);
-        try expectEqual(@as(u8, 0xd5), s3.y.d);
-        try expectEqual(@as(u8, 0x52), s3.y.e);
-        try expectEqual(@as(u8, 0xe9), s3.y.f);
+        try expect(@as(u8, 0xf4) == s3.x.a);
+        try expect(@as(u8, 0x1f) == s3.x.b);
+        try expect(@as(u8, 0xc7) == s3.x.c);
+        try expect(@as(u8, 0xd5) == s3.y.d);
+        try expect(@as(u8, 0x52) == s3.y.e);
+        try expect(@as(u8, 0xe9) == s3.y.f);
     }
 
     const S4 = packed struct { a: i32, b: i8 };
@@ -37,13 +38,13 @@ test "packed struct explicit backing integer" {
 
     const expectedBitSize = 80;
     const expectedByteSize = @sizeOf(u80);
-    try expectEqual(expectedBitSize, @bitSizeOf(S5));
-    try expectEqual(expectedByteSize, @sizeOf(S5));
-    try expectEqual(expectedBitSize, @bitSizeOf(S6));
-    try expectEqual(expectedByteSize, @sizeOf(S6));
+    try expect(expectedBitSize == @bitSizeOf(S5));
+    try expect(expectedByteSize == @sizeOf(S5));
+    try expect(expectedBitSize == @bitSizeOf(S6));
+    try expect(expectedByteSize == @sizeOf(S6));
 
-    try expectEqual(5, @offsetOf(S5, "c"));
-    try expectEqual(40, @bitOffsetOf(S5, "c"));
-    try expectEqual(9, @offsetOf(S6, "c"));
-    try expectEqual(72, @bitOffsetOf(S6, "c"));
+    try expect(5 == @offsetOf(S5, "c"));
+    try expect(40 == @bitOffsetOf(S5, "c"));
+    try expect(9 == @offsetOf(S6, "c"));
+    try expect(72 == @bitOffsetOf(S6, "c"));
 }

--- a/test/behavior/popcount.zig
+++ b/test/behavior/popcount.zig
@@ -1,7 +1,6 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "@popCount integers" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO

--- a/test/behavior/ptrfromint.zig
+++ b/test/behavior/ptrfromint.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
+const expect = std.testing.expect;
 const builtin = @import("builtin");
-const expectEqual = std.testing.expectEqual;
 
 test "casting integer address to function pointer" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
@@ -38,7 +38,7 @@ test "@ptrFromInt creates null pointer" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     const ptr = @as(?*u32, @ptrFromInt(0));
-    try expectEqual(@as(?*u32, null), ptr);
+    try expect(@as(?*u32, null) == ptr);
 }
 
 test "@ptrFromInt creates allowzero zero pointer" {
@@ -47,5 +47,5 @@ test "@ptrFromInt creates allowzero zero pointer" {
     if (builtin.zig_backend == .stage2_spirv) return error.SkipZigTest;
 
     const ptr = @as(*allowzero u32, @ptrFromInt(0));
-    try expectEqual(@as(usize, 0), @intFromPtr(ptr));
+    try expect(@as(usize, 0) == @intFromPtr(ptr));
 }

--- a/test/behavior/return_address.zig
+++ b/test/behavior/return_address.zig
@@ -1,5 +1,5 @@
-const builtin = @import("builtin");
 const testing = @import("std").testing;
+const builtin = @import("builtin");
 
 fn retAddr() usize {
     return @returnAddress();
@@ -12,5 +12,5 @@ test "return address" {
 
     _ = retAddr();
     // TODO: #14938
-    try testing.expectEqual(0, comptime retAddr());
+    try testing.expect(0 == comptime retAddr());
 }

--- a/test/behavior/shuffle.zig
+++ b/test/behavior/shuffle.zig
@@ -1,8 +1,7 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const mem = std.mem;
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "@shuffle int" {
     if (builtin.zig_backend == .stage2_aarch64) return error.SkipZigTest;
@@ -123,10 +122,10 @@ fn testShuffle(
     for (mask, x_elems) |m, x_elem| {
         if (m >= 0) {
             // Element from A
-            try expectEqual(x_elem, a_elems[@intCast(m)]);
+            try expect(x_elem == a_elems[@intCast(m)]);
         } else {
             // Element from B
-            try expectEqual(x_elem, b_elems[@intCast(~m)]);
+            try expect(x_elem == b_elems[@intCast(~m)]);
         }
     }
 }

--- a/test/behavior/sizeof_and_typeof.zig
+++ b/test/behavior/sizeof_and_typeof.zig
@@ -1,8 +1,7 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "@sizeOf and @TypeOf" {
     const y: @TypeOf(x) = 120;
@@ -314,7 +313,7 @@ test "@bitSizeOf on array of structs" {
         foo: u64,
     };
 
-    try expectEqual(128, @bitSizeOf([2]S));
+    try expect(128 == @bitSizeOf([2]S));
 }
 
 test "lazy abi size used in comparison" {

--- a/test/behavior/slice.zig
+++ b/test/behavior/slice.zig
@@ -1,11 +1,10 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqualSlices = std.testing.expectEqualSlices;
 const expectEqualStrings = std.testing.expectEqualStrings;
-const expectEqual = std.testing.expectEqual;
 const mem = std.mem;
+const builtin = @import("builtin");
 
 // comptime array passed as slice argument
 comptime {
@@ -853,12 +852,12 @@ test "slice field ptr const" {
     const const_slice: []const u8 = "string";
 
     const const_ptr_const_slice = &const_slice;
-    try expectEqual(*const []const u8, @TypeOf(&const_ptr_const_slice.*));
-    try expectEqual(*const [*]const u8, @TypeOf(&const_ptr_const_slice.ptr));
+    try expect(*const []const u8 == @TypeOf(&const_ptr_const_slice.*));
+    try expect(*const [*]const u8 == @TypeOf(&const_ptr_const_slice.ptr));
 
     var var_ptr_const_slice = &const_slice;
-    try expectEqual(*const []const u8, @TypeOf(&var_ptr_const_slice.*));
-    try expectEqual(*const [*]const u8, @TypeOf(&var_ptr_const_slice.ptr));
+    try expect(*const []const u8 == @TypeOf(&var_ptr_const_slice.*));
+    try expect(*const [*]const u8 == @TypeOf(&var_ptr_const_slice.ptr));
 }
 
 test "slice field ptr var" {
@@ -867,12 +866,12 @@ test "slice field ptr var" {
     var var_slice: []const u8 = "string";
 
     var var_ptr_var_slice = &var_slice;
-    try expectEqual(*[]const u8, @TypeOf(&var_ptr_var_slice.*));
-    try expectEqual(*[*]const u8, @TypeOf(&var_ptr_var_slice.ptr));
+    try expect(*[]const u8 == @TypeOf(&var_ptr_var_slice.*));
+    try expect(*[*]const u8 == @TypeOf(&var_ptr_var_slice.ptr));
 
     const const_ptr_var_slice = &var_slice;
-    try expectEqual(*[]const u8, @TypeOf(&const_ptr_var_slice.*));
-    try expectEqual(*[*]const u8, @TypeOf(&const_ptr_var_slice.ptr));
+    try expect(*[]const u8 == @TypeOf(&const_ptr_var_slice.*));
+    try expect(*[*]const u8 == @TypeOf(&const_ptr_var_slice.ptr));
 }
 
 test "global slice field access" {

--- a/test/behavior/string_literals.zig
+++ b/test/behavior/string_literals.zig
@@ -109,5 +109,5 @@ test "including the sentinel when dereferencing a string literal" {
     const const_derefed = const_str[0 .. const_str.len + 1].*;
 
     try std.testing.expectEqualSlices(u8, &var_derefed, &const_derefed);
-    try std.testing.expectEqual(0, const_derefed[3]);
+    try std.testing.expect(0 == const_derefed[3]);
 }

--- a/test/behavior/struct.zig
+++ b/test/behavior/struct.zig
@@ -1,12 +1,12 @@
 const std = @import("std");
-const builtin = @import("builtin");
-const native_endian = builtin.target.cpu.arch.endian();
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualSlices = std.testing.expectEqualSlices;
 const maxInt = std.math.maxInt;
+const builtin = @import("builtin");
 
+const native_endian = builtin.target.cpu.arch.endian();
 top_level_field: i32,
 
 test "top level fields" {
@@ -990,7 +990,7 @@ test "struct with 0-length union array field" {
 
     var s: S = undefined;
     _ = &s;
-    try expectEqual(@as(usize, 0), s.zero_length.len);
+    try expect(@as(usize, 0) == s.zero_length.len);
 }
 
 test "packed struct with undefined initializers" {
@@ -1296,13 +1296,13 @@ test "fieldParentPtr of a zero-bit field" {
                 const a = A{ .u = 0 };
                 const b_ptr = &a.b;
                 const a_ptr: *const A = @fieldParentPtr("b", b_ptr);
-                try std.testing.expectEqual(&a, a_ptr);
+                try std.testing.expect(&a == a_ptr);
             }
             {
                 var a = A{ .u = 0 };
                 const b_ptr = &a.b;
                 const a_ptr: *A = @fieldParentPtr("b", b_ptr);
-                try std.testing.expectEqual(&a, a_ptr);
+                try std.testing.expect(&a == a_ptr);
             }
         }
         fn testNestedStruct(comptime A: type) !void {
@@ -1310,17 +1310,17 @@ test "fieldParentPtr of a zero-bit field" {
                 const a = A{ .u = 0 };
                 const c_ptr = &a.b.c;
                 const b_ptr: @TypeOf(&a.b) = @fieldParentPtr("c", c_ptr);
-                try std.testing.expectEqual(&a.b, b_ptr);
+                try std.testing.expect(&a.b == b_ptr);
                 const a_ptr: *const A = @fieldParentPtr("b", b_ptr);
-                try std.testing.expectEqual(&a, a_ptr);
+                try std.testing.expect(&a == a_ptr);
             }
             {
                 var a = A{ .u = 0 };
                 const c_ptr = &a.b.c;
                 const b_ptr: @TypeOf(&a.b) = @fieldParentPtr("c", c_ptr);
-                try std.testing.expectEqual(&a.b, b_ptr);
+                try std.testing.expect(&a.b == b_ptr);
                 const a_ptr: *const A = @fieldParentPtr("b", b_ptr);
-                try std.testing.expectEqual(&a, a_ptr);
+                try std.testing.expect(&a == a_ptr);
             }
         }
         fn doTheTest() !void {
@@ -1388,10 +1388,10 @@ test "struct has only one reference" {
     const pointer_nested_pointer_packed_struct: *const anyopaque = &S.pointerNestedPointerPackedStruct;
     try expect(pointer_nested_packed_struct != pointer_nested_pointer_packed_struct);
 
-    try expectEqual(@alignOf(struct {}), S.optionalComptimeIntParam(@alignOf(struct {})));
-    try expectEqual(@alignOf(struct { x: u8 }), S.errorUnionComptimeIntParam(@alignOf(struct { x: u8 })));
-    try expectEqual(@sizeOf(struct { x: u16 }), S.optionalComptimeIntParam(@sizeOf(struct { x: u16 })));
-    try expectEqual(@sizeOf(struct { x: u32 }), S.errorUnionComptimeIntParam(@sizeOf(struct { x: u32 })));
+    try expect(@alignOf(struct {}) == S.optionalComptimeIntParam(@alignOf(struct {})));
+    try expect(@alignOf(struct { x: u8 }) == S.errorUnionComptimeIntParam(@alignOf(struct { x: u8 })));
+    try expect(@sizeOf(struct { x: u16 }) == S.optionalComptimeIntParam(@sizeOf(struct { x: u16 })));
+    try expect(@sizeOf(struct { x: u32 }) == S.errorUnionComptimeIntParam(@sizeOf(struct { x: u32 })));
 }
 
 test "no dependency loop on pointer to optional struct" {
@@ -1571,9 +1571,9 @@ test "struct field pointer has correct alignment" {
             comptime assert(@TypeOf(bp) == *align(1) u32);
             comptime assert(@TypeOf(cp) == *u32); // undefined layout, cannot inherit larger alignment
 
-            try expectEqual(@as(u32, 123), ap.*);
-            try expectEqual(@as(u32, 456), bp.*);
-            try expectEqual(@as(u32, 789), cp.*);
+            try expect(@as(u32, 123) == ap.*);
+            try expect(@as(u32, 456) == bp.*);
+            try expect(@as(u32, 789) == cp.*);
         }
     };
 
@@ -1608,13 +1608,13 @@ test "extern struct field pointer has correct alignment" {
             comptime assert(@TypeOf(byp) == *align(1) u16);
             comptime assert(@TypeOf(cyp) == *align(@alignOf(u32)) u16);
 
-            try expectEqual(@as(u32, 1), axp.*);
-            try expectEqual(@as(u32, 3), bxp.*);
-            try expectEqual(@as(u32, 5), cxp.*);
+            try expect(@as(u32, 1) == axp.*);
+            try expect(@as(u32, 3) == bxp.*);
+            try expect(@as(u32, 5) == cxp.*);
 
-            try expectEqual(@as(u16, 2), ayp.*);
-            try expectEqual(@as(u16, 4), byp.*);
-            try expectEqual(@as(u16, 6), cyp.*);
+            try expect(@as(u16, 2) == ayp.*);
+            try expect(@as(u16, 4) == byp.*);
+            try expect(@as(u16, 6) == cyp.*);
         }
     };
 
@@ -1669,7 +1669,7 @@ test "runtime side-effects in comptime-known struct init" {
         },
     };
     try expectEqual(S{ .a = 1, .b = 2, .c = 4, .d = 8 }, init);
-    try expectEqual(@as(u4, std.math.maxInt(u4)), side_effects);
+    try expect(@as(u4, std.math.maxInt(u4)) == side_effects);
 }
 
 test "pointer to struct initialized through reference to anonymous initializer provides result types" {
@@ -1706,7 +1706,7 @@ test "comptimeness of optional and error union payload is analyzed properly" {
     const C = struct { x: comptime_int };
     const c: anyerror!?C = .{ .x = 3 };
     const x = (try c).?.x;
-    try std.testing.expectEqual(3, x);
+    try std.testing.expect(3 == x);
 }
 
 test "initializer uses own alignment" {
@@ -1716,8 +1716,8 @@ test "initializer uses own alignment" {
 
     var s: S = .{};
     _ = &s;
-    try expectEqual(4, @alignOf(S));
-    try expectEqual(@as(usize, 5), s.x);
+    try expect(4 == @alignOf(S));
+    try expect(@as(usize, 5) == s.x);
 }
 
 test "initializer uses own size" {
@@ -1727,8 +1727,8 @@ test "initializer uses own size" {
 
     var s: S = .{};
     _ = &s;
-    try expectEqual(4, @sizeOf(S));
-    try expectEqual(@as(usize, 5), s.x);
+    try expect(4 == @sizeOf(S));
+    try expect(@as(usize, 5) == s.x);
 }
 
 test "initializer takes a pointer to a variable inside its struct" {
@@ -1743,7 +1743,7 @@ test "initializer takes a pointer to a variable inside its struct" {
         fn doTheTest() !void {
             var foo: S = .{};
             _ = &foo;
-            try expectEqual(&S.instance, foo.s);
+            try expect(&S.instance == foo.s);
         }
     };
 
@@ -1813,8 +1813,8 @@ test "extern struct fields are aligned to 1" {
         .a = 1,
         .b = 2,
     };
-    try std.testing.expectEqual(1, foo.a);
-    try std.testing.expectEqual(2, foo.b);
+    try std.testing.expect(1 == foo.a);
+    try std.testing.expect(2 == foo.b);
 }
 
 test "assign to slice.len of global variable" {
@@ -1910,7 +1910,7 @@ test "runtime value in nested initializer passed as pointer to function" {
         a: Bar,
 
         fn takeFoo(foo: *const @This()) !void {
-            try std.testing.expectEqual(@as(u32, 24), foo.a.b);
+            try std.testing.expect(@as(u32, 24) == foo.a.b);
         }
     };
 
@@ -1950,8 +1950,8 @@ test "struct field default value is a call" {
     };
 
     const x = X{};
-    try std.testing.expectEqual(@as(u16, 0), x.y.a);
-    try std.testing.expectEqual(false, x.y.b);
+    try std.testing.expect(@as(u16, 0) == x.y.a);
+    try std.testing.expect(false == x.y.b);
     try std.testing.expectEqual(Z{ .a = 0 }, x.y.c);
     try std.testing.expectEqual(Z{ .a = 0 }, x.y.d);
 }

--- a/test/behavior/switch.zig
+++ b/test/behavior/switch.zig
@@ -1,4 +1,3 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
@@ -6,6 +5,7 @@ const expectError = std.testing.expectError;
 const expectEqual = std.testing.expectEqual;
 const minInt = std.math.minInt;
 const maxInt = std.math.maxInt;
+const builtin = @import("builtin");
 
 test "switch with numbers" {
     if (builtin.zig_backend == .stage2_sparc64) return error.SkipZigTest; // TODO
@@ -744,7 +744,7 @@ test "switch capture copies its payload" {
                 .A => |value| {
                     // Modify the original union
                     tmp = .{ .B = 0x10101010 };
-                    try expectEqual(@as(u8, 42), value);
+                    try expect(@as(u8, 42) == value);
                 },
                 else => unreachable,
             }
@@ -819,7 +819,7 @@ test "comptime inline switch" {
         };
     };
 
-    try expectEqual(u32, value);
+    try expect(u32 == value);
 }
 
 test "switch capture peer type resolution" {
@@ -835,8 +835,8 @@ test "switch capture peer type resolution" {
         }
     };
 
-    try expectEqual(@as(u64, 100), U.innerVal(.{ .a = 100 }));
-    try expectEqual(@as(u64, 200), U.innerVal(.{ .b = 200 }));
+    try expect(@as(u64, 100) == U.innerVal(.{ .a = 100 }));
+    try expect(@as(u64, 200) == U.innerVal(.{ .b = 200 }));
 }
 
 test "switch capture peer type resolution for in-memory coercible payloads" {
@@ -857,8 +857,8 @@ test "switch capture peer type resolution for in-memory coercible payloads" {
         }
     };
 
-    try expectEqual(@as(c_int, 100), U.innerVal(.{ .a = 100 }));
-    try expectEqual(@as(c_int, 200), U.innerVal(.{ .b = 200 }));
+    try expect(@as(c_int, 100) == U.innerVal(.{ .a = 100 }));
+    try expect(@as(c_int, 200) == U.innerVal(.{ .b = 200 }));
 }
 
 test "switch pointer capture peer type resolution" {
@@ -893,8 +893,8 @@ test "inline switch range that includes the maximum value of the switched type" 
     const inputs: [3]u8 = .{ 0, 254, 255 };
     for (inputs) |input| {
         switch (input) {
-            inline 254...255 => |val| try expectEqual(input, val),
-            else => |val| try expectEqual(input, val),
+            inline 254...255 => |val| try expect(input == val),
+            else => |val| try expect(input == val),
         }
     }
 }

--- a/test/behavior/switch_on_captured_error.zig
+++ b/test/behavior/switch_on_captured_error.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectError = std.testing.expectError;
-const expectEqual = std.testing.expectEqual;
 const builtin = @import("builtin");
 
 test "switch on error union catch capture" {
@@ -30,7 +29,7 @@ test "switch on error union catch capture" {
                     error.B => 1,
                     error.C => 2,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -40,7 +39,7 @@ test "switch on error union catch capture" {
                     error.B => @intFromError(err) + 4,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -50,7 +49,7 @@ test "switch on error union catch capture" {
                     error.B => @intFromError(err) + 4,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
         }
 
@@ -62,7 +61,7 @@ test "switch on error union catch capture" {
                     error.A, error.B => 0,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -71,7 +70,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -80,7 +79,7 @@ test "switch on error union catch capture" {
                     error.A, error.B => 0,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -89,7 +88,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -98,7 +97,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -110,7 +109,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     else => 1,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -119,7 +118,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -128,7 +127,7 @@ test "switch on error union catch capture" {
                     error.A => 1,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 1), b);
+                try expect(@as(u64, 1) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -137,7 +136,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     else => 1,
                 };
-                try expectEqual(@as(u64, 1), b);
+                try expect(@as(u64, 1) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -146,7 +145,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -158,7 +157,7 @@ test "switch on error union catch capture" {
                     error.A => |e| @intFromError(e) + 4,
                     else => 0,
                 };
-                try expectEqual(@as(u64, @intFromError(error.A) + 4), b);
+                try expect(@as(u64, @intFromError(error.A) + 4) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -167,7 +166,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -176,7 +175,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -185,7 +184,7 @@ test "switch on error union catch capture" {
                     error.A => |e| @intFromError(e) + 4,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -194,7 +193,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     error.B, error.C => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -206,7 +205,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     inline else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -215,7 +214,7 @@ test "switch on error union catch capture" {
                     error.A => |e| @intFromError(e) + 4,
                     inline else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -223,7 +222,7 @@ test "switch on error union catch capture" {
                 const b: u64 = a catch |err| switch (err) {
                     inline else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -232,7 +231,7 @@ test "switch on error union catch capture" {
                     error.A => 0,
                     inline error.B, error.C => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -243,7 +242,7 @@ test "switch on error union catch capture" {
                 const b: u64 = a catch |err| switch (err) {
                     else => |e| return e,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: error{}!u64 = 0;
@@ -252,7 +251,7 @@ test "switch on error union catch capture" {
                     error.UnknownError => return error.Fail,
                     else => |e| return e,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
         }
 
@@ -263,7 +262,7 @@ test "switch on error union catch capture" {
                     else => 3,
                 });
                 comptime assert(@TypeOf(ptr) == *const usize);
-                try expectEqual(ptr, &(a catch unreachable));
+                try expect(ptr == &(a catch unreachable));
             }
             {
                 const a: anyerror!usize = error.A;
@@ -271,7 +270,7 @@ test "switch on error union catch capture" {
                     else => 3,
                 });
                 comptime assert(@TypeOf(ptr) == *const comptime_int);
-                try expectEqual(3, ptr.*);
+                try expect(3 == ptr.*);
             }
             {
                 var a: anyerror!usize = 0;
@@ -281,7 +280,7 @@ test "switch on error union catch capture" {
                 });
                 comptime assert(@TypeOf(ptr) == *usize);
                 ptr.* += 1;
-                try expectEqual(@as(usize, 1), a catch unreachable);
+                try expect(@as(usize, 1) == a catch unreachable);
             }
             {
                 var a: anyerror!usize = error.A;
@@ -330,7 +329,7 @@ test "switch on error union if else capture" {
                     error.B => 1,
                     error.C => 2,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -340,7 +339,7 @@ test "switch on error union if else capture" {
                     error.B => @intFromError(err) + 4,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -350,7 +349,7 @@ test "switch on error union if else capture" {
                     error.B => @intFromError(err) + 4,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
         }
 
@@ -363,7 +362,7 @@ test "switch on error union if else capture" {
                     error.B => 1,
                     error.C => 2,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -373,7 +372,7 @@ test "switch on error union if else capture" {
                     error.B => @intFromError(err) + 4,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -383,7 +382,7 @@ test "switch on error union if else capture" {
                     error.B => @intFromError(err) + 4,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
         }
 
@@ -395,7 +394,7 @@ test "switch on error union if else capture" {
                     error.A, error.B => 0,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -404,7 +403,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -413,7 +412,7 @@ test "switch on error union if else capture" {
                     error.A, error.B => 0,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -422,7 +421,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -431,7 +430,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -443,7 +442,7 @@ test "switch on error union if else capture" {
                     error.A, error.B => 0,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -452,7 +451,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -461,7 +460,7 @@ test "switch on error union if else capture" {
                     error.A, error.B => 0,
                     error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -470,7 +469,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -479,7 +478,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -491,7 +490,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => 1,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -500,7 +499,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -509,7 +508,7 @@ test "switch on error union if else capture" {
                     error.A => 1,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 1), b);
+                try expect(@as(u64, 1) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -518,7 +517,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => 1,
                 };
-                try expectEqual(@as(u64, 1), b);
+                try expect(@as(u64, 1) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -527,7 +526,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -539,7 +538,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => 1,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = 3;
@@ -548,7 +547,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 3), b);
+                try expect(@as(u64, 3) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -557,7 +556,7 @@ test "switch on error union if else capture" {
                     error.A => 1,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, 1), b);
+                try expect(@as(u64, 1) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -566,7 +565,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => 1,
                 };
-                try expectEqual(@as(u64, 1), b);
+                try expect(@as(u64, 1) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -575,7 +574,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -587,7 +586,7 @@ test "switch on error union if else capture" {
                     error.A => |e| @intFromError(e) + 4,
                     else => 0,
                 };
-                try expectEqual(@as(u64, @intFromError(error.A) + 4), b);
+                try expect(@as(u64, @intFromError(error.A) + 4) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -596,7 +595,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -605,7 +604,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -614,7 +613,7 @@ test "switch on error union if else capture" {
                     error.A => |e| @intFromError(e) + 4,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -623,7 +622,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -635,7 +634,7 @@ test "switch on error union if else capture" {
                     error.A => |e| @intFromError(e) + 4,
                     else => 0,
                 };
-                try expectEqual(@as(u64, @intFromError(error.A) + 4), b);
+                try expect(@as(u64, @intFromError(error.A) + 4) == b);
             }
             {
                 var a: Error!u64 = error.A;
@@ -644,7 +643,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -653,7 +652,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -662,7 +661,7 @@ test "switch on error union if else capture" {
                     error.A => |e| @intFromError(e) + 4,
                     else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -671,7 +670,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     error.B, error.C => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -683,7 +682,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     inline else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -692,7 +691,7 @@ test "switch on error union if else capture" {
                     error.A => |e| @intFromError(e) + 4,
                     inline else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -700,7 +699,7 @@ test "switch on error union if else capture" {
                 const b: u64 = if (a) |x| x else |err| switch (err) {
                     inline else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -709,7 +708,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     inline error.B, error.C => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -721,7 +720,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     inline else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -730,7 +729,7 @@ test "switch on error union if else capture" {
                     error.A => |e| @intFromError(e) + 4,
                     inline else => @intFromError(err) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -738,7 +737,7 @@ test "switch on error union if else capture" {
                 const b: u64 = if (a) |*x| x.* else |err| switch (err) {
                     inline else => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
             {
                 var a: Error!u64 = error.B;
@@ -747,7 +746,7 @@ test "switch on error union if else capture" {
                     error.A => 0,
                     inline error.B, error.C => |e| @intFromError(e) + 4,
                 };
-                try expectEqual(@as(u64, @intFromError(error.B) + 4), b);
+                try expect(@as(u64, @intFromError(error.B) + 4) == b);
             }
         }
 
@@ -758,7 +757,7 @@ test "switch on error union if else capture" {
                 const b: u64 = if (a) |x| x else |err| switch (err) {
                     else => |e| return e,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: error{}!u64 = 0;
@@ -767,7 +766,7 @@ test "switch on error union if else capture" {
                     error.UnknownError => return error.Fail,
                     else => |e| return e,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
         }
 
@@ -778,7 +777,7 @@ test "switch on error union if else capture" {
                 const b: u64 = if (a) |*x| x.* else |err| switch (err) {
                     else => |e| return e,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
             {
                 var a: error{}!u64 = 0;
@@ -787,7 +786,7 @@ test "switch on error union if else capture" {
                     error.UnknownError => return error.Fail,
                     else => |e| return e,
                 };
-                try expectEqual(@as(u64, 0), b);
+                try expect(@as(u64, 0) == b);
             }
         }
 
@@ -798,7 +797,7 @@ test "switch on error union if else capture" {
                     else => 3,
                 });
                 comptime assert(@TypeOf(ptr) == *const usize);
-                try expectEqual(ptr, &(a catch unreachable));
+                try expect(ptr == &(a catch unreachable));
             }
             {
                 const a: anyerror!usize = error.A;
@@ -806,7 +805,7 @@ test "switch on error union if else capture" {
                     else => 3,
                 });
                 comptime assert(@TypeOf(ptr) == *const comptime_int);
-                try expectEqual(3, ptr.*);
+                try expect(3 == ptr.*);
             }
             {
                 var a: anyerror!usize = 0;
@@ -816,7 +815,7 @@ test "switch on error union if else capture" {
                 });
                 comptime assert(@TypeOf(ptr) == *usize);
                 ptr.* += 1;
-                try expectEqual(@as(usize, 1), a catch unreachable);
+                try expect(@as(usize, 1) == a catch unreachable);
             }
             {
                 var a: anyerror!usize = error.A;

--- a/test/behavior/tuple.zig
+++ b/test/behavior/tuple.zig
@@ -1,10 +1,10 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const testing = std.testing;
 const assert = std.debug.assert;
 const expect = testing.expect;
 const expectEqualStrings = std.testing.expectEqualStrings;
 const expectEqual = std.testing.expectEqual;
+const builtin = @import("builtin");
 
 test "tuple concatenation" {
     if (builtin.zig_backend == .stage2_arm) return error.SkipZigTest; // TODO
@@ -442,18 +442,18 @@ test "tuple pointer is indexable" {
 
     const x: S = .{ 123, true };
     comptime assert(@TypeOf(&(&x)[0]) == *const u32); // validate constness
-    try expectEqual(@as(u32, 123), (&x)[0]);
-    try expectEqual(true, (&x)[1]);
+    try expect(@as(u32, 123) == (&x)[0]);
+    try expect(true == (&x)[1]);
 
     var y: S = .{ 123, true };
     comptime assert(@TypeOf(&(&y)[0]) == *u32); // validate constness
-    try expectEqual(@as(u32, 123), (&y)[0]);
-    try expectEqual(true, (&y)[1]);
+    try expect(@as(u32, 123) == (&y)[0]);
+    try expect(true == (&y)[1]);
 
     (&y)[0] = 100;
     (&y)[1] = false;
-    try expectEqual(@as(u32, 100), (&y)[0]);
-    try expectEqual(false, (&y)[1]);
+    try expect(@as(u32, 100) == (&y)[0]);
+    try expect(false == (&y)[1]);
 }
 
 test "coerce anon tuple to tuple" {
@@ -465,8 +465,8 @@ test "coerce anon tuple to tuple" {
     _ = .{ &x, &y };
     const t = .{ x, y };
     const s: struct { u8, u16 } = t;
-    try expectEqual(x, s[0]);
-    try expectEqual(y, s[1]);
+    try expect(x == s[0]);
+    try expect(y == s[1]);
 }
 
 test "empty tuple type" {
@@ -575,7 +575,7 @@ test "empty struct in tuple" {
 
     const T = struct { struct {} };
     const info = @typeInfo(T);
-    try std.testing.expectEqual(@as(usize, 1), info.@"struct".fields.len);
+    try std.testing.expect(@as(usize, 1) == info.@"struct".fields.len);
     try std.testing.expectEqualStrings("0", info.@"struct".fields[0].name);
     try std.testing.expect(@typeInfo(info.@"struct".fields[0].type) == .@"struct");
 }
@@ -587,7 +587,7 @@ test "empty union in tuple" {
 
     const T = struct { union {} };
     const info = @typeInfo(T);
-    try std.testing.expectEqual(@as(usize, 1), info.@"struct".fields.len);
+    try std.testing.expect(@as(usize, 1) == info.@"struct".fields.len);
     try std.testing.expectEqualStrings("0", info.@"struct".fields[0].name);
     try std.testing.expect(@typeInfo(info.@"struct".fields[0].type) == .@"union");
 }

--- a/test/behavior/type.zig
+++ b/test/behavior/type.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const Type = std.builtin.Type;
 const testing = std.testing;
 const assert = std.debug.assert;
+const builtin = @import("builtin");
 
 fn testTypes(comptime types: []const type) !void {
     inline for (types) |testType| {
@@ -265,85 +265,85 @@ test "Type.Struct" {
 
     const A = @Type(@typeInfo(struct { x: u8, y: u32 }));
     const infoA = @typeInfo(A).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.auto, infoA.layout);
+    try testing.expect(Type.ContainerLayout.auto == infoA.layout);
     try testing.expectEqualSlices(u8, "x", infoA.fields[0].name);
-    try testing.expectEqual(u8, infoA.fields[0].type);
-    try testing.expectEqual(@as(?*const anyopaque, null), infoA.fields[0].default_value_ptr);
+    try testing.expect(u8 == infoA.fields[0].type);
+    try testing.expect(@as(?*const anyopaque, null) == infoA.fields[0].default_value_ptr);
     try testing.expectEqualSlices(u8, "y", infoA.fields[1].name);
-    try testing.expectEqual(u32, infoA.fields[1].type);
-    try testing.expectEqual(@as(?*const anyopaque, null), infoA.fields[1].default_value_ptr);
+    try testing.expect(u32 == infoA.fields[1].type);
+    try testing.expect(@as(?*const anyopaque, null) == infoA.fields[1].default_value_ptr);
     try testing.expectEqualSlices(Type.Declaration, &.{}, infoA.decls);
-    try testing.expectEqual(@as(bool, false), infoA.is_tuple);
+    try testing.expect(@as(bool, false) == infoA.is_tuple);
 
     var a = A{ .x = 0, .y = 1 };
-    try testing.expectEqual(@as(u8, 0), a.x);
-    try testing.expectEqual(@as(u32, 1), a.y);
+    try testing.expect(@as(u8, 0) == a.x);
+    try testing.expect(@as(u32, 1) == a.y);
     a.y += 1;
-    try testing.expectEqual(@as(u32, 2), a.y);
+    try testing.expect(@as(u32, 2) == a.y);
 
     const B = @Type(@typeInfo(extern struct { x: u8, y: u32 = 5 }));
     const infoB = @typeInfo(B).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.@"extern", infoB.layout);
+    try testing.expect(Type.ContainerLayout.@"extern" == infoB.layout);
     try testing.expectEqualSlices(u8, "x", infoB.fields[0].name);
-    try testing.expectEqual(u8, infoB.fields[0].type);
-    try testing.expectEqual(@as(?*const anyopaque, null), infoB.fields[0].default_value_ptr);
+    try testing.expect(u8 == infoB.fields[0].type);
+    try testing.expect(@as(?*const anyopaque, null) == infoB.fields[0].default_value_ptr);
     try testing.expectEqualSlices(u8, "y", infoB.fields[1].name);
-    try testing.expectEqual(u32, infoB.fields[1].type);
-    try testing.expectEqual(@as(u32, 5), infoB.fields[1].defaultValue().?);
-    try testing.expectEqual(@as(usize, 0), infoB.decls.len);
-    try testing.expectEqual(@as(bool, false), infoB.is_tuple);
+    try testing.expect(u32 == infoB.fields[1].type);
+    try testing.expect(@as(u32, 5) == infoB.fields[1].defaultValue().?);
+    try testing.expect(@as(usize, 0) == infoB.decls.len);
+    try testing.expect(@as(bool, false) == infoB.is_tuple);
 
     const C = @Type(@typeInfo(packed struct { x: u8 = 3, y: u32 = 5 }));
     const infoC = @typeInfo(C).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.@"packed", infoC.layout);
+    try testing.expect(Type.ContainerLayout.@"packed" == infoC.layout);
     try testing.expectEqualSlices(u8, "x", infoC.fields[0].name);
-    try testing.expectEqual(u8, infoC.fields[0].type);
-    try testing.expectEqual(@as(u8, 3), infoC.fields[0].defaultValue().?);
+    try testing.expect(u8 == infoC.fields[0].type);
+    try testing.expect(@as(u8, 3) == infoC.fields[0].defaultValue().?);
     try testing.expectEqualSlices(u8, "y", infoC.fields[1].name);
-    try testing.expectEqual(u32, infoC.fields[1].type);
-    try testing.expectEqual(@as(u32, 5), infoC.fields[1].defaultValue().?);
-    try testing.expectEqual(@as(usize, 0), infoC.decls.len);
-    try testing.expectEqual(@as(bool, false), infoC.is_tuple);
+    try testing.expect(u32 == infoC.fields[1].type);
+    try testing.expect(@as(u32, 5) == infoC.fields[1].defaultValue().?);
+    try testing.expect(@as(usize, 0) == infoC.decls.len);
+    try testing.expect(@as(bool, false) == infoC.is_tuple);
 
     // anon structs
     const D = @Type(@typeInfo(@TypeOf(.{ .x = 3, .y = 5 })));
     const infoD = @typeInfo(D).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.auto, infoD.layout);
+    try testing.expect(Type.ContainerLayout.auto == infoD.layout);
     try testing.expectEqualSlices(u8, "x", infoD.fields[0].name);
-    try testing.expectEqual(comptime_int, infoD.fields[0].type);
-    try testing.expectEqual(@as(comptime_int, 3), infoD.fields[0].defaultValue().?);
+    try testing.expect(comptime_int == infoD.fields[0].type);
+    try testing.expect(@as(comptime_int, 3) == infoD.fields[0].defaultValue().?);
     try testing.expectEqualSlices(u8, "y", infoD.fields[1].name);
-    try testing.expectEqual(comptime_int, infoD.fields[1].type);
-    try testing.expectEqual(@as(comptime_int, 5), infoD.fields[1].defaultValue().?);
-    try testing.expectEqual(@as(usize, 0), infoD.decls.len);
-    try testing.expectEqual(@as(bool, false), infoD.is_tuple);
+    try testing.expect(comptime_int == infoD.fields[1].type);
+    try testing.expect(@as(comptime_int, 5) == infoD.fields[1].defaultValue().?);
+    try testing.expect(@as(usize, 0) == infoD.decls.len);
+    try testing.expect(@as(bool, false) == infoD.is_tuple);
 
     // tuples
     const E = @Type(@typeInfo(@TypeOf(.{ 1, 2 })));
     const infoE = @typeInfo(E).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.auto, infoE.layout);
+    try testing.expect(Type.ContainerLayout.auto == infoE.layout);
     try testing.expectEqualSlices(u8, "0", infoE.fields[0].name);
-    try testing.expectEqual(comptime_int, infoE.fields[0].type);
-    try testing.expectEqual(@as(comptime_int, 1), infoE.fields[0].defaultValue().?);
+    try testing.expect(comptime_int == infoE.fields[0].type);
+    try testing.expect(@as(comptime_int, 1) == infoE.fields[0].defaultValue().?);
     try testing.expectEqualSlices(u8, "1", infoE.fields[1].name);
-    try testing.expectEqual(comptime_int, infoE.fields[1].type);
-    try testing.expectEqual(@as(comptime_int, 2), infoE.fields[1].defaultValue().?);
-    try testing.expectEqual(@as(usize, 0), infoE.decls.len);
-    try testing.expectEqual(@as(bool, true), infoE.is_tuple);
+    try testing.expect(comptime_int == infoE.fields[1].type);
+    try testing.expect(@as(comptime_int, 2) == infoE.fields[1].defaultValue().?);
+    try testing.expect(@as(usize, 0) == infoE.decls.len);
+    try testing.expect(@as(bool, true) == infoE.is_tuple);
 
     // empty struct
     const F = @Type(@typeInfo(struct {}));
     const infoF = @typeInfo(F).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.auto, infoF.layout);
+    try testing.expect(Type.ContainerLayout.auto == infoF.layout);
     try testing.expect(infoF.fields.len == 0);
-    try testing.expectEqual(@as(bool, false), infoF.is_tuple);
+    try testing.expect(@as(bool, false) == infoF.is_tuple);
 
     // empty tuple
     const G = @Type(@typeInfo(@TypeOf(.{})));
     const infoG = @typeInfo(G).@"struct";
-    try testing.expectEqual(Type.ContainerLayout.auto, infoG.layout);
+    try testing.expect(Type.ContainerLayout.auto == infoG.layout);
     try testing.expect(infoG.fields.len == 0);
-    try testing.expectEqual(@as(bool, true), infoG.is_tuple);
+    try testing.expect(@as(bool, true) == infoG.is_tuple);
 }
 
 test "Type.Enum" {
@@ -361,9 +361,9 @@ test "Type.Enum" {
             .is_exhaustive = true,
         },
     });
-    try testing.expectEqual(true, @typeInfo(Foo).@"enum".is_exhaustive);
-    try testing.expectEqual(@as(u8, 1), @intFromEnum(Foo.a));
-    try testing.expectEqual(@as(u8, 5), @intFromEnum(Foo.b));
+    try testing.expect(true == @typeInfo(Foo).@"enum".is_exhaustive);
+    try testing.expect(@as(u8, 1) == @intFromEnum(Foo.a));
+    try testing.expect(@as(u8, 5) == @intFromEnum(Foo.b));
     const Bar = @Type(.{
         .@"enum" = .{
             .tag_type = u32,
@@ -375,10 +375,10 @@ test "Type.Enum" {
             .is_exhaustive = false,
         },
     });
-    try testing.expectEqual(false, @typeInfo(Bar).@"enum".is_exhaustive);
-    try testing.expectEqual(@as(u32, 1), @intFromEnum(Bar.a));
-    try testing.expectEqual(@as(u32, 5), @intFromEnum(Bar.b));
-    try testing.expectEqual(@as(u32, 6), @intFromEnum(@as(Bar, @enumFromInt(6))));
+    try testing.expect(false == @typeInfo(Bar).@"enum".is_exhaustive);
+    try testing.expect(@as(u32, 1) == @intFromEnum(Bar.a));
+    try testing.expect(@as(u32, 5) == @intFromEnum(Bar.b));
+    try testing.expect(@as(u32, 6) == @intFromEnum(@as(Bar, @enumFromInt(6))));
 
     { // from https://github.com/ziglang/zig/issues/19985
         { // enum with single field can be initialized.
@@ -389,7 +389,7 @@ test "Type.Enum" {
                 .decls = &.{},
             } });
             const s: struct { E } = .{.foo};
-            try testing.expectEqual(.foo, s[0]);
+            try testing.expect(.foo == s[0]);
         }
 
         { // meta.FieldEnum() with single field
@@ -402,7 +402,7 @@ test "Type.Enum" {
                     @field(s, @tagName(tag)) = 42;
                 },
             }
-            try testing.expectEqual(42, s.foo);
+            try testing.expect(42 == s.foo);
         }
     }
 }
@@ -425,7 +425,7 @@ test "Type.Union" {
     var untagged = Untagged{ .int = 1 };
     untagged.float = 2.0;
     untagged.int = 3;
-    try testing.expectEqual(@as(i32, 3), untagged.int);
+    try testing.expect(@as(i32, 3) == untagged.int);
 
     const PackedUntagged = @Type(.{
         .@"union" = .{
@@ -440,8 +440,8 @@ test "Type.Union" {
     });
     var packed_untagged: PackedUntagged = .{ .signed = -1 };
     _ = &packed_untagged;
-    try testing.expectEqual(@as(i32, -1), packed_untagged.signed);
-    try testing.expectEqual(~@as(u32, 0), packed_untagged.unsigned);
+    try testing.expect(@as(i32, -1) == packed_untagged.signed);
+    try testing.expect(~@as(u32, 0) == packed_untagged.unsigned);
 
     const Tag = @Type(.{
         .@"enum" = .{
@@ -466,9 +466,9 @@ test "Type.Union" {
         },
     });
     var tagged = Tagged{ .signed = -1 };
-    try testing.expectEqual(Tag.signed, @as(Tag, tagged));
+    try testing.expect(Tag.signed == @as(Tag, tagged));
     tagged = .{ .unsigned = 1 };
-    try testing.expectEqual(Tag.unsigned, @as(Tag, tagged));
+    try testing.expect(Tag.unsigned == @as(Tag, tagged));
 }
 
 test "Type.Union from Type.Enum" {
@@ -520,7 +520,7 @@ test "Type.Union from empty regular enum" {
             .decls = &.{},
         },
     });
-    try testing.expectEqual(@sizeOf(U), 0);
+    try testing.expect(@sizeOf(U) == 0);
 }
 
 test "Type.Union from empty Type.Enum" {
@@ -540,7 +540,7 @@ test "Type.Union from empty Type.Enum" {
             .decls = &.{},
         },
     });
-    try testing.expectEqual(@sizeOf(U), 0);
+    try testing.expect(@sizeOf(U) == 0);
 }
 
 test "Type.Fn" {
@@ -563,13 +563,13 @@ test "Type.Fn" {
         } };
 
         const fn_type = @Type(fn_info);
-        try std.testing.expectEqual(T, fn_type);
+        try std.testing.expect(T == fn_type);
     }
 
     {
         const fn_info = @typeInfo(T);
         const fn_type = @Type(fn_info);
-        try std.testing.expectEqual(T, fn_type);
+        try std.testing.expect(T == fn_type);
     }
 }
 
@@ -717,7 +717,7 @@ test "@Type should resolve its children types" {
     comptime var sparse_info = @typeInfo(anyerror!sparse);
     sparse_info.error_union.payload = dense;
     const B = @Type(sparse_info);
-    try testing.expectEqual(anyerror!dense, B);
+    try testing.expect(anyerror!dense == B);
 }
 
 test "struct field names sliced at comptime from larger string" {
@@ -752,7 +752,7 @@ test "struct field names sliced at comptime from larger string" {
         });
 
         const gen_fields = @typeInfo(T).@"struct".fields;
-        try testing.expectEqual(3, gen_fields.len);
+        try testing.expect(3 == gen_fields.len);
         try testing.expectEqualStrings("f1", gen_fields[0].name);
         try testing.expectEqualStrings("f2", gen_fields[1].name);
         try testing.expectEqualStrings("f3", gen_fields[2].name);

--- a/test/behavior/undefined.zig
+++ b/test/behavior/undefined.zig
@@ -1,8 +1,7 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const expect = std.testing.expect;
-const expectEqual = std.testing.expectEqual;
 const mem = std.mem;
+const builtin = @import("builtin");
 
 fn initStaticArray() [10]i32 {
     var array: [10]i32 = undefined;

--- a/test/behavior/union.zig
+++ b/test/behavior/union.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 const endian = builtin.cpu.arch.endian();
 const expect = std.testing.expect;
 const assert = std.debug.assert;
-const expectEqual = std.testing.expectEqual;
 const Tag = std.meta.Tag;
 
 const FooWithFloats = union {
@@ -1053,7 +1052,7 @@ test "@unionInit on union with tag but no fields" {
             _ = &data;
             var o = Data.decode(&[_]u8{});
             _ = &o;
-            try expectEqual(Type.no_op, o);
+            try expect(Type.no_op == o);
         }
     };
 
@@ -1475,9 +1474,9 @@ test "defined-layout union field pointer has correct alignment" {
             comptime assert(@TypeOf(bp) == *align(1) u32);
             comptime assert(@TypeOf(cp) == *align(64) u32);
 
-            try expectEqual(@as(u32, 123), ap.*);
-            try expectEqual(@as(u32, 456), bp.*);
-            try expectEqual(@as(u32, 789), cp.*);
+            try expect(@as(u32, 123) == ap.*);
+            try expect(@as(u32, 456) == bp.*);
+            try expect(@as(u32, 789) == cp.*);
         }
     };
 
@@ -1510,9 +1509,9 @@ test "undefined-layout union field pointer has correct alignment" {
             comptime assert(@TypeOf(bp) == *align(1) u32);
             comptime assert(@TypeOf(cp) == *u32); // undefined layout so does not inherit larger aligns
 
-            try expectEqual(@as(u32, 123), ap.*);
-            try expectEqual(@as(u32, 456), bp.*);
-            try expectEqual(@as(u32, 789), cp.*);
+            try expect(@as(u32, 123) == ap.*);
+            try expect(@as(u32, 456) == bp.*);
+            try expect(@as(u32, 789) == cp.*);
         }
     };
 
@@ -1554,9 +1553,9 @@ test "packed union field pointer has correct alignment" {
     b.u = .{ .x = 456 };
     c.u = .{ .x = 789 };
 
-    try expectEqual(@as(u20, 123), ap.*);
-    try expectEqual(@as(u20, 456), bp.*);
-    try expectEqual(@as(u20, 789), cp.*);
+    try expect(@as(u20, 123) == ap.*);
+    try expect(@as(u20, 456) == bp.*);
+    try expect(@as(u20, 789) == cp.*);
 }
 
 test "union with 128 bit integer" {
@@ -1595,8 +1594,8 @@ test "memset extern union" {
         fn doTheTest() !void {
             var u: U = undefined;
             @memset(std.mem.asBytes(&u), 0);
-            try expectEqual(@as(u8, 0), u.foo);
-            try expectEqual(@as(u32, 0), u.bar);
+            try expect(@as(u8, 0) == u.foo);
+            try expect(@as(u32, 0) == u.bar);
         }
     };
 
@@ -1616,8 +1615,8 @@ test "memset packed union" {
         fn doTheTest() !void {
             var u: U = undefined;
             @memset(@as([]u8, @ptrCast(&u)), 42);
-            try expectEqual(@as(u32, 0x2a2a2a2a), u.a);
-            try expectEqual(@as(u32, 0x2a2a2a2a), u.b);
+            try expect(@as(u32, 0x2a2a2a2a) == u.a);
+            try expect(@as(u32, 0x2a2a2a2a) == u.b);
         }
     };
 
@@ -1655,9 +1654,9 @@ test "reinterpret extern union" {
                     break :blk u;
                 };
 
-                try expectEqual(@as(u8, 0x2a), u.foo);
-                try expectEqual(littleToNativeEndian(u32, 0xbbbbbb2a), u.bar);
-                try expectEqual(littleToNativeEndian(u32, 0xbbbbbb2a), u.baz);
+                try expect(@as(u8, 0x2a) == u.foo);
+                try expect(littleToNativeEndian(u32, 0xbbbbbb2a) == u.bar);
+                try expect(littleToNativeEndian(u32, 0xbbbbbb2a) == u.baz);
             }
 
             {
@@ -1672,28 +1671,28 @@ test "reinterpret extern union" {
                         .big => .{ 0x2a000000, 0xff000000 },
                     };
 
-                    try expectEqual(@as(u8, 0x2a), u.foo);
-                    try expectEqual(@as(u32, expected), u.bar & mask);
-                    try expectEqual(@as(u32, expected), u.baz & mask);
+                    try expect(@as(u8, 0x2a) == u.foo);
+                    try expect(@as(u32, expected) == u.bar & mask);
+                    try expect(@as(u32, expected) == u.baz & mask);
                 }
 
                 // Writing to a larger field
                 u.baz = 0xbbbbbbbb;
-                try expectEqual(@as(u8, 0xbb), u.foo);
-                try expectEqual(@as(u32, 0xbbbbbbbb), u.bar);
-                try expectEqual(@as(u32, 0xbbbbbbbb), u.baz);
+                try expect(@as(u8, 0xbb) == u.foo);
+                try expect(@as(u32, 0xbbbbbbbb) == u.bar);
+                try expect(@as(u32, 0xbbbbbbbb) == u.baz);
 
                 // Writing to the same field
                 u.baz = 0xcccccccc;
-                try expectEqual(@as(u8, 0xcc), u.foo);
-                try expectEqual(@as(u32, 0xcccccccc), u.bar);
-                try expectEqual(@as(u32, 0xcccccccc), u.baz);
+                try expect(@as(u8, 0xcc) == u.foo);
+                try expect(@as(u32, 0xcccccccc) == u.bar);
+                try expect(@as(u32, 0xcccccccc) == u.baz);
 
                 // Writing to a smaller field
                 u.foo = 0xdd;
-                try expectEqual(@as(u8, 0xdd), u.foo);
-                try expectEqual(littleToNativeEndian(u32, 0xccccccdd), u.bar);
-                try expectEqual(littleToNativeEndian(u32, 0xccccccdd), u.baz);
+                try expect(@as(u8, 0xdd) == u.foo);
+                try expect(littleToNativeEndian(u32, 0xccccccdd) == u.bar);
+                try expect(littleToNativeEndian(u32, 0xccccccdd) == u.baz);
             }
         }
     };
@@ -1735,13 +1734,13 @@ test "reinterpret packed union" {
                     break :blk u;
                 };
 
-                try expectEqual(@as(u8, 0x2a), u.foo.a);
-                try expectEqual(@as(u12, 0xe2a), u.qux.a);
+                try expect(@as(u8, 0x2a) == u.foo.a);
+                try expect(@as(u12, 0xe2a) == u.qux.a);
 
                 // https://github.com/ziglang/zig/issues/17360
                 if (@inComptime()) {
-                    try expectEqual(@as(u29, 0x1bbbbe2a), u.bar.a);
-                    try expectEqual(@as(u64, 0xbbbbbe2a), u.baz);
+                    try expect(@as(u29, 0x1bbbbe2a) == u.bar.a);
+                    try expect(@as(u64, 0xbbbbbe2a) == u.baz);
                 }
             }
 
@@ -1749,31 +1748,31 @@ test "reinterpret packed union" {
                 // Union initialization
                 var u: U = .{ .baz = 0 }; // ensure all bits are defined
                 u.qux.a = 0xe2a;
-                try expectEqual(@as(u8, 0x2a), u.foo.a);
-                try expectEqual(@as(u12, 0xe2a), u.qux.a);
-                try expectEqual(@as(u29, 0xe2a), u.bar.a & 0xfff);
-                try expectEqual(@as(u64, 0xe2a), u.baz & 0xfff);
+                try expect(@as(u8, 0x2a) == u.foo.a);
+                try expect(@as(u12, 0xe2a) == u.qux.a);
+                try expect(@as(u29, 0xe2a) == u.bar.a & 0xfff);
+                try expect(@as(u64, 0xe2a) == u.baz & 0xfff);
 
                 // Writing to a larger field
                 u.baz = 0xbbbbbbbb;
-                try expectEqual(@as(u8, 0xbb), u.foo.a);
-                try expectEqual(@as(u12, 0xbbb), u.qux.a);
-                try expectEqual(@as(u29, 0x1bbbbbbb), u.bar.a);
-                try expectEqual(@as(u64, 0xbbbbbbbb), u.baz);
+                try expect(@as(u8, 0xbb) == u.foo.a);
+                try expect(@as(u12, 0xbbb) == u.qux.a);
+                try expect(@as(u29, 0x1bbbbbbb) == u.bar.a);
+                try expect(@as(u64, 0xbbbbbbbb) == u.baz);
 
                 // Writing to the same field
                 u.baz = 0xcccccccc;
-                try expectEqual(@as(u8, 0xcc), u.foo.a);
-                try expectEqual(@as(u12, 0xccc), u.qux.a);
-                try expectEqual(@as(u29, 0x0ccccccc), u.bar.a);
-                try expectEqual(@as(u64, 0xcccccccc), u.baz);
+                try expect(@as(u8, 0xcc) == u.foo.a);
+                try expect(@as(u12, 0xccc) == u.qux.a);
+                try expect(@as(u29, 0x0ccccccc) == u.bar.a);
+                try expect(@as(u64, 0xcccccccc) == u.baz);
 
                 // Writing to a smaller field
                 u.foo.a = 0xdd;
-                try expectEqual(@as(u8, 0xdd), u.foo.a);
-                try expectEqual(@as(u12, 0xcdd), u.qux.a);
-                try expectEqual(@as(u29, 0x0cccccdd), u.bar.a);
-                try expectEqual(@as(u64, 0xccccccdd), u.baz);
+                try expect(@as(u8, 0xdd) == u.foo.a);
+                try expect(@as(u12, 0xcdd) == u.qux.a);
+                try expect(@as(u29, 0x0cccccdd) == u.bar.a);
+                try expect(@as(u64, 0xccccccdd) == u.baz);
             }
         }
     };
@@ -1842,13 +1841,13 @@ test "inner struct initializer uses union layout" {
 
     {
         const u: namespace.U = .{ .a = .{} };
-        try expectEqual(4, @alignOf(namespace.U));
-        try expectEqual(@as(usize, 5), u.a.x);
+        try expect(4 == @alignOf(namespace.U));
+        try expect(@as(usize, 5) == u.a.x);
     }
 
     {
         const u: namespace.U = .{ .b = .{} };
-        try expectEqual(@as(usize, @sizeOf(namespace.U) + 2), u.b.y);
+        try expect(@as(usize, @sizeOf(namespace.U) + 2) == u.b.y);
     }
 }
 
@@ -1867,13 +1866,13 @@ test "inner struct initializer uses packed union layout" {
 
     {
         const u: namespace.U = .{ .a = .{} };
-        try expectEqual(4, @alignOf(namespace.U));
-        try expectEqual(@as(usize, 5), u.a.x);
+        try expect(4 == @alignOf(namespace.U));
+        try expect(@as(usize, 5) == u.a.x);
     }
 
     {
         const u: namespace.U = .{ .b = .{} };
-        try expectEqual(@as(usize, @sizeOf(namespace.U) + 2), u.b.y);
+        try expect(@as(usize, @sizeOf(namespace.U) + 2) == u.b.y);
     }
 }
 
@@ -1986,15 +1985,15 @@ test "pass register-sized field as non-register-sized union" {
 
     const S = struct {
         fn taggedUnion(u: union(enum) { x: usize, y: [2]usize }) !void {
-            try expectEqual(@as(usize, 42), u.x);
+            try expect(@as(usize, 42) == u.x);
         }
 
         fn untaggedUnion(u: union { x: usize, y: [2]usize }) !void {
-            try expectEqual(@as(usize, 42), u.x);
+            try expect(@as(usize, 42) == u.x);
         }
 
         fn externUnion(u: extern union { x: usize, y: [2]usize }) !void {
-            try expectEqual(@as(usize, 42), u.x);
+            try expect(@as(usize, 42) == u.x);
         }
     };
 
@@ -2046,7 +2045,7 @@ test "pass nested union with rls" {
 
     var c: u7 = 32;
     _ = &c;
-    try expectEqual(@as(u7, 32), Union.getC(.{ .b = .{ .c = c } }));
+    try expect(@as(u7, 32) == Union.getC(.{ .b = .{ .c = c } }));
 }
 
 test "runtime union init, most-aligned field != largest" {

--- a/test/behavior/var_args.zig
+++ b/test/behavior/var_args.zig
@@ -1,6 +1,6 @@
-const builtin = @import("builtin");
 const std = @import("std");
 const expect = std.testing.expect;
+const builtin = @import("builtin");
 
 fn add(args: anytype) i32 {
     var sum = @as(i32, 0);
@@ -133,14 +133,14 @@ test "simple variadic function" {
 
     if (builtin.zig_backend != .stage2_c) {
         // pre C23 doesn't support varargs without a preceding runtime arg.
-        try std.testing.expectEqual(@as(c_int, 0), S.simple(@as(c_int, 0)));
-        try std.testing.expectEqual(@as(c_int, 1024), S.simple(@as(c_int, 1024)));
+        try std.testing.expect(@as(c_int, 0) == S.simple(@as(c_int, 0)));
+        try std.testing.expect(@as(c_int, 1024) == S.simple(@as(c_int, 1024)));
     }
-    try std.testing.expectEqual(@as(c_int, 0), S.compatible(undefined, @as(c_int, 0)));
-    try std.testing.expectEqual(@as(c_int, 1024), S.compatible(undefined, @as(c_int, 1024)));
-    try std.testing.expectEqual(@as(c_int, 0), S.add(0));
-    try std.testing.expectEqual(@as(c_int, 1), S.add(1, @as(c_int, 1)));
-    try std.testing.expectEqual(@as(c_int, 3), S.add(2, @as(c_int, 1), @as(c_int, 2)));
+    try std.testing.expect(@as(c_int, 0) == S.compatible(undefined, @as(c_int, 0)));
+    try std.testing.expect(@as(c_int, 1024) == S.compatible(undefined, @as(c_int, 1024)));
+    try std.testing.expect(@as(c_int, 0) == S.add(0));
+    try std.testing.expect(@as(c_int, 1) == S.add(1, @as(c_int, 1)));
+    try std.testing.expect(@as(c_int, 3) == S.add(2, @as(c_int, 1), @as(c_int, 2)));
 
     {
         // Test type coercion of a var args argument.
@@ -269,9 +269,9 @@ test "copy VaList" {
         }
     };
 
-    try std.testing.expectEqual(@as(c_int, 0), S.add(0));
-    try std.testing.expectEqual(@as(c_int, 3), S.add(1, @as(c_int, 1)));
-    try std.testing.expectEqual(@as(c_int, 9), S.add(2, @as(c_int, 1), @as(c_int, 2)));
+    try std.testing.expect(@as(c_int, 0) == S.add(0));
+    try std.testing.expect(@as(c_int, 3) == S.add(1, @as(c_int, 1)));
+    try std.testing.expect(@as(c_int, 9) == S.add(2, @as(c_int, 1), @as(c_int, 2)));
 }
 
 test "unused VaList arg" {
@@ -303,5 +303,5 @@ test "unused VaList arg" {
         }
     };
     const x = S.thirdArg(0, @as(c_int, 1), @as(c_int, 2));
-    try std.testing.expectEqual(@as(c_int, 2), x);
+    try std.testing.expect(@as(c_int, 2) == x);
 }

--- a/test/behavior/zon.zig
+++ b/test/behavior/zon.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualDeep = std.testing.expectEqualDeep;
@@ -7,17 +6,17 @@ const expectEqualSlices = std.testing.expectEqualSlices;
 const expectEqualStrings = std.testing.expectEqualStrings;
 
 test "bool" {
-    try expectEqual(true, @as(bool, @import("zon/true.zon")));
-    try expectEqual(false, @as(bool, @import("zon/false.zon")));
+    try expect(true == @as(bool, @import("zon/true.zon")));
+    try expect(false == @as(bool, @import("zon/false.zon")));
 }
 
 test "optional" {
     const some: ?u32 = @import("zon/some.zon");
     const none: ?u32 = @import("zon/none.zon");
     const @"null": @TypeOf(null) = @import("zon/none.zon");
-    try expectEqual(@as(u32, 10), some);
-    try expectEqual(@as(?u32, null), none);
-    try expectEqual(null, @"null");
+    try expect(@as(u32, 10) == some);
+    try expect(@as(?u32, null) == none);
+    try expect(null == @"null");
 }
 
 test "union" {
@@ -33,9 +32,9 @@ test "union" {
         const union2: Union = @import("zon/union2.zon");
         const union3: Union = @import("zon/union3.zon");
 
-        try expectEqual(1.5, union1.x);
-        try expectEqual(true, union2.y);
-        try expectEqual({}, union3.z);
+        try expect(1.5 == union1.x);
+        try expect(true == union2.y);
+        try expect({} == union3.z);
     }
 
     // Inferred tag
@@ -50,9 +49,9 @@ test "union" {
         const union2: Union = @import("zon/union2.zon");
         const union3: Union = @import("zon/union3.zon");
 
-        try expectEqual(1.5, union1.x);
-        try expectEqual(true, union2.y);
-        try expectEqual({}, union3.z);
+        try expect(1.5 == union1.x);
+        try expect(true == union2.y);
+        try expect({} == union3.z);
     }
 
     // Explicit tag
@@ -72,9 +71,9 @@ test "union" {
         const union2: Union = @import("zon/union2.zon");
         const union3: Union = @import("zon/union3.zon");
 
-        try expectEqual(1.5, union1.x);
-        try expectEqual(true, union2.y);
-        try expectEqual({}, union3.z);
+        try expect(1.5 == union1.x);
+        try expect(true == union2.y);
+        try expect({} == union3.z);
     }
 }
 
@@ -162,17 +161,17 @@ test "comptime fields" {
 }
 
 test "char" {
-    try expectEqual(@as(u8, 'a'), @as(u8, @import("zon/a.zon")));
-    try expectEqual(@as(u8, 'z'), @as(u8, @import("zon/z.zon")));
+    try expect(@as(u8, 'a') == @as(u8, @import("zon/a.zon")));
+    try expect(@as(u8, 'z') == @as(u8, @import("zon/z.zon")));
 }
 
 test "arrays" {
     try expectEqual([0]u8{}, @as([0]u8, @import("zon/vec0.zon")));
     try expectEqual([0:1]u8{}, @as([0:1]u8, @import("zon/vec0.zon")));
-    try expectEqual(1, @as([0:1]u8, @import("zon/vec0.zon"))[0]);
+    try expect(1 == @as([0:1]u8, @import("zon/vec0.zon"))[0]);
     try expectEqual([4]u8{ 'a', 'b', 'c', 'd' }, @as([4]u8, @import("zon/array.zon")));
     try expectEqual([4:2]u8{ 'a', 'b', 'c', 'd' }, @as([4:2]u8, @import("zon/array.zon")));
-    try expectEqual(2, @as([4:2]u8, @import("zon/array.zon"))[4]);
+    try expect(2 == @as([4:2]u8, @import("zon/array.zon"))[4]);
 }
 
 test "slices, arrays, tuples" {
@@ -227,7 +226,7 @@ test "string literals" {
     try expectEqualSlices(u8, "ab\\c", @import("zon/abc-escaped.zon"));
     const zero_terminated: [:0]const u8 = @import("zon/abc.zon");
     try expectEqualDeep(zero_terminated, "abc");
-    try expectEqual(0, zero_terminated[zero_terminated.len]);
+    try expect(0 == zero_terminated[zero_terminated.len]);
     try expectEqualStrings(
         \\Hello, world!
         \\This is a multiline string!
@@ -243,9 +242,9 @@ test "enum literals" {
         baz,
         @"0\na",
     };
-    try expectEqual(Enum.foo, @as(Enum, @import("zon/foo.zon")));
-    try expectEqual(.foo, @as(@TypeOf(.foo), @import("zon/foo.zon")));
-    try expectEqual(Enum.@"0\na", @as(Enum, @import("zon/escaped_enum.zon")));
+    try expect(Enum.foo == @as(Enum, @import("zon/foo.zon")));
+    try expect(.foo == @as(@TypeOf(.foo), @import("zon/foo.zon")));
+    try expect(Enum.@"0\na" == @as(Enum, @import("zon/escaped_enum.zon")));
 }
 
 test "int" {
@@ -467,25 +466,25 @@ test "vector" {
 
 test "pointers" {
     // Primitive with varying levels of pointers
-    try expectEqual(@as(u8, 'a'), @as(*const u8, @import("zon/a.zon")).*);
-    try expectEqual(@as(u8, 'a'), @as(*const *const u8, @import("zon/a.zon")).*.*);
-    try expectEqual(@as(u8, 'a'), @as(*const *const *const u8, @import("zon/a.zon")).*.*.*);
+    try expect(@as(u8, 'a') == @as(*const u8, @import("zon/a.zon")).*);
+    try expect(@as(u8, 'a') == @as(*const *const u8, @import("zon/a.zon")).*.*);
+    try expect(@as(u8, 'a') == @as(*const *const *const u8, @import("zon/a.zon")).*.*.*);
 
     // Primitive optional with varying levels of pointers
-    try expectEqual(@as(u8, 'a'), @as(?*const u8, @import("zon/a.zon")).?.*);
-    try expectEqual(null, @as(?*const u8, @import("zon/none.zon")));
+    try expect(@as(u8, 'a') == @as(?*const u8, @import("zon/a.zon")).?.*);
+    try expect(null == @as(?*const u8, @import("zon/none.zon")));
 
-    try expectEqual(@as(u8, 'a'), @as(*const ?u8, @import("zon/a.zon")).*.?);
-    try expectEqual(null, @as(*const ?u8, @import("zon/none.zon")).*);
+    try expect(@as(u8, 'a') == @as(*const ?u8, @import("zon/a.zon")).*.?);
+    try expect(null == @as(*const ?u8, @import("zon/none.zon")).*);
 
-    try expectEqual(@as(u8, 'a'), @as(?*const *const u8, @import("zon/a.zon")).?.*.*);
-    try expectEqual(null, @as(?*const *const u8, @import("zon/none.zon")));
+    try expect(@as(u8, 'a') == @as(?*const *const u8, @import("zon/a.zon")).?.*.*);
+    try expect(null == @as(?*const *const u8, @import("zon/none.zon")));
 
-    try expectEqual(@as(u8, 'a'), @as(*const ?*const u8, @import("zon/a.zon")).*.?.*);
-    try expectEqual(null, @as(*const ?*const u8, @import("zon/none.zon")).*);
+    try expect(@as(u8, 'a') == @as(*const ?*const u8, @import("zon/a.zon")).*.?.*);
+    try expect(null == @as(*const ?*const u8, @import("zon/none.zon")).*);
 
-    try expectEqual(@as(u8, 'a'), @as(*const *const ?u8, @import("zon/a.zon")).*.*.?);
-    try expectEqual(null, @as(*const *const ?u8, @import("zon/none.zon")).*.*);
+    try expect(@as(u8, 'a') == @as(*const *const ?u8, @import("zon/a.zon")).*.*.?);
+    try expect(null == @as(*const *const ?u8, @import("zon/none.zon")).*.*);
 
     try expectEqual([3]u8{ 2, 4, 6 }, @as(*const [3]u8, @import("zon/vec3_int.zon")).*);
 
@@ -552,22 +551,22 @@ test "anon" {
 test "build.zig.zon" {
     const build = @import("zon/build.zig.zon");
 
-    try expectEqual(4, @typeInfo(@TypeOf(build)).@"struct".fields.len);
+    try expect(4 == @typeInfo(@TypeOf(build)).@"struct".fields.len);
     try expectEqualStrings("temp", build.name);
     try expectEqualStrings("0.0.0", build.version);
 
     const dependencies = build.dependencies;
-    try expectEqual(2, @typeInfo(@TypeOf(dependencies)).@"struct".fields.len);
+    try expect(2 == @typeInfo(@TypeOf(dependencies)).@"struct".fields.len);
 
     const example_0 = dependencies.example_0;
-    try expectEqual(2, @typeInfo(@TypeOf(dependencies)).@"struct".fields.len);
+    try expect(2 == @typeInfo(@TypeOf(dependencies)).@"struct".fields.len);
     try expectEqualStrings("https://example.com/foo.tar.gz", example_0.url);
     try expectEqualStrings("...", example_0.hash);
 
     const example_1 = dependencies.example_1;
-    try expectEqual(2, @typeInfo(@TypeOf(dependencies)).@"struct".fields.len);
+    try expect(2 == @typeInfo(@TypeOf(dependencies)).@"struct".fields.len);
     try expectEqualStrings("../foo", example_1.path);
-    try expectEqual(false, example_1.lazy);
+    try expect(false == example_1.lazy);
 
     try expectEqual(.{ "build.zig", "build.zig.zon", "src" }, build.paths);
 }


### PR DESCRIPTION
Does not fully close https://github.com/ziglang/zig/issues/24361 (this is only a first, simple change set)

Summary:
* where the type of the operands allows, change `expectEqual(x, y)` to `expect(x == y)` for files in `test/behavior/**`

```
# without these changes (master branch)
$ git grep expectEqual test/behavior | wc -l
1018

# with these changes
$ git grep expectEqual test/behavior | wc -l
314
```

My editor was configured to re-order imports on save. Hope that isn't a huge issue.

Verification evidence:
* the CI should pass, no new tests are introduced, only changes to existing tests


note: I had closed my previous PR to prevent unintended CI runs during rebase etc https://github.com/ziglang/zig/pull/24389

note to self: use this for testing if you have to rebase again:
```
zig build test-behavior -Dskip-release -Dskip-non-native -Dskip-llvm=true -Dskip-libc -Dskip-single-threaded --watch
```