### PR TITLE
std.zig.AstRlAnnotate: remove pointless switch

### DIFF
--- a/lib/std/zig/AstRlAnnotate.zig
+++ b/lib/std/zig/AstRlAnnotate.zig
@@ -340,14 +340,7 @@ fn expr(astrl: *AstRlAnnotate, node: Ast.Node.Index, block: ?*Block, ri: ResultI
             for (full.ast.params) |param_node| {
                 _ = try astrl.expr(param_node, block, ResultInfo.type_only);
             }
-            return switch (tree.nodeTag(node)) {
-                .call_one,
-                .call_one_comma,
-                .call,
-                .call_comma,
-                => false, // TODO: once function calls are passed result locations this will change
-                else => unreachable,
-            };
+            return false; // TODO: once function calls are passed result locations this will change
         },
 
         .@"return" => {


### PR DESCRIPTION
This switch has the same cases as the outer one, so there is no use for it.