### PR TITLE
http.responseHasBody: a PUT response can have a body

### DIFF
--- a/lib/std/http.zig
+++ b/lib/std/http.zig
@@ -44,8 +44,8 @@ pub const Method = enum {
     /// Actual behavior from clients may vary and should still be checked
     pub fn responseHasBody(m: Method) bool {
         return switch (m) {
-            .GET, .POST, .DELETE, .CONNECT, .OPTIONS, .PATCH => true,
-            .HEAD, .PUT, .TRACE => false,
+            .GET, .POST, .PUT, .DELETE, .CONNECT, .OPTIONS, .PATCH => true,
+            .HEAD, .TRACE => false,
         };
     }
 


### PR DESCRIPTION
HEAD/TRACE are bodyless, but PUT responses are body-capable per RFC 7231.