### PR TITLE
std.Io: vectored sendmsg/recvmsg

### DIFF
--- a/lib/std/Io.zig
+++ b/lib/std/Io.zig
@@ -700,7 +700,7 @@ pub const VTable = struct {
     netListenUnix: *const fn (?*anyopaque, *const net.UnixAddress, net.UnixAddress.ListenOptions) net.UnixAddress.ListenError!net.Socket.Handle,
     netConnectUnix: *const fn (?*anyopaque, *const net.UnixAddress) net.UnixAddress.ConnectError!net.Socket.Handle,
     netSend: *const fn (?*anyopaque, net.Socket.Handle, []net.OutgoingMessage, net.SendFlags) struct { ?net.Socket.SendError, usize },
-    netReceive: *const fn (?*anyopaque, net.Socket.Handle, message_buffer: []net.IncomingMessage, data_buffer: []u8, net.ReceiveFlags, Timeout) struct { ?net.Socket.ReceiveTimeoutError, usize },
+    netReceive: *const fn (?*anyopaque, net.Socket.Handle, message_buffer: []net.IncomingMessage, net.ReceiveFlags, Timeout) struct { ?net.Socket.ReceiveTimeoutError, usize },
     /// Returns 0 on end of stream.
     netRead: *const fn (?*anyopaque, src: net.Socket.Handle, data: [][]u8) net.Stream.Reader.Error!usize,
     netWrite: *const fn (?*anyopaque, dest: net.Socket.Handle, header: []const u8, data: []const []const u8, splat: usize) net.Stream.Writer.Error!usize,


### PR DESCRIPTION
Add support for vectored `sendmsg`/`recvmsg` (`netSend`/`netReceive`) in `std.Io` and the `Threaded` and `Kqueue` implementations.

The only users of these functions are `std.Io.net.Socket`, which I adapted to keep its existing API, and `std.Io.Threaded.lookupDns`

`netReceive` was somewhat special-cased for lookupDns I think. Instead of each message having a its own data buffer(or buffers for vectored io), it would use a common buffer and partition it for each message. This fits the `lookupDns` use-case, but is seriously limiting for a general purpose interface. It makes implementing things such as ring buffers impossible.

The changes boil down to:
- `IncomingMessage.data` is now caller supplied instead of populated by the Io implementation. It can be a single buffer or multiple for vectored operations
- Added separate field for `bytes_sent`/`bytes_received` instead of reusing the slice length
- Made `OutgoingMessage.address` nullable to allow for usage with connected sockets (TCP, Unix) which do not need an address

