### PR TITLE
testing.expectEqualDeep: fix for enums with format method

### DIFF
--- a/lib/std/testing.zig
+++ b/lib/std/testing.zig
@@ -760,7 +760,7 @@ fn expectEqualDeepInner(comptime T: type, expected: T, actual: T) error{TestExpe
         .error_set,
         => {
             if (actual != expected) {
-                print("expected {}, found {}\n", .{ expected, actual });
+                print("expected {any}, found {any}\n", .{ expected, actual });
                 return error.TestExpectedEqual;
             }
         },


### PR DESCRIPTION
Previously enums with a format method tripped the condition of an ambiguous format string.