### PR TITLE
std.Zig.AstGen: handle properly .inferred_ptr and .destructure in enum_literal handling

### DIFF
--- a/lib/std/zig/AstGen.zig
+++ b/lib/std/zig/AstGen.zig
@@ -1006,9 +1006,9 @@ fn expr(gz: *GenZir, scope: *Scope, ri: ResultInfo, node: Ast.Node.Index) InnerE
                 .field_name_start = str_index,
             });
             switch (ri.rl) {
-                .discard, .none, .ref => unreachable, // no result type
+                .discard, .none, .ref, .inferred_ptr, .destructure => unreachable, // no result type
                 .ty, .coerced_ty => return res, // `decl_literal` does the coercion for us
-                .ref_coerced_ty, .ptr, .inferred_ptr, .destructure => return rvalue(gz, ri, res, node),
+                .ref_coerced_ty, .ptr => return rvalue(gz, ri, res, node),
             }
         } else return simpleStrTok(gz, ri, tree.nodeMainToken(node), node, .enum_literal),
         .error_value => return simpleStrTok(gz, ri, tree.nodeMainToken(node) + 2, node, .error_value),


### PR DESCRIPTION
`rl.resultType()` returns `null` for `inferred_ptr` and `destructure`, so move that to the unreachable block.