### PR TITLE
fix 'redundant comptime keyword' error source location and add tests

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -2117,10 +2117,10 @@ fn comptimeExprAst(
     node: Ast.Node.Index,
 ) InnerError!Zir.Inst.Ref {
     const astgen = gz.astgen;
-    if (gz.is_comptime) {
-        try astgen.appendErrorNode(node, "redundant comptime keyword in already comptime scope", .{});
-    }
     const tree = astgen.tree;
+    if (gz.is_comptime) {
+        try astgen.appendErrorTok(tree.nodeMainToken(node), "redundant comptime keyword in already comptime scope", .{});
+    }
     const body_node = tree.nodeData(node).node;
     return comptimeExpr2(gz, scope, ri, body_node, node, .comptime_keyword);
 }
@@ -3469,7 +3469,7 @@ fn assignDestructure(gz: *GenZir, scope: *Scope, node: Ast.Node.Index) InnerErro
 
     const full = tree.assignDestructure(node);
     if (full.comptime_token != null and gz.is_comptime) {
-        return astgen.appendErrorNode(node, "redundant comptime keyword in already comptime scope", .{});
+        return astgen.appendErrorTok(full.comptime_token.?, "redundant comptime keyword in already comptime scope", .{});
     }
 
     // If this expression is marked comptime, we must wrap the whole thing in a comptime block.
@@ -3525,7 +3525,7 @@ fn assignDestructureMaybeDecls(
 
     const full = tree.assignDestructure(node);
     if (full.comptime_token != null and gz.is_comptime) {
-        try astgen.appendErrorNode(node, "redundant comptime keyword in already comptime scope", .{});
+        try astgen.appendErrorTok(full.comptime_token.?, "redundant comptime keyword in already comptime scope", .{});
     }
 
     const is_comptime = full.comptime_token != null or gz.is_comptime;

--- a/test/cases/compile_errors/redundant_comptime_keyword.zig
+++ b/test/cases/compile_errors/redundant_comptime_keyword.zig
@@ -1,0 +1,11 @@
+comptime {
+    _ = comptime 0;
+}
+comptime {
+    comptime _, _ = .{ 0, 0 };
+}
+
+// error
+//
+// :2:9: error: redundant comptime keyword in already comptime scope
+// :5:5: error: redundant comptime keyword in already comptime scope


### PR DESCRIPTION
before the tested cases would point at the entire comptime expression and the `=` respectively 