### PR TITLE
Update Style Guide to suggest TitleCase for Type aliases as is the reality in the standard library

### DIFF
--- a/doc/langref.html.in
+++ b/doc/langref.html.in
@@ -7150,7 +7150,6 @@ const TypeName = @import("dir_name/TypeName.zig");
 var global_var: i32 = undefined;
 const const_name = 42;
 const PrimitiveTypeAlias = f32;
-const StringAlias = []u8;
 
 const StructName = struct {
     field: i32,


### PR DESCRIPTION
closes #25859

As @taylordotfish noticed the standard library seems to treat type aliases as types and uses TitleCase.
I have changed the relevant parts in the style guide accordingly.

I have also taken the liberty of improving the wording to make it a little simpler to parse for a human. I did this in a separate commit though so if this is unintended, only the first commit could be merged.