### PR TITLE
std.ArrayList: memset to undefined in shrinkRetainingCapacity and clearRetainingCapacity

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -381,11 +381,14 @@ pub fn AlignedManaged(comptime T: type, comptime alignment: ?mem.Alignment) type
         pub fn shrinkRetainingCapacity(self: *Self, new_len: usize) void {
             assert(new_len <= self.items.len);
             self.items.len = new_len;
+            @memset(self.items[new_len..], undefined);
         }
 
+        /// Reduce length to 0.
         /// Invalidates all element pointers.
         pub fn clearRetainingCapacity(self: *Self) void {
             self.items.len = 0;
+            @memset(self.items, undefined);
         }
 
         /// Invalidates all element pointers.


### PR DESCRIPTION
Fixes #25796