### PR TITLE
Fix integer underflow in Unit.resizeHeader()

### DIFF
--- a/src/link/Dwarf.zig
+++ b/src/link/Dwarf.zig
@@ -635,7 +635,7 @@ const Unit = struct {
         const available_len = if (unit.prev.unwrap()) |prev_unit| prev_excess: {
             const prev_unit_ptr = sec.getUnit(prev_unit);
             break :prev_excess unit.off - prev_unit_ptr.off - prev_unit_ptr.len;
-        } else 0;
+        } else unit.off;
         if (available_len + unit.header_len < len)
             try unit.resize(sec, dwarf, len - unit.header_len, unit.len - unit.header_len + len);
         if (unit.header_len > len) {


### PR DESCRIPTION
When a DWARF unit has no previous unit (i.e., it's the first unit in a section), the code incorrectly calculated `available_len = 0`, even though there was actually `unit.off` bytes of available space before the unit.

```zig
const available_len = if (unit.prev.unwrap()) |prev_unit| prev_excess: {
    const prev_unit_ptr = sec.getUnit(prev_unit);
    break :prev_excess unit.off - prev_unit_ptr.off - prev_unit_ptr.len;
} else 0;  // ← BUG: Should be unit.off, not 0
```