### PR TITLE
flate.Compress: simplify huffman node comparisons

### DIFF
--- a/lib/std/compress/flate/Compress.zig
+++ b/lib/std/compress/flate/Compress.zig
@@ -993,14 +993,15 @@ const huffman = struct {
     const max_leafs = 286;
     const max_nodes = max_leafs * 2;
 
-    const Node = struct {
-        freq: u16,
+    const Node = packed struct(u32) {
         depth: u16,
+        freq: u16,
 
         pub const Index = u16;
 
+        /// `freq` is more significant than `depth`
         pub fn smaller(a: Node, b: Node) bool {
-            return if (a.freq != b.freq) a.freq < b.freq else a.depth < b.depth;
+            return @as(u32, @bitCast(a)) < @as(u32, @bitCast(b));
         }
     };
 


### PR DESCRIPTION
Instead of comparing each field, nodes are now compared as 32-bit values where `freq` is in the most significant bits.

Comparing with `Compress.Huffman`, this is slightly faster:
```
Benchmark 1 (65 runs): ./run-with-stdin.sh ./jit-deflate-huffman-old ./sample
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          77.4ms ±  998us    75.5ms … 82.0ms          1 ( 2%)        0%
  peak_rss           5.44MB ±  109KB    5.17MB … 5.62MB          0 ( 0%)        0%
  cpu_cycles          350M  ±  478K      349M  …  352M           1 ( 2%)        0%
  instructions        690M  ±  359       690M  …  690M           2 ( 3%)        0%
  cache_references   1.23M  ± 26.4K     1.19M  … 1.33M           5 ( 8%)        0%
  cache_misses       52.2K  ± 3.39K     44.7K  … 68.4K           6 ( 9%)        0%
  branch_misses       200K  ± 1.89K      197K  …  210K           1 ( 2%)        0%
Benchmark 2 (65 runs): ./run-with-stdin.sh ./jit-deflate-huffman-new ./sample
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          76.9ms ±  880us    74.9ms … 79.9ms          2 ( 3%)          -  0.6% ±  0.4%
  peak_rss           5.46MB ±  103KB    5.17MB … 5.63MB          1 ( 2%)          +  0.5% ±  0.7%
  cpu_cycles          349M  ±  505K      348M  …  351M           0 ( 0%)          -  0.3% ±  0.0%
  instructions        685M  ±  514       685M  …  685M           2 ( 3%)          -  0.7% ±  0.0%
  cache_references   1.22M  ± 23.2K     1.18M  … 1.28M           0 ( 0%)          -  0.8% ±  0.7%
  cache_misses       53.5K  ± 2.77K     48.9K  … 63.8K           2 ( 3%)          +  2.4% ±  2.0%
  branch_misses       200K  ± 1.13K      198K  …  203K           0 ( 0%)          +  0.2% ±  0.3%
```