### PR TITLE
Fix `ArrayList` init capacity of zero-sized type

### DIFF
--- a/lib/std/array_list.zig
+++ b/lib/std/array_list.zig
@@ -1363,7 +1363,7 @@ pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
             return self.getLast();
         }
 
-        const init_capacity: comptime_int = @max(1, std.atomic.cache_line / @sizeOf(T));
+        const init_capacity: comptime_int = @max(1, std.atomic.cache_line / @max(@sizeOf(T), 1));
 
         /// Called when memory growth is necessary. Returns a capacity larger than
         /// minimum that grows super-linearly.


### PR DESCRIPTION
When initializing an `ArrayList` of any zero-sized type, the `init_capacity` field calculation was resulting in illegal division by 0. 

Ran into this issue when attempting to convert https://github.com/ziglang/zig/blob/b31a03f134792b8fae20a625f68499c6548f8443/lib/std/json/static.zig#L466 into unmanaged `ArrayList`.

Changes pass all standard library tests on local machine, and resolves the issue above.

Wasn't sure how to add a test that would cause a failure for zero-sized types, rather than triggering IB/crashing test suite.