### PR TITLE
Add 0 to SIG enum

### DIFF
--- a/lib/std/c.zig
+++ b/lib/std/c.zig
@@ -2662,6 +2662,8 @@ pub const SIG = switch (native_os) {
         pub const IOT: SIG = .ABRT;
         pub const POLL: SIG = .EMT;
 
+        /// Invalid signal. Used in kill to perform checking without sending signal.
+        INVAL = 0,
         /// hangup
         HUP = 1,
         /// interrupt
@@ -2756,6 +2758,7 @@ pub const SIG = switch (native_os) {
         pub const RTMIN = 65;
         pub const RTMAX = 126;
 
+        INVAL = 0,
         HUP = 1,
         INT = 2,
         QUIT = 3,
@@ -2821,6 +2824,7 @@ pub const SIG = switch (native_os) {
 
         pub const POLL: SIG = .IO;
 
+        INVAL = 0,
         HUP = 1,
         INT = 2,
         QUIT = 3,
@@ -2895,6 +2899,7 @@ pub const SIG = switch (native_os) {
 
         pub const IOT: SIG = .ABRT;
 
+        INVAL = 0,
         HUP = 1,
         INT = 2,
         QUIT = 3,
@@ -2941,6 +2946,7 @@ pub const SIG = switch (native_os) {
 
         pub const IOT: SIG = .ABRT;
 
+        INVAL = 0,
         HUP = 1,
         INT = 2,
         QUIT = 3,
@@ -2989,6 +2995,7 @@ pub const SIG = switch (native_os) {
 
         pub const IOT: SIG = .ABRT;
 
+        INVAL = 0,
         HUP = 1,
         INT = 2,
         QUIT = 3,
@@ -3035,6 +3042,7 @@ pub const SIG = switch (native_os) {
 
         pub const IOT: SIG = .ABRT;
 
+        INVAL = 0,
         HUP = 1,
         INT = 2,
         QUIT = 3,

--- a/lib/std/os/linux.zig
+++ b/lib/std/os/linux.zig
@@ -3741,6 +3741,8 @@ pub const SIG = if (is_mips) enum(u32) {
     pub const IOT: SIG = .ABRT;
     pub const POLL: SIG = .IO;
 
+    INVAL = 0,
+
     // /arch/mips/include/uapi/asm/signal.h#L25
     HUP = 1,
     INT = 2,
@@ -3787,6 +3789,8 @@ pub const SIG = if (is_mips) enum(u32) {
     pub const PWR: SIG = .LOST;
     pub const POLL: SIG = .IO;
 
+    /// Perform error checking without sending signal.
+    INVAL = 0,
     HUP = 1,
     INT = 2,
     QUIT = 3,
@@ -3830,6 +3834,8 @@ pub const SIG = if (is_mips) enum(u32) {
     pub const POLL: SIG = .IO;
     pub const IOT: SIG = .ABRT;
 
+    /// Perform error checking without sending signal.
+    INVAL = 0,
     HUP = 1,
     INT = 2,
     QUIT = 3,

--- a/lib/std/os/plan9.zig
+++ b/lib/std/os/plan9.zig
@@ -141,6 +141,8 @@ pub fn getpid() u32 {
     return tos.pid;
 }
 pub const SIG = struct {
+    /// Invalid signal. Used in kill to perform checking without sending signal.
+    pub const INVAL = 0;
     /// hangup
     pub const HUP = 1;
     /// interrupt

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -980,12 +980,3 @@ const CommonOpenFlags = packed struct {
         return result;
     }
 };
-
-test "kill 0 can be used to perform checks of sending signal" {
-    if (native_os == .wasi) return error.SkipZigTest;
-    if (native_os == .windows) return error.SkipZigTest;
-    posix.kill(posix.getpid(), .INVAL) catch |err| switch (err) {
-        posix.KillError.PermissionDenied => return,
-        else => return err,
-    };
-}

--- a/lib/std/posix/test.zig
+++ b/lib/std/posix/test.zig
@@ -980,3 +980,12 @@ const CommonOpenFlags = packed struct {
         return result;
     }
 };
+
+test "kill 0 can be used to perform checks of sending signal" {
+    if (native_os == .wasi) return error.SkipZigTest;
+    if (native_os == .windows) return error.SkipZigTest;
+    posix.kill(posix.getpid(), .INVAL) catch |err| switch (err) {
+        posix.KillError.PermissionDenied => return,
+        else => return err,
+    };
+}

--- a/test/standalone/posix/build.zig
+++ b/test/standalone/posix/build.zig
@@ -20,6 +20,9 @@ const cases = [_]Case{
     .{
         .src_path = "relpaths.zig",
     },
+    .{
+        .src_path = "kill.zig",
+    },
 };
 
 pub fn build(b: *std.Build) void {

--- a/test/standalone/posix/kill.zig
+++ b/test/standalone/posix/kill.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const posix = std.posix;
+const builtin = @import("builtin");
+const native_os = builtin.target.os.tag;
 
 pub fn main() !void {
     try test_kill_zero_self_should_succeed();
@@ -7,6 +9,10 @@ pub fn main() !void {
 }
 
 fn test_kill_nonexistent() !void {
+    if ((native_os != .linux) and (native_os != .macos)) return;
+    // Linux is limited by PID_MAX_LIMIT constant which is around 4 million
+    // MacOS maximum pid appears to be 99999 and not configurable.
+    // Others are unknown thus not tested.
     const impossible_pid: posix.pid_t = 1_999_999_999;
     posix.kill(impossible_pid, .INVAL) catch |err| switch (err) {
         posix.KillError.ProcessNotFound => return,
@@ -16,5 +22,7 @@ fn test_kill_nonexistent() !void {
 }
 
 fn test_kill_zero_self_should_succeed() !void {
+    // Windows does not have kill -0 equivalent
+    if (native_os == .windows) return;
     try posix.kill(posix.getpid(), .INVAL);
 }

--- a/test/standalone/posix/kill.zig
+++ b/test/standalone/posix/kill.zig
@@ -14,11 +14,7 @@ fn test_kill_nonexistent() !void {
     // MacOS maximum pid appears to be 99999 and not configurable.
     // Others are unknown thus not tested.
     const impossible_pid: posix.pid_t = 1_999_999_999;
-    posix.kill(impossible_pid, .INVAL) catch |err| switch (err) {
-        posix.KillError.ProcessNotFound => return,
-        else => return err,
-    };
-    return error.ProcessShouldHaveNotBeenFound;
+    try std.testing.expectError(posix.KillError.ProcessNotFound, posix.kill(impossible_pid, .INVAL));
 }
 
 fn test_kill_zero_self_should_succeed() !void {

--- a/test/standalone/posix/kill.zig
+++ b/test/standalone/posix/kill.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+const posix = std.posix;
+
+pub fn main() !void {
+    try test_kill_zero_self_should_succeed();
+    try test_kill_nonexistent();
+}
+
+fn test_kill_nonexistent() !void {
+    const impossible_pid: posix.pid_t = 1_999_999_999;
+    posix.kill(impossible_pid, .INVAL) catch |err| switch (err) {
+        posix.KillError.ProcessNotFound => return,
+        else => return err,
+    };
+    return error.ProcessShouldHaveNotBeenFound;
+}
+
+fn test_kill_zero_self_should_succeed() !void {
+    try posix.kill(posix.getpid(), .INVAL);
+}


### PR DESCRIPTION
Closes #26011 

I checked for manpages of kill on linux, freebsd, macos, openbsd, illumos, netbsd, openbsd. They all stated 0 can be used. I did not find manpages for others, but I assume it is all the same, so i added 0 to all of the enums.