### PR TITLE
Add missing ws2_32 for zig cc to work correctly.

### DIFF
--- a/src/libs/mingw.zig
+++ b/src/libs/mingw.zig
@@ -1055,4 +1055,5 @@ pub const always_link_libs = [_][]const u8{
     "ntdll",
     "shell32",
     "user32",
+    "ws2_32",
 };


### PR DESCRIPTION
This PR adds ws2_32 to the libraries that always need to be linked because of the changes happening in the IO update.

If we don't add it then on windows you can't import stdio in a C file while compiling with zig cc.

Minimal repoduction:
```
#include <stdio.h>

int main(int argc, char **argv) {
    const char *cc = getenv("CC");

    return 0;
}
```
> zig cc -o bootstrap.exe bootstrap.copy.c
<img width="654" height="123" alt="image" src="https://github.com/user-attachments/assets/ff7f732f-3538-49f8-bb7a-8a7d0b1698a4" />


