### PR TITLE
Io.net: fix compile error in `receive` and `receiveTimeout`

### DIFF
--- a/lib/std/Io/net.zig
+++ b/lib/std/Io/net.zig
@@ -1118,7 +1118,7 @@ pub const Socket = struct {
     /// See also:
     /// * `receiveTimeout`
     pub fn receive(s: *const Socket, io: Io, buffer: []u8) ReceiveError!IncomingMessage {
-        var message: IncomingMessage = undefined;
+        var message: IncomingMessage = .init;
         const maybe_err, const count = io.vtable.netReceive(io.userdata, s.handle, (&message)[0..1], buffer, .{}, .none);
         if (maybe_err) |err| switch (err) {
             // No timeout is passed to `netReceieve`, so it must not return timeout related errors.
@@ -1144,7 +1144,7 @@ pub const Socket = struct {
         buffer: []u8,
         timeout: Io.Timeout,
     ) ReceiveTimeoutError!IncomingMessage {
-        var message: IncomingMessage = undefined;
+        var message: IncomingMessage = .init;
         const maybe_err, const count = io.vtable.netReceive(io.userdata, s.handle, (&message)[0..1], buffer, .{}, timeout);
         if (maybe_err) |err| return err;
         assert(1 == count);


### PR DESCRIPTION
Correctly uses the `netReceive` API. 
If an error was returned, we propagate that error, otherwise assert we only received one message.

follow-up question: for these types of tests where we need to bind to a specific port, how to decide the port? 
can't use port 0 here, since we're binding, not allocating a port.
i just used port 8000, but i'd like to avoid hardcoding it if possible.