### PR TITLE
crypto.kt{128,256} cleanups & revert workarounds

### DIFF
--- a/lib/std/crypto/kangarootwelve.zig
+++ b/lib/std/crypto/kangarootwelve.zig
@@ -1234,7 +1234,7 @@ test "KT128 sequential and parallel produce same output for many random lengths"
     var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
     const random = prng.random();
 
-    const num_tests = 1000;
+    const num_tests = if (builtin.mode == .Debug) 10 else 1000;
     const max_length = 250000;
 
     for (0..num_tests) |_| {


### PR DESCRIPTION
Use atomic writes for CVs to avoid inconsistencies when hashing the leaves on platforms with weak memory ordering.

Also do not rely on the cpu count. Instead, set a maximum number of chunks per thread. As a bonus, we get better cache locality.

Fixes #25985