### PR TITLE
std.Io.net: fix off-by-one in HostName.expand

### DIFF
--- a/lib/std/Io/net/HostName.zig
+++ b/lib/std/Io/net/HostName.zig
@@ -136,8 +136,6 @@ pub fn expand(noalias packet: []const u8, start_i: usize, noalias dest_buffer: [
             dest_i += label_len;
             i += 1 + label_len;
         } else {
-            dest[dest_i] = 0;
-            dest_i += 1;
             return .{
                 len orelse i - start_i + 1,
                 try .init(dest[0..dest_i]),


### PR DESCRIPTION
This fixes a bug in `HostName.expand` that I found while working on my project.
 
When using `std.http.Client` to connect to a domain that uses a CNAME, my diagnostics caught an `InvalidDnsCnameRecord` error. I found that the issue was due to an off-by-one in the slice passed to `HostName.validate`. I fixed the bug and added a test with comments, mostly for my own learning. I know the porting to `std.Io` is underway, so take it for what it's worth.

Here is an example to reproduce with `https://blog.github.com`:

```zig
const std = @import("std");

pub fn main() anyerror!void {
    const allocator = std.heap.page_allocator;

    var threaded = std.Io.Threaded.init(allocator);
    defer std.Io.Threaded.deinit(&threaded);
    const io = std.Io.Threaded.io(&threaded);

    var client = std.http.Client{
        .allocator = allocator,
        .io = io,
    };
    defer client.deinit();

    const uri = try std.Uri.parse("https://blog.github.com");
    std.log.info("Connecting to: https://blog.github.com", .{});

    var req = client.request(.GET, uri, .{}) catch |err| {
        std.log.err("http.Client.request failed: {s}", .{@errorName(err)});
        return err;
    };
    defer req.deinit();

    std.log.info("Sending request", .{});
    try req.sendBodiless();

    var redirect_buffer: [1024]u8 = undefined;
    _ = try req.receiveHead(&redirect_buffer);
}
```

Output from `zig build run`:

```
info: Connecting to: https://blog.github.com
error: http.Client.request failed: InvalidDnsCnameRecord
error: InvalidDnsCnameRecord
/usr/lib/zig/std/Io/net/HostName.zig:246:13: 0x11bbf71 in connect (std.zig)
try end;
^
/usr/lib/zig/std/http/Client.zig:1447:18: 0x11a1214 in connectTcpOptions (std.zig)
var stream = try host.connect(io, port, .{ .mode = .stream });
^
/usr/lib/zig/std/http/Client.zig:1419:5: 0x119f8a7 in connectTcp (std.zig)
return connectTcpOptions(client, .{ .host = host, .port = port, .protocol = protocol });
^
/usr/lib/zig/std/http/Client.zig:1592:14: 0x1190b70 in connect (std.zig)
    } orelse return client.connectTcp(host, port, protocol);
^
/usr/lib/zig/std/http/Client.zig:1708:18: 0x117defc in request (std.zig)
break :c try client.connect(host_name, uriPort(uri, protocol), protocol);
^
/home/fox/Coding/apca/src/main.zig:21:9: 0x117b612 in main (main.zig)
return err;
^
run
└─ run exe standalone-test failure
error: process exited with error code 1
failed command: ./.zig-cache/o/74cbf6cff85e01ebc54a0b6c3c22ec9e/standalone-test

Build Summary: 2/4 steps succeeded (1 failed)
run transitive failure
└─ run exe standalone-test failure

error: the following build command failed with exit code 1:
.zig-cache/o/0ae7bf86e2ec25e2a707c43ae1c07691/build /usr/bin/zig /usr/lib/zig /home/fox/Coding/apca .zig-cache /home/fox/.cache/zig --seed 0x378e2bb -Zc330daa63d37b9c3 run
```

Output from `dig blog.github.com`:

```
; <<>> DiG 9.20.15 <<>> blog.github.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 40590
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 5

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;blog.github.com.               IN      A

;; ANSWER SECTION:
blog.github.com.        2698    IN      CNAME   github.github.io.
github.github.io.       3342    IN      A       185.199.109.153
github.github.io.       3342    IN      A       185.199.111.153
github.github.io.       3342    IN      A       185.199.108.153
github.github.io.       3342    IN      A       185.199.110.153

;; ADDITIONAL SECTION:
github.github.io.       2698    IN      AAAA    2606:50c0:8001::153
github.github.io.       2698    IN      AAAA    2606:50c0:8000::153
github.github.io.       2698    IN      AAAA    2606:50c0:8003::153
github.github.io.       2698    IN      AAAA    2606:50c0:8002::153

;; Query time: 1 msec
;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
;; WHEN: Thu Nov 13 00:48:32 CET 2025
;; MSG SIZE  rcvd: 250
```

---
Closes #25811
Duplicate of #25845