### PR TITLE
io_uring(tests): Fix 1/N valgrind reports

### DIFF
--- a/lib/std/os/linux/IoUring.zig
+++ b/lib/std/os/linux/IoUring.zig
@@ -2181,6 +2181,7 @@ test "write_fixed/read_fixed" {
     var raw_buffers: [2][11]u8 = undefined;
     // First buffer will be written to the file.
     @memset(&raw_buffers[0], 'z');
+    @memset(&raw_buffers[1], 0);
     raw_buffers[0][0.."foobar".len].* = "foobar".*;
 
     var buffers = [2]posix.iovec{


### PR DESCRIPTION
Part of https://github.com/ziglang/zig/issues/24753

This commit is the first patch for fixing errors reported by valgrind in the `IoUring.zig` tests. This commit addresses the following:

```
7/41 IoUring.test.write_fixed/read_fixed...==47580== Conditional jump or move depends on uninitialised value(s)
==47580==    at 0x112089D: testing.expectEqualSlices__anon_24471 (testing.zig:365)
==47580==    by 0x1133491: IoUring.test.write_fixed/read_fixed (IoUring.zig:2224)
==47580==    by 0x11B320A: test_runner.mainTerminal (test_runner.zig:248)
==47580==    by 0x11AE5DE: test_runner.main (test_runner.zig:71)
==47580==    by 0x11ADE18: callMain (start.zig:705)
==47580==    by 0x11ADE18: callMainWithArgs (start.zig:674)
==47580==    by 0x11ADE18: main (start.zig:689)
==47580==
==47580== Conditional jump or move depends on uninitialised value(s)
==47580==    at 0x112089D: testing.expectEqualSlices__anon_24471 (testing.zig:365)
==47580==    by 0x113353C: IoUring.test.write_fixed/read_fixed (IoUring.zig:2225)
==47580==    by 0x11B320A: test_runner.mainTerminal (test_runner.zig:248)
==47580==    by 0x11AE5DE: test_runner.main (test_runner.zig:71)
==47580==    by 0x11ADE18: callMain (start.zig:705)
==47580==    by 0x11ADE18: callMainWithArgs (start.zig:674)
==47580==    by 0x11ADE18: main (start.zig:689)
==47580==
==47580== Conditional jump or move depends on uninitialised value(s)
==47580==    at 0x112089D: testing.expectEqualSlices__anon_24471 (testing.zig:365)
==47580==    by 0x11335E7: IoUring.test.write_fixed/read_fixed (IoUring.zig:2226)
==47580==    by 0x11B320A: test_runner.mainTerminal (test_runner.zig:248)
==47580==    by 0x11AE5DE: test_runner.main (test_runner.zig:71)
==47580==    by 0x11ADE18: callMain (start.zig:705)
==47580==    by 0x11ADE18: callMainWithArgs (start.zig:674)
==47580==    by 0x11ADE18: main (start.zig:689)
==47580==
```

The memory for the buffer[1] is never explicitly initialized, hence valgrind's report.

I opted to simply initialize the memory to a default value of 0. Happy to discuss a different approach if preferred.