### PR TITLE
link.Elf: Don't emit malformed archive headers

### DIFF
--- a/src/link/Elf/Archive.zig
+++ b/src/link/Elf/Archive.zig
@@ -118,7 +118,6 @@ pub fn setArHdr(opts: struct {
         .ar_fmag = undefined,
     };
     @memset(mem.asBytes(&hdr), 0x20);
-    @memcpy(&hdr.ar_fmag, elf.ARFMAG);
 
     {
         var writer: std.Io.Writer = .fixed(&hdr.ar_name);
@@ -129,10 +128,15 @@ pub fn setArHdr(opts: struct {
             .name_off => |x| writer.print("/{d}", .{x}) catch unreachable,
         }
     }
+    hdr.ar_date[0] = '0';
+    hdr.ar_uid[0] = '0';
+    hdr.ar_gid[0] = '0';
+    hdr.ar_mode[0] = '0';
     {
         var writer: std.Io.Writer = .fixed(&hdr.ar_size);
         writer.print("{d}", .{opts.size}) catch unreachable;
     }
+    hdr.ar_fmag = elf.ARFMAG.*;
 
     return hdr;
 }


### PR DESCRIPTION
Closes #25129

Brought to my attention by [a post on Ziggit](https://ziggit.dev/t/how-do-i-statically-dynamically-link-to-a-c-exe-using-build-zig/12859). The self-hosted ELF linker currently initializes all archive header fields to all spaces without any digits, which ld.lld doesn't like.

Tested by compiling

```zig
//! By convention, root.zig is the root source file when making a library. If
//! you are making an executable, the convention is to delete this file and
//! start with main.zig instead.
const std = @import("std");
const testing = std.testing;

export fn add_one(number: i64) i64 {
    return number + 1;
}

test "basic add functionality" {
    try testing.expect(add_one(3) == 4);
}
```

(from https://github.com/ziglang/zig/issues/25129#issuecomment-3327804347) using `zig build-lib root.zig -target x86_64-linux-gnu -fno-llvm`. Before/after:

```diff
 Offset(h) 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f
 
 00000000  21 3c 61 72 63 68 3e 0a 2f 53 59 4d 36 34 2f 20  !<arch>./SYM64/ 
-00000010  20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20                  
+00000010  20 20 20 20 20 20 20 20 30 20 20 20 20 20 20 20          0       
-00000020  20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20                  
+00000020  20 20 20 20 30 20 20 20 20 20 30 20 20 20 20 20      0     0     
-00000030  20 20 20 20 20 20 20 20 32 34 20 20 20 20 20 20          24      
+00000030  30 20 20 20 20 20 20 20 32 34 20 20 20 20 20 20  0       24      
 00000040  20 20 60 0a 00 00 00 00 00 00 00 01 00 00 00 00    `.............
 00000050  00 00 00 5c 61 64 64 5f 6f 6e 65 00 72 6f 6f 74  ...\add_one.root
-00000060  2e 6f 2f 20 20 20 20 20 20 20 20 20 20 20 20 20  .o/             
+00000060  2e 6f 2f 20 20 20 20 20 20 20 20 20 30 20 20 20  .o/         0   
-00000070  20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20                  
+00000070  20 20 20 20 20 20 20 20 30 20 20 20 20 20 30 20          0     0 
-00000080  20 20 20 20 20 20 20 20 20 20 20 20 38 38 34 33              8843
+00000080  20 20 20 20 30 20 20 20 20 20 20 20 37 36 38 30      0       7680
-00000090  31 32 30 20 20 20 60 0a 7f 45 4c 46 02 01 01 00  120   `..ELF....
+00000090  35 32 38 20 20 20 60 0a 7f 45 4c 46 02 01 01 00  528   `..ELF....
```

Side note: There are three different archive definitions in the code base, [`std.elf.ar_hdr`](https://github.com/ziglang/zig/blob/26db54d69b9a7f58a45897bb9523f95e3b8dd054/lib/std/elf.zig#L2827), [`link.MachO.Archive.ar_hdr`](https://github.com/ziglang/zig/blob/26db54d69b9a7f58a45897bb9523f95e3b8dd054/src/link/MachO/Archive.zig#L133) and [`link.Wasm.Archive.Header`](https://github.com/ziglang/zig/blob/26db54d69b9a7f58a45897bb9523f95e3b8dd054/src/link/Wasm/Archive.zig#L25), which each do things in subtly different ways. Maybe it would be useful to consolidate them into `std.ar` or something like that?