### PR TITLE
docs: Update doc comments for `std.math.isPowerOfTwo`

### DIFF
--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -1118,6 +1118,8 @@ pub fn alignCast(comptime alignment: Alignment, ptr: anytype) AlignCastError!Ali
     return error.UnalignedMemory;
 }
 
+/// Returns whether `int` is an integral power of two.
+///
 /// Asserts `int > 0`.
 pub fn isPowerOfTwo(int: anytype) bool {
     assert(int > 0);


### PR DESCRIPTION
Because I think the current doc comments for [`std.math.isPowerOfTwo`](https://ziglang.org/documentation/master/std/#std.math.isPowerOfTwo) is insufficient to explain how it works.