### PR TITLE
std.http: allow fetching with no payload

### DIFF
--- a/lib/std/http/Client.zig
+++ b/lib/std/http/Client.zig
@@ -1803,6 +1803,11 @@ pub fn fetch(client: *Client, options: FetchOptions) FetchError!FetchResult {
         try body.writer.writeAll(payload);
         try body.end();
         try req.connection.?.flush();
+    } else if (http.Method.requestHasBody(req.method)) {
+        req.transfer_encoding = .{ .content_length = 0 };
+        var body = try req.sendBodyUnflushed(&.{});
+        try body.end();
+        try req.connection.?.flush();
     } else {
         try req.sendBodiless();
     }


### PR DESCRIPTION
When a POST, PUT, or PATCH request is sent by Client.fetch without a payload an assert fails in `sendBodiless` as these HTTP methods are expected to have a body. However, the HTTP spec does not _require_ them to have a  body.

Some prior art on this ambiguity:
- https://groups.google.com/g/golang-codereviews/c/VvYtMmdpfAA?pli=1
- `https://github.com/square/okhttp/issues/7005`

This change handles this scenario more gracefully and is consistent with how curl and other "fetch" abstractions do it. It mostly saves some dev tedium from handling this (suppose requests are crafted as user input to a zig executable).

```sh
$ curl -X POST http://localhost/echo/post 
{
  "args": {},
  "data": {}, # <--
  "files": {},
  "form": {},
  "headers": {
    "host": "localhost",
    "accept": "*/*",
    "accept-encoding": "gzip",
    "user-agent": "curl/8.7.1",
    "content-length": "0" # <--
  },
  "json": null,
  "url": "https://localhost/echo/post"
}
# null payload vs explicitly empty "" payload
$ curl -X POST -d "" http://localhost/echo/post
{
  "args": {},
  "data": "", # <--
  "files": {},
  "form": {},
  "headers": {
    "host": "localhost",
    "content-length": "0", # <--
    "accept-encoding": "gzip",
    "accept": "*/*",
    "user-agent": "curl/8.7.1",
    "content-type": "application/x-www-form-urlencoded"
  },
  "json": null,
  "url": "localhost/echo/post"
}
```