### PR TITLE
Fix `std.Io` and `std.heap.page_allocator` on Wasm

### DIFF
--- a/lib/std/Io/Threaded.zig
+++ b/lib/std/Io/Threaded.zig
@@ -797,9 +797,10 @@ fn await(
     result_alignment: std.mem.Alignment,
 ) void {
     _ = result_alignment;
+    if (builtin.single_threaded) return;
     const t: *Threaded = @ptrCast(@alignCast(userdata));
-    const closure: *AsyncClosure = @ptrCast(@alignCast(any_future));
-    closure.waitAndDeinit(t.allocator, result);
+    const ac: *AsyncClosure = @ptrCast(@alignCast(any_future));
+    ac.waitAndDeinit(t.allocator, result);
 }
 
 fn cancel(
@@ -809,6 +810,7 @@ fn cancel(
     result_alignment: std.mem.Alignment,
 ) void {
     _ = result_alignment;
+    if (builtin.single_threaded) return;
     const t: *Threaded = @ptrCast(@alignCast(userdata));
     const ac: *AsyncClosure = @ptrCast(@alignCast(any_future));
     ac.closure.requestCancel();

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1830,7 +1830,16 @@ pub const POLL = switch (native_os) {
 /// Basic memory protection flags
 pub const PROT = switch (native_os) {
     .linux => linux.PROT,
-    .emscripten => emscripten.PROT,
+    // https://github.com/emscripten-core/emscripten/blob/08e2de1031913e4ba7963b1c56f35f036a7d4d56/system/lib/libc/musl/include/sys/mman.h#L57-L62
+    // lib/libc/include/wasm-wasi-musl/sys/mman.h
+    .emscripten, .wasi => struct {
+        pub const NONE = 0;
+        pub const READ = 1;
+        pub const WRITE = 2;
+        pub const EXEC = 4;
+        pub const GROWSDOWN = 0x01000000;
+        pub const GROWSUP = 0x02000000;
+    },
     // https://github.com/SerenityOS/serenity/blob/6d59d4d3d9e76e39112842ec487840828f1c9bfe/Kernel/API/POSIX/sys/mman.h#L28-L31
     .openbsd, .haiku, .dragonfly, .netbsd, .illumos, .freebsd, .windows, .serenity => struct {
         /// page can not be accessed
@@ -8692,7 +8701,9 @@ pub const O = switch (native_os) {
 
 pub const MAP = switch (native_os) {
     .linux => linux.MAP,
-    .emscripten => packed struct(u32) {
+    // https://github.com/emscripten-core/emscripten/blob/08e2de1031913e4ba7963b1c56f35f036a7d4d56/system/lib/libc/musl/include/sys/mman.h#L21-L39
+    // lib/libc/include/wasm-wasi-musl/sys/mman.h
+    .emscripten, .wasi => packed struct(u32) {
         TYPE: enum(u4) {
             SHARED = 0x01,
             PRIVATE = 0x02,

--- a/lib/std/heap.zig
+++ b/lib/std/heap.zig
@@ -366,7 +366,7 @@ pub const page_allocator: Allocator = if (@hasDecl(root, "os") and
     @hasDecl(root.os, "heap") and
     @hasDecl(root.os.heap, "page_allocator"))
     root.os.heap.page_allocator
-else if (builtin.target.cpu.arch.isWasm()) .{
+else if (builtin.target.cpu.arch.isWasm() and !builtin.link_libc) .{
     .ptr = undefined,
     .vtable = &WasmAllocator.vtable,
 } else if (builtin.target.os.tag == .plan9) .{

--- a/lib/std/os/emscripten.zig
+++ b/lib/std/os/emscripten.zig
@@ -331,15 +331,6 @@ pub const POLL = struct {
     pub const RDBAND = 0x080;
 };
 
-pub const PROT = struct {
-    pub const NONE = 0x0;
-    pub const READ = 0x1;
-    pub const WRITE = 0x2;
-    pub const EXEC = 0x4;
-    pub const GROWSDOWN = 0x01000000;
-    pub const GROWSUP = 0x02000000;
-};
-
 pub const rlim_t = u64;
 
 pub const RLIM = struct {


### PR DESCRIPTION
Closes #25856
Closes #19072

- Single-threaded Wasm builds should not have a dependency on pthreads.
- `std.heap.page_allocator` should use `PageAllocator`, not `WasmAllocator`, when linking libc. It's the libc's responsibility to manage the heap and having Zig try to grow the main Wasm memory can cause all sorts of problems. Changing this fixes a long-standing annoyance with `DebugAllocator` being useless on WASI+libc/Emscripten unless the user overrides the (default) backing allocator. Now, `DebugAllocator` Just Works.

<details><summary>Test/repro:</summary>

Install/activate the latest Emscripten, run `zig build --sysroot "$(em-config CACHE)/sysroot" && python -m http.server -d zig-out/www` and open the page in your web browser.

```zig
// build.zig
const std = @import("std");

pub fn build(b: *std.Build) void {
    const target = b.resolveTargetQuery(.{ .cpu_arch = .wasm32, .os_tag = .emscripten });
    const optimize: std.builtin.OptimizeMode = .Debug;

    const emscripten_system_include_path: std.Build.LazyPath = if (b.sysroot) |sysroot|
        .{ .cwd_relative = b.pathJoin(&.{ sysroot, "include" }) }
    else {
        std.process.fatal("'--sysroot' is required", .{});
    };

    const repro_mod = b.createModule(.{
        .root_source_file = b.path("build.zig"),
        .target = target,
        .optimize = optimize,
        .link_libc = true,
    });

    repro_mod.addSystemIncludePath(emscripten_system_include_path);

    const repro_lib = b.addLibrary(.{
        .linkage = .static,
        .name = "repro",
        .root_module = repro_mod,
    });

    const run_emcc = b.addSystemCommand(&.{"emcc"});
    run_emcc.addArtifactArg(repro_lib);

    run_emcc.addArgs(&.{
        "-O0",
        "-g",
        "-fsanitize=undefined",
    });

    // Patch the default HTML shell.
    run_emcc.addArg("--pre-js");
    run_emcc.addFileArg(b.addWriteFiles().add("pre.js", (
        // Display stderr output on the page
        \\Module['printErr'] ??= Module['print'];
        // Disable ANSI escape sequences
        \\Module['preRun'] = [].concat(Module['preRun'] ?? [], () => ENV.TERM ??= 'dumb');
    )));

    run_emcc.addArg("-o");
    const repro_html = run_emcc.addOutputFileArg("index.html");

    b.getInstallStep().dependOn(&b.addInstallDirectory(.{
        .source_dir = repro_html.dirname(),
        .install_dir = .{ .custom = "www" },
        .install_subdir = "",
    }).step);
}

pub const std_options: std.Options = .{ .log_level = .debug };

pub fn main() !void {
    var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
    defer std.debug.assert(debug_allocator.deinit() == .ok);

    const gpa = debug_allocator.allocator();

    const byte = try gpa.create(u8);
    defer gpa.destroy(byte);

    std.debug.print("Hello, World!\n", .{});
}
```

</details>

Without the changeset, `emcc` fails with `error: undefined symbol: pthread_kill`.
With the first commit, linking succeeds but the app OOMs.
With the last commit, the app works.