### PR TITLE
utf8ByteSequenceLength: reject start bytes > 0xF4

### DIFF
--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -752,7 +752,7 @@ test "misc invalid utf8" {
 fn testMiscInvalidUtf8() !void {
     // codepoint out of bounds
     try testError("\xf4\x90\x80\x80", error.Utf8CodepointTooLarge);
-    try testError("\xf7\xbf\xbf\xbf", error.Utf8CodepointTooLarge);
+    try testError("\xf7\xbf\xbf\xbf", error.Utf8InvalidStartByte);
     // surrogate halves
     try testValid("\xed\x9f\xbf", 0xd7ff);
     try testError("\xed\xa0\x80", error.Utf8EncodesSurrogateHalf);

--- a/lib/std/unicode.zig
+++ b/lib/std/unicode.zig
@@ -31,7 +31,7 @@ pub fn utf8ByteSequenceLength(first_byte: u8) !u3 {
         0b0000_0000...0b0111_1111 => 1,
         0b1100_0000...0b1101_1111 => 2,
         0b1110_0000...0b1110_1111 => 3,
-        0b1111_0000...0b1111_0111 => 4,
+        0b1111_0000...0b1111_0100 => 4,
         else => error.Utf8InvalidStartByte,
     };
 }


### PR DESCRIPTION
UTF-8 start bytes in the range `[0xF5 .. 0xFF]` are disallowed as they would encode code points above `U+10FFFF`