### PR TITLE
std.zig.AstGen: use shrinkRetainingCapacity while shrinking scratch list

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -5004,7 +5004,7 @@ fn structDeclInner(
     defer block_scope.unstack();
 
     const scratch_top = astgen.scratch.items.len;
-    defer astgen.scratch.items.len = scratch_top;
+    defer astgen.scratch.shrinkRetainingCapacity(scratch_top);
 
     var backing_int_body_len: usize = 0;
     const backing_int_ref: Zir.Inst.Ref = blk: {
@@ -5225,7 +5225,7 @@ fn tupleDecl(
     //        init: Inst.Ref, // `.none` for non-`comptime` fields
     //    }
     const fields_start = astgen.scratch.items.len;
-    defer astgen.scratch.items.len = fields_start;
+    defer astgen.scratch.shrinkRetainingCapacity(fields_start);
 
     try astgen.scratch.ensureUnusedCapacity(gpa, container_decl.ast.members.len * 2);
 
@@ -7269,7 +7269,7 @@ fn switchExprErrUnion(
     const case_table_end = multi_case_table + multi_cases_len;
 
     try astgen.scratch.resize(gpa, case_table_end);
-    defer astgen.scratch.items.len = scratch_top;
+    defer astgen.scratch.shrinkRetainingCapacity(scratch_top);
 
     var block_scope = parent_gz.makeSubBlock(scope);
     // block_scope not used for collecting instructions
@@ -7804,7 +7804,7 @@ fn switchExpr(
     const multi_case_table = scalar_case_table + scalar_cases_len;
     const case_table_end = multi_case_table + multi_cases_len;
     try astgen.scratch.resize(gpa, case_table_end);
-    defer astgen.scratch.items.len = scratch_top;
+    defer astgen.scratch.shrinkRetainingCapacity(scratch_top);
 
     var block_scope = parent_gz.makeSubBlock(scope);
     // block_scope not used for collecting instructions
@@ -10134,7 +10134,7 @@ fn callExpr(
     try gz.instructions.append(astgen.gpa, call_index);
 
     const scratch_top = astgen.scratch.items.len;
-    defer astgen.scratch.items.len = scratch_top;
+    defer astgen.scratch.shrinkRetainingCapacity(scratch_top);
 
     var scratch_index = scratch_top;
     try astgen.scratch.resize(astgen.gpa, scratch_top + call.ast.params.len);


### PR DESCRIPTION
After #25832 it has safety features (memset to undefined), we can take use of that here, since scratch is a temporary storage.