### PR TITLE
`std.math`: Better `comptime_float` and `comptime_int` support in `std.math` functions

### DIFF
--- a/lib/std/fmt.zig
+++ b/lib/std/fmt.zig
@@ -540,10 +540,7 @@ pub fn parseIntSizeSuffix(buf: []const u8, digit_base: u8) ParseIntError!usize {
     } else if (without_i.len != without_B.len) {
         return error.InvalidCharacter;
     }
-    const multiplier = math.powi(usize, magnitude_base, orders_of_magnitude) catch |err| switch (err) {
-        error.Underflow => unreachable,
-        error.Overflow => return error.Overflow,
-    };
+    const multiplier = try math.powi(usize, magnitude_base, orders_of_magnitude);
     const number = try std.fmt.parseInt(usize, without_suffix, digit_base);
     return math.mul(usize, number, multiplier);
 }

--- a/lib/std/math.zig
+++ b/lib/std/math.zig
@@ -81,8 +81,10 @@ pub fn approxEqAbs(comptime T: type, x: T, y: T, tolerance: T) bool {
     if (x == y)
         return true;
 
-    if (isNan(x) or isNan(y))
+    if (isNan(x) or isNan(y)) {
+        if (T == comptime_float) unreachable;
         return false;
+    }
 
     return @abs(x - y) <= tolerance;
 }
@@ -109,8 +111,10 @@ pub fn approxEqRel(comptime T: type, x: T, y: T, tolerance: T) bool {
     if (x == y)
         return true;
 
-    if (isNan(x) or isNan(y))
+    if (isNan(x) or isNan(y)) {
+        if (T == comptime_float) unreachable;
         return false;
+    }
 
     return @abs(x - y) <= @max(@abs(x), @abs(y)) * tolerance;
 }

--- a/lib/std/math/big/int_test.zig
+++ b/lib/std/math/big/int_test.zig
@@ -484,6 +484,7 @@ fn toFloat(comptime Float: type) !void {
     );
 }
 test toFloat {
+    @setEvalBranchQuota(1_100);
     if (builtin.zig_backend == .stage2_llvm) return error.SkipZigTest; // https://github.com/ziglang/zig/issues/24191
     try toFloat(f16);
     try toFloat(f32);

--- a/lib/std/math/frexp.zig
+++ b/lib/std/math/frexp.zig
@@ -1,5 +1,6 @@
 const std = @import("../std.zig");
 const math = std.math;
+const assert = std.debug.assert;
 const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectApproxEqAbs = std.testing.expectApproxEqAbs;
@@ -20,8 +21,10 @@ pub fn Frexp(comptime T: type) type {
 ///  - frexp(nan)   = nan, undefined
 pub fn frexp(x: anytype) Frexp(@TypeOf(x)) {
     const T: type = @TypeOf(x);
+    const info = @typeInfo(T);
+    comptime assert(info == .float or info == .comptime_float);
 
-    const bits: comptime_int = @typeInfo(T).float.bits;
+    const bits: comptime_int = if (info == .float) info.float.bits else 128;
     const Int: type = std.meta.Int(.unsigned, bits);
 
     const exp_bits: comptime_int = math.floatExponentBits(T);
@@ -43,7 +46,7 @@ pub fn frexp(x: anytype) Frexp(@TypeOf(x)) {
     const extra_denorm_shift: comptime_int = 1 - ones_place;
 
     var result: Frexp(T) = undefined;
-    var v: Int = @bitCast(x);
+    var v: Int = if (info == .float) @bitCast(x) else @bitCast(@as(f128, x));
 
     const m: MantInt = @truncate(v);
     const e: ExpInt = @truncate(v >> mant_bits);
@@ -81,7 +84,7 @@ pub fn frexp(x: anytype) Frexp(@TypeOf(x)) {
         },
     }
 
-    result.significand = @bitCast(v);
+    result.significand = if (info == .float) @bitCast(v) else @as(f128, @bitCast(v));
     return result;
 }
 
@@ -91,23 +94,22 @@ fn FrexpTests(comptime Float: type) type {
         const T = Float;
         test "normal" {
             const epsilon = 1e-6;
-            var r: Frexp(T) = undefined;
 
-            r = frexp(@as(T, 1.3));
-            try expectApproxEqAbs(0.65, r.significand, epsilon);
-            try expectEqual(1, r.exponent);
+            const r1 = frexp(@as(T, 1.3));
+            try expectApproxEqAbs(0.65, r1.significand, epsilon);
+            try expectEqual(1, r1.exponent);
 
-            r = frexp(@as(T, 78.0234));
-            try expectApproxEqAbs(0.609558, r.significand, epsilon);
-            try expectEqual(7, r.exponent);
+            const r2 = frexp(@as(T, 78.0234));
+            try expectApproxEqAbs(0.609558, r2.significand, epsilon);
+            try expectEqual(7, r2.exponent);
 
-            r = frexp(@as(T, -1234.5678));
-            try expectEqual(11, r.exponent);
-            try expectApproxEqAbs(-0.602816, r.significand, epsilon);
+            const r3 = frexp(@as(T, -1234.5678));
+            try expectEqual(11, r3.exponent);
+            try expectApproxEqAbs(-0.602816, r3.significand, epsilon);
         }
         test "max" {
             const exponent = math.floatExponentMax(T) + 1;
-            const significand = 1.0 - math.floatEps(T) / 2;
+            const significand = 1.0 - math.floatEps(T) / 2.0;
             const r: Frexp(T) = frexp(math.floatMax(T));
             try expectEqual(exponent, r.exponent);
             try expectEqual(significand, r.significand);
@@ -126,17 +128,16 @@ fn FrexpTests(comptime Float: type) type {
             try expectEqual(0.5, r.significand);
         }
         test "zero" {
-            var r: Frexp(T) = undefined;
+            const r1 = frexp(@as(T, 0.0));
+            try expectEqual(0, r1.exponent);
+            try expect(math.isPositiveZero(r1.significand));
 
-            r = frexp(@as(T, 0.0));
-            try expectEqual(0, r.exponent);
-            try expect(math.isPositiveZero(r.significand));
-
-            r = frexp(@as(T, -0.0));
-            try expectEqual(0, r.exponent);
-            try expect(math.isNegativeZero(r.significand));
+            const r2 = frexp(@as(T, -0.0));
+            try expectEqual(0, r2.exponent);
+            try expect(math.isNegativeZero(r2.significand));
         }
         test "inf" {
+            if (T == comptime_float) return;
             var r: Frexp(T) = undefined;
 
             r = frexp(math.inf(T));
@@ -148,6 +149,7 @@ fn FrexpTests(comptime Float: type) type {
             try expect(math.isNegativeInf(r.significand));
         }
         test "nan" {
+            if (T == comptime_float) return;
             const r: Frexp(T) = frexp(math.nan(T));
             try expect(math.isNan(r.significand));
         }
@@ -156,53 +158,64 @@ fn FrexpTests(comptime Float: type) type {
 
 // Generate tests for each floating point type
 comptime {
-    for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
+    for ([_]type{ f16, f32, f64, f80, f128, comptime_float }) |T| {
         _ = FrexpTests(T);
     }
 }
 
 test frexp {
-    inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
+    @setEvalBranchQuota(1_500);
+
+    inline for ([_]type{ f16, f32, f64, f80, f128, comptime_float }) |T| {
         const max_exponent = math.floatExponentMax(T) + 1;
         const min_exponent = math.floatExponentMin(T) + 1;
         const truemin_exponent = min_exponent - math.floatFractionalBits(T);
 
-        var result: Frexp(T) = undefined;
-        comptime var x: T = undefined;
-
         // basic usage
         // value -> {significand, exponent},
         // value == significand * (2 ^ exponent)
-        x = 1234.5678;
-        result = frexp(x);
-        try expectEqual(11, result.exponent);
-        try expectApproxEqAbs(0.602816, result.significand, 1e-6);
-        try expectEqual(x, math.ldexp(result.significand, result.exponent));
+        const x1 = 1234.5678;
+        const result1 = frexp(x1);
+        try expectEqual(11, result1.exponent);
+        try expectApproxEqAbs(0.602816, result1.significand, 1e-6);
+        try expectEqual(x1, math.ldexp(result1.significand, result1.exponent));
 
         // float maximum
-        x = math.floatMax(T);
-        result = frexp(x);
-        try expectEqual(max_exponent, result.exponent);
-        try expectEqual(1.0 - math.floatEps(T) / 2, result.significand);
-        try expectEqual(x, math.ldexp(result.significand, result.exponent));
+        const x2 = math.floatMax(T);
+        const result2 = frexp(x2);
+        try expectEqual(max_exponent, result2.exponent);
+        try expectEqual(1.0 - math.floatEps(T) / 2.0, result2.significand);
+        try expectEqual(x2, math.ldexp(result2.significand, result2.exponent));
 
         // float minimum
-        x = math.floatMin(T);
-        result = frexp(x);
-        try expectEqual(min_exponent, result.exponent);
-        try expectEqual(0.5, result.significand);
-        try expectEqual(x, math.ldexp(result.significand, result.exponent));
+        const x3 = math.floatMin(T);
+        const result3 = frexp(x3);
+        try expectEqual(min_exponent, result3.exponent);
+        try expectEqual(0.5, result3.significand);
+        try expectEqual(x3, math.ldexp(result3.significand, result3.exponent));
 
         // float true minimum
         // subnormal -> {normal, exponent}
-        x = math.floatTrueMin(T);
-        result = frexp(x);
-        try expectEqual(truemin_exponent, result.exponent);
-        try expectEqual(0.5, result.significand);
-        try expectEqual(x, math.ldexp(result.significand, result.exponent));
+        const x4 = math.floatTrueMin(T);
+        const result4 = frexp(x4);
+        try expectEqual(truemin_exponent, result4.exponent);
+        try expectEqual(0.5, result4.significand);
+        try expectEqual(x4, math.ldexp(result4.significand, result4.exponent));
+
+        // zero -> {zero, zero} (+)
+        const result5 = frexp(@as(T, 0.0));
+        try expectEqual(0, result5.exponent);
+        try expect(math.isPositiveZero(result5.significand));
+
+        // zero -> {zero, zero} (-)
+        const result6 = frexp(@as(T, -0.0));
+        try expectEqual(0, result6.exponent);
+        try expect(math.isNegativeZero(result6.significand));
+
+        if (T == comptime_float) return;
 
         // infinity -> {infinity, zero} (+)
-        result = frexp(math.inf(T));
+        var result = frexp(math.inf(T));
         try expectEqual(0, result.exponent);
         try expect(math.isPositiveInf(result.significand));
 
@@ -210,16 +223,6 @@ test frexp {
         result = frexp(-math.inf(T));
         try expectEqual(0, result.exponent);
         try expect(math.isNegativeInf(result.significand));
-
-        // zero -> {zero, zero} (+)
-        result = frexp(@as(T, 0.0));
-        try expectEqual(0, result.exponent);
-        try expect(math.isPositiveZero(result.significand));
-
-        // zero -> {zero, zero} (-)
-        result = frexp(@as(T, -0.0));
-        try expectEqual(0, result.exponent);
-        try expect(math.isNegativeZero(result.significand));
 
         // nan -> {nan, undefined}
         result = frexp(math.nan(T));

--- a/lib/std/math/isfinite.zig
+++ b/lib/std/math/isfinite.zig
@@ -4,14 +4,14 @@ const expect = std.testing.expect;
 
 /// Returns whether x is a finite value.
 pub fn isFinite(x: anytype) bool {
-    const T = @TypeOf(x);
+    const T = if (@TypeOf(x) == comptime_float) f128 else @TypeOf(x);
     const TBits = std.meta.Int(.unsigned, @typeInfo(T).float.bits);
     const remove_sign = ~@as(TBits, 0) >> 1;
-    return @as(TBits, @bitCast(x)) & remove_sign < @as(TBits, @bitCast(math.inf(T)));
+    return @as(TBits, @bitCast(@as(T, x))) & remove_sign < @as(TBits, @bitCast(math.inf(T)));
 }
 
 test isFinite {
-    inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
+    inline for ([_]type{ f16, f32, f64, f80, f128, comptime_float }) |T| {
         // normals
         try expect(isFinite(@as(T, 1.0)));
         try expect(isFinite(-@as(T, 1.0)));
@@ -24,6 +24,8 @@ test isFinite {
         // other float limits
         try expect(isFinite(math.floatMin(T)));
         try expect(isFinite(math.floatMax(T)));
+
+        if (T == comptime_float) return;
 
         // inf & nan
         try expect(!isFinite(math.inf(T)));

--- a/lib/std/math/iszero.zig
+++ b/lib/std/math/iszero.zig
@@ -5,36 +5,50 @@ const expect = std.testing.expect;
 /// Returns whether x is positive zero.
 pub inline fn isPositiveZero(x: anytype) bool {
     const T = @TypeOf(x);
-    const bit_count = @typeInfo(T).float.bits;
+    const bit_count, const F = switch (@typeInfo(T)) {
+        .float => |float| .{ float.bits, T },
+        .comptime_float => .{ 128, f128 },
+        else => @compileError("unknown floating point type " ++ @typeName(T)),
+    };
     const TBits = std.meta.Int(.unsigned, bit_count);
-    return @as(TBits, @bitCast(x)) == @as(TBits, 0);
+    return @as(TBits, @bitCast(@as(F, x))) == @as(TBits, 0);
 }
 
 /// Returns whether x is negative zero.
 pub inline fn isNegativeZero(x: anytype) bool {
     const T = @TypeOf(x);
-    const bit_count = @typeInfo(T).float.bits;
+    const bit_count, const F = switch (@typeInfo(T)) {
+        .float => |float| .{ float.bits, T },
+        .comptime_float => .{ 128, f128 },
+        else => @compileError("unknown floating point type " ++ @typeName(T)),
+    };
     const TBits = std.meta.Int(.unsigned, bit_count);
-    return @as(TBits, @bitCast(x)) == @as(TBits, 1) << (bit_count - 1);
+    return @as(TBits, @bitCast(@as(F, x))) == @as(TBits, 1) << (bit_count - 1);
 }
 
 test isPositiveZero {
-    inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
+    inline for ([_]type{ f16, f32, f64, f80, f128, comptime_float }) |T| {
         try expect(isPositiveZero(@as(T, 0.0)));
         try expect(!isPositiveZero(@as(T, -0.0)));
         try expect(!isPositiveZero(math.floatMin(T)));
         try expect(!isPositiveZero(math.floatMax(T)));
+
+        if (T == comptime_float) return;
+
         try expect(!isPositiveZero(math.inf(T)));
         try expect(!isPositiveZero(-math.inf(T)));
     }
 }
 
 test isNegativeZero {
-    inline for ([_]type{ f16, f32, f64, f80, f128 }) |T| {
+    inline for ([_]type{ f16, f32, f64, f80, f128, comptime_float }) |T| {
         try expect(isNegativeZero(@as(T, -0.0)));
         try expect(!isNegativeZero(@as(T, 0.0)));
         try expect(!isNegativeZero(math.floatMin(T)));
         try expect(!isNegativeZero(math.floatMax(T)));
+
+        if (T == comptime_float) return;
+
         try expect(!isNegativeZero(math.inf(T)));
         try expect(!isNegativeZero(-math.inf(T)));
     }

--- a/lib/std/math/nextafter.zig
+++ b/lib/std/math/nextafter.zig
@@ -144,7 +144,7 @@ test "int" {
 }
 
 test "float" {
-    @setEvalBranchQuota(4000);
+    @setEvalBranchQuota(5000);
 
     // normal -> normal
     try expect(nextAfter(f16, 0x1.234p0, 2.0) == 0x1.238p0);

--- a/lib/std/math/signbit.zig
+++ b/lib/std/math/signbit.zig
@@ -43,6 +43,9 @@ fn testFloats(comptime Type: type) !void {
     try expect(!signbit(@as(Type, 1.0)));
     try expect(signbit(@as(Type, -2.0)));
     try expect(signbit(@as(Type, -0.0)));
+
+    if (Type == comptime_float) return;
+
     try expect(!signbit(math.inf(Type)));
     try expect(signbit(-math.inf(Type)));
     try expect(!signbit(math.nan(Type)));

--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -290,19 +290,16 @@ pub inline fn expectApproxEqAbs(expected: anytype, actual: anytype, tolerance: a
 
 fn expectApproxEqAbsInner(comptime T: type, expected: T, actual: T, tolerance: T) !void {
     switch (@typeInfo(T)) {
-        .float => if (!math.approxEqAbs(T, expected, actual, tolerance)) {
+        .float, .comptime_float => if (!math.approxEqAbs(T, expected, actual, tolerance)) {
             print("actual {}, not within absolute tolerance {} of expected {}\n", .{ actual, tolerance, expected });
             return error.TestExpectedApproxEqAbs;
         },
-
-        .comptime_float => @compileError("Cannot approximately compare two comptime_float values"),
-
         else => @compileError("Unable to compare non floating point values"),
     }
 }
 
 test expectApproxEqAbs {
-    inline for ([_]type{ f16, f32, f64, f128 }) |T| {
+    inline for ([_]type{ f16, f32, f64, f128, comptime_float }) |T| {
         const pos_x: T = 12.0;
         const pos_y: T = 12.06;
         const neg_x: T = -12.0;
@@ -326,19 +323,16 @@ pub inline fn expectApproxEqRel(expected: anytype, actual: anytype, tolerance: a
 
 fn expectApproxEqRelInner(comptime T: type, expected: T, actual: T, tolerance: T) !void {
     switch (@typeInfo(T)) {
-        .float => if (!math.approxEqRel(T, expected, actual, tolerance)) {
+        .float, .comptime_float => if (!math.approxEqRel(T, expected, actual, tolerance)) {
             print("actual {}, not within relative tolerance {} of expected {}\n", .{ actual, tolerance, expected });
             return error.TestExpectedApproxEqRel;
         },
-
-        .comptime_float => @compileError("Cannot approximately compare two comptime_float values"),
-
         else => @compileError("Unable to compare non floating point values"),
     }
 }
 
 test expectApproxEqRel {
-    inline for ([_]type{ f16, f32, f64, f128 }) |T| {
+    inline for ([_]type{ f16, f32, f64, f128, comptime_float }) |T| {
         const eps_value = comptime math.floatEps(T);
         const sqrt_eps_value = comptime @sqrt(eps_value);
 

--- a/test/behavior/x86_64/binary.zig
+++ b/test/behavior/x86_64/binary.zig
@@ -176,7 +176,7 @@ fn binary(comptime op: anytype, comptime opts: struct { compare: Compare = .rela
             try testArgs(u1025, 0x1dea81169800bac2f3afcf3be5dbd2d8eefbace8a24a2da0a383a928d1109459f34028be4413119f1af00ad90ce4d63064016dc1cee5b783c79c1998a0a49de21c4db71d432273576503589fc966c7ec2d730fa9bc4c5ff3128a82653ab8149528de67804718e39722f89b91c75d012ea41c642c889f0db95c882a9790a5e922f, 0x156fe02946ab9069a644dcc1f2b1afa04ee88ab1de19575a2715abf4a52bf374d297fdf78455ccdb87a934d3d818d774b63865eaedfdad3c56a56b8fcc62703c391aedf16cf770af06d7d205f93778c012df54fe5290084e1cd2bbec86a2f295cdce69a2cd774e064580f3c9cfae60d17b12f610e86566e68d5183d706c8ad8af);
         }
         fn testFloats() !void {
-            @setEvalBranchQuota(21_700);
+            @setEvalBranchQuota(25_000);
 
             try testArgs(f16, -nan(f16), -nan(f16));
             try testArgs(f16, -nan(f16), -inf(f16));
@@ -4646,7 +4646,7 @@ fn binary(comptime op: anytype, comptime opts: struct { compare: Compare = .rela
             });
         }
         fn testFloatVectors() !void {
-            @setEvalBranchQuota(21_700);
+            @setEvalBranchQuota(25_000);
 
             try testArgs(@Vector(1, f16), .{
                 -tmin(f16),

--- a/test/behavior/x86_64/cast.zig
+++ b/test/behavior/x86_64/cast.zig
@@ -3133,7 +3133,7 @@ fn cast(comptime op: anytype, comptime opts: struct { compare: Compare = .relaxe
             try testArgs(i1024, u1025, 1 << 1024);
         }
         fn testFloats() !void {
-            @setEvalBranchQuota(3_100);
+            @setEvalBranchQuota(3_500);
 
             try testArgs(f16, f16, -nan(f16));
             try testArgs(f16, f16, -inf(f16));
@@ -6387,7 +6387,7 @@ fn cast(comptime op: anytype, comptime opts: struct { compare: Compare = .relaxe
             try testArgs(@Vector(3, i1024), @Vector(3, u1025), .{ 0, 1, 1 << 1024 });
         }
         fn testFloatVectors() !void {
-            @setEvalBranchQuota(6_700);
+            @setEvalBranchQuota(7_500);
 
             try testArgs(@Vector(1, f16), @Vector(1, f16), .{
                 1e0,
@@ -6890,7 +6890,7 @@ fn cast(comptime op: anytype, comptime opts: struct { compare: Compare = .relaxe
             });
         }
         fn testIntsFromFloats() !void {
-            @setEvalBranchQuota(2_600);
+            @setEvalBranchQuota(2_700);
 
             try testArgs(i8, f16, -0x0.8p8);
             try testArgs(i8, f16, next(f16, -0x0.8p8, -0.0));


### PR DESCRIPTION
Adds `comptime_float` support to 
- `approxEqAbs`
- `approxEqRel`
-  various `std.math.float` functions
-  `isNormal`
-  `isFinite`
-  `isPositiveZero`
-  `isNegativeZero`
-  `frexp`
-  `ldexp`
-  `pow`

Also adds `comptime_int` support to `powi`.

Starts adoption of the comptime_float behavior described in https://github.com/ziglang/zig/issues/21205#issuecomment-2613393221 

Closes: #23602 