### PR TITLE
std.Io.Threaded: add missing statx masks

### DIFF
--- a/lib/std/Io/Threaded.zig
+++ b/lib/std/Io/Threaded.zig
@@ -1299,7 +1299,7 @@ fn dirStatPathLinux(
             dir.handle,
             sub_path_posix,
             flags,
-            linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_ATIME | linux.STATX_MTIME | linux.STATX_CTIME,
+            linux.STATX_INO | linux.STATX_SIZE | linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_ATIME | linux.STATX_MTIME | linux.STATX_CTIME,
             &statx,
         );
         switch (linux.E.init(rc)) {
@@ -1446,7 +1446,7 @@ fn fileStatLinux(userdata: ?*anyopaque, file: Io.File) Io.File.StatError!Io.File
             file.handle,
             "",
             linux.AT.EMPTY_PATH,
-            linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_ATIME | linux.STATX_MTIME | linux.STATX_CTIME,
+            linux.STATX_INO | linux.STATX_SIZE | linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_ATIME | linux.STATX_MTIME | linux.STATX_CTIME,
             &statx,
         );
         switch (linux.E.init(rc)) {


### PR DESCRIPTION
statx does not guarantee that the values requested by the mask be present and those not requested be absent which is why this worked

statx(2)
```
       It should be noted that the kernel may return fields that weren't requested and may fail to
       return fields that were requested, depending  on  what  the  backing  filesystem  supports.
       (Fields  that  are  given values despite being unrequested can just be ignored.)  In either
       case, stx_mask will not be equal mask.
```

masks were added in the order they are used in `statFromLinux`