### PR TITLE
std.Progress: Terminate progress escape codes with `ST` not `BEL`

### DIFF
--- a/lib/std/Progress.zig
+++ b/lib/std/Progress.zig
@@ -698,13 +698,13 @@ const save = "\x1b7";
 const restore = "\x1b8";
 const finish_sync = "\x1b[?2026l";
 
-const progress_remove = "\x1b]9;4;0\x07";
-const @"progress_normal {d}" = "\x1b]9;4;1;{d}\x07";
-const @"progress_error {d}" = "\x1b]9;4;2;{d}\x07";
-const progress_pulsing = "\x1b]9;4;3\x07";
-const progress_pulsing_error = "\x1b]9;4;2\x07";
-const progress_normal_100 = "\x1b]9;4;1;100\x07";
-const progress_error_100 = "\x1b]9;4;2;100\x07";
+const progress_remove = "\x1b]9;4;0\x1b\\";
+const @"progress_normal {d}" = "\x1b]9;4;1;{d}\x1b\\";
+const @"progress_error {d}" = "\x1b]9;4;2;{d}\x1b\\";
+const progress_pulsing = "\x1b]9;4;3\x1b\\";
+const progress_pulsing_error = "\x1b]9;4;2\x1b\\";
+const progress_normal_100 = "\x1b]9;4;1;100\x1b\\";
+const progress_error_100 = "\x1b]9;4;2;100\x1b\\";
 
 const TreeSymbol = enum {
     /// ├─


### PR DESCRIPTION
`ST` is the "string terminator" and what is actually prescribed in the standard for escape codes. Use of `BEL` as a terminator is apparently a historical oddity that persists for compatibility. Unfortunately, not all terminals support using `BEL`, including Ubuntu's new default terminal, Ptyxis. Using `ST` should make it work in more terminals.

Further reading:

- https://en.wikipedia.org/wiki/ANSI_escape_code#Operating_System_Command_sequences
- https://ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf