### PR TITLE
src/codegen/spirv/Assembler.zig: fix OpConstant /w floats

### DIFF
--- a/src/codegen/spirv/Assembler.zig
+++ b/src/codegen/spirv/Assembler.zig
@@ -754,12 +754,12 @@ fn parseContextDependentNumber(ass: *Assembler) !void {
             const id = entry.value_ptr.*;
             if (id != result_id) continue;
             const info = entry.key_ptr.*;
-            switch (info.bits) {
+            return switch (info.bits) {
                 16 => try ass.parseContextDependentFloat(16),
                 32 => try ass.parseContextDependentFloat(32),
                 64 => try ass.parseContextDependentFloat(64),
                 else => return ass.fail(tok.start, "cannot parse {}-bit info literal", .{info.bits}),
-            }
+            };
         }
     }
 


### PR DESCRIPTION
apologies if this wasn't an oversight and if there was some reason behind the lack of a return but i couldn't find any indications towards that

previously, the following code would fail to compile:
```zig
export fn main() callconv(.spirv_kernel) void {
    asm volatile (
        \\ %f32 = OpTypeFloat 32
        \\ %foo = OpConstant %f32 0
    );
}
```

with the following output:
```
test2.zig:1:8: error: failed to assemble SPIR-V inline assembly
export fn main() callconv(.spirv_kernel) void {
~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test2.zig:1:8: note: cannot parse literal constant
```