### PR TITLE
incr-check: Kill child process on error

### DIFF
--- a/tools/incr-check.zig
+++ b/tools/incr-check.zig
@@ -588,6 +588,8 @@ const Eval = struct {
     fn fatal(eval: *Eval, comptime fmt: []const u8, args: anytype) noreturn {
         eval.tmp_dir.close();
         if (!eval.preserve_tmp_on_fatal) {
+            // Kill the child since it holds an open handle to its CWD which is the tmp dir path
+            _ = eval.child.kill() catch {};
             std.fs.cwd().deleteTree(eval.tmp_dir_path) catch |err| {
                 std.log.warn("failed to delete tree '{s}': {s}", .{ eval.tmp_dir_path, @errorName(err) });
             };


### PR DESCRIPTION
Since the child process is spawned with the tmp directory as its CWD, the child process opens it without DELETE access. On error, the child process would still be alive while the tmp directory is attempting to be deleted, so it would fail with `.SHARING_VIOLATION => return error.FileBusy`.

Fixes arguably the least important part of #22510, since it's only the directory itself that would fail to get deleted, all the files inside would get deleted just fine.