### PR TITLE
compiler: warn when using -fincremental with LLVM backend

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3360,6 +3360,10 @@ fn buildOutputType(
         fatal("--debug-incremental requires -fincremental", .{});
     }
 
+    if (incremental and create_module.resolved_options.use_llvm) {
+        warn("-fincremental is currently unsupported by the LLVM backend; crashes or miscompilations are likely", .{});
+    }
+
     const cache_mode: Compilation.CacheMode = b: {
         // Once incremental compilation is the default, we'll want some smarter logic here,
         // considering things like the backend in use and whether there's a ZCU.


### PR DESCRIPTION
Also update the compiler's logFn to use color like the default one does.