### PR TITLE
Add unwrapped optional assignment tests

### DIFF
--- a/test/behavior/optional.zig
+++ b/test/behavior/optional.zig
@@ -304,6 +304,20 @@ test "self-referential struct through a slice of optional" {
     try expect(n.data == null);
 }
 
+test "assigning to an unwrapped optional" {
+    var foo: ?u8 = 10;
+    foo.? = 12;
+    try expect(foo.? == 12);
+}
+
+test "assigning to an unwrapped optional in comptime context" {
+    comptime {
+        var foo: ?u8 = 10;
+        foo.? = 12;
+        try expect(foo.? == 12);
+    }
+}
+
 test "assigning to an unwrapped optional field in an inline loop" {
     comptime var maybe_pos_arg: ?comptime_int = null;
     inline for ("ab") |x| {

--- a/test/cases/compile_errors/optional unwrap assign comptime.zig
+++ b/test/cases/compile_errors/optional unwrap assign comptime.zig
@@ -1,0 +1,9 @@
+pub fn main() !void {
+    comptime {
+        var foo: ?u8 = null;
+        foo.? = 10;
+    }
+}
+// error
+//
+// 4:12: error: unable to unwrap null

--- a/test/cases/safety/optional unwrap assign.zig
+++ b/test/cases/safety/optional unwrap assign.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+
+pub fn panic(message: []const u8, _: ?*std.builtin.StackTrace, _: ?usize) noreturn {
+    if (std.mem.eql(u8, message, "attempt to use null value")) {
+        std.process.exit(0);
+    }
+    std.process.exit(1);
+}
+pub fn main() !void {
+    var foo: ?u8 = null;
+    foo.? = 10; // should fail, since foo is null.
+    return error.TestFailed;
+}
+// run
+// backend=selfhosted,llvm
+// target=x86_64-linux


### PR DESCRIPTION
Zig supports:

```
foo.? = val
```

assignment, currently there are no much tests for them, so lets add few.