### PR TITLE
std.posix: sendmsg on linux can return errno(110) ETIMEDOUT

### DIFF
--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -5631,7 +5631,7 @@ pub fn sendto(
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTCONN => return error.SocketUnconnected,
             .NETDOWN => return error.NetworkDown,
-            .TIMEOUT => return error.ConnectionTimedOut,
+            .TIMEDOUT => return error.ConnectionTimedOut,
             else => |err| return unexpectedErrno(err),
         }
     }

--- a/lib/std/posix.zig
+++ b/lib/std/posix.zig
@@ -5436,6 +5436,9 @@ pub const SendError = error{
 
     /// The destination address is not listening.
     ConnectionRefused,
+
+    /// The connection timed out.
+    ConnectionTimedOut,
 } || UnexpectedError;
 
 pub const SendMsgError = SendError || error{
@@ -5522,6 +5525,7 @@ pub fn sendmsg(
                 .NETUNREACH => return error.NetworkUnreachable,
                 .NOTCONN => return error.SocketUnconnected,
                 .NETDOWN => return error.NetworkDown,
+                .TIMEDOUT => return error.ConnectionTimedOut,
                 else => |err| return unexpectedErrno(err),
             }
         }
@@ -5627,6 +5631,7 @@ pub fn sendto(
             .NETUNREACH => return error.NetworkUnreachable,
             .NOTCONN => return error.SocketUnconnected,
             .NETDOWN => return error.NetworkDown,
+            .TIMEOUT => return error.ConnectionTimedOut,
             else => |err| return unexpectedErrno(err),
         }
     }


### PR DESCRIPTION
Addresses #25815 

I am seeing socket writes using std.posix.sendmsg() return ETIMEDOUT on linux (arm64), which are currently unhandled

Applying this patch on the test machine on 0.15.2 - have not seen any unhandled errors since

will do the same patch to the 0.15.x branch 