### PR TITLE
std.zig.AstGen: properly handle grouped_expression

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2607,7 +2607,7 @@ fn blockExprStmts(gz: *GenZir, parent_scope: *Scope, statements: []const Ast.Nod
                 .assign_mul_wrap => try assignOp(gz, scope, statement, .mulwrap),
 
                 .grouped_expression => {
-                    inner_node = tree.nodeData(statement).node_and_token[0];
+                    inner_node = tree.nodeData(inner_node).node_and_token[0];
                     continue;
                 },
 

--- a/test/cases/compile_errors/doubled_grouped_expr_as_stmt.zig
+++ b/test/cases/compile_errors/doubled_grouped_expr_as_stmt.zig
@@ -1,0 +1,9 @@
+pub export fn entry() void {
+    ((1 + 1)); // makes sure that the doubled grouped_expression does not cause an endless loop in AstGen.
+}
+
+// error
+//
+// :2:9: error: value of type 'comptime_int' ignored
+// :2:9: note: all non-void values must be used
+// :2:9: note: to discard the value, assign it to '_'


### PR DESCRIPTION
This fixes a bug, endless loop in AstGen.