### PR TITLE
system specific errno

### DIFF
--- a/lib/std/Thread.zig
+++ b/lib/std/Thread.zig
@@ -1622,7 +1622,7 @@ const LinuxThreadImpl = struct {
             linux.CLONE.PARENT_SETTID | linux.CLONE.CHILD_CLEARTID |
             linux.CLONE.SIGHAND | linux.CLONE.SYSVSEM | linux.CLONE.SETTLS;
 
-        switch (linux.E.init(linux.clone(
+        switch (linux.errno(linux.clone(
             Instance.entryFn,
             @intFromPtr(&mapped[stack_offset]),
             flags,
@@ -1661,7 +1661,7 @@ const LinuxThreadImpl = struct {
             const tid = self.thread.child_tid.load(.seq_cst);
             if (tid == 0) break;
 
-            switch (linux.E.init(linux.futex_4arg(
+            switch (linux.errno(linux.futex_4arg(
                 &self.thread.child_tid.raw,
                 .{ .cmd = .WAIT, .private = false },
                 @bitCast(tid),

--- a/lib/std/Thread/Futex.zig
+++ b/lib/std/Thread/Futex.zig
@@ -269,7 +269,7 @@ const LinuxImpl = struct {
             if (timeout != null) &ts else null,
         );
 
-        switch (linux.E.init(rc)) {
+        switch (linux.errno(rc)) {
             .SUCCESS => {}, // notified by `wake()`
             .INTR => {}, // spurious wakeup
             .AGAIN => {}, // ptr.* != expect
@@ -290,7 +290,7 @@ const LinuxImpl = struct {
             @min(max_waiters, std.math.maxInt(i32)),
         );
 
-        switch (linux.E.init(rc)) {
+        switch (linux.errno(rc)) {
             .SUCCESS => {}, // successful wake up
             .INVAL => {}, // invalid futex_wait() on ptr done elsewhere
             .FAULT => {}, // pointer became invalid while doing the wake

--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -72,6 +72,11 @@ pub inline fn versionCheck(comptime version: std.SemanticVersion) bool {
     };
 }
 
+/// Get the errno if rc is -1 and SUCCESS if rc is not -1.
+pub fn errno(rc: anytype) E {
+    return if (rc == -1) @enumFromInt(_errno().*) else .SUCCESS;
+}
+
 pub const ino_t = switch (native_os) {
     .linux => linux.ino_t,
     .emscripten => emscripten.ino_t,
@@ -11542,6 +11547,6 @@ const private = struct {
     extern threadlocal var errno: c_int;
 
     fn errnoFromThreadLocal() *c_int {
-        return &errno;
+        return &private.errno;
     }
 };

--- a/lib/std/fs/Dir.zig
+++ b/lib/std/fs/Dir.zig
@@ -378,7 +378,7 @@ pub const Iterator = switch (native_os) {
                         self.first_iter = false;
                     }
                     const rc = linux.getdents64(self.dir.fd, &self.buf, self.buf.len);
-                    switch (linux.E.init(rc)) {
+                    switch (linux.errno(rc)) {
                         .SUCCESS => {},
                         .BADF => unreachable, // Dir is invalid or was opened without iteration ability
                         .FAULT => unreachable,

--- a/lib/std/os/linux/bpf.zig
+++ b/lib/std/os/linux/bpf.zig
@@ -1,5 +1,5 @@
 const std = @import("../../std.zig");
-const errno = linux.E.init;
+const errno = linux.errno;
 const unexpectedErrno = std.posix.unexpectedErrno;
 const expectEqual = std.testing.expectEqual;
 const expectError = std.testing.expectError;

--- a/lib/std/os/linux/tls.zig
+++ b/lib/std/os/linux/tls.zig
@@ -555,7 +555,7 @@ pub fn initStatic(phdrs: []elf.Phdr) void {
         }
 
         const begin_addr = mmap_tls(area_desc.size + area_desc.alignment - 1);
-        if (@call(.always_inline, linux.E.init, .{begin_addr}) != .SUCCESS) @trap();
+        if (@call(.always_inline, linux.errno, .{begin_addr}) != .SUCCESS) @trap();
 
         const area_ptr: [*]align(page_size_min) u8 = @ptrFromInt(begin_addr);
 

--- a/lib/std/os/plan9.zig
+++ b/lib/std/os/plan9.zig
@@ -94,13 +94,15 @@ pub const E = enum(u16) {
     OVERFLOW,
     LOOP,
     TXTBSY,
-
-    pub fn init(r: usize) E {
-        const signed_r: isize = @bitCast(r);
-        const int = if (signed_r > -4096 and signed_r < 0) -signed_r else 0;
-        return @enumFromInt(int);
-    }
 };
+
+/// Get the errno from a syscall return value. SUCCESS means no error.
+pub fn errno(r: usize) E {
+    const signed_r: isize = @bitCast(r);
+    const int = if (signed_r > -4096 and signed_r < 0) -signed_r else 0;
+    return @enumFromInt(int);
+}
+
 // The max bytes that can be in the errstr buff
 pub const ERRMAX = 128;
 var errstr_buf: [ERRMAX]u8 = undefined;

--- a/lib/std/process.zig
+++ b/lib/std/process.zig
@@ -1772,7 +1772,7 @@ pub fn totalSystemMemory() TotalSystemMemoryError!u64 {
         .linux => {
             var info: std.os.linux.Sysinfo = undefined;
             const result: usize = std.os.linux.sysinfo(&info);
-            if (std.os.linux.E.init(result) != .SUCCESS) {
+            if (std.os.linux.errno(result) != .SUCCESS) {
                 return error.UnknownTotalSystemMemory;
             }
             // Promote to u64 to avoid overflow on systems where info.totalram is a 32-bit usize

--- a/src/link/Elf/ZigObject.zig
+++ b/src/link/Elf/ZigObject.zig
@@ -1437,7 +1437,7 @@ fn updateNavCode(
                     .len = code.len,
                 }};
                 const rc = std.os.linux.process_vm_writev(pid, &code_vec, &remote_vec, 0);
-                switch (std.os.linux.E.init(rc)) {
+                switch (std.os.linux.errno(rc)) {
                     .SUCCESS => assert(rc == code.len),
                     else => |errno| log.warn("process_vm_writev failure: {s}", .{@tagName(errno)}),
                 }
@@ -2026,7 +2026,7 @@ fn writeTrampoline(tr_sym: Symbol, target: Symbol, elf_file: *Elf) !void {
                     .len = out.len,
                 }};
                 const rc = std.os.linux.process_vm_writev(pid, &local_vec, &remote_vec, 0);
-                switch (std.os.linux.E.init(rc)) {
+                switch (std.os.linux.errno(rc)) {
                     .SUCCESS => assert(rc == out.len),
                     else => |errno| log.warn("process_vm_writev failure: {s}", .{@tagName(errno)}),
                 }

--- a/src/link/MappedFile.zig
+++ b/src/link/MappedFile.zig
@@ -645,7 +645,7 @@ fn resizeNode(mf: *MappedFile, gpa: std.mem.Allocator, ni: Node.Index, requested
             @intCast(requested_size +| requested_size / growth_factor),
         ) - old_size;
         _, const file_size = Node.Index.root.location(mf).resolve(mf);
-        while (true) switch (linux.E.init(switch (std.math.order(range_file_offset, file_size)) {
+        while (true) switch (linux.errno(switch (std.math.order(range_file_offset, file_size)) {
             .lt => linux.fallocate(
                 mf.file.handle,
                 linux.FALLOC.FL_INSERT_RANGE,
@@ -858,7 +858,7 @@ fn moveRange(mf: *MappedFile, old_file_offset: u64, new_file_offset: u64, size: 
     // delete the copy of this node at the old location
     if (is_linux and !mf.flags.fallocate_punch_hole_unsupported and
         size >= mf.flags.block_size.toByteUnits() * 2 - 1) while (true)
-        switch (linux.E.init(linux.fallocate(
+        switch (linux.errno(linux.fallocate(
             mf.file.handle,
             linux.FALLOC.FL_PUNCH_HOLE | linux.FALLOC.FL_KEEP_SIZE,
             @intCast(old_file_offset),
@@ -910,7 +910,7 @@ fn copyFileRange(
                 @intCast(remaining_size),
                 0,
             );
-            switch (linux.E.init(copy_len)) {
+            switch (linux.errno(copy_len)) {
                 .SUCCESS => {
                     if (copy_len == 0) break;
                     remaining_size -= copy_len;


### PR DESCRIPTION
This PR closes #19849 by introducing an `errno` function in `std.os.linux`, `std.os.plan9` and `std.c`. 

The new `copy_file_range error` test fails on master with `-target x86_64-linux-gnu.2.17 -lc`, but passes with this PR.

This PR also removes the `E.init` functions, because IMO they have the problem that, e.g. on Linux with libc, it is not at all obvious that `std.c.E.init` needs the return value of a syscall and not the return value of a libc syscall wrapper.