### PR TITLE
Fix madvice/msync flags for BSDs

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -1640,7 +1640,17 @@ pub const MSF = switch (native_os) {
         pub const DEACTIVATE = 0x8;
         pub const SYNC = 0x10;
     },
-    .openbsd, .haiku, .dragonfly, .netbsd, .illumos, .freebsd => struct {
+    .freebsd, .dragonfly => struct {
+        pub const SYNC = 0;
+        pub const ASYNC = 1;
+        pub const INVALIDATE = 2;
+    },
+    .openbsd => struct {
+        pub const ASYNC = 1;
+        pub const SYNC = 2;
+        pub const INVALIDATE = 4;
+    },
+    .haiku, .netbsd, .illumos => struct {
         pub const ASYNC = 1;
         pub const INVALIDATE = 2;
         pub const SYNC = 4;


### PR DESCRIPTION
The `.netbsd` and `.openbsd` branches of `MADV` was completely missing. Validated against the actual system headers.

https://github.com/NetBSD/src/blob/trunk/sys/sys/mman.h#L197
https://github.com/openbsd/src/blob/master/sys/sys/mman.h#L102

`MSF.SYNC` was also wrong on OpenBSD, FreeBSD and DragonFlyBSD.

https://github.com/freebsd/freebsd-src/blob/main/sys/sys/mman.h#L145
https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/mman.h#L130