### PR TITLE
`std.Io.Threaded`: Raise specific error when DNS lookup returns no A/AAAA records

### DIFF
--- a/lib/std/Io/Threaded.zig
+++ b/lib/std/Io/Threaded.zig
@@ -5302,7 +5302,7 @@ fn lookupDnsSearch(
         if (lookupDns(t, lookup_canon_name, &rc, resolved, options)) |result| {
             return result;
         } else |err| switch (err) {
-            error.UnknownHostName => continue,
+            error.UnknownHostName, error.NoAddressReturned => continue,
             else => |e| return e,
         }
     }
@@ -5496,7 +5496,7 @@ fn lookupDns(
     }
 
     try resolved.putOne(t_io, .{ .canonical_name = canonical_name orelse .{ .bytes = lookup_canon_name } });
-    if (addresses_len == 0) return error.NameServerFailure;
+    if (addresses_len == 0) return error.NoAddressReturned;
 }
 
 fn lookupHosts(

--- a/lib/std/Io/net/HostName.zig
+++ b/lib/std/Io/net/HostName.zig
@@ -75,6 +75,7 @@ pub const LookupError = error{
     InvalidDnsAAAARecord,
     InvalidDnsCnameRecord,
     NameServerFailure,
+    NoAddressReturned,
     /// Failed to open or read "/etc/hosts" or "/etc/resolv.conf".
     DetectingNetworkConfigurationFailed,
 } || Io.Clock.Error || IpAddress.BindError || Io.Cancelable;


### PR DESCRIPTION
This is an immediate fix for #25948.

Whenever a particular hostname + suffix fails to resolve, `lookupDnsSearch` will continue on to the next search domain.
A new error is added in order to avoid squashing `NameServerFailure` which indicates a network/server error.

