### PR TITLE
Harden against windows-style accessdenied bs on other platforms when renaming build output from tmp

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3129,8 +3129,8 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) UpdateE
             // directory are open by closing and reopening the file handles.
             // While this need is only documented on windows, there are some
             // niche scenarios, such as WSL on ReFS, where it may be required
-            // on other platforms. As the workaround is low-cost, just 
-            // use it on all platforms rather than trying to isolate every 
+            // on other platforms. As the workaround is low-cost, just
+            // use it on all platforms rather than trying to isolate every
             // specific case where it's needed.
             const need_writable_dance: enum { no, lf_only, lf_and_debug } = w: {
                 if (comp.bin_file) |lf| {
@@ -3180,7 +3180,7 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) UpdateE
                     .root_dir = comp.dirs.local_cache,
                     .sub_path = try fs.path.join(arena, &.{ o_sub_path, comp.emit_bin.? }),
                 };
-                const result: (link.File.OpenError || error{HotSwapUnavailableOnHostOperatingSystem,RenameAcrossMountPoints,InvalidFileName})!void = switch (need_writable_dance) {
+                const result: (link.File.OpenError || error{ HotSwapUnavailableOnHostOperatingSystem, RenameAcrossMountPoints, InvalidFileName })!void = switch (need_writable_dance) {
                     .no => {},
                     .lf_only => lf.makeWritable(),
                     .lf_and_debug => res: {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -3156,8 +3156,8 @@ pub fn update(comp: *Compilation, main_progress_node: std.Progress.Node) UpdateE
                     };
                     break :dance .no;
                 }
-                
-                std.debug.print("trying windows AccessDenied workaround\n", .{});
+
+                log.debug("trying windows AccessDenied workaround\n", .{});
 
                 const d = if (comp.bin_file) |f| f.closeBin() else .no;
                 renameTmpIntoCache(comp.dirs.local_cache, tmp_dir_sub_path, o_sub_path) catch |err| {

--- a/src/link.zig
+++ b/src/link.zig
@@ -669,6 +669,7 @@ pub const File = struct {
                     unreachable;
                 mf.unmap();
             },
+            else => {},
         }
         f.close();
         base.file = null;


### PR DESCRIPTION
Fixes #24586, fixes #24955.

This pr changes the AccessDenied during renaming output directory workaround to be run on all platforms as a defensive measure, since the overhead of the workaround is very minimal, and we cant be certain that there isnt some other niche case where the issue appears in addition to the one niche target that does - WSL on a ReFS filesystem.
(Ive been trying to get the proprietary ReFS driver for linux to see if this is needed in that case but thats even more niche).

The update to line 3194 is only needed to make it typecheck correctly, the main change of the PR is removing the if checking for windows.
