### PR TITLE
std.log: add generic tracing support with std.log.span

### DIFF
--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -335,9 +335,9 @@ pub fn Span(
 
         /// Begins the span on this thread's current executor.
         pub fn begin(self: *Self) void {
-            trace(level, scope, &self.any, .begin, current_executor, format, self.args);
             self.prev = current_span;
             current_span = &self.any;
+            trace(level, scope, &self.any, .begin, current_executor, format, self.args);
         }
 
         /// Ends the span on this thread's current executor.

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -171,7 +171,8 @@ pub const ExecutorId = enum(u64) {
         return self;
     }
 
-    /// Acquires a new executor ID, replacing the current one on this thread.
+    /// Places this executor as the current for this thread, asserting that
+    /// there is no existing executor in use.
     pub fn enter(self: ExecutorId) void {
         std.debug.assert(current_executor == .none);
         current_executor = self;
@@ -355,8 +356,8 @@ pub fn Span(
             trace(level, scope, &self.any, .enter, current_executor, format, self.args);
         }
 
-        /// Signals that this span has exited execution on the current executor. Replaces this thread's
-        /// current span with the previous span.
+        /// Signals that this span has exited execution on the current executor. Removes the thread's
+        /// current span.
         pub fn exit(self: *Self) void {
             std.debug.assert(current_span == &self.any);
             trace(level, scope, &self.any, .exit, current_executor, format, self.args);

--- a/lib/std/log.zig
+++ b/lib/std/log.zig
@@ -113,6 +113,285 @@ pub fn defaultLog(
     stderr.print(format ++ "\n", args) catch return;
 }
 
+fn trace(
+    comptime level: Level,
+    comptime scope: @EnumLiteral(),
+    any_span: *AnySpan,
+    event: SpanEvent,
+    executor: ExecutorId,
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    if (comptime !logEnabled(level, scope)) return;
+
+    std.options.traceFn(level, scope, any_span, event, executor, format, args);
+}
+
+pub fn defaultTrace(
+    comptime level: Level,
+    comptime scope: @EnumLiteral(),
+    any_span: *AnySpan,
+    event: SpanEvent,
+    executor: ExecutorId,
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    _ = any_span;
+    _ = executor;
+    switch (event) {
+        .begin => log(level, scope, "[>>] " ++ format, args),
+        .end => log(level, scope, "[<<] " ++ format, args),
+        else => {},
+    }
+}
+
+/// This thread's current executor ID.
+pub threadlocal var current_executor: ExecutorId = .none;
+
+/// This thread's currently tracked span.
+pub threadlocal var current_span: ?*AnySpan = null;
+
+/// A monotonically increasing, unique identifier for an "executor". Depending
+/// on the `std.Io` implementation in use, an executor can be a native thread, a
+/// green thread, etc.
+pub const ExecutorId = enum(u64) {
+    none = std.math.maxInt(u64),
+    _,
+
+    /// A globally unique, monotonically increasing executor identifier.
+    var next_id: std.atomic.Value(u64) = .init(0);
+
+    pub fn create() ExecutorId {
+        return @enumFromInt(next_id.fetchAdd(1, .monotonic));
+    }
+
+    pub fn createAndEnter() ExecutorId {
+        const self = create();
+        self.enter();
+        return self;
+    }
+
+    /// Acquires a new executor ID, replacing the current one on this thread.
+    pub fn enter(self: ExecutorId) void {
+        std.debug.assert(current_executor == .none);
+        current_executor = self;
+    }
+
+    /// Places this executor as the current executor on this thread, asserting
+    /// that the current executor is what we expect.
+    pub fn compareExchange(self: ExecutorId, expected: ExecutorId) void {
+        std.debug.assert(current_executor == expected);
+        current_executor = self;
+    }
+
+    /// Releases this executor ID, setting the current executor ID to `.none`.
+    pub fn exit(self: ExecutorId) void {
+        std.debug.assert(current_executor == self);
+        current_executor = .none;
+    }
+};
+
+/// A monotonically increasing, unique identifier for an individual `Span`. Only
+/// unique within the application's lifetime.
+pub const SpanId = enum(u64) {
+    none = std.math.maxInt(u64),
+    _,
+
+    /// A globally unique, monotonically increasing `Span` identifier.
+    var next_id: std.atomic.Value(u64) = .init(0);
+
+    /// Acquires a new `SpanId`.
+    pub fn createNext() SpanId {
+        return @enumFromInt(next_id.fetchAdd(1, .monotonic));
+    }
+};
+
+/// A type erased interface to a `Span`.
+pub const AnySpan = struct {
+    linkFn: *const fn (*AnySpan) void,
+    unlinkFn: *const fn (*AnySpan) void,
+
+    pub const empty: AnySpan = .{
+        .linkFn = struct {
+            fn link(_: *AnySpan) void {}
+        }.link,
+        .unlinkFn = struct {
+            fn unlink(_: *AnySpan) void {}
+        }.unlink,
+    };
+
+    pub fn link(self: *AnySpan) void {
+        self.linkFn(self);
+    }
+
+    pub fn unlink(self: *AnySpan) void {
+        self.unlinkFn(self);
+    }
+
+    /// Get a pointer to the typed `Span`.
+    pub fn asSpan(
+        any: *AnySpan,
+        comptime level: Level,
+        comptime scope: @EnumLiteral(),
+        comptime format: []const u8,
+        comptime Args: type,
+    ) *Span(level, scope, format, Args) {
+        const self: *Span(level, scope, format, Args) = @fieldParentPtr("any", any);
+        return self;
+    }
+};
+
+/// A tracing span that is generic over the log level and scope, which can be
+/// configured via `std.Options`. When the scope or level has been disabled, this
+/// type becomes zero sized and all methods become no-ops, allowing tracing to be
+/// compiled out.
+///
+/// ```zig
+/// const span = log.span(.info, "begin request", .{});
+/// span.begin();
+/// defer span.end();
+/// ```
+///
+/// An initialized span can be moved where it needs to be, but once it has begun,
+/// moving or copying a span is illegal behavior.
+///
+/// When dealing with concurrent execution, to properly track spans in the task
+/// that is running concurrently, the original span must be linked and unlinked to
+/// the new executor.
+///
+/// ```zig
+/// std.thread.Spawn(.{}, struct {
+///     fn myFn(span: *AnySpan) void {
+///        span.link();
+///        defer span.unlink();
+///
+///       // new spans on this thread are linked to the original
+///     }
+/// }.myFn, .{ &span.any });
+/// ```
+pub fn Span(
+    comptime level: Level,
+    comptime scope: @EnumLiteral(),
+    comptime format: []const u8,
+    comptime Args: type,
+) type {
+    return if (!logEnabled(level, scope)) struct {
+        const Self = @This();
+
+        id: void,
+        address: void,
+        args: void,
+        prev: void,
+        any: AnySpan = .empty,
+        userdata: void,
+
+        pub fn init(_: usize, _: Args) Self {
+            return .{};
+        }
+        pub fn begin(_: *Self) void {}
+        pub fn end(_: *Self) void {}
+        pub fn enter(_: *Self) void {}
+        pub fn exit(_: *Self) void {}
+        pub fn link(_: *Self) void {}
+        pub fn unlink(_: *Self) void {}
+    } else struct {
+        const Self = @This();
+
+        id: SpanId,
+        address: usize,
+        args: Args,
+        /// A pointer to the parent span on this executor, forming a linked list.
+        prev: ?*AnySpan,
+        /// The `AnySpan` type erased interface.
+        any: AnySpan,
+        /// Custom userdata for the span, defined on `std.Options`.
+        userdata: std.options.SpanUserdata,
+
+        /// Initializes the `Span`, but does not begin it.
+        pub fn init(address: usize, args: Args) Self {
+            return .{
+                .id = .createNext(),
+                .address = address,
+                .args = args,
+                .prev = null,
+                .any = .{
+                    .linkFn = struct {
+                        fn link(any: *AnySpan) void {
+                            const self = any.asSpan(level, scope, format, Args);
+                            return self.link();
+                        }
+                    }.link,
+                    .unlinkFn = struct {
+                        fn unlink(any: *AnySpan) void {
+                            const self = any.asSpan(level, scope, format, Args);
+                            return self.unlink();
+                        }
+                    }.unlink,
+                },
+                .userdata = undefined,
+            };
+        }
+
+        /// Begins the span on this thread's current executor.
+        pub fn begin(self: *Self) void {
+            trace(level, scope, &self.any, .begin, current_executor, format, self.args);
+            self.prev = current_span;
+            current_span = &self.any;
+        }
+
+        /// Ends the span on this thread's current executor.
+        pub fn end(self: *Self) void {
+            std.debug.assert(current_span == &self.any);
+            trace(level, scope, &self.any, .end, current_executor, format, self.args);
+            current_span = self.prev;
+            self.* = undefined;
+        }
+
+        /// Signals that this span has entered execution on the current executor. Replaces this thread's
+        /// current span with itself.
+        pub fn enter(self: *Self) void {
+            std.debug.assert(current_span == null);
+            current_span = &self.any;
+            trace(level, scope, &self.any, .enter, current_executor, format, self.args);
+        }
+
+        /// Signals that this span has exited execution on the current executor. Replaces this thread's
+        /// current span with the previous span.
+        pub fn exit(self: *Self) void {
+            std.debug.assert(current_span == &self.any);
+            trace(level, scope, &self.any, .exit, current_executor, format, self.args);
+            current_span = null;
+        }
+
+        /// Links the span to this thread's current executor.
+        pub fn link(self: *Self) void {
+            std.debug.assert(current_span == null);
+            trace(level, scope, &self.any, .link, current_executor, format, self.args);
+        }
+
+        /// Unlinks the span from this thread's current executor.
+        pub fn unlink(self: *Self) void {
+            std.debug.assert(current_span == null);
+            trace(level, scope, &self.any, .unlink, current_executor, format, self.args);
+        }
+    };
+}
+
+pub const SpanEvent = enum {
+    /// The span has begun work on this thread's current executor.
+    begin,
+    /// The span has ended work on this thread's current executor.
+    end,
+    /// A child executor has been linked to the span.
+    link,
+    /// A child executor has been unlinked from the span.
+    unlink,
+    /// The span itself has moved to an executor.
+    enter,
+    /// The span itself has moved from an executor.
+    exit,
+};
+
 /// Returns a scoped logging namespace that logs all messages using the scope
 /// provided here.
 pub fn scoped(comptime scope: @EnumLiteral()) type {
@@ -155,6 +434,16 @@ pub fn scoped(comptime scope: @EnumLiteral()) type {
         ) void {
             log(.debug, scope, format, args);
         }
+
+        /// Initialize a new tracing span. The span must be explicitly begun
+        /// and ended after initialization.
+        pub fn span(
+            comptime level: Level,
+            comptime format: []const u8,
+            args: anytype,
+        ) Span(level, scope, format, @TypeOf(args)) {
+            return .init(@returnAddress(), args);
+        }
     };
 }
 
@@ -180,3 +469,7 @@ pub const info = default.info;
 /// Log a debug message using the default scope. This log level is intended to
 /// be used for messages which are only useful for debugging.
 pub const debug = default.debug;
+
+/// Initialize a new tracing span using the default scope. The span must be
+/// explicitly begun and ended after initialization.
+pub const span = default.span;

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -129,6 +129,19 @@ pub const Options = struct {
         args: anytype,
     ) void = log.defaultLog,
 
+    /// Userdata associated with every std.log.Span.
+    SpanUserdata: type = void,
+
+    traceFn: fn (
+        comptime level: log.Level,
+        comptime scope: @EnumLiteral(),
+        span: *log.AnySpan,
+        event: log.SpanEvent,
+        executor: log.ExecutorId,
+        comptime format: []const u8,
+        args: anytype,
+    ) void = log.defaultTrace,
+
     /// Overrides `std.heap.page_size_min`.
     page_size_min: ?usize = null,
     /// Overrides `std.heap.page_size_max`.

--- a/lib/std/std.zig
+++ b/lib/std/std.zig
@@ -129,17 +129,16 @@ pub const Options = struct {
         args: anytype,
     ) void = log.defaultLog,
 
-    /// Userdata associated with every std.log.Span.
+    /// Per-span userdata. Copied on every span/executor context change; keep it small.
     SpanUserdata: type = void,
 
     traceFn: fn (
         comptime level: log.Level,
         comptime scope: @EnumLiteral(),
-        span: *log.AnySpan,
-        event: log.SpanEvent,
-        executor: log.ExecutorId,
-        comptime format: []const u8,
-        args: anytype,
+        comptime src: SourceLocation,
+        comptime event: log.SpanEvent,
+        executor: log.Executor,
+        span: *log.Span,
     ) void = log.defaultTrace,
 
     /// Overrides `std.heap.page_size_min`.


### PR DESCRIPTION
this PR introduces a `std.log.span()` method, following the existing patterns for `std.log`:

- support for log levels
- support for scoping
- all calls removed at comptime when scope/level is disabled
- support for a custom `traceFn` implementation

## Usage

There are three different APIs being exposed here.

### Instrumenting code

Anyone who wants to instrument their code (application and library authors) can add spans to their code like this:

```zig
pub fn main() !void {
    var threaded = std.Io.Threaded.init(std.heap.page_allocator);
    defer threaded.deinit();

    const io = threaded.io();

    var work = log.span(.info, "scheduling work", .{});
    work.begin();
    defer work.end();

    var group: std.Io.Group = .init;
    group.async(io, doWork, .{io});
    group.async(io, doWork, .{io});
    group.async(io, doWork, .{io});
    group.wait(io);
}

fn doWork(io: std.Io) void {
    var span = log.span(.info, "doing a unit of work", .{});
    span.begin();
    defer span.end();

    io.sleep(.fromMilliseconds(1), .awake) catch {};
}
```

### Implementing a tracing backend

Application authors can provide a `traceFn` on `std.Options` that consumes the events. Here's a stupid one that I used to test when developing; it prints a column for each thread and [visualizes the spans](https://gist.github.com/tristanpemble/56b18cd584dfbe5a74cbcaed3ec7a738?permalink_comment_id=5879917#gistcomment-5879917)

```zig
pub const std_options: std.Options = .{
    .traceFn = myTraceFn,
};

var mutex: std.Thread.Mutex = .{};
var state: [max_executors]u32 = @splat(0);

fn myTraceFn(
    comptime level: log.Level,
    comptime scope: @EnumLiteral(),
    any: *log.AnySpan,
    event: log.SpanEvent,
    executor: log.ExecutorId,
    comptime format: []const u8,
    args: anytype,
) void {
    mutex.lock();
    defer mutex.unlock();

    const span = any.asSpan(level, scope, format, @TypeOf(args));
    const span_id: usize = @intCast(@intFromEnum(span.id));
    const exec_id: usize = if (executor == .none) 0 else @as(usize, @intCast(@intFromEnum(executor))) + 1;

    const sign: u8 = switch (event) {
        .begin => '[',
        .end => ']',
        .enter => '>',
        .exit => '<',
        .link => '+',
        .unlink => '-',
    };

    switch (event) {
        .begin => state[exec_id] += 1,
        .end => state[exec_id] -= 1,
        else => {},
    }

    for (0..max_executors) |e| {
        if (e == exec_id) {
            std.debug.print("{c}{:0>2} ", .{ sign, span_id });
        } else if (state[e] > 0) {
            std.debug.print(" || ", .{});
        } else {
            std.debug.print("    ", .{});
        }
    }
    std.debug.print("\n", .{});
}
```

### Implementing a `std.Io`

This requires support by any implementation of `std.Io`. You can look at how I implemented it in `Threaded`, but the idea is simple:

- each "executor" (thread, fiber, etc) gets a unique `ExecutorId`
- as the executor is moved between threads, they should `executor_id.enter()` and `executor_id.exit()` on that thread
- as work is created, it should store the `std.log.current_span`
- as work is scheduled, it should `span.link()`, linking the original span to this executor
- as work is completed, it should `span.unlink()`, unlinking the original span to this executor
- as work is suspended/resumed, it should `span.exit()` and `span.enter()` accordingly

## Misc Details

### Userdata

Some tracing backends might need userdata to be stored on the span. `std.Options` has a `SpanUserdata: type` field (default `void`). when the span is created, its `userdata: SpanUserdata` is unintialized. the `traceFn` implementation can 
store user data on it as `SpanEvent`s are handled.

### Source location

I'm conflicted on whether to include `SourceLocation` as part of the API. For a middleground, I am tracking the `@returnAddress()` of the call to `std.log.span()`; the implementation can decide if they would like to use this to gather the `SourceLocation` from debug data.

if we do include it in the API, it will make the `span()` calls slightly more verbose.

### Timing data

I opted not to include timing data. Some backends use their own timing, some don't. It seemed like something that the `traceFn` implementation should handle.

## Caveats

The biggest caveat to my design is that it depends on a linked list of stack allocated data. Each `Span` stores a pointer to its previous `Span`. What that means is that moving the span after you have called `begin()` is an illegal operation:

```zig
const span = log.span(.info, "hello", .{});
// move span wherever you want
span.begin(); // we have now stored the stack pointer -- moving after this point is illegal behavior!
```

I don't love it, but I also think it's kind of ok - the split design of initializing a span and beginning it allows you to move the span where it needs to be stored before beginning it.

## Open Questions

**Status of IoUring/Kqueue?**

I started working on IoUring but quickly found out that it looks like it's not currently complete. Is it? Let me know what's up here. Until I can test on IoUring/Kqueue I can't validate this design against a fiber model

**Should std.log.ExecutorId be part of std.Io?**

To me this concept feels pretty intrinsically tied to Io implementations; it's essentially a monotonic identifier for native threads/green threads/fibers/whatever.

**Should this be moved to a new module, like `std.trace`?**

I go back and forth on this, but it shares a lot with `std.log`, so I left it there.

**Should we create a default executor ID in start(), or leave it as .none?**

`std.log.current_executor` defaults to a `.none`. this helps catch implementation errors in `std.Io` when adding support. if you're not using `std.Io`, all your executors will be `none` -- which I think is ok. but there could be an argument to automatically set the main thread's "executor ID"

**Should we update `logFn` to include span information?**

People often like to tie logs to the spans, right now I don't have that wired. It would be a breaking change, but may be valuable.

**Default `traceFn`?**

I put a default `traceFn` that logs the beginning and end of the trace. Should there even be a default? If there is, what should it do?

**Various bikeshedding on names, etc.**

I have spent a lot of time on naming but I am still not sure what the best names for a lot of these concepts are. I am very open to suggestions.

## Issues

implements #5987